### PR TITLE
fix: LBA-2224 prise en compte d'un autre code bloquant la recréation des index

### DIFF
--- a/server/src/common/model/index.ts
+++ b/server/src/common/model/index.ts
@@ -53,7 +53,7 @@ export async function createMongoDBIndexes() {
     mongooseInstance.modelNames().map(async (name) => {
       const model = mongooseInstance.model(name)
       return model.createIndexes({ background: true }).catch(async (e) => {
-        if (e.codeName === "IndexOptionsConflict") {
+        if (e.codeName === "IndexOptionsConflict" || e.codeName === "IndexKeySpecsConflict") {
           const err = new Error(`Conflict in indexes for ${name}`, { cause: e })
           logger.error(err)
           captureException(err)


### PR DESCRIPTION
Un index regular ne peut pas être remplacé par un index regular asc + unique
La routine de recréation d'index attend un autre code d'erreur que celui qui se produit dans ce cas là.
-> prise en compte du nouveau code d'erreur 