### PR TITLE
fix: api bulk

### DIFF
--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -191,9 +191,15 @@ export const getOffreAvecInfoMandataire = async (id: string | ObjectId): Promise
  * @param {number} payload.page
  * @param {number} payload.limit
  */
-export const getFormulaires = async (query: Filter<IRecruiter>, select: object, { page, limit }: { page?: number; limit?: number }) => {
-  const response = getDbCollection("recruiters").find({ query }, { projection: select })
-  const data = page && limit ? await response.skip(page).limit(limit).toArray() : await response.toArray()
+export const getFormulaires = async (query: Filter<IRecruiter>, select: object, { page = 1, limit = 150 }: { page?: number; limit?: number }) => {
+  const response = await getDbCollection("recruiters").find(query, { projection: select })
+  const data =
+    page && limit
+      ? await response
+          .skip(page > 0 ? (page - 1) * limit : 0)
+          .limit(limit)
+          .toArray()
+      : await response.toArray()
   const total = await getDbCollection("recruiters").countDocuments(query)
   const number_of_page = limit ? Math.ceil(total / limit) : undefined
   return {

--- a/shared/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
+++ b/shared/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
@@ -2771,10 +2771,6 @@ exports[`generateOpenApiSchema > should generate proper schema 1`] = `
                 "type": "string",
               },
             },
-            "required": [
-              "createdAt",
-              "updatedAt",
-            ],
             "type": "object",
           },
         ],
@@ -5040,7 +5036,45 @@ Limite : 5 appel(s) / 1 seconde(s)
                   "properties": {
                     "data": {
                       "items": {
-                        "$ref": "#/components/schemas/Recruiter",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/Recruiter",
+                          },
+                          {
+                            "allOf": [
+                              {
+                                "$ref": "#/components/schemas/RecruiterWritable",
+                              },
+                              {
+                                "default": undefined,
+                                "properties": {
+                                  "_id": {
+                                    "description": "Identifiant unique",
+                                  },
+                                  "createdAt": {
+                                    "description": "Date de creation",
+                                    "type": "string",
+                                  },
+                                  "distance": {
+                                    "type": [
+                                      "number",
+                                      "null",
+                                    ],
+                                  },
+                                  "updatedAt": {
+                                    "description": "Date de mise à jour",
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "createdAt",
+                                  "updatedAt",
+                                ],
+                                "type": "object",
+                              },
+                            ],
+                          },
+                        ],
                       },
                       "type": "array",
                     },
@@ -7364,7 +7398,7 @@ Limite : 5 appel(s) / 1 seconde(s)
 ",
         "parameters": [
           {
-            "description": "query mongodb query allowing specific filtering, JSON stringified",
+            "description": "query mongodb query allowing specific filtering, JSON stringified : {'status':'Actif'}",
             "in": "query",
             "name": "query",
             "required": false,
@@ -7378,7 +7412,7 @@ Limite : 5 appel(s) / 1 seconde(s)
             "name": "select",
             "required": false,
             "schema": {
-              "example": "{_id: 1, first_name:1, last_name:0}",
+              "example": "{'_id': 1, 'first_name':1, 'last_name':0}",
               "type": "string",
             },
           },
@@ -7388,10 +7422,9 @@ Limite : 5 appel(s) / 1 seconde(s)
             "name": "page",
             "required": false,
             "schema": {
-              "type": [
-                "number",
-                "null",
-              ],
+              "default": 1,
+              "minimum": 1,
+              "type": "number",
             },
           },
           {
@@ -7400,6 +7433,7 @@ Limite : 5 appel(s) / 1 seconde(s)
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 500,
               "type": [
                 "number",
                 "null",
@@ -7781,7 +7815,45 @@ Limite : 5 appel(s) / 1 seconde(s)
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Recruiter",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Recruiter",
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/RecruiterWritable",
+                        },
+                        {
+                          "default": undefined,
+                          "properties": {
+                            "_id": {
+                              "description": "Identifiant unique",
+                            },
+                            "createdAt": {
+                              "description": "Date de creation",
+                              "type": "string",
+                            },
+                            "distance": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                            "updatedAt": {
+                              "description": "Date de mise à jour",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "createdAt",
+                            "updatedAt",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
                 },
               },
             },
@@ -7942,7 +8014,45 @@ Limite : 5 appel(s) / 1 seconde(s)
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Recruiter",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Recruiter",
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/RecruiterWritable",
+                        },
+                        {
+                          "default": undefined,
+                          "properties": {
+                            "_id": {
+                              "description": "Identifiant unique",
+                            },
+                            "createdAt": {
+                              "description": "Date de creation",
+                              "type": "string",
+                            },
+                            "distance": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                            "updatedAt": {
+                              "description": "Date de mise à jour",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "createdAt",
+                            "updatedAt",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
                 },
               },
             },
@@ -8698,7 +8808,45 @@ Limite : 5 appel(s) / 1 seconde(s)
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Recruiter",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Recruiter",
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/RecruiterWritable",
+                        },
+                        {
+                          "default": undefined,
+                          "properties": {
+                            "_id": {
+                              "description": "Identifiant unique",
+                            },
+                            "createdAt": {
+                              "description": "Date de creation",
+                              "type": "string",
+                            },
+                            "distance": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                            "updatedAt": {
+                              "description": "Date de mise à jour",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "createdAt",
+                            "updatedAt",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
                 },
               },
             },
@@ -8865,7 +9013,45 @@ Limite : 5 appel(s) / 1 seconde(s)
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Recruiter",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Recruiter",
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/RecruiterWritable",
+                        },
+                        {
+                          "default": undefined,
+                          "properties": {
+                            "_id": {
+                              "description": "Identifiant unique",
+                            },
+                            "createdAt": {
+                              "description": "Date de creation",
+                              "type": "string",
+                            },
+                            "distance": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                            "updatedAt": {
+                              "description": "Date de mise à jour",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "createdAt",
+                            "updatedAt",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
                 },
               },
             },

--- a/shared/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
+++ b/shared/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
@@ -7433,6 +7433,7 @@ Limite : 5 appel(s) / 1 seconde(s)
             "name": "limit",
             "required": false,
             "schema": {
+              "default": 150,
               "maximum": 500,
               "type": [
                 "number",

--- a/shared/routes/v1Jobs.routes.ts
+++ b/shared/routes/v1Jobs.routes.ts
@@ -79,7 +79,7 @@ export const zV1JobsRoutes = {
             .optional()
             .openapi({
               param: {
-                description: "query mongodb query allowing specific filtering, JSON stringified",
+                description: "query mongodb query allowing specific filtering, JSON stringified : {'status':'Actif'}",
               },
             }), // mongo query
           select: z
@@ -89,11 +89,13 @@ export const zV1JobsRoutes = {
               param: {
                 description: "select fields to return",
               },
-              example: "{_id: 1, first_name:1, last_name:0}",
+              example: "{'_id': 1, 'first_name':1, 'last_name':0}",
             }), // mongo projection
           page: z.coerce
             .number()
+            .min(1)
             .optional()
+            .default(1)
             .openapi({
               param: {
                 description: "the current page.",
@@ -101,6 +103,7 @@ export const zV1JobsRoutes = {
             }),
           limit: z.coerce
             .number()
+            .max(500)
             .optional()
             .openapi({
               param: {
@@ -112,7 +115,7 @@ export const zV1JobsRoutes = {
       response: {
         "200": z
           .object({
-            data: z.array(ZRecruiter).optional(),
+            data: z.array(ZRecruiter.partial()).optional(),
             pagination: z
               .object({
                 page: z.number().optional(),

--- a/shared/routes/v1Jobs.routes.ts
+++ b/shared/routes/v1Jobs.routes.ts
@@ -94,8 +94,8 @@ export const zV1JobsRoutes = {
           page: z.coerce
             .number()
             .min(1)
-            .optional()
             .default(1)
+            .optional()
             .openapi({
               param: {
                 description: "the current page.",
@@ -104,6 +104,7 @@ export const zV1JobsRoutes = {
           limit: z.coerce
             .number()
             .max(500)
+            .default(150)
             .optional()
             .openapi({
               param: {


### PR DESCRIPTION
Depuis la migration mongoDB, la route était inopérante : 
- la `query` contenant une double accolade 
- la pagination n'était pas correct
- le passage du paramètre `page = 0` retournait tous les résultats
- la selection réduite des champs retournés ne fonctionnait pas

`limit` par défaut = 150 (max: 500)
`page` par défaut = 1 (inférieur impossible, erreur zod) 
