### PR TITLE
fix: france travail: ajout de log error

### DIFF
--- a/server/src/common/apis/FranceTravail.ts
+++ b/server/src/common/apis/FranceTravail.ts
@@ -79,7 +79,7 @@ const getFtAccessToken = async (access: "OFFRE" | "ROME" | "ROMEV4"): Promise<FT
     tokens[access] = newTokenObject
     return newTokenObject
   } catch (error: any) {
-    sentryCaptureException(error, { extra: { responseData: error.response?.data } })
+    logger.error("error lors de la récupération d'un token pour l'API FT", JSON.stringify(error))
     throw Boom.internal("impossible d'obtenir un token pour l'API france travail")
   }
 }


### PR DESCRIPTION
Ajout d'un log lorsqu'il y a une erreur lors de la récupération du token de france travail