### PR TITLE
fix: max_old_space_size for job processor

### DIFF
--- a/.infra/docker-compose.production.yml
+++ b/.infra/docker-compose.production.yml
@@ -30,6 +30,8 @@ services:
           memory: 2g
       replicas: 2
     stop_grace_period: 2m
+    environment:
+      NODE_OPTIONS: "--max_old_space_size=2048"
     volumes:
       - /opt/app/data/server:/data
       - /opt/app/.env_server:/app/server/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ COPY ./server/static /app/server/static
 
 EXPOSE 5000
 WORKDIR /app/server
-ENV NODE_OPTIONS=--max_old_space_size=2048
 CMD ["node", "dist/index.js", "start"]
 
 


### PR DESCRIPTION
- use default `max_old_space_size` for job-processor docker