### PR TITLE
fix: add operation details in sentry

### DIFF
--- a/server/src/http/sentry.ts
+++ b/server/src/http/sentry.ts
@@ -23,7 +23,7 @@ function getOptions(): Sentry.NodeOptions {
     enabled: config.env !== "local",
     integrations: [
       new Sentry.Integrations.Http({ tracing: true }),
-      new Sentry.Integrations.Mongo({ useMongoose: false }),
+      new Sentry.Integrations.Mongo({ useMongoose: false, describeOperations: true }),
       Sentry.extraErrorDataIntegration({ depth: 16 }),
       Sentry.captureConsoleIntegration({ levels: ["error"] }),
     ],


### PR DESCRIPTION
Il y a des operations MongoDB assez slow, à savoir si c'est index manquant ou un problème de perf du cluster.

https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/performance/lba-server:b3d593dd7e5147a79cb43b3f9064b6cf/?end=2024-07-02T11%3A30%3A00&environment=production&project=4&query=http.method%3APOST&referrer=performance-transaction-summary&showTransactions=outlier&start=2024-07-02T03%3A42%3A01&transaction=POST+%2Fapi%2Fappointment-request%2Fcontext%2Fcreate&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29