### PR TITLE
fix: ajout de venv a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,5 @@ cypress.env
 assets/*
 tmp
 
+venv
+


### PR DESCRIPTION
Ubuntu recommande maintenant d'utiliser les environnements virtuels pour python.
cf https://docs.python.org/3/library/venv.html
J'ajoute donc le répertoire `venv` au `.gitignore`