### PR TITLE
feat: LBA-2244 hotfix titres de formations manquants

### DIFF
--- a/server/src/common/model/schema/formationCatalogue/formationCatalogue.schema.ts
+++ b/server/src/common/model/schema/formationCatalogue/formationCatalogue.schema.ts
@@ -89,6 +89,10 @@ const mnaFormationSchema = new Schema<IFormationCatalogue>(
       type: String,
       description: "Intitulé long de la formation normalisé BCN",
     },
+    intitule_rco: {
+      type: String,
+      description: "Intitulé RCO de la formation",
+    },
     intitule_court: {
       type: String,
       description: "Intitulé court de la formation normalisé BCN",

--- a/server/src/services/formation.service.ts
+++ b/server/src/services/formation.service.ts
@@ -52,6 +52,7 @@ const minimalDataMongoFields = {
   etablissement_gestionnaire_siret: 1,
   intitule_court: 1,
   intitule_long: 1,
+  intitule_rco: 1,
   lieu_formation_adresse: 1,
   lieu_formation_geo_coordonnees: 1,
   localite: 1,
@@ -338,7 +339,7 @@ const transformFormation = (rawFormation: IFormationCatalogue): ILbaItemFormatio
 
   const resultFormation: ILbaItemFormation = {
     ideaType: LBA_ITEM_TYPE_OLD.FORMATION,
-    title: (rawFormation?.intitule_long || rawFormation.intitule_court) ?? null,
+    title: (rawFormation.intitule_long || rawFormation.intitule_court || rawFormation.intitule_rco) ?? null,
     longTitle: rawFormation.intitule_long ?? null,
     id: rawFormation.cle_ministere_educatif ?? null,
     idRco: rawFormation.id_formation ?? null,
@@ -421,7 +422,7 @@ const transformFormationWithMinimalData = (rawFormation: IFormationCatalogue): I
 
   const resultFormation: ILbaItemFormation = {
     ideaType: LBA_ITEM_TYPE_OLD.FORMATION,
-    title: (rawFormation?.intitule_long || rawFormation.intitule_court) ?? null,
+    title: (rawFormation.intitule_long || rawFormation.intitule_court || rawFormation.intitule_rco) ?? null,
     id: rawFormation.cle_ministere_educatif ?? null,
 
     place: {


### PR DESCRIPTION
Un bug des données du catalogue fait que 935 formations n'ont pas de titre.
Le hotfix utilise l'intitule_rco en recours
Ne corrige pas la construction du bouton prise de rendez-vous