### PR TITLE
fix: gestion d'erreur dans le dépot simplifié lors de la création d'entreprise

### DIFF
--- a/ui/components/espace_pro/Authentification/InformationCreationCompte.tsx
+++ b/ui/components/espace_pro/Authentification/InformationCreationCompte.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/router"
 import { useContext, useState } from "react"
 import * as Yup from "yup"
 
+import { ApiError } from "@/utils/api.utils"
+
 import { AUTHTYPE } from "../../../common/contants"
 import { phoneValidation } from "../../../common/validation/fieldValidations"
 import { WidgetContext } from "../../../context/contextWidget"
@@ -182,10 +184,11 @@ export const InformationCreationCompte = () => {
       })
       .catch((error) => {
         console.error(error)
-        const { response } = error
-        const payload: { error: string; statusCode: number; message: string } = response.data
-        setFieldError("email", payload.message)
-        setSubmitting(false)
+        if (error instanceof ApiError) {
+          const payload: { error: string; statusCode: number; message: string } = error.context.errorData
+          setFieldError("email", payload.message)
+          setSubmitting(false)
+        }
       })
   }
 


### PR DESCRIPTION
Dans le dépot simplifié,
lors de la création d'entreprise, 
lorsqu'un compte existait déjà, l'erreur n'était pas gérée correctement

![image](https://github.com/mission-apprentissage/labonnealternance/assets/5033491/29343e79-876c-4fd1-a0dd-252be50c3acf)
