### PR TITLE
fix: sentry: pas de capture sur les erreurs 400-499

### DIFF
--- a/ui/utils/api.ts
+++ b/ui/utils/api.ts
@@ -109,11 +109,14 @@ export const getEntrepriseInformation = async (
     const data = await apiGet("/etablissement/entreprise/:siret", { params: { siret }, querystring: removeUndefinedFields(options) }, { timeout: 7000 })
     return { statusCode: 200, data, error: false }
   } catch (error: unknown) {
-    captureException(error)
     if (error instanceof ApiError && error.context?.statusCode >= 400) {
       const { errorData, statusCode, message } = error.context
+      if (error.context.statusCode >= 500) {
+        captureException(error)
+      }
       return { statusCode, message, data: errorData, error: true }
     } else {
+      captureException(error)
       return { statusCode: 500, message: "unkown error", error: true }
     }
   }


### PR DESCRIPTION
https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/3909/?environment=production&project=4&project=8&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=4