### PR TITLE
fix: fix deployment Docker for ui project

### DIFF
--- a/ui/Dockerfile.develop
+++ b/ui/Dockerfile.develop
@@ -35,7 +35,7 @@ RUN adduser --system --uid 1001 nextjs
 
 # You only need to copy next.config.js if you are NOT using the default configuration
 # COPY --from=builder-production /app/next.config.js ./
-COPY --from=builder /app/public ./public
+COPY --from=builder --chmod=744 --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder /app/package.json ./package.json
 
 # Automatically leverage output traces to reduce image size

--- a/ui/Dockerfile.production
+++ b/ui/Dockerfile.production
@@ -35,7 +35,7 @@ RUN adduser --system --uid 1001 nextjs
 
 # You only need to copy next.config.js if you are NOT using the default configuration
 # COPY --from=builder-production /app/next.config.js ./
-COPY --from=builder /app/public ./public
+COPY --from=builder --chmod=744 --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder /app/package.json ./package.json
 
 # Automatically leverage output traces to reduce image size

--- a/ui/Dockerfile.recette
+++ b/ui/Dockerfile.recette
@@ -35,7 +35,7 @@ RUN adduser --system --uid 1001 nextjs
 
 # You only need to copy next.config.js if you are NOT using the default configuration
 # COPY --from=builder-production /app/next.config.js ./
-COPY --from=builder /app/public ./public
+COPY --from=builder --chmod=744 --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder /app/package.json ./package.json
 
 # Automatically leverage output traces to reduce image size


### PR DESCRIPTION
le serveur du projet `ui` ne démarre pas à cause d'un problème de droits sur les fichiers images. Cette PR fix les droits sur ces fichiers.