### PR TITLE
fix(create-application): scan_status no more required in request body

### DIFF
--- a/shared/models/applications.model.ts
+++ b/shared/models/applications.model.ts
@@ -149,6 +149,7 @@ export const ZNewApplication = ZApplication.extend({
     company_feedback_date: true,
     created_at: true,
     last_update_at: true,
+    scan_status: true,
   })
   .openapi("ApplicationUi")
 
@@ -209,6 +210,7 @@ export const ZNewApplicationV2 = ZApplication.extend({
     company_feedback_date: true,
     created_at: true,
     last_update_at: true,
+    scan_status: true,
   })
   .openapi("ApplicationUi")
 


### PR DESCRIPTION
Fix suggestion related to issue : https://github.com/mission-apprentissage/labonnealternance/issues/1382 regarding `scan_status` required attribute in create application request body.