### PR TITLE
feat: job-partner - keep recruteurs lba in computed

### DIFF
--- a/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
@@ -3,9 +3,11 @@ import { createRequire } from "module"
 import { pipeline } from "node:stream/promises"
 import path from "path"
 
+import { internal } from "@hapi/boom"
 import { ObjectId } from "bson"
 import { groupData, oleoduc, transformData, writeData } from "oleoduc"
 import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
+import { IComputedJobsPartners } from "shared/models/jobsPartnersComputed.model"
 import rawRecruteursLbaModel, { ZRecruteursLbaRaw } from "shared/models/rawRecruteursLba.model"
 
 import __dirname from "@/common/dirname"
@@ -15,8 +17,6 @@ import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { sentryCaptureException } from "@/common/utils/sentryUtils"
 import { notifyToSlack } from "@/common/utils/slackUtils"
 import config from "@/config"
-
-import { rawToComputedJobsPartners } from "../rawToComputedJobsPartners"
 
 import { recruteursLbaToJobPartners } from "./recruteursLbaMapper"
 
@@ -89,7 +89,9 @@ const importRecruteursLbaToRawCollection = async () => {
     parser(),
     streamArray(),
     transformData((doc) => {
-      const recruteur = { createdAt: now, _id: new ObjectId(), ...doc.value }
+      const { value } = doc
+      const partner_job_id = `${value.siret}-${value.phone}-${value.email}`
+      const recruteur = { createdAt: now, _id: new ObjectId(), partner_job_id, ...doc.value }
       if (!ZRecruteursLbaRaw.safeParse(recruteur).success) return null
       return recruteur
     }),
@@ -123,10 +125,70 @@ export const importRecruteursLbaRaw = async () => {
 }
 
 export const importRecruteurLbaToComputed = async () => {
-  await rawToComputedJobsPartners({
-    collectionSource: rawRecruteursLbaModel.collectionName,
-    partnerLabel: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
-    zodInput: ZRecruteursLbaRaw,
-    mapper: recruteursLbaToJobPartners,
+  const collectionSource = rawRecruteursLbaModel.collectionName
+  const partnerLabel = JOBPARTNERS_LABEL.RECRUTEURS_LBA
+  const zodInput = ZRecruteursLbaRaw
+  const mapper = recruteursLbaToJobPartners
+
+  logger.info(`début d'import dans computed_jobs_partners pour partner_label=${partnerLabel}`)
+  const counters = { total: 0, success: 0, error: 0 }
+  const importDate = new Date()
+  await oleoduc(
+    getDbCollection(collectionSource).find({}).stream(),
+    writeData(
+      async (document: any) => {
+        counters.total++
+        try {
+          const parsedDocument = zodInput.parse(document)
+          const { _id, ...computedJobPartner } = mapper(parsedDocument) // remove _id from document
+          await getDbCollection("computed_jobs_partners").updateOne(
+            { partner_job_id: document.partner_job_id },
+            { $set: { ...computedJobPartner, updated_at: importDate }, $setOnInsert: { offer_status_history: [], _id: new ObjectId() } },
+            {
+              upsert: true,
+            }
+          )
+          counters.success++
+        } catch (err) {
+          counters.error++
+          const newError = internal(`error converting raw job to partner_label job for id=${document._id} partner_label=${partnerLabel}`)
+          logger.error(newError.message, err)
+          newError.cause = err
+          sentryCaptureException(newError)
+        }
+      },
+      { parallel: 10 }
+    )
+  )
+  const message = `import dans computed_jobs_partners pour partner_label=${partnerLabel} terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}`
+  logger.info(message)
+  await notifyToSlack({
+    subject: `mapping Raw => computed_jobs_partners`,
+    message,
+    error: counters.error > 0,
   })
+}
+
+export const removeMissingRecruteursLbaFromRaw = async () => {
+  const results = (await getDbCollection("computed_jobs_partners")
+    .aggregate([
+      { $match: { partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA } },
+      {
+        $lookup: {
+          from: "raw_recruteurslba",
+          localField: "partner_job_id",
+          foreignField: "partner_job_id",
+          as: "matching",
+        },
+      },
+      { $match: { matching: { $size: 0 } } },
+      { $project: { _id: 1 } },
+    ])
+    .toArray()) as IComputedJobsPartners[]
+
+  const idsToRemove = results.map(({ _id }) => _id)
+
+  if (idsToRemove.length) {
+    await getDbCollection("computed_jobs_partners").deleteMany({ _id: { $in: idsToRemove } })
+  }
 }

--- a/server/src/jobs/offrePartenaire/recruteur-lba/recruteursLbaMapper.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/recruteursLbaMapper.ts
@@ -7,12 +7,12 @@ import { IRecruteursLbaRaw } from "shared/models/rawRecruteursLba.model"
 import { blankComputedJobPartner } from "../fillComputedJobsPartners"
 
 export const recruteursLbaToJobPartners = (recruteursLba: IRecruteursLbaRaw): IComputedJobsPartners => {
-  const { siret, enseigne, raison_sociale, naf_code, naf_label, street_name, street_number, zip_code, email, phone, company_size, rome_codes, _id } = recruteursLba
+  const { siret, enseigne, raison_sociale, naf_code, naf_label, street_name, street_number, zip_code, email, phone, company_size, rome_codes, partner_job_id } = recruteursLba
   return {
     ...blankComputedJobPartner(),
     _id: new ObjectId(),
     partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
-    partner_job_id: _id.toString(),
+    partner_job_id: partner_job_id,
     workplace_siret: siret,
     workplace_brand: enseigne,
     workplace_legal_name: raison_sociale,

--- a/server/src/jobs/simpleJobDefinitions.ts
+++ b/server/src/jobs/simpleJobDefinitions.ts
@@ -28,7 +28,7 @@ import { importPassRaw, importPassToComputed } from "./offrePartenaire/pass/impo
 import { processJobPartners } from "./offrePartenaire/processJobPartners"
 import { processJobPartnersForApi } from "./offrePartenaire/processJobPartnersForApi"
 import { rankJobPartners } from "./offrePartenaire/rankJobPartners"
-import { importRecruteurLbaToComputed, importRecruteursLbaRaw } from "./offrePartenaire/recruteur-lba/importRecruteursLbaRaw"
+import { importRecruteurLbaToComputed, importRecruteursLbaRaw, removeMissingRecruteursLbaFromRaw } from "./offrePartenaire/recruteur-lba/importRecruteursLbaRaw"
 import { importRHAlternanceRaw, importRHAlternanceToComputed } from "./offrePartenaire/rh-alternance/importRHAlternance"
 import { exportLbaJobsToS3 } from "./partenaireExport/exportJobsToS3"
 import { activateOptoutOnEtablissementAndUpdateReferrersOnETFA } from "./rdv/activateOptoutOnEtablissementAndUpdateReferrersOnETFA"
@@ -247,6 +247,10 @@ export const simpleJobDefinitions: SimpleJobDefinition[] = [
   {
     fct: cancelRemovedJobsPartners,
     description: "Met à jour la collection jobs_partners en mettant à 'Annulé' les offres qui ne sont plus dans computed_jobs_partners",
+  },
+  {
+    fct: removeMissingRecruteursLbaFromRaw,
+    description: "Met à jour la collection computed_jobs_partners en supprimant les entreprises qui ne sont plus dans raw_recruteurslba",
   },
   {
     fct: processApplications,

--- a/shared/models/rawRecruteursLba.model.ts
+++ b/shared/models/rawRecruteursLba.model.ts
@@ -4,6 +4,7 @@ import { IModelDescriptor, zObjectId } from "./common.js"
 
 export const ZRecruteursLbaRaw = z.object({
   _id: zObjectId,
+  partner_job_id: z.string(),
   createdAt: z.date(),
   siret: z.string(),
   enseigne: z.string(),
@@ -23,6 +24,6 @@ export type IRecruteursLbaRaw = z.output<typeof ZRecruteursLbaRaw>
 
 export default {
   zod: ZRecruteursLbaRaw,
-  indexes: [],
+  indexes: [[{ partner_job_id: 1 }, {}]],
   collectionName: "raw_recruteurslba",
 } as const satisfies IModelDescriptor


### PR DESCRIPTION
- keep recruteurs_lba in computed by creating a `job_parnter_id` and using upsert
- add a job to remove missing recruteurs_lba from `computed_` if not present in `raw_`