### PR TITLE
fix: LBA-2412 génération des liens profonds en échec

### DIFF
--- a/server/src/services/trainingLinks.service.ts
+++ b/server/src/services/trainingLinks.service.ts
@@ -164,7 +164,7 @@ const getLBALink = async (wish: IWish): Promise<string> => {
   const formations = await getTrainingsFromParameters(wish)
 
   // Handle single formation case
-  if (formations.length === 1) {
+  if (formations?.length === 1) {
     const { rome_codes, lieu_formation_geo_coordonnees } = formations[0]
     const [latitude, longitude] = lieu_formation_geo_coordonnees!.split(",")
     return buildEmploiUrl({ params: { romes: rome_codes as string[], lat: latitude, lon: longitude, radius: "60", ...utmData } })
@@ -192,7 +192,7 @@ const getLBALink = async (wish: IWish): Promise<string> => {
     : await getRomesGlobaux({ rncp: wish.rncp, cfd: wish.cfd, mef: wish.mef })
 
   // Build url based on formations and coordinates
-  if (formations.length) {
+  if (formations?.length) {
     let formation = formations[0]
     let lat, lon
     if (formations.length > 1 && wLat && wLon) {

--- a/server/src/services/trainingLinks.service.ts
+++ b/server/src/services/trainingLinks.service.ts
@@ -97,7 +97,7 @@ const getTrainingsFromParameters = async (wish: IWish): Promise<IFormationCatalo
     }
   }
 
-  return formations
+  return formations || []
 }
 
 const getRomesGlobaux = async ({ rncp, cfd, mef }) => {


### PR DESCRIPTION
L'appel par bal de la route traininglinks ne produit quasiment aucun lien profond alors que les données émises devrait fournir à minima des liens vers la recherche LBA