### PR TITLE
fix: erreur 401 lors d'une erreur sur le format de l'authentification API

### DIFF
--- a/server/src/http/controllers/v2/jobs.controller.v2.test.ts
+++ b/server/src/http/controllers/v2/jobs.controller.v2.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/common/apis/franceTravail/franceTravail.client")
 vi.mock("@/common/apis/apiEntreprise/apiEntreprise.client")
 
 const httpClient = useServer()
+
 const token = getApiApprentissageTestingToken({ email: "test@test.fr", organisation: "Un super Partenaire", habilitations: { "jobs:write": true } })
 
 const fakeToken = getApiApprentissageTestingTokenFromInvalidPrivateKey({
@@ -76,10 +77,10 @@ describe("GET /jobs/search", () => {
     expect(response.json()).toEqual({ statusCode: 401, error: "Unauthorized", message: "Unauthorized" })
   })
 
-  it("should return 403 if api key is invalid", async () => {
+  it("should return 401 if api key is invalid", async () => {
     const response = await httpClient().inject({ method: "GET", path: "/api/v2/jobs/search", headers: { authorization: `Bearer ${fakeToken}` } })
-    expect.soft(response.statusCode).toBe(403)
-    expect(response.json()).toEqual({ statusCode: 403, error: "Forbidden", message: "Invalid JWT token" })
+    expect.soft(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({ statusCode: 401, error: "Unauthorized", message: "Invalid JWT token" })
   })
 
   it("should throw ZOD error if ROME is not formatted correctly", async () => {
@@ -350,8 +351,8 @@ describe("POST /jobs", async () => {
       headers: { authorization: `Bearer ${fakeToken}` },
     })
 
-    expect.soft(response.statusCode).toBe(403)
-    expect(response.json()).toEqual({ error: "Forbidden", message: "Invalid JWT token", statusCode: 403 })
+    expect.soft(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({ statusCode: 401, error: "Unauthorized", message: "Invalid JWT token" })
     expect(await getDbCollection("jobs_partners").countDocuments({})).toBe(0)
   })
 
@@ -498,7 +499,7 @@ describe("PUT /jobs/:id", async () => {
     }
   })
 
-  it("should return 403 if no token is not signed by API", async () => {
+  it("should return 401 if no token is not signed by API", async () => {
     const response = await httpClient().inject({
       method: "PUT",
       path: `/api/v2/jobs/${id.toString()}`,
@@ -506,8 +507,8 @@ describe("PUT /jobs/:id", async () => {
       headers: { authorization: `Bearer ${fakeToken}` },
     })
 
-    expect.soft(response.statusCode).toBe(403)
-    expect(response.json()).toEqual({ error: "Forbidden", message: "Invalid JWT token", statusCode: 403 })
+    expect.soft(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({ error: "Unauthorized", message: "Invalid JWT token", statusCode: 401 })
     expect(await getDbCollection("jobs_partners").findOne({ _id: id })).toEqual(originalJob)
   })
 

--- a/server/src/security/accessApiApprentissageService.ts
+++ b/server/src/security/accessApiApprentissageService.ts
@@ -1,4 +1,4 @@
-import { forbidden, isBoom, unauthorized } from "@hapi/boom"
+import { isBoom, unauthorized } from "@hapi/boom"
 import jwt from "jsonwebtoken"
 import { z } from "zod"
 
@@ -29,19 +29,19 @@ export const parseApiApprentissageToken = (jwtToken: string): IApiApprentissageT
     })
     const parseResult = ZApiApprentissageTokenData.safeParse(payload)
     if (!parseResult.success) {
-      throw forbidden("Payload doesn't match expected schema")
+      throw unauthorized("Payload doesn't match expected schema")
     }
     return parseResult.data
   } catch (err: unknown) {
     if (err instanceof TokenExpiredError) {
-      const e = forbidden("JWT expired")
+      const e = unauthorized("JWT expired")
       e.cause = err
       throw e
     }
 
     if (err instanceof JsonWebTokenError) {
       logger.warn("invalid jwt token", jwtToken, err)
-      const e = forbidden("Invalid JWT token")
+      const e = unauthorized("Invalid JWT token")
       e.cause = err
       throw e
     }


### PR DESCRIPTION
Dans l'API je transmets les erreurs 400 & 403 au client, les autres je les garde coté API et considère que ce sont des erreurs interne (format du token invalide, signature invalide...)
