### PR TITLE
fix: "mailing" attribute replaced by "to_etablissement_emails"

### DIFF
--- a/server/src/http/routes/auth/emails.controller.ts
+++ b/server/src/http/routes/auth/emails.controller.ts
@@ -73,7 +73,7 @@ export default ({ etablissements }) => {
         }
       }
 
-      const [etablissementFound] = await etablissements.find({ "mailing.message_id": { $regex: messageId } })
+      const [etablissementFound] = await etablissements.find({ "to_etablissement_emails.message_id": { $regex: messageId } })
 
       // If mail sent from etablissement model
       if (etablissementFound) {


### PR DESCRIPTION
Remplacement de l'attribut "mailing" par "to_etablissement_emails" (de la collection **etablissement**)

⚠️  PR tirée depuis la branch `infra/refactor`.