### PR TITLE
fix: ajout de warnings sur toutes les erreurs FranceTravail

### DIFF
--- a/server/src/common/apis/FranceTravail.ts
+++ b/server/src/common/apis/FranceTravail.ts
@@ -82,16 +82,21 @@ export const getFranceTravailTokenFromAPI = async (access: IAccessParams): Promi
 /**
  * @description Search for FT Jobs
  */
-export const searchForFtJobs = async (params: {
-  codeROME?: string
-  commune?: string
-  sort: number
-  natureContrat: string
-  range: string
-  niveauFormation?: string
-  insee?: string
-  distance?: number
-}): Promise<FTResponse | null | ""> => {
+export const searchForFtJobs = async (
+  params: {
+    codeROME?: string
+    commune?: string
+    sort: number
+    natureContrat: string
+    range: string
+    niveauFormation?: string
+    insee?: string
+    distance?: number
+  },
+  options: {
+    throwOnError: boolean
+  }
+): Promise<FTResponse | null | ""> => {
   const token = await getToken("OFFRE")
 
   try {
@@ -114,6 +119,9 @@ export const searchForFtJobs = async (params: {
     return data
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
+    if (options.throwOnError) {
+      throw error
+    }
     sentryCaptureException(error, { extra: { responseData: error.response?.data } })
     return null
   }

--- a/server/src/services/ftjob.service.ts
+++ b/server/src/services/ftjob.service.ts
@@ -221,7 +221,7 @@ export const getFtJobs = async ({
 
     const distance = radius || 10
 
-    const params: { codeROME: string; commune?: string; sort: number; natureContrat: string; range: string; niveauFormation?: string; insee?: string; distance?: number } = {
+    const params: Parameters<typeof searchForFtJobs>[0] = {
       codeROME: romes.join(","),
       commune: codeInsee,
       sort: hasLocation ? 2 : 0, //sort: 0, TODO: remettre sort 0 après expérimentation CBS
@@ -239,7 +239,7 @@ export const getFtJobs = async ({
       params.distance = distance
     }
 
-    const jobs = await searchForFtJobs(params)
+    const jobs = await searchForFtJobs(params, { throwOnError: false })
 
     if (jobs === null || jobs === "") {
       const emptyPeResponse: FTResponse = { resultats: [] }
@@ -297,7 +297,7 @@ export const getFtJobsV2 = async ({
     params.niveauFormation = NIVEAUX_POUR_OFFRES_PE[diploma]
   }
 
-  const jobs = await searchForFtJobs(params)
+  const jobs = await searchForFtJobs(params, { throwOnError: true })
 
   if (jobs === null || jobs === "") {
     return { resultats: [] }


### PR DESCRIPTION
Corrige https://github.com/mission-apprentissage/labonnealternance/pull/1462 qui ne catch que les erreurs d'authentification à Ft (`getToken`)