### PR TITLE
Lbac 1642 uniformisation de l'activation d'un recruteur entreprise

### DIFF
--- a/server/src/common/model/schema/jobs/jobs.schema.ts
+++ b/server/src/common/model/schema/jobs/jobs.schema.ts
@@ -1,6 +1,5 @@
-import { IJob } from "shared"
+import { IJob, JOB_STATUS } from "shared"
 
-import { JOB_STATUS } from "../../../../services/constant.service"
 import { model, Schema } from "../../../mongodb"
 
 export const jobsSchema = new Schema<IJob>(

--- a/server/src/http/controllers/jobs/jobs.controller.ts
+++ b/server/src/http/controllers/jobs/jobs.controller.ts
@@ -1,12 +1,12 @@
 import Boom from "boom"
-import { IJob, zRoutes } from "shared"
+import { IJob, JOB_STATUS, zRoutes } from "shared"
 
 import { getUserFromRequest } from "@/security/authenticationService"
 import { Appellation } from "@/services/rome.service.types"
 
 import { Recruiter } from "../../../common/model/index"
 import { getNearEtablissementsFromRomes } from "../../../services/catalogue.service"
-import { ACTIVE, ANNULEE, JOB_STATUS, POURVUE } from "../../../services/constant.service"
+import { ACTIVE, ANNULEE, POURVUE } from "../../../services/constant.service"
 import dayjs from "../../../services/dayjs.service"
 import { entrepriseOnboardingWorkflow } from "../../../services/etablissement.service"
 import {

--- a/server/src/http/routes/user.controller.ts
+++ b/server/src/http/routes/user.controller.ts
@@ -1,12 +1,11 @@
 import Boom from "boom"
-import { IJob, zRoutes } from "shared/index"
+import { IJob, getUserStatus, zRoutes } from "shared/index"
 
 import { Recruiter, UserRecruteur } from "../../common/model/index"
 import { getStaticFilePath } from "../../common/utils/getStaticFilePath"
 import config from "../../config"
-import { ENTREPRISE, ETAT_UTILISATEUR, JOB_STATUS, RECRUITER_STATUS } from "../../services/constant.service"
-import dayjs from "../../services/dayjs.service"
-import { addExpirationPeriod, deleteFormulaire, getFormulaire, reactivateRecruiter, sendDelegationMailToCFA, updateOffre } from "../../services/formulaire.service"
+import { ENTREPRISE, ETAT_UTILISATEUR, RECRUITER_STATUS } from "../../services/constant.service"
+import { activateEntrepriseRecruiterForTheFirstTime, deleteFormulaire, getFormulaire, reactivateRecruiter } from "../../services/formulaire.service"
 import mailer from "../../services/mailer.service"
 import { getUserAndRecruitersDataForOpcoUser } from "../../services/user.service"
 import {
@@ -176,10 +175,8 @@ export default (server: Server) => {
       const user = await UserRecruteur.findOne({ _id: req.params.userId }).lean()
 
       if (!user) throw Boom.notFound("User not found")
-      if (!user.status || user.status.length === 0) throw Boom.internal("User doesn't have status")
-
-      // @ts-expect-error: TODO
-      const status_current = user.status.pop().status
+      const status_current = getUserStatus(user.status)
+      if (!status_current) throw Boom.internal("User doesn't have status")
 
       return res.status(200).send({ status_current })
     }
@@ -269,18 +266,7 @@ export default (server: Server) => {
         } else {
           // le compte se trouve validé et on procède à l'activation de la première offre et à la notification aux CFAs
           if (userFormulaire?.jobs?.length) {
-            const job: IJob = Object.assign(userFormulaire.jobs[0], { job_status: JOB_STATUS.ACTIVE, job_expiration_date: addExpirationPeriod(dayjs()).format("YYYY-MM-DD") })
-            await updateOffre(job._id.toString(), job)
-
-            if (job?.delegations && job?.delegations.length) {
-              await Promise.all(
-                job.delegations.map(
-                  async (delegation) =>
-                    // TODO NIMP
-                    await sendDelegationMailToCFA(delegation.email as string, job, userFormulaire as any, delegation.siret_code as string)
-                )
-              )
-            }
+            await activateEntrepriseRecruiterForTheFirstTime(userFormulaire)
           }
         }
       }

--- a/server/src/jobs/lba_recruteur/user/misc/updateSiretInfosInError.ts
+++ b/server/src/jobs/lba_recruteur/user/misc/updateSiretInfosInError.ts
@@ -1,14 +1,14 @@
 import Boom from "boom"
-import type { IUserRecruteur } from "shared"
+import { JOB_STATUS, type IUserRecruteur } from "shared"
 
 import { logger } from "../../../../common/logger"
 import { Recruiter, UserRecruteur } from "../../../../common/model/index"
 import { asyncForEach } from "../../../../common/utils/asyncUtils"
 import { sentryCaptureException } from "../../../../common/utils/sentryUtils"
 import { notifyToSlack } from "../../../../common/utils/slackUtils"
-import { CFA, ENTREPRISE, ETAT_UTILISATEUR, JOB_STATUS, RECRUITER_STATUS } from "../../../../services/constant.service"
+import { CFA, ENTREPRISE, ETAT_UTILISATEUR, RECRUITER_STATUS } from "../../../../services/constant.service"
 import { autoValidateCompany, getEntrepriseDataFromSiret, sendEmailConfirmationEntreprise } from "../../../../services/etablissement.service"
-import { archiveFormulaire, getFormulaire, sendMailNouvelleOffre, updateFormulaire, updateOffre } from "../../../../services/formulaire.service"
+import { activateEntrepriseRecruiterForTheFirstTime, archiveFormulaire, getFormulaire, sendMailNouvelleOffre, updateFormulaire } from "../../../../services/formulaire.service"
 import { autoValidateUser, deactivateUser, getUser, setUserInError, updateUser } from "../../../../services/userRecruteur.service"
 
 const updateUserRecruteursSiretInfosInError = async () => {
@@ -38,11 +38,7 @@ const updateUserRecruteursSiretInfosInError = async () => {
           const result = await autoValidateCompany(updatedUserRecruteur)
           updatedUserRecruteur = result.userRecruteur
           if (result.validated) {
-            await Promise.all(
-              recruteur.jobs.map(async (job) => {
-                await updateOffre(job._id.toString(), { ...job, job_status: JOB_STATUS.ACTIVE })
-              })
-            )
+            await activateEntrepriseRecruiterForTheFirstTime(recruteur)
             await sendEmailConfirmationEntreprise(updatedUserRecruteur, recruteur)
           }
         } else {

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -2,7 +2,8 @@ import { isEmailBurner } from "burner-email-providers"
 import Joi from "joi"
 import type { EnforceDocument } from "mongoose"
 import { oleoduc, writeData } from "oleoduc"
-import { IApplication, IApplicationUI, ILbaCompany } from "shared"
+import { IApplication, IApplicationUI, ILbaCompany, JOB_STATUS } from "shared"
+import { RECRUITER_STATUS } from "shared/constants/recruteur.js"
 
 import { getStaticFilePath } from "@/common/utils/getStaticFilePath"
 
@@ -16,7 +17,6 @@ import config from "../config.js"
 
 import { BrevoEventStatus } from "./brevo.service.js"
 import { scan } from "./clamav.service"
-import { JOB_STATUS, RECRUITER_STATUS } from "./constant.service"
 import { getOffreAvecInfoMandataire } from "./formulaire.service"
 import mailer from "./mailer.service.js"
 import { validateCaller } from "./queryValidator.service.js"

--- a/server/src/services/constant.service.ts
+++ b/server/src/services/constant.service.ts
@@ -2,13 +2,6 @@ export const POURVUE = "Pourvue"
 export const ANNULEE = "Annulée"
 export const ACTIVE = "Active"
 
-export enum JOB_STATUS {
-  ACTIVE = "Active",
-  POURVUE = "Pourvue",
-  ANNULEE = "Annulée",
-  EN_ATTENTE = "En attente",
-}
-
 export enum RECRUITER_STATUS {
   ACTIF = "Actif",
   ARCHIVE = "Archivé",

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -622,7 +622,7 @@ export const extendOffre = async (id: IJob["_id"]): Promise<IJob> => {
     { "jobs._id": id },
     {
       $set: {
-        "jobs.$.job_expiration_date": addExpirationPeriod(dayjs()).format("YYYY-MM-DD"),
+        "jobs.$.job_expiration_date": addExpirationPeriod(dayjs()).toDate(),
         "jobs.$.job_last_prolongation_date": Date.now(),
         "jobs.$.job_update_date": Date.now(),
       },
@@ -645,7 +645,7 @@ const activateAndExtendOffre = async (id: IJob["_id"]): Promise<IJob> => {
     { "jobs._id": id },
     {
       $set: {
-        "jobs.$.job_expiration_date": addExpirationPeriod(dayjs()).format("YYYY-MM-DD"),
+        "jobs.$.job_expiration_date": addExpirationPeriod(dayjs()).toDate(),
         "jobs.$.job_status": JOB_STATUS.ACTIVE,
       },
     },

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -656,7 +656,7 @@ const activateAndExtendOffre = async (id: IJob["_id"]): Promise<IJob> => {
   }
   const job = recruiter.jobs.find((job) => job._id.toString() === id.toString())
   if (!job) {
-    throw Boom.notFound(`job with id=${id} not found`)
+    throw Boom.internal(`unexpected: job with id=${id} not found`)
   }
   return job
 }

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -635,7 +635,7 @@ export const extendOffre = async (id: IJob["_id"]): Promise<IJob> => {
   }
   const job = recruiter.jobs.find((job) => job._id.toString() === id.toString())
   if (!job) {
-    throw Boom.notFound(`job with id=${id} not found`)
+    throw Boom.internal(`unexpected: job with id=${id} not found`)
   }
   return job
 }

--- a/server/src/services/lbajob.service.ts
+++ b/server/src/services/lbajob.service.ts
@@ -1,4 +1,4 @@
-import { IJob, IRecruiter } from "shared"
+import { IJob, IRecruiter, JOB_STATUS } from "shared"
 
 import { encryptMailWithIV } from "../common/utils/encryptString"
 import { IApiError, manageApiError } from "../common/utils/errorManager"
@@ -7,7 +7,7 @@ import { trackApiCall } from "../common/utils/sendTrackingEvent"
 import { sentryCaptureException } from "../common/utils/sentryUtils"
 
 import { IApplicationCount, getApplicationByJobCount } from "./application.service"
-import { JOB_STATUS, NIVEAUX_POUR_LBA, RECRUITER_STATUS } from "./constant.service"
+import { NIVEAUX_POUR_LBA, RECRUITER_STATUS } from "./constant.service"
 import { getJobsFromElasticSearch, getOffreAvecInfoMandataire, incrementLbaJobViewCount } from "./formulaire.service"
 import { ILbaItemLbaJob } from "./lbaitem.shared.service.types"
 import type { ILbaJobEsResult } from "./lbajob.service.types"

--- a/shared/constants/recruteur.ts
+++ b/shared/constants/recruteur.ts
@@ -1,7 +1,3 @@
-export const POURVUE = "Pourvue"
-export const ANNULEE = "Annulée"
-export const ACTIVE = "Active"
-
 export enum JOB_STATUS {
   ACTIVE = "Active",
   POURVUE = "Pourvue",

--- a/ui/components/ItemDetail/CandidatureLba/CandidatureLba.tsx
+++ b/ui/components/ItemDetail/CandidatureLba/CandidatureLba.tsx
@@ -2,6 +2,7 @@ import { CloseIcon } from "@chakra-ui/icons"
 import { Box, Button, Image, Modal, ModalContent, ModalHeader, ModalOverlay, Text, useDisclosure } from "@chakra-ui/react"
 import { useFormik } from "formik"
 import React, { useEffect, useState, useContext } from "react"
+import { JOB_STATUS } from "shared"
 
 import { DisplayContext } from "../../../context/DisplayContextProvider"
 import { getItemId } from "../../../utils/getItemId"
@@ -81,7 +82,7 @@ const CandidatureLba = ({ item, fakeLocalStorage = undefined }) => {
             })}
           </Box>
         ) : (
-          (kind !== "matcha" || item.job.status === "Active") && (
+          (kind !== "matcha" || item.job.status === JOB_STATUS.ACTIVE) && (
             <>
               <Box my={4}>
                 <Button

--- a/ui/components/ItemDetail/CandidatureLba/CandidatureLba.tsx
+++ b/ui/components/ItemDetail/CandidatureLba/CandidatureLba.tsx
@@ -2,7 +2,7 @@ import { CloseIcon } from "@chakra-ui/icons"
 import { Box, Button, Image, Modal, ModalContent, ModalHeader, ModalOverlay, Text, useDisclosure } from "@chakra-ui/react"
 import { useFormik } from "formik"
 import React, { useEffect, useState, useContext } from "react"
-import { JOB_STATUS } from "shared"
+import { JOB_STATUS } from "shared/models/job.model"
 
 import { DisplayContext } from "../../../context/DisplayContextProvider"
 import { getItemId } from "../../../utils/getItemId"

--- a/ui/components/espace_pro/AjouterVoeux.tsx
+++ b/ui/components/espace_pro/AjouterVoeux.tsx
@@ -29,7 +29,7 @@ import { Formik } from "formik"
 import omit from "lodash/omit"
 import { useRouter } from "next/router"
 import { useContext, useEffect, useState } from "react"
-import { JOB_STATUS } from "shared"
+import { JOB_STATUS } from "shared/models/job.model"
 import * as Yup from "yup"
 
 import { useAuth } from "@/context/UserContext"

--- a/ui/components/espace_pro/AjouterVoeux.tsx
+++ b/ui/components/espace_pro/AjouterVoeux.tsx
@@ -29,6 +29,7 @@ import { Formik } from "formik"
 import omit from "lodash/omit"
 import { useRouter } from "next/router"
 import { useContext, useEffect, useState } from "react"
+import { JOB_STATUS } from "shared"
 import * as Yup from "yup"
 
 import { useAuth } from "@/context/UserContext"
@@ -192,7 +193,7 @@ const AjouterVoeuxForm = (props) => {
         job_description: props.job_description ?? undefined,
         job_creation_date: props.job_creation_date ?? dayjs().format(DATE_FORMAT),
         job_expiration_date: props.job_expiration_date ?? dayjs().add(2, "month").format(DATE_FORMAT),
-        job_status: props.job_status ?? "Active",
+        job_status: props.job_status ?? JOB_STATUS.ACTIVE,
         job_type: props.job_type ?? ["Apprentissage"],
         is_multi_published: props.is_multi_published ?? undefined,
         delegations: props.delegations ?? undefined,


### PR DESCRIPTION
* remplacement de l'utilisation de `JOB_STATUS` de `constant.service.ts` par celui de `job.model.ts`
* introduction de la fonction `activateEntrepriseRecruiterForTheFirstTime` pour gérer la 1ère activation d'un recruteur entreprise
* envoi systématique des délégations lors de la 1ère activation du recruteur entreprise