### PR TITLE
fix: LBA-2416 restauration chemins utilisables en local pour seed et seed update

### DIFF
--- a/.bin/scripts/seed-apply.sh
+++ b/.bin/scripts/seed-apply.sh
@@ -34,7 +34,7 @@ ansible-vault view --vault-password-file="$ROOT_DIR/.bin/scripts/get-vault-passw
 
 rm -f "$SEED_GZ"
 gpg -d --batch --passphrase-file "$PASSPHRASE" -o "$SEED_GZ" "$SEED_GPG"
-cat "$SEED_GZ" | /opt/app/tools/docker-compose.sh -f "$ROOT_DIR/docker-compose.yml" exec -iT mongodb mongorestore --archive --nsInclude="labonnealternance.*" --uri="${TARGET_DB}" --drop --gzip
+cat "$SEED_GZ" | docker compose -f "$ROOT_DIR/docker-compose.yml" exec -iT mongodb mongorestore --archive --nsInclude="labonnealternance.*" --uri="${TARGET_DB}" --drop --gzip
 
 yarn build:dev
 yarn cli migrations:up

--- a/.bin/scripts/seed-update.sh
+++ b/.bin/scripts/seed-update.sh
@@ -32,13 +32,13 @@ trap delete_cleartext EXIT
 
 ansible-vault view --vault-password-file="$ROOT_DIR/.bin/scripts/get-vault-password-client.sh" "$VAULT_FILE" | yq '.vault.SEED_GPG_PASSPHRASE' > "$PASSPHRASE"
 
-/opt/app/tools/docker-compose.sh -f "$ROOT_DIR/docker-compose.yml" up mongodb -d
+docker compose -f "$ROOT_DIR/docker-compose.yml" up mongodb -d
 mkdir -p "$ROOT_DIR/.infra/files/mongodb"
 
 yarn build:dev
 yarn cli migrations:up
 yarn cli recreate:indexes
 
-/opt/app/tools/docker-compose.sh -f "$ROOT_DIR/docker-compose.yml" exec -it mongodb mongodump --uri "$TARGET_DB" --gzip --archive > "$SEED_GZ" 
+docker compose -f "$ROOT_DIR/docker-compose.yml" exec -it mongodb mongodump --uri "$TARGET_DB" --gzip --archive > "$SEED_GZ" 
 rm -f "$SEED_GPG"
 gpg  -c --cipher-algo twofish --batch --passphrase-file "$PASSPHRASE" -o "$SEED_GPG" "$SEED_GZ"


### PR DESCRIPTION
Les tâches seed et seed:update pointent sur un docker-compose.sh n'existant pas en local. Restauration de l'utilisation de docker compose