### PR TITLE
feat: LBA-2197 conservation utilisateurs specifiques

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -46,7 +46,7 @@ fileignoreconfig:
 - filename: server/src/http/routes/auth/password.controller.ts
   checksum: 0eb3948d875508edf6d31f0ffe1290aac0cc02c9c80c913bcb04a312edd062cc
 - filename: server/src/jobs/database/obfuscateCollections.ts
-  checksum: c773ff392de466e14ed61b818ad90b7e69ba8a3fcf74263d446d346781e519bb
+  checksum: 9b7aa9538398882159db97f7d271a37ff368cc73faa184993dc9ce13a088950e
 - filename: server/src/jobs/job.actions.ts
   checksum: d716e214d828109181a138f0ae253d5489a3c544b2625917b458d1e07886c408
 - filename: server/src/jobs/lba_recruteur/formulaire/misc/removeVersionKeyFromRecruiters.ts


### PR DESCRIPTION
Lors du job d'obfuscation des données, conserver les utilisateurs spécifiques CFA / OPCO / Admin en prenant en compte la nouvelle archi users multi compte