### PR TITLE
fix: LBA-2299 erreur invisible d'envoi de candidature offre lba sans naf_label

### DIFF
--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -458,7 +458,7 @@ const offreOrCompanyToCompanyFields = (LbaJob: ILbaJob): Partial<IApplication> =
     const application: Partial<IApplication> = {
       company_siret: establishment_siret,
       company_name: establishment_enseigne || establishment_raison_sociale || "Enseigne inconnue",
-      company_naf: naf_label ?? undefined,
+      company_naf: naf_label ?? "",
       job_title: rome_appellation_label ?? rome_label ?? undefined,
       company_address: is_delegated ? null : address,
       job_id: job._id.toString(),

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -330,6 +330,7 @@ export const sendApplicationV2 = async ({
         errorTitle: "error_sending_application",
       })
     }
+    throw Boom.badRequest(BusinessErrorCodes.UNKNOWN)
   }
 }
 


### PR DESCRIPTION
fix l'erreur sentry 4567 .
-> Utilisation de string vide en guise de naf_label
-> ajout d'une levée d'erreur vers l'ui qui manquait