### PR TITLE
fix(lba-2425): erreur 500 job search v3

### DIFF
--- a/server/src/services/ftjob.service.ts
+++ b/server/src/services/ftjob.service.ts
@@ -307,7 +307,7 @@ export const getFtJobsV2 = async ({
     return { resultats: [] }
   }
 
-  return jobs.data
+  return jobs.data || { resultats: [] }
 }
 
 /**


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?assignee=712020%3A9a003bb4-d766-4edc-b4ab-ecd6529e3353&selectedIssue=LBA-2425

Erreur provoquée par un résultat vide sur recherche des offres FT