### PR TITLE
fix: LBA-2222 validation de modèles en prod

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -39,6 +39,8 @@ fileignoreconfig:
   checksum: 35c729e66f2b345f9be3197def8b033d7afe9b92258be9f2ed13a8a0e97c9602
 - filename: server/src/db/migrations/20231127120528-remove-password.ts
   checksum: 5c7a2ec4655f0543f42bfbccc759bff4eb10456946885531c91107cac3e8dbc0
+- filename: server/src/db/migrations/202405230000000-migrate-fix-missing-date-blacklist.ts
+  checksum: 967bd89c16914bc70cf25d886d9800fb6fddcd53a8b87a1e78bda1c2167897ba
 - filename: server/src/http/controllers/appointments/appointments.controller.ts
   checksum: dc77c04efc26dcd8ca4816f392ab24a32a92cb45ca4b94adb593a08e7a2d231e
 - filename: server/src/http/routes/appointmentRequest.controller.ts

--- a/server/src/db/migrations/202405230000000-migrate-fix-missing-date-blacklist.ts
+++ b/server/src/db/migrations/202405230000000-migrate-fix-missing-date-blacklist.ts
@@ -1,0 +1,24 @@
+import { Db } from "mongodb"
+
+import { logger } from "@/common/logger"
+
+export const up = async (db: Db) => {
+  // suppression des entrées ne respectant pas la validation email zod
+  const emailRegexp = /^([A-Z0-9_+-]+\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9-]*\.)+[A-Z]{2,}$/i
+  await db.collection("emailblacklists").deleteMany({ email: { $not: emailRegexp } })
+
+  // restauration du champ created_at pour les entrées qui en sont dépourvues
+  const DATE = dayjs().toDate()
+  await db.collection("emailblacklists").updateMany(
+    { created_at: { $exists: false } },
+    {
+      $set: { created_at: DATE },
+    },
+    {
+      // @ts-expect-error bypassDocumentValidation is not properly set in @types/mongodb
+      bypassDocumentValidation: true,
+    }
+  )
+
+  logger.info("20240523000000-correction-modeles-lba-2222")
+}

--- a/server/src/db/migrations/202405230000000-migrate-fix-missing-date-blacklist.ts
+++ b/server/src/db/migrations/202405230000000-migrate-fix-missing-date-blacklist.ts
@@ -8,7 +8,7 @@ export const up = async (db: Db) => {
   await db.collection("emailblacklists").deleteMany({ email: { $not: emailRegexp } })
 
   // restauration du champ created_at pour les entrées qui en sont dépourvues
-  const DATE = dayjs().toDate()
+  const DATE = new Date()
   await db.collection("emailblacklists").updateMany(
     { created_at: { $exists: false } },
     {

--- a/server/src/db/migrations/202405230000000-migrate-fix-missing-date-blacklist.ts
+++ b/server/src/db/migrations/202405230000000-migrate-fix-missing-date-blacklist.ts
@@ -20,5 +20,16 @@ export const up = async (db: Db) => {
     }
   )
 
+  await db.collection("applications").updateMany(
+    { applicant_email: { $not: emailRegexp } },
+    {
+      $set: { applicant_email: "faux_email@faux-domaine.fr" },
+    },
+    {
+      // @ts-expect-error bypassDocumentValidation is not properly set in @types/mongodb
+      bypassDocumentValidation: true,
+    }
+  )
+
   logger.info("20240523000000-correction-modeles-lba-2222")
 }

--- a/server/src/jobs/database/validateModels.ts
+++ b/server/src/jobs/database/validateModels.ts
@@ -11,7 +11,6 @@ import {
   ZEmailBlacklist,
   ZEtablissement,
   ZGeoLocation,
-  ZJob,
   ZLbaCompany,
   ZLbaLegacyCompany,
   ZOptout,
@@ -46,7 +45,6 @@ import {
   Etablissement,
   FormationCatalogue,
   GeoLocation,
-  Job,
   LbaCompany,
   LbaCompanyLegacy,
   Optout,
@@ -117,7 +115,6 @@ export async function validateModels(): Promise<void> {
   await validateModel(FormationCatalogue, zFormationCatalogueSchema)
   await validateModel(GeoLocation, ZGeoLocation)
   // //  await validateModel(InternalJobs, ZInternalJobs)
-  await validateModel(Job, ZJob)
   await validateModel(LbaCompany, ZLbaCompany)
   await validateModel(LbaCompanyLegacy, ZLbaLegacyCompany)
   //  await validateModel(Opco, ZOpco)

--- a/server/src/jobs/updateBrevoBlockedEmails/updateBrevoBlockedEmails.ts
+++ b/server/src/jobs/updateBrevoBlockedEmails/updateBrevoBlockedEmails.ts
@@ -10,7 +10,7 @@ import config from "../../config"
 
 const saveBlacklistEmails = async (contacts) => {
   for (let i = 0; i < contacts.length; ++i) {
-    const email = contacts[i].email
+    const email = contacts[i].email.toLowerCase()
     const blackListedEmail = await EmailBlacklist.findOne({ email })
     if (!blackListedEmail) {
       await processBlacklistedEmail(email, "brevo_spam")

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -10,6 +10,7 @@ import { RECRUITER_STATUS } from "shared/constants/recruteur"
 import { prepareMessageForMail, removeUrlsFromText } from "shared/helpers/common"
 import { IUser2 } from "shared/models/user2.model"
 import { INewApplicationV2NEWCompanySiret, INewApplicationV2NEWJobId } from "shared/routes/application.routes.v2"
+import { z } from "zod"
 
 import { getStaticFilePath } from "@/common/utils/getStaticFilePath"
 import { UserForAccessToken, user2ToUserForToken } from "@/security/accessTokenService"

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -83,11 +83,14 @@ export const isEmailBlacklisted = async (email: string): Promise<boolean> => Boo
  */
 export const addEmailToBlacklist = async (email: string, blacklistingOrigin: string): Promise<void> => {
   try {
+    z.string().email().parse(email)
+
     await EmailBlacklist.findOneAndUpdate(
       { email },
       {
         email,
         blacklisting_origin: blacklistingOrigin,
+        $setOnInsert: { created_at: new Date() },
       },
       { upsert: true }
     )

--- a/server/src/services/emails.service.ts
+++ b/server/src/services/emails.service.ts
@@ -41,5 +41,5 @@ export const processHardBounceWebhookEvent = async (payload) => {
 }
 
 export const processBlacklistedEmail = async (email: string, origin: string) => {
-  await Promise.all([addEmailToBlacklist(email, origin), await removeEmailFromLbaCompanies(email), await disableEligibleTraininForAppointmentWithEmail(email)])
+  await Promise.all([addEmailToBlacklist(email, origin), removeEmailFromLbaCompanies(email), disableEligibleTraininForAppointmentWithEmail(email)])
 }

--- a/shared/models/emailBlacklist.model.ts
+++ b/shared/models/emailBlacklist.model.ts
@@ -7,7 +7,7 @@ import { zObjectId } from "./common"
 export const ZEmailBlacklist = z
   .object({
     _id: zObjectId,
-    email: z.string(),
+    email: z.string().email(),
     blacklisting_origin: z.string(),
     created_at: z.coerce.date(),
   })

--- a/shared/models/unsubscribedLbaCompany.model.ts
+++ b/shared/models/unsubscribedLbaCompany.model.ts
@@ -3,6 +3,7 @@ import { z } from "../helpers/zodWithOpenApi"
 import { ZLbaCompany } from "./lbaCompany.model"
 
 export const ZUnsubscribedLbaCompany = ZLbaCompany.pick({
+  _id: true,
   siret: true,
   raison_sociale: true,
   enseigne: true,


### PR DESCRIPTION
La validation des modèles sur les collections applications, jobs, emailblacklists et unsubscribedbonnesboites indique des cas anormaux :
- applications : des emails mal formés qui seront remplacés par une seule fausse adresse
- emailblacklists: le champ created_at est manquant sur les occurences récentes (bug), des emails sont erronés (les documents seront supprimés)
- unsubscribedbonnesboites : correction du modèle en ajoutant _id
- jobs : suppression de la validation sur cette collection