### PR TITLE
fix: geopoint manquants dans recruiters

### DIFF
--- a/server/src/migrations/20241218094540-fix-recruiter-missing-geopoint.ts
+++ b/server/src/migrations/20241218094540-fix-recruiter-missing-geopoint.ts
@@ -1,0 +1,11 @@
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+
+export const up = async () => {
+  logger.info("20241218-fix-recruiter-missing-geopoint started")
+  for await (const { _id, geo_coordinates } of getDbCollection("recruiters").find({ geopoint: null, geo_coordinates: { $ne: null } })) {
+    const [latitude, longitude] = geo_coordinates!.split(",").map((coord) => parseFloat(coord))
+    await getDbCollection("recruiters").updateOne({ _id }, { $set: { geopoint: { type: "Point", coordinates: [longitude, latitude] } } })
+  }
+  logger.info("20241218-fix-recruiter-missing-geopoint ended")
+}


### PR DESCRIPTION
Des recruiters créés au moins de juin n'ont pas de valeur pour le champ geopoint.
Une migration permet de résoudre le souci.