### PR TITLE
fix: reduce trace sample rate

### DIFF
--- a/ui/sentry.client.config.ts
+++ b/ui/sentry.client.config.ts
@@ -8,7 +8,7 @@ import { publicConfig } from "./config.public"
 
 init({
   dsn: publicConfig.sentry_dsn,
-  tracesSampleRate: publicConfig.env === "production" ? 0.1 : 1.0,
+  tracesSampleRate: publicConfig.env === "production" ? 0.01 : 1.0,
   tracePropagationTargets: [/^https:\/\/[^/]*\.apprentissage\.beta\.gouv\.fr/, publicConfig.baseUrl, publicConfig.apiEndpoint, /^\//],
   environment: publicConfig.env,
   enabled: !publicConfig.sentryDisabled,

--- a/ui/sentry.edge.config.ts
+++ b/ui/sentry.edge.config.ts
@@ -9,7 +9,7 @@ import { publicConfig } from "./config.public"
 
 init({
   dsn: publicConfig.sentry_dsn,
-  tracesSampleRate: publicConfig.env === "production" ? 0.1 : 1.0,
+  tracesSampleRate: publicConfig.env === "production" ? 0.01 : 1.0,
   tracePropagationTargets: [/^https:\/\/[^/]*\.apprentissage\.beta\.gouv\.fr/, publicConfig.baseUrl, publicConfig.apiEndpoint],
   environment: publicConfig.env,
   enabled: !publicConfig.sentryDisabled,

--- a/ui/sentry.server.config.ts
+++ b/ui/sentry.server.config.ts
@@ -8,7 +8,7 @@ import { publicConfig } from "./config.public"
 
 init({
   dsn: publicConfig.sentry_dsn,
-  tracesSampleRate: publicConfig.env === "production" ? 0.1 : 1.0,
+  tracesSampleRate: publicConfig.env === "production" ? 0.01 : 1.0,
   tracePropagationTargets: [/^https:\/\/[^/]*\.apprentissage\.beta\.gouv\.fr/, publicConfig.baseUrl, publicConfig.apiEndpoint],
   environment: publicConfig.env,
   enabled: !publicConfig.sentryDisabled,


### PR DESCRIPTION
On a trop d'event sur le Sentry, on atteint les limites du disque. 

Pour `lba-ui` on a actuellement 11k transactions / jours, on diminue de 10% --> On en garde 1_000

Pour `lba-server`, le traceSample n'affecte pas reellement en vrai. Car si un transaction a un parent, alors elle est trace si et seulement si la parent est trace. Et comme on a pas beaucoup d'appels en direct, en diminuant `lba-ui` de 10% on diminue `lba-server` de 10% (on passera alors de 100k / jour à 10k / jour).

Et de plus on reduit encore plus le profiling, pour passer de 1k / jour à 10 / jour)