### PR TITLE
fix: LBA-2295 : Envoyer à FT offres remontant à 60j

### DIFF
--- a/server/src/jobs/partenaireExport/exportToFranceTravail.ts
+++ b/server/src/jobs/partenaireExport/exportToFranceTravail.ts
@@ -174,7 +174,7 @@ const formatData = (offre) => {
 
 const getJobsToExport = async () => {
   const buffer: any[] = []
-  const threshold = dayjs().subtract(30, "days").toDate()
+  const threshold = dayjs().subtract(60, "days").toDate()
   const offres: any[] = await getDbCollection("jobs")
     .find({
       job_status: JOB_STATUS.ACTIVE,


### PR DESCRIPTION
Envoyer les offres dont la date de MAJ remonte à 60j ou moins (on reste à 60j pour garder une certaine fraîcheur et car avec le système actuel, on ne peut avoir d'offres actives avec une date de MAJ > 60j)

https://tableaudebord-apprentissage.atlassian.net/browse/LBA-2295