### PR TITLE
fix: parcoursup training activation

### DIFF
--- a/server/src/jobs/rdv/syncEtablissementsAndFormations.ts
+++ b/server/src/jobs/rdv/syncEtablissementsAndFormations.ts
@@ -72,7 +72,7 @@ export const syncEtablissementsAndFormations = async ({ etablissements }) => {
         }
 
         // Activate premium referrers
-        if (etablissement?.premium_activation_date) {
+        if (etablissement?.premium_activation_date && formationMinistereEducatif?.parcoursup_id) {
           referrersToActivate.push(referrers.PARCOURSUP.name)
         }
 


### PR DESCRIPTION
On active une formation sur parcoursup que si et seulement si:
- l'établissement a accepté le premium (**premium_activation_date** avec une date)
- la formation a un **parcoursup_id**