### PR TITLE
fix: recherche entreprise avec siret uniquement

### DIFF
--- a/ui/components/espace_pro/Authentification/CreationCompte.tsx
+++ b/ui/components/espace_pro/Authentification/CreationCompte.tsx
@@ -173,7 +173,7 @@ const CreationCompteForm = ({
               name="establishment_siret"
               handleSearch={(search: string) => searchEntreprise(search)}
               renderItem={({ raison_sociale, siret, adresse }, highlighted) => <EntrepriseCard {...{ raison_sociale, siret, adresse, highlighted }} />}
-              itemToString={({ raison_sociale, siret, adresse }) => `${raison_sociale} - ${siret} - ${adresse}`}
+              itemToString={({ siret }) => siret}
               onInputFieldChange={(value, hasError) => {
                 setSearchInput(value)
                 if (!hasError) return


### PR DESCRIPTION
- l'API recherche-entreprise ne ramène plus de résultat avec la raison sociale - SIRET - adresse en appel --> retrait de la raison sociale et de l'adresse dans l'appel