### PR TITLE
feat: LBA-2238 Remise en place temporaire champ competencesDeBase

### DIFF
--- a/server/src/services/lbajob.service.ts
+++ b/server/src/services/lbajob.service.ts
@@ -366,6 +366,11 @@ function transformLbaJob({ recruiter, applicationCountByJob }: { recruiter: Part
       token: generateApplicationToken({ jobId: offre._id.toString() }),
     }
 
+    //TODO: remove when 1j1s switch to api V2
+    if (resultJob?.job?.romeDetails) {
+      resultJob.job.romeDetails.competencesDeBase = resultJob.job.romeDetails?.competences?.savoir_faire
+    }
+
     return resultJob
   })
 }

--- a/shared/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
+++ b/shared/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
@@ -1039,6 +1039,50 @@ exports[`generateOpenApiSchema > should generate proper schema 1`] = `
                 },
                 "type": "object",
               },
+              "competencesDeBase": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "code_ogr": {
+                            "type": "string",
+                          },
+                          "coeur_metier": {
+                            "type": [
+                              "string",
+                              "null",
+                            ],
+                          },
+                          "libelle": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "libelle",
+                          "code_ogr",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "libelle": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "libelle",
+                    "items",
+                  ],
+                  "type": "object",
+                },
+                "type": [
+                  "array",
+                  "null",
+                ],
+              },
               "contextes_travail": {
                 "items": {
                   "additionalProperties": false,
@@ -1955,6 +1999,50 @@ exports[`generateOpenApiSchema > should generate proper schema 1`] = `
                   },
                 },
                 "type": "object",
+              },
+              "competencesDeBase": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "code_ogr": {
+                            "type": "string",
+                          },
+                          "coeur_metier": {
+                            "type": [
+                              "string",
+                              "null",
+                            ],
+                          },
+                          "libelle": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "libelle",
+                          "code_ogr",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "libelle": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "libelle",
+                    "items",
+                  ],
+                  "type": "object",
+                },
+                "type": [
+                  "array",
+                  "null",
+                ],
               },
               "contextes_travail": {
                 "items": {

--- a/shared/models/rome.model.ts
+++ b/shared/models/rome.model.ts
@@ -139,7 +139,7 @@ export const ZReferentielRome = z
     definition: z.string(),
     acces_metier: z.string(),
     competences: ZRomeCompetence,
-    competencesDeBase: z.array(ZRomeCategorieSavoir).nullish(),
+    competencesDeBase: z.array(ZRomeCategorieSavoir).nullish(), //TODO: remove when 1j1s switch to api V2
     contextes_travail: z.array(ZRomeContextesTravail).nullish(),
     mobilites: z.array(ZRomeMobilite).nullish(),
   })

--- a/shared/models/rome.model.ts
+++ b/shared/models/rome.model.ts
@@ -139,6 +139,7 @@ export const ZReferentielRome = z
     definition: z.string(),
     acces_metier: z.string(),
     competences: ZRomeCompetence,
+    competencesDeBase: z.array(ZRomeCategorieSavoir).nullish(),
     contextes_travail: z.array(ZRomeContextesTravail).nullish(),
     mobilites: z.array(ZRomeMobilite).nullish(),
   })


### PR DESCRIPTION
1j1s a besoin du champ competencesDeBase pour l'affichage des offres LBA.
ce champ a été supprimé en changeant le référentiel.
restauration en mode dégradé temporaire avant le passage à la V2 de 1j1s