### PR TITLE
fix: erreurs de formats offres FT pour search v3

### DIFF
--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -547,8 +547,8 @@ export const convertFranceTravailJobToJobOfferApi = (offresEmploiFranceTravail: 
           brand: null,
           legal_name: null,
           website: null,
-          name: offreFT.entreprise.nom,
-          description: offreFT.entreprise.description,
+          name: offreFT.entreprise.nom ?? null,
+          description: offreFT.entreprise.description ?? null,
           size: null,
           location: {
             address: offreFT.lieuTravail.libelle,


### PR DESCRIPTION
Certains offres FT ne remontent pas le nom de la société. La valeur null n'est pas utilisée mais undefined ce qui provoque une erreur zod.
--> gestion du cas et utilisation de null à la place de undefined