### PR TITLE
feat: add periodic controls to appointments & applications

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -166,7 +166,7 @@ program
   .action(createJobAction("fix-diffusible-companies"))
 
 program.command("check-diffusible-companies").description("Check companies are diffusible").action(createJobAction("check-diffusible-companies"))
-program.command("fiab:kevin").description("Run migrations up").action(createJobAction("fiab:kevin"))
+
 program.command("db:obfuscate").description("Pseudonymisation des documents").option("-q, --queued", "Run job asynchronously", false).action(createJobAction("db:obfuscate"))
 
 program.command("migrations:up").description("Run migrations up").action(createJobAction("migrations:up"))

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -13,7 +13,6 @@ import { cronsInit, cronsScheduler } from "./crons_actions"
 import { checkDiffusibleCompanies, fixDiffusibleCompanies } from "./database/fixDiffusibleCompanies"
 import { obfuscateCollections } from "./database/obfuscateCollections"
 import { removeVersionKeyFromAllCollections } from "./database/removeVersionKeyFromAllCollections"
-import { fixCollections } from "./database/temp/fixCollections"
 import { validateModels } from "./database/validateModels"
 import updateDiplomesMetiers from "./diplomesMetiers/updateDiplomesMetiers"
 import updateDomainesMetiers from "./domainesMetiers/updateDomainesMetiers"
@@ -219,8 +218,6 @@ export async function runJob(job: IInternalJobsCronTask | IInternalJobsSimple): 
         return controlApplications()
       case "control:appointments":
         return controlAppointments()
-      case "fiab:kevin":
-        return fixCollections()
       case "recruiters:set-missing-job-start-date":
         return updateMissingStartDate()
       case "recruiters:get-missing-geocoordinates":

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -184,11 +184,11 @@ export const CronsMap = {
     handler: () => addJob({ name: "users:anonimize", payload: {} }),
   },
   "Contrôle quotidien des candidatures": {
-    cron_string: "0 9-19/1 * * 1-5",
+    cron_string: "0 10-19/1 * * 1-5",
     handler: () => addJob({ name: "control:applications", payload: {} }),
   },
   "Contrôle quotidien des prises de rendez-vous": {
-    cron_string: "0 9-19/2 * * 1-5",
+    cron_string: "0 11-19/2 * * 1-5",
     handler: () => addJob({ name: "control:appointments", payload: {} }),
   },
   // TODO A activer autour du 15/12/2023

--- a/server/src/jobs/verifications/controlApplications.ts
+++ b/server/src/jobs/verifications/controlApplications.ts
@@ -7,6 +7,6 @@ export const controlApplications = async () => {
   const timestamp = dayjs().subtract(1, "hour").toDate()
   const countApplications = await Application.countDocuments({ created_at: { $gte: timestamp } })
   if (countApplications === 0) {
-    await notifyToSlack({ subject: "Verification des candidatures", message: "Aucune candidature prise dans la dernière heure" })
+    await notifyToSlack({ subject: "Verification des candidatures", message: "Aucune candidature prise dans la dernière heure", error: true })
   }
 }

--- a/server/src/jobs/verifications/controlApplications.ts
+++ b/server/src/jobs/verifications/controlApplications.ts
@@ -1,0 +1,12 @@
+import dayjs from "shared/helpers/dayjs"
+
+import { Application } from "../../common/model"
+import { notifyToSlack } from "../../common/utils/slackUtils"
+
+export const controlApplications = async () => {
+  const timestamp = dayjs().subtract(1, "hour").toDate()
+  const countAppointments = await Application.countDocuments({ created_at: { $gte: timestamp } })
+  if (countAppointments === 0) {
+    await notifyToSlack({ subject: "Verification des candidatures", message: "Aucune candidature prise dans la dernière heure" })
+  }
+}

--- a/server/src/jobs/verifications/controlApplications.ts
+++ b/server/src/jobs/verifications/controlApplications.ts
@@ -5,8 +5,8 @@ import { notifyToSlack } from "../../common/utils/slackUtils"
 
 export const controlApplications = async () => {
   const timestamp = dayjs().subtract(1, "hour").toDate()
-  const countAppointments = await Application.countDocuments({ created_at: { $gte: timestamp } })
-  if (countAppointments === 0) {
+  const countApplications = await Application.countDocuments({ created_at: { $gte: timestamp } })
+  if (countApplications === 0) {
     await notifyToSlack({ subject: "Verification des candidatures", message: "Aucune candidature prise dans la dernière heure" })
   }
 }

--- a/server/src/jobs/verifications/controlAppointments.ts
+++ b/server/src/jobs/verifications/controlAppointments.ts
@@ -1,0 +1,12 @@
+import dayjs from "shared/helpers/dayjs"
+
+import { Appointment } from "../../common/model"
+import { notifyToSlack } from "../../common/utils/slackUtils"
+
+export const controlAppointments = async () => {
+  const timestamp = dayjs().subtract(2, "hours").toDate()
+  const countAppointments = await Appointment.countDocuments({ created_at: { $gte: timestamp } })
+  if (countAppointments === 0) {
+    await notifyToSlack({ subject: "Verification des rendez-vous", message: "Aucun rendez-vous pris depuis 2 heures" })
+  }
+}

--- a/server/src/jobs/verifications/controlAppointments.ts
+++ b/server/src/jobs/verifications/controlAppointments.ts
@@ -7,6 +7,6 @@ export const controlAppointments = async () => {
   const timestamp = dayjs().subtract(2, "hours").toDate()
   const countAppointments = await Appointment.countDocuments({ created_at: { $gte: timestamp } })
   if (countAppointments === 0) {
-    await notifyToSlack({ subject: "Verification des rendez-vous", message: "Aucun rendez-vous pris depuis 2 heures" })
+    await notifyToSlack({ subject: "Verification des rendez-vous", message: "Aucun rendez-vous pris depuis 2 heures", error: true })
   }
 }


### PR DESCRIPTION
- Pour les Appointments: contrôle, de 9h à 19h qu’au moins RDV est pris toutes les 2h (peu importe la source).
Dans le cas contraire, lancer une alerte Slack

- Pour les Applications: contrôle, de 9h à 19h qu’au moins une candidature est envoyée toutes les 1h (peu importe la source).
Dans le cas contraire, lancer une alerte Slack