### PR TITLE
feat: increase mongodb pool size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@
 /ui/.eslintrc.js
 
 !/package.json
+!/.yarn/cache
 !/.yarn/patches
 !/.yarn/plugins
 !/.yarn/releases

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.0",
   "author": "MNA",
   "license": "MIT",
+  "private": true,
   "packageManager": "yarn@3.6.1",
   "engines": {
     "node": ">=20",

--- a/server/src/common/mongodb.ts
+++ b/server/src/common/mongodb.ts
@@ -20,6 +20,7 @@ export const connectToMongo = (mongoUri = config.mongodb.uri) => {
       useFindAndModify: false,
       keepAlive: true,
       autoIndex: false,
+      poolSize: 1_000,
     })
     mongooseInstance.Promise = global.Promise // Get the default connection
     db = mongooseInstance.connection


### PR DESCRIPTION
As per https://mongoosejs.com/docs/5.x/docs/api/mongoose.html#mongoose_Mongoose-connect 
> The maximum number of sockets the MongoDB driver will keep open for this connection. By default, poolSize is 5. Keep in mind that, as of MongoDB 3.4, MongoDB only allows one operation per socket at a time, so you may want to increase this if you find you have a few slow queries that are blocking faster queries from proceeding. See Slow Trains in MongoDB and Node.js.


Default `poolSize` is set to `5`