### PR TITLE
feat: update read date from backend

### DIFF
--- a/server/src/http/controllers/appointmentRequest.controller.ts
+++ b/server/src/http/controllers/appointmentRequest.controller.ts
@@ -271,7 +271,9 @@ export default (server: Server) => {
         throw Boom.notFound()
       }
 
-      await Appointment.findByIdAndUpdate(appointmentId, { cfa_read_appointment_details_date: new Date() })
+      if (!appointment.cfa_read_appointment_details_date) {
+        await Appointment.findByIdAndUpdate(appointmentId, { cfa_read_appointment_details_date: new Date() })
+      }
 
       const [etablissement, user] = await Promise.all([
         EligibleTrainingsForAppointment.findOne(

--- a/server/src/http/controllers/appointmentRequest.controller.ts
+++ b/server/src/http/controllers/appointmentRequest.controller.ts
@@ -271,6 +271,8 @@ export default (server: Server) => {
         throw Boom.notFound()
       }
 
+      await Appointment.findByIdAndUpdate(appointmentId, { cfa_read_appointment_details_date: new Date() })
+
       const [etablissement, user] = await Promise.all([
         EligibleTrainingsForAppointment.findOne(
           { cle_ministere_educatif: appointment.cle_ministere_educatif },

--- a/server/src/services/appLinks.service.ts
+++ b/server/src/services/appLinks.service.ts
@@ -254,13 +254,6 @@ export function createRdvaAppointmentIdPageLink(email: string, siret: string, et
     { type: "cfa", email, siret },
     [
       generateScope({
-        schema: zRoutes.patch["/etablissements/:id/appointments/:appointmentId"],
-        options: {
-          params: { id: etablissementId, appointmentId },
-          querystring: undefined,
-        },
-      }),
-      generateScope({
         schema: zRoutes.get["/appointment-request/context/recap"],
         options: {
           params: undefined,

--- a/shared/routes/etablissement.routes.ts
+++ b/shared/routes/etablissement.routes.ts
@@ -1,6 +1,6 @@
 import { extensions } from "../helpers/zodHelpers/zodPrimitives"
 import { z } from "../helpers/zodWithOpenApi"
-import { ZAppointment, ZEtablissement } from "../models"
+import { ZEtablissement } from "../models"
 import { zObjectId } from "../models/common"
 
 import { IRoutesDef } from "./common.routes"
@@ -141,20 +141,6 @@ export const zEtablissementRoutes = {
       securityScheme: {
         auth: "cookie-session",
         access: "admin",
-        resources: {},
-      },
-    },
-    "/etablissements/:id/appointments/:appointmentId": {
-      method: "patch",
-      path: "/etablissements/:id/appointments/:appointmentId",
-      body: z.object({ has_been_read: z.boolean() }).strict(),
-      params: z.object({ id: zObjectId, appointmentId: zObjectId }).strict(),
-      response: {
-        "200": ZAppointment,
-      },
-      securityScheme: {
-        auth: "access-token",
-        access: null,
         resources: {},
       },
     },

--- a/ui/pages/espace-pro/establishment/[establishmentId]/appointments/[appointmentId].tsx
+++ b/ui/pages/espace-pro/establishment/[establishmentId]/appointments/[appointmentId].tsx
@@ -1,11 +1,11 @@
-import { Box, Text, UnorderedList, ListItem } from "@chakra-ui/react"
+import { Box, ListItem, Text, UnorderedList } from "@chakra-ui/react"
 import { useFormik } from "formik"
 import { useRouter } from "next/router"
 import { useEffect, useState } from "react"
 import * as Yup from "yup"
 
 import { reasons } from "@/components/RDV/types"
-import { apiGet, apiPatch, apiPost } from "@/utils/api.utils"
+import { apiGet, apiPost } from "@/utils/api.utils"
 
 import { formatDate } from "../../../../../common/utils/dateUtils"
 import { FormLayoutComponent } from "../../../../../components/espace_pro/Candidat/layout/FormLayoutComponent"
@@ -20,12 +20,10 @@ import { CfaCandidatInformationUnreachable } from "../../../../../components/esp
  */
 export default function CfaCandidatInformationPage() {
   const router = useRouter()
-  const { establishmentId, appointmentId, token } = router.query as { establishmentId: string; appointmentId: string; token: string }
+  const { appointmentId, token } = router.query as { establishmentId: string; appointmentId: string; token: string }
   const [data, setData] = useState(null)
 
   const [currentState, setCurrentState] = useState("initial")
-
-  const utmSource = typeof window !== "undefined" ? new URLSearchParams(window.location.search).get("utm_source") : ""
 
   const formik = useFormik({
     initialValues: {
@@ -90,28 +88,16 @@ export default function CfaCandidatInformationPage() {
    */
   useEffect(() => {
     const fetchData = async () => {
-      if (appointmentId && establishmentId) {
-        if (utmSource === "mail") {
-          await apiPatch("/etablissements/:id/appointments/:appointmentId", {
-            params: { id: establishmentId, appointmentId },
-            body: { has_been_read: true },
-            headers: {
-              authorization: `Bearer ${token}`,
-            },
-          })
-        }
-
-        const response = await apiGet("/appointment-request/context/recap", {
-          querystring: { appointmentId },
-          headers: {
-            authorization: `Bearer ${token}`,
-          },
-        })
-        setData(response)
-      }
+      const response = await apiGet("/appointment-request/context/recap", {
+        querystring: { appointmentId },
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      })
+      setData(response)
     }
     fetchData().catch(console.error)
-  }, [utmSource, appointmentId])
+  }, [appointmentId])
 
   return (
     <FormLayoutComponent


### PR DESCRIPTION
- update `cfa_read_appointment_details_date` upon `/appointment-request/context/recap` request instead of back and forth from the UI
https://mna-matcha.atlassian.net/browse/LBAC-1946