### PR TITLE
fix: correction du mapping niveau de diplome LBA et FT

### DIFF
--- a/server/src/services/ftjob.service.ts
+++ b/server/src/services/ftjob.service.ts
@@ -231,10 +231,7 @@ export const getFtJobs = async ({
 
     if (diploma) {
       const niveauRequis = NIVEAUX_POUR_OFFRES_PE[diploma]
-      if (niveauRequis && niveauRequis !== "NV5") {
-        // pas de filtrage sur niveau requis NV5 car pas de résultats
-        params.niveauFormation = niveauRequis
-      }
+      params.niveauFormation = niveauRequis
     }
 
     if (hasLocation) {

--- a/shared/constants/recruteur.ts
+++ b/shared/constants/recruteur.ts
@@ -73,10 +73,11 @@ export const NIVEAUX_POUR_LBA = {
 // en revanche pour l'api offres de France Travail le filtre sur le niveau est le niveau
 // requis en entrée.
 export const NIVEAUX_POUR_OFFRES_PE = {
-  "4 (BAC...)": "NV5",
-  "5 (BTS, DEUST...)": "NV4",
-  "6 (Licence, BUT...)": "NV3",
-  "7 (Master, titre ingénieur...)": "NV2",
+  "3 (CAP...)": "NV5",
+  "4 (BAC...)": "NV4",
+  "5 (BTS, DEUST...)": "NV3",
+  "6 (Licence, BUT...)": "NV2",
+  "7 (Master, titre ingénieur...)": "NV1",
 } as const
 
 export const UNSUBSCRIBE_EMAIL_ERRORS = {


### PR DESCRIPTION
Discussion à avoir avec @guilletmarion 

Le mapping du filtre FT est le suivant:

```json
[
  {
    "code": "AFS",
    "libelle": "Aucune formation scolaire"
  },
  {
    "code": "CP4",
    "libelle": "Primaire à 4ème"
  },
  {
    "code": "CFG",
    "libelle": "4ème achevée"
  },
  {
    "code": "C3A",
    "libelle": "3ème achevée ou Brevet"
  },
  {
    "code": "C12",
    "libelle": "2nd ou 1ère achevée"
  },
  {
    "code": "NV5",
    "libelle": "CAP, BEP et équivalents"
  },
  {
    "code": "NV4b",
    "libelle": "Niveau Bac"
  },
  {
    "code": "NV4",
    "libelle": "Bac ou équivalent"
  },
  {
    "code": "NV3",
    "libelle": "Bac+2 ou équivalents"
  },
  {
    "code": "NV2",
    "libelle": "Bac+3, Bac+4 ou équivalents"
  },
  {
    "code": "NV1",
    "libelle": "Bac+5 et plus ou équivalents"
  }
]
```

> Hello,
> Je viens de tester l'API FT avec les niveaux de diplômes.
> J'ai procédé ainsi
> 1. Depuis la page https://francetravail.io/data/api/offres-emploi/documentation#/api-reference/operations/recupererListeOffre, saisi d'un niveau de diplôme issu du [référentiel FT](https://francetravail.io/data/api/offres-emploi/documentation#/api-reference/operations/recupererReferentielNiveauxFormations)
> 2. Lancement d'une requête
> 3. analyse des résultats
> 
> En saisissant "NV1", l'ensemble des résultats retournés sont associés au moins à ce niveau de diplôme ("Bac+5 et plus ou équivalents")
> En saisissant "NV2", l'ensemble des résultats retournés sont associés au moins à ce niveau de diplôme ("Bac+3, Bac+4 ou équivalents")
> En saisissant "NV4", l'ensemble des résultats retournés sont associés au moins à ce niveau de diplôme ("Bac ou équivalent")
> En saisissant "NV5", l'ensemble des résultats retournés sont associés au moins à ce niveau de diplôme ("CAP, BEP et équivalents")
> A noter qu'une offre peut être associée à plusieurs niveaux de diplômes.
> Mais dans tous les cas, au vu des tests, le filtre par niveau de diplôme est bien un filtre de type égal strict et non égal à un certains niveau ou aux niveaux inférieurs/supérieurs.

> j'en ai pas mal discuté avec eux, ils ont validé ce mapping en connaissant la manière dont on l'exploite.
> Et j'ai analysé leurs offres aussi pour voir si c'était cohérent.
> "Du coup si tu vises Bac+3, on prend les requis Bac" en théorie oui, mais sur l'alternance c'est différent.
> Les recruteurs recrutent un jeune qui se forme en Master.
> Ils sont intéressés par la formation que fait le candidat, parfois plus que par la formation qu'a déjà le candidat.
donc dans les fait, quand tu analyses les offres, tu te rends compte que pour l'alternance, c'est quasi toujours le niveau visé en fin d'études qui est indiqué par les recruteurs

> [!CAUTION]
> Il faudra également spécifier le mapping du champs `workplace_opco` pour etre cohérent. Et voir comment traduire le tableau avec des critères requis ou demandé vers un seul