### PR TITLE
feat: update logic to fill new fields

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -36,6 +36,7 @@ import { checkAwaitingCompaniesValidation } from "./jobs/lba_recruteur/user/misc
 import updateBrevoBlockedEmails from "./jobs/updateBrevoBlockedEmails/updateBrevoBlockedEmails.js"
 import { importReferentielOnisep } from "./jobs/rdv/importReferentielOnisep.js"
 import updateReferentielRncpRomes from "./jobs/referentielRncpRome/updateReferentielRncpRomes.js"
+import { updateFormationCatalogue } from "./jobs/formationsCatalogue/updateFormationCatalogue.js"
 
 cli.addHelpText("after", null)
 
@@ -260,6 +261,13 @@ cli
   .description("Importe les formations depuis le Catalogue")
   .action(() => {
     runScript(() => importCatalogueFormationJob())
+  })
+
+cli
+  .command("sync-catalogue-trainings-extra-data")
+  .description("Mise à jour des champs spécifiques de la collection formations catalogue")
+  .action(() => {
+    runScript((components) => updateFormationCatalogue(components))
   })
 
 cli

--- a/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
+++ b/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { oleoduc, writeData, transformData } from "oleoduc"
+import { oleoduc, writeData } from "oleoduc"
 import { logger } from "../../common/logger.js"
 import { FormationCatalogue } from "../../common/model/index.js"
 import { rebuildIndex, resetIndexAndDb } from "../../common/utils/esUtils.js"

--- a/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
+++ b/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
@@ -16,7 +16,7 @@ const importFormations = async () => {
     failed: 0,
   }
 
-  const formationCatalogueMe = getFormationsFromCatalogueMe({
+  const formationCatalogueMe = await getFormationsFromCatalogueMe({
     query: { parcoursup_id: { $ne: null }, affelnet_statut: { $ne: null }, cle_ministere_educatif: { $ne: null } },
     select: { parcoursup_id: 1, affelnet_statut: 1, cle_ministere_educatif: 1 },
   })

--- a/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
+++ b/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
@@ -17,6 +17,7 @@ const importFormations = async () => {
   }
 
   const formationCatalogueMe = await getFormationsFromCatalogueMe({
+    limit: 1000,
     query: { parcoursup_id: { $ne: null }, affelnet_statut: { $ne: null }, cle_ministere_educatif: { $ne: null } },
     select: { parcoursup_id: 1, affelnet_statut: 1, cle_ministere_educatif: 1 },
   })
@@ -25,8 +26,8 @@ const importFormations = async () => {
     await oleoduc(
       await getAllFormationsFromCatalogue(),
       transformData((formation) => {
-        const { parcoursup_id, affelnet_statut } = formationCatalogueMe.find((formationME) => formationME.cle_ministere_educatif === formation.cle_ministere_educatif)
-        return { ...formation, parcoursup_id: parcoursup_id ?? null, affelnet_statut: affelnet_statut ?? null }
+        const found = formationCatalogueMe.find((formationME) => formationME.cle_ministere_educatif === formation.cle_ministere_educatif)
+        return { ...formation, parcoursup_id: found?.parcoursup_id ?? null, affelnet_statut: found?.affelnet_statut ?? null }
       }),
       writeData(async (formation) => {
         stats.total++

--- a/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
+++ b/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
@@ -5,7 +5,7 @@ import { FormationCatalogue } from "../../common/model/index.js"
 import { rebuildIndex, resetIndexAndDb } from "../../common/utils/esUtils.js"
 import { sentryCaptureException } from "../../common/utils/sentryUtils.js"
 import { notifyToSlack } from "../../common/utils/slackUtils.js"
-import { countFormations, getAllFormationsFromCatalogue, getFormationsFromCatalogueMe } from "../../services/catalogue.service.js"
+import { countFormations, getAllFormationsFromCatalogue } from "../../services/catalogue.service.js"
 
 const importFormations = async () => {
   logger.info(`Début import`)
@@ -16,19 +16,9 @@ const importFormations = async () => {
     failed: 0,
   }
 
-  const formationCatalogueMe = await getFormationsFromCatalogueMe({
-    limit: 1000,
-    query: { parcoursup_id: { $ne: null }, affelnet_statut: { $ne: null }, cle_ministere_educatif: { $ne: null } },
-    select: { parcoursup_id: 1, affelnet_statut: 1, cle_ministere_educatif: 1 },
-  })
-
   try {
     await oleoduc(
       await getAllFormationsFromCatalogue(),
-      transformData((formation) => {
-        const found = formationCatalogueMe.find((formationME) => formationME.cle_ministere_educatif === formation.cle_ministere_educatif)
-        return { ...formation, parcoursup_id: found?.parcoursup_id ?? null, affelnet_statut: found?.affelnet_statut ?? null }
-      }),
       writeData(async (formation) => {
         stats.total++
         try {

--- a/server/src/jobs/formationsCatalogue/updateFormationCatalogue.ts
+++ b/server/src/jobs/formationsCatalogue/updateFormationCatalogue.ts
@@ -1,0 +1,24 @@
+import { logger } from "../../common/logger.js"
+import { FormationCatalogue } from "../../common/model/index.js"
+import { IFormationCatalogue } from "../../common/model/schema/formationCatalogue/formationCatalogue.types.js"
+import { asyncForEach } from "../../common/utils/asyncUtils.js"
+import { getFormationsFromCatalogueMe } from "../../services/catalogue.service.js"
+
+export const updateFormationCatalogue = async ({ db }) => {
+  logger.info("--- update formation catalogue data --- start")
+  const formations = await FormationCatalogue.find({ $and: [{ affelnet_statut: null }, { parcoursup_id: null }] }).lean()
+
+  logger.info(`${formations.length} à contrôler...`)
+
+  await asyncForEach(formations, async (formation: IFormationCatalogue) => {
+    const formationME = await getFormationsFromCatalogueMe({
+      limit: 1,
+      query: { cle_ministere_educatif: formation.cle_ministere_educatif },
+      select: { parcoursup_id: 1, affelnet_statut: 1 },
+    })
+    const { parcoursup_id, affelnet_statut } = formationME[0]
+
+    await db.collection("formationcatalogues").updateOne({ cle_ministere_educatif: formation.cle_ministere_educatif }, { $set: { parcoursup_id, affelnet_statut } })
+  })
+  logger.info("--- update formation catalogue data --- end")
+}


### PR DESCRIPTION
- fetch `parcoursup_id` & `affelnet_statut` from catalagoue ME and add them into `formationscatalogues` collection upon batch

jira : https://mna-matcha.atlassian.net/browse/LBAC-1358