### PR TITLE
chore: réécriture de getFtJobsV2 et suppession temporaire du param diploma de la route v2

### DIFF
--- a/server/src/http/controllers/jobs.controller.v2.ts
+++ b/server/src/http/controllers/jobs.controller.v2.ts
@@ -419,13 +419,13 @@ export default (server: Server) => {
       getJobs({
         romes: payload.romes,
         distance: payload.radius,
-        niveau: payload.diploma,
+        niveau: null, // payload.diploma,
         lat: payload.latitude,
         lon: payload.longitude,
         isMinimalData: false,
       }),
       getJobsPartnersFromDB(payload),
-      getFtJobsV2({ jobLimit: 150, caller: "api-apprentissage", api: zRoutes.get["/jobs/rome"].path, ...payload, insee: payload.insee ?? undefined }),
+      getFtJobsV2({ diploma: null, jobLimit: 150, caller: "api-apprentissage", api: zRoutes.get["/jobs/rome"].path, ...payload, insee: payload.insee ?? null }),
     ])
 
     return res.send({
@@ -450,13 +450,13 @@ export default (server: Server) => {
       getJobs({
         romes,
         distance: payload.radius,
-        niveau: payload.diploma,
+        niveau: null, // payload.diploma,
         lat: payload.latitude,
         lon: payload.longitude,
         isMinimalData: false,
       }),
       getJobsPartnersFromDB({ ...payload, romes }),
-      getFtJobsV2({ romes, jobLimit: 150, caller: "api-apprentissage", api: zRoutes.get["/jobs/rncp"].path, ...payload, insee: payload.insee ?? undefined }),
+      getFtJobsV2({ diploma: null, romes, jobLimit: 150, caller: "api-apprentissage", api: zRoutes.get["/jobs/rncp"].path, ...payload, insee: payload.insee ?? null }),
     ])
 
     return res.send({

--- a/server/src/services/lbajob.service.ts
+++ b/server/src/services/lbajob.service.ts
@@ -47,7 +47,7 @@ export const getJobs = async ({
   lat: number | undefined
   lon: number | undefined
   romes: string[]
-  niveau: string
+  niveau: string | null
   caller?: string | null
   isMinimalData: boolean
 }): Promise<IRecruiter[]> => {

--- a/shared/routes/jobOpportunity.routes.ts
+++ b/shared/routes/jobOpportunity.routes.ts
@@ -1,4 +1,4 @@
-import { NIVEAUX_POUR_LBA, OPCOS } from "../constants/recruteur"
+import { OPCOS } from "../constants/recruteur"
 import { extensions } from "../helpers/zodHelpers/zodPrimitives"
 import { z } from "../helpers/zodWithOpenApi"
 
@@ -10,7 +10,7 @@ const ZJobOpportunityQuerystringBase = z.object({
   latitude: extensions.latitude(),
   longitude: extensions.longitude(),
   radius: z.number().min(0).max(200).default(30),
-  diploma: extensions.buildEnum(NIVEAUX_POUR_LBA).default(NIVEAUX_POUR_LBA.INDIFFERENT),
+  // diploma: extensions.buildEnum(NIVEAUX_POUR_LBA).default(NIVEAUX_POUR_LBA.INDIFFERENT),
   opco: extensions.buildEnum(OPCOS).optional(),
   opcoUrl: z.string().optional(),
 })


### PR DESCRIPTION
- Le param `insee` n'existe pas
- Le param `commune` est optionnel, et si fourni alors le param `distance` est requis

--> Il est possible de rechercher sans géoloc