### PR TITLE
Feat update api

### DIFF
--- a/server/src/http/controllers/jobs/jobs.controller.ts
+++ b/server/src/http/controllers/jobs/jobs.controller.ts
@@ -29,7 +29,7 @@ export class JobsController extends Controller {
   @Response<"Establishment not found">(400)
   @SuccessResponse("200", "Establishment found")
   @Get("/establishment")
-  public async getEstablishment(@Body() { siret, email }: { siret: string; email: string }): Promise<TEstablishmentResponseSuccess["establishment_id"] | TResponseError> {
+  public async getEstablishment(@Query() siret: string, @Query() email: string): Promise<TEstablishmentResponseSuccess["establishment_id"] | TResponseError> {
     const establishment = await Recruiter.findOne({ establishment_siret: siret, email: email })
 
     if (!establishment) {

--- a/server/src/http/controllers/jobs/jobs.controller.ts
+++ b/server/src/http/controllers/jobs/jobs.controller.ts
@@ -21,6 +21,27 @@ import { ICredential } from "../../../common/model/schema/credentials/credential
 @Security("api_key")
 export class JobsController extends Controller {
   /**
+   * Get existing establishment id from siret & email
+   * @param {String} siret Establishment siret
+   * @param {String} email Establishment email
+   * @returns {Promise<TEstablishmentResponseSuccess["establishment_id"]>} response
+   */
+  @Response<"Establishment not found">(400)
+  @SuccessResponse("200", "Establishment found")
+  @Get("/establishment")
+  public async getEstablishment(@Body() body: { siret: string; email: string }): Promise<TEstablishmentResponseSuccess["establishment_id"] | TResponseError> {
+    const establishment = await Recruiter.findOne({ establishment_siret: body.siret, email: body.email })
+
+    if (!establishment) {
+      this.setStatus(400)
+      return { error: true, message: "Establishment not found" }
+    }
+
+    this.setStatus(200)
+    return establishment.establishment_id
+  }
+
+  /**
    * Get all jobs related to my organization
    * @param {Filter<IRecruiter>} query mongodb query allowing specific filtering, JSON stringified.
    * @param {Object} select fields to return, ex {_id: 1, first_name:1, last_name:0}

--- a/server/src/http/controllers/jobs/jobs.controller.ts
+++ b/server/src/http/controllers/jobs/jobs.controller.ts
@@ -22,8 +22,8 @@ import { ICredential } from "../../../common/model/schema/credentials/credential
 export class JobsController extends Controller {
   /**
    * Get existing establishment id from siret & email
-   * @param {String} siret Establishment siret
-   * @param {String} email Establishment email
+   * @param {string} siret Establishment siret
+   * @param {string} email Establishment email
    * @returns {Promise<TEstablishmentResponseSuccess["establishment_id"]>} response
    */
   @Response<"Establishment not found">(400)
@@ -250,7 +250,7 @@ export class JobsController extends Controller {
    * Get related training organization related to a job offer.
    * A job ID is required
    *
-   * @param {String} jobId
+   * @param {string} jobId
    */
   @Response<"Get delegations failed">(400)
   @SuccessResponse("200", "Get Delegations success")
@@ -303,7 +303,7 @@ export class JobsController extends Controller {
    * Update a job offer status to "Provided".
    * A job ID is required
    *
-   * @param {String} jobId
+   * @param {string} jobId
    */
   @Response<"Job update failed">(400)
   @SuccessResponse("204", "Job updated")
@@ -326,7 +326,7 @@ export class JobsController extends Controller {
    * Update a job offer status to "Canceled".
    * A job ID is required
    *
-   * @param {String} jobId
+   * @param {string} jobId
    */
   @Response<"Job update failed">(400)
   @SuccessResponse("204", "Job updated")
@@ -349,7 +349,7 @@ export class JobsController extends Controller {
    * Update a job expiration date by 30 days.
    * A job ID is required
    *
-   * @param {String} jobId
+   * @param {string} jobId
    */
   @Response<"Job update failed">(400)
   @SuccessResponse("204", "Job updated")

--- a/server/src/http/controllers/jobs/jobs.controller.ts
+++ b/server/src/http/controllers/jobs/jobs.controller.ts
@@ -29,8 +29,8 @@ export class JobsController extends Controller {
   @Response<"Establishment not found">(400)
   @SuccessResponse("200", "Establishment found")
   @Get("/establishment")
-  public async getEstablishment(@Body() body: { siret: string; email: string }): Promise<TEstablishmentResponseSuccess["establishment_id"] | TResponseError> {
-    const establishment = await Recruiter.findOne({ establishment_siret: body.siret, email: body.email })
+  public async getEstablishment(@Body() { siret, email }: { siret: string; email: string }): Promise<TEstablishmentResponseSuccess["establishment_id"] | TResponseError> {
+    const establishment = await Recruiter.findOne({ establishment_siret: siret, email: email })
 
     if (!establishment) {
       this.setStatus(400)

--- a/server/src/http/controllers/jobs/jobs.types.ts
+++ b/server/src/http/controllers/jobs/jobs.types.ts
@@ -13,11 +13,11 @@ export type TJob = {
   job_duration: number
   job_type: string[]
   is_disabled_elligible: boolean
-  job_count: number
-  job_rythm: string
+  job_count?: number
+  job_rythm?: string
   job_start_date: string
   job_employer_description?: string
-  job_description: string
+  job_description?: string
 }
 
 export interface ICreateJobBody extends TJob {
@@ -33,6 +33,7 @@ export interface IGetDelegation {
   nom_departement: string
   entreprise_raison_sociale: string
   geo_coordonnees: string
+  distance_en_km: string
 }
 export interface ICreateDelegation {
   establishmentIds: string[]

--- a/server/src/http/controllers/jobs/jobs.validators.ts
+++ b/server/src/http/controllers/jobs/jobs.validators.ts
@@ -39,9 +39,11 @@ export const createJobSchema = Joi.object({
   job_type: Joi.array().items(Joi.string().valid("Apprentissage", "Professionalisation").required()),
   is_disabled_elligible: Joi.boolean().default(false),
   job_count: Joi.number().default(1),
-  job_rythm: Joi.string().valid("Indifférent", "2 jours / 3 jours", "1 semaine / 1 semaine", "2 semaines / 3 semaines", "6 semaines / 6 semaines").default("Indifférent"),
+  job_rythm: Joi.string()
+    .valid("Indifférent", "2 jours / 3 jours", "1 semaine / 1 semaine", "2 semaines / 3 semaines", "6 semaines / 6 semaines", "Non renseigné")
+    .default("Non renseigné"),
   job_duration: Joi.number().min(6).max(36).required(),
-  job_description: Joi.string().required(),
+  job_description: Joi.string(),
   job_employer_description: Joi.string(),
 })
 


### PR DESCRIPTION
- Ajout d'une route permettant de récupérer `establishment_id` à partir d'un siret et d'un email
- Rend non obligatoire job_count, job_rythm, job_description
- Ajout le type "Non renseigné" dans le paramètre job_rythm, valeur par défaut
- Ajoute au type la distance en km retourné par l'API GET delegations