### PR TITLE
fix: suppression de l ancien format de auth scope

### DIFF
--- a/cypress/e2e/manual/create-many-applications.cy.ts
+++ b/cypress/e2e/manual/create-many-applications.cy.ts
@@ -2,7 +2,7 @@ import { givenAMatchaOffer } from "../../pages/givenAMatchaOffer"
 import { generateRandomString } from "../../utils/generateRandomString"
 
 describe("create-many-applications", () => {
-  it("create-many-applications", () => {
+  it.skip("create-many-applications", () => {
     cy.viewport(1271, 721)
 
     givenAMatchaOffer((recruiter) => {

--- a/server/src/security/accessTokenService.ts
+++ b/server/src/security/accessTokenService.ts
@@ -5,7 +5,6 @@ import { PathParam, QueryString } from "shared/helpers/generateUri"
 import { IUserRecruteur } from "shared/models"
 import { IUserWithAccount } from "shared/models/userWithAccount.model"
 import { IRouteSchema, WithSecurityScheme } from "shared/routes/common.routes"
-import { assertUnreachable } from "shared/utils"
 import { Jsonify } from "type-fest"
 import { AnyZodObject, z } from "zod"
 
@@ -31,18 +30,7 @@ type AuthorizedValuesRecord<ZodObject> = ZodObject extends AnyZodObject
     }
   : undefined
 
-// TODO à retirer à partir du 01/02/2024
-type OldIScope<Schema extends SchemaWithSecurity> = {
-  schema: Schema
-  options:
-    | "all"
-    | {
-        params: AuthorizedValuesRecord<Schema["params"]>
-        querystring: AuthorizedValuesRecord<Schema["querystring"]>
-      }
-}
-
-type NewIScope<Schema extends SchemaWithSecurity> = {
+type IScope<Schema extends SchemaWithSecurity> = {
   method: Schema["method"]
   path: Schema["path"]
   options:
@@ -52,10 +40,7 @@ type NewIScope<Schema extends SchemaWithSecurity> = {
         querystring: AuthorizedValuesRecord<Schema["querystring"]>
       }
 }
-
-type IScope<Schema extends SchemaWithSecurity> = NewIScope<Schema> | OldIScope<Schema>
-
-export const generateScope = <Schema extends SchemaWithSecurity>(scope: Omit<NewIScope<Schema>, "method" | "path"> & { schema: Schema }): NewIScope<Schema> => {
+export const generateScope = <Schema extends SchemaWithSecurity>(scope: Omit<IScope<Schema>, "method" | "path"> & { schema: Schema }): IScope<Schema> => {
   const { schema, options } = scope
   return { options, path: schema.path, method: schema.method }
 }
@@ -96,7 +81,7 @@ export const applicationToUserForToken = ({ company_siret, jobId }: IApplication
   }
 }
 
-export function generateAccessToken(user: UserForAccessToken, scopes: ReadonlyArray<NewIScope<SchemaWithSecurity>>, options: { expiresIn?: string } = {}): string {
+export function generateAccessToken(user: UserForAccessToken, scopes: ReadonlyArray<IScope<SchemaWithSecurity>>, options: { expiresIn?: string } = {}): string {
   const identity: IAccessToken["identity"] = "_id" in user ? { type: "IUser2", _id: user._id.toString(), email: user.email.toLowerCase() } : user
   const data: IAccessToken<SchemaWithSecurity> = {
     identity,
@@ -111,19 +96,6 @@ export function generateAccessToken(user: UserForAccessToken, scopes: ReadonlyAr
     sentryCaptureException(internal(`Token généré trop long : ${token.length}`))
   }
   return token
-}
-
-function getMethodAndPath<Schema extends SchemaWithSecurity>(scope: IScope<Schema>) {
-  if ("schema" in scope) {
-    const { schema } = scope
-    const { method, path } = schema
-    return { method, path }
-  } else if ("method" in scope && "path" in scope) {
-    const { method, path } = scope
-    return { method, path }
-  } else {
-    assertUnreachable(scope)
-  }
 }
 
 function isAllowAllValue(x: unknown): x is AllowAllType {
@@ -142,7 +114,7 @@ export function getAccessTokenScope<Schema extends SchemaWithSecurity>(
 ): IScope<Schema> | null {
   return (
     token?.scopes.find((scope) => {
-      const { method, path } = getMethodAndPath(scope)
+      const { method, path } = scope
       if (path !== schema.path || method !== schema.method) {
         return false
       }


### PR DESCRIPTION
Suppression de l'ancien format des scope dans l'auth.
La cohabitation des 2 formats était lié à un changement de la structure des tokens