### PR TITLE
fix: computed validation

### DIFF
--- a/server/src/jobs/offrePartenaire/rawToComputedJobsPartners.ts
+++ b/server/src/jobs/offrePartenaire/rawToComputedJobsPartners.ts
@@ -2,7 +2,7 @@ import { internal } from "@hapi/boom"
 import { Filter } from "mongodb"
 import { oleoduc, writeData } from "oleoduc"
 import { z } from "shared/helpers/zodWithOpenApi"
-import { JOBPARTNERS_LABEL, ZJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
+import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
 import { IComputedJobsPartners } from "shared/models/jobsPartnersComputed.model"
 import { CollectionName } from "shared/models/models"
 import { AnyZodObject } from "zod"
@@ -45,7 +45,6 @@ export const rawToComputedJobsPartners = async <ZodInput extends AnyZodObject>({
           await getDbCollection("computed_jobs_partners").insertOne({
             ...computedJobPartner,
             partner_label: partnerLabel,
-            validated: ZJobsPartnersOfferPrivate.safeParse(computedJobPartner).success,
             created_at: importDate,
           })
           counters.success++

--- a/server/src/jobs/offrePartenaire/validateComputedJobPartners.ts
+++ b/server/src/jobs/offrePartenaire/validateComputedJobPartners.ts
@@ -16,7 +16,7 @@ type BulkOperation = AnyBulkWriteOperation<IComputedJobsPartners>
 
 export const validateComputedJobPartners = async () => {
   logger.info(`validation des computed_job_partners`)
-  const toUpdateCount = await getDbCollection("computed_jobs_partners").countDocuments({})
+  const toUpdateCount = await getDbCollection("computed_jobs_partners").countDocuments({ business_error: null })
   logger.info(`${toUpdateCount} documents à traiter`)
   const counters = { total: 0, success: 0, error: 0 }
   await oleoduc(


### PR DESCRIPTION
- La validation ne doit pas se faire au passage de la raw vers la computed : si des erreurs business sont déjà présentes, elles ne seront pas prises en compte. Autant laisser le job de validation faire ce travail.
- Correction du comptage des offres à valider.