### PR TITLE
feat: LBA-2286 Enregistrement des bonnes boîtes désinscrites depuis SAVE

### DIFF
--- a/server/src/jobs/lbb/updateSAVECompanies.ts
+++ b/server/src/jobs/lbb/updateSAVECompanies.ts
@@ -1,5 +1,6 @@
 import { oleoduc, transformData, writeData } from "oleoduc"
 
+import { db } from "@/common/mongodb"
 import { checkIsDiffusible } from "@/services/etablissement.service"
 
 import { LbaCompany, UnsubscribedLbaCompany } from "../../common/model"
@@ -124,7 +125,7 @@ export const removeSAVECompanies = async () => {
       // Ce bloc ne sera utile qu'une seule fois.
       const unsubed = await UnsubscribedLbaCompany.findOne({ siret: company.siret })
       if (!unsubed) {
-        const toUnsub = new UnsubscribedLbaCompany({
+        const toUnsub = {
           siret: company.siret,
           raison_sociale: "",
           enseigne: "Suppression via script SAVE",
@@ -139,11 +140,11 @@ export const removeSAVECompanies = async () => {
           last_update_at: new Date(),
           unsubscribe_date: new Date(),
           unsubscribe_reason: "Autre",
-        })
-        await toUnsub.save()
+        }
+        await db.collection("unsubscribedbonnesboites").insertOne(toUnsub)
       }
 
-      await LbaCompany.deleteOne({ siret: company.siret })
+      await db.collection("bonnesboites").deleteOne({ siret: company.siret })
     })
   )
 

--- a/server/src/jobs/lbb/updateSAVECompanies.ts
+++ b/server/src/jobs/lbb/updateSAVECompanies.ts
@@ -3,7 +3,7 @@ import { oleoduc, transformData, writeData } from "oleoduc"
 import { db } from "@/common/mongodb"
 import { checkIsDiffusible } from "@/services/etablissement.service"
 
-import { LbaCompany, UnsubscribedLbaCompany } from "../../common/model"
+import { LbaCompany } from "../../common/model"
 import { logMessage } from "../../common/utils/logMessage"
 
 import { downloadSAVEFile, getCompanyMissingData, initMaps, streamSAVECompanies } from "./lbaCompaniesUtils"
@@ -123,7 +123,7 @@ export const removeSAVECompanies = async () => {
     ),
     writeData(async (company) => {
       // Ce bloc ne sera utile qu'une seule fois.
-      const unsubed = await UnsubscribedLbaCompany.findOne({ siret: company.siret })
+      const unsubed = await db.collection("unsubscribedbonnesboites").findOne({ siret: company.siret })
       if (!unsubed) {
         const toUnsub = {
           siret: company.siret,


### PR DESCRIPTION
L'ancien fichier de support FT contient des siret qui doivent être persistés dans la collection unsubscribedbonnesboites. 
En jouant le script de mise à jour avec cette modification ce sera chose faite.
Une autre PR viendra supprimer tout ce qui concerne ces vieux fichiers de support qui sont obsolètes.