### PR TITLE
fix: refactor fillFieldsForPartnersFactory: mise a jour de tous les champs passés par getData

### DIFF
--- a/server/src/jobs/offrePartenaire/fillOpcoInfosForPartners.test.ts
+++ b/server/src/jobs/offrePartenaire/fillOpcoInfosForPartners.test.ts
@@ -131,6 +131,31 @@ describe("fillOpcoInfosForPartners", () => {
     expect.soft(job.errors).toEqual([])
     expect.soft({ workplace_opco, workplace_idcc }).toEqual({ workplace_opco: OPCOS_LABEL.AFDAS, workplace_idcc: null })
   })
+  it("should not fill opco if already present", async () => {
+    // given
+    await givenSomeComputedJobPartners([
+      {
+        workplace_siret: "42476141900045",
+        workplace_opco: OPCOS_LABEL.ATLAS,
+        workplace_idcc: null,
+      },
+    ])
+    await getDbCollection("opcos").insertOne({
+      _id: new ObjectId(),
+      siren: "424761419",
+      opco: OPCOS_LABEL.CONSTRUCTYS,
+      idcc: "267",
+    })
+    // when
+    await fillOpcoInfosForPartners()
+    // then
+    const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect.soft(jobs.length).toBe(1)
+    const [job] = jobs
+    const { workplace_opco, workplace_idcc } = job
+    expect.soft(job.errors).toEqual([])
+    expect.soft({ workplace_opco, workplace_idcc }).toEqual({ workplace_opco: OPCOS_LABEL.ATLAS, workplace_idcc: 267 })
+  })
   it("should set opco to unknown when data is not found", async () => {
     // given
     await givenSomeComputedJobPartners([

--- a/server/src/jobs/offrePartenaire/fillOpcoInfosForPartners.ts
+++ b/server/src/jobs/offrePartenaire/fillOpcoInfosForPartners.ts
@@ -33,8 +33,8 @@ export const fillOpcoInfosForPartners = async () => {
           }
         }
         const result: Pick<IComputedJobsPartners, (typeof filledFields)[number]> = {
-          workplace_idcc: parsedIdcc,
-          workplace_opco: opco,
+          workplace_idcc: document.workplace_idcc ?? parsedIdcc,
+          workplace_opco: document.workplace_opco ?? opco,
         }
         return result
       })

--- a/server/src/jobs/offrePartenaire/fillSiretInfosForPartners.ts
+++ b/server/src/jobs/offrePartenaire/fillSiretInfosForPartners.ts
@@ -1,5 +1,4 @@
 import { BusinessErrorCodes } from "shared/constants/errorCodes"
-import { IGeoPoint } from "shared/models"
 import { COMPUTED_ERROR_SOURCE, IComputedJobsPartners } from "shared/models/jobsPartnersComputed.model"
 import { isEnum } from "shared/utils"
 
@@ -29,8 +28,6 @@ export const fillSiretInfosForPartners = async () => {
       const [document] = documents
       const { workplace_siret: siret } = document
 
-      const workplace_geopoint: IGeoPoint | null = "workplace_geopoint" in document ? (document.workplace_geopoint as IGeoPoint) : null
-      const workplace_address_label: string | null = "workplace_address_label" in document ? (document.workplace_address_label as string) : null
       const response = await getSiretInfos(siret)
       if (!response) {
         return []
@@ -43,14 +40,14 @@ export const fillSiretInfosForPartners = async () => {
       const { establishment_enseigne, establishment_raison_sociale, naf_code, naf_label, geo_coordinates, establishment_size, address } = formatEntrepriseData(data)
 
       const result: Pick<IComputedJobsPartners, (typeof filledFields)[number]> = {
-        workplace_size: establishment_size,
-        workplace_legal_name: establishment_raison_sociale,
-        workplace_brand: establishment_enseigne,
-        workplace_name: establishment_enseigne ?? establishment_raison_sociale,
-        workplace_address_label: (address || workplace_address_label) ?? undefined,
-        workplace_naf_code: naf_code,
-        workplace_naf_label: naf_label,
-        workplace_geopoint: workplace_geopoint || (geo_coordinates ? convertStringCoordinatesToGeoPoint(geo_coordinates) : undefined),
+        workplace_size: document.workplace_size ?? establishment_size,
+        workplace_legal_name: document.workplace_legal_name ?? establishment_raison_sociale,
+        workplace_brand: document.workplace_brand ?? establishment_enseigne,
+        workplace_name: document.workplace_name ?? establishment_enseigne ?? establishment_raison_sociale,
+        workplace_address_label: document.workplace_address_label ?? address,
+        workplace_naf_code: document.workplace_naf_code ?? naf_code,
+        workplace_naf_label: document.workplace_naf_label ?? naf_label,
+        workplace_geopoint: document.workplace_geopoint ?? (geo_coordinates ? convertStringCoordinatesToGeoPoint(geo_coordinates) : null),
       }
 
       return [result]


### PR DESCRIPTION
refactor de la fonction fillFieldsForPartnersFactory
Actuellement, seuls les champs vides sont mis à jour.
Ce n'est pas un comportement qu'on peut intuiter facilement.
Je le supprime donc. Les valeurs de champs renvoyées sont maintenant mises à jour tel quel
J'en profite pour optimiser et ajouter une projection