### PR TITLE
fix: boom seems to not expose named exports

### DIFF
--- a/server/src/services/external/api-alternance/certification.service.ts
+++ b/server/src/services/external/api-alternance/certification.service.ts
@@ -1,5 +1,5 @@
 import axios from "axios"
-import { internal } from "boom"
+import Boom from "boom"
 
 import { sentryCaptureException } from "../../../common/utils/sentryUtils"
 import config from "../../../config"
@@ -18,7 +18,7 @@ const getFirstCertificationFromAPIApprentissage = async (rncp: string, throwOnEr
     sentryCaptureException(error, { responseData: error.response?.data })
 
     if (throwOnError) {
-      const err = internal("Erreur lors de la récupération des informations de certification", {
+      const err = Boom.internal("Erreur lors de la récupération des informations de certification", {
         responseData: error.response?.data,
         rncp: rncp,
       })

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts
@@ -1,6 +1,6 @@
 import { generateFtJobFixture } from "@tests/fixtures/ftJobs.fixture"
 import { useMongo } from "@tests/utils/mongo.test.utils"
-import { internal } from "boom"
+import Boom from "boom"
 import nock from "nock"
 import { NIVEAUX_POUR_LBA, NIVEAUX_POUR_OFFRES_PE, RECRUITER_STATUS } from "shared/constants"
 import { generateCfaFixture } from "shared/fixtures/cfa.fixture"
@@ -380,7 +380,7 @@ describe("findJobsOpportunities", () => {
           },
           new JobOpportunityRequestContext({ path: "/api/route" }, "api-alternance")
         )
-      ).rejects.toThrowError(internal("Erreur lors de la récupération des informations de certification"))
+      ).rejects.toThrowError(Boom.internal("Erreur lors de la récupération des informations de certification"))
     })
 
     it("should throw bad request when rncp code is not found", async () => {
@@ -400,7 +400,7 @@ describe("findJobsOpportunities", () => {
           },
           new JobOpportunityRequestContext({ path: "/api/route" }, "api-alternance")
         )
-      ).rejects.toThrowError(internal("Cannot find an active Certification for the given RNCP"))
+      ).rejects.toThrowError(Boom.internal("Cannot find an active Certification for the given RNCP"))
 
       expect(scopeApiAlternance.isDone()).toBeTruthy()
     })
@@ -422,7 +422,7 @@ describe("findJobsOpportunities", () => {
           },
           new JobOpportunityRequestContext({ path: "/api/route" }, "api-alternance")
         )
-      ).rejects.toThrowError(internal("Cannot find an active Certification for the given RNCP"))
+      ).rejects.toThrowError(Boom.internal("Cannot find an active Certification for the given RNCP"))
 
       expect(scopeApiAlternance.isDone()).toBeTruthy()
     })

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -1,4 +1,4 @@
-import { badRequest } from "boom"
+import Boom from "boom"
 import { Filter } from "mongodb"
 import { assertUnreachable, IGeoPoint, IJob, ILbaCompany, IRecruiter, JOB_STATUS, parseEnum } from "shared"
 import { NIVEAU_DIPLOME_LABEL, NIVEAUX_POUR_LBA, NIVEAUX_POUR_OFFRES_PE, TRAINING_CONTRACT_TYPE } from "shared/constants"
@@ -458,7 +458,7 @@ async function resolveQuery(query: IJobOpportunityGetQuery): Promise<IJobOpportu
     const rncpRomes = await getRomesFromRncp(query.rncp, true)
 
     if (rncpRomes == null) {
-      throw badRequest("Cannot find an active Certification for the given RNCP", { rncp: query.rncp })
+      throw Boom.badRequest("Cannot find an active Certification for the given RNCP", { rncp: query.rncp })
     }
 
     romeCriteria.push(...rncpRomes)


### PR DESCRIPTION
Des imports de named exports depuis Boom provoquent des erreurs car cette dernière lib semble ne pas les exposer.
Remplacement par import default de Boom et utilisation par Boom.internal ou Boom.badRequest