### PR TITLE
feat(lba-2456): ajout de la route getJobById (v3)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -102,7 +102,7 @@ fileignoreconfig:
 - filename: server/src/services/jobs/jobOpportunity/__snapshots__/jobOpportunity.service.test.ts.snap
   checksum: 01dd54f682dc81ecc5ad2099f2cf01e8e6011c0d22c38607f7998d2ce28bf155
 - filename: server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts
-  checksum: 019e2e69727a016ecf674f54423883c7c2ce93dd0f953de3e8d04cd87b4f859c
+  checksum: d1cb4c0ab00e83e0b7d320ce206850f08592c64a60b561e5f5860eba7d2544b2
 - filename: server/src/services/partnerJob.service.test.ts
   checksum: b488a3b67b801c3fa5b012d2ba2b120b21af4f459b966c6629e6e681ead97913
 - filename: server/src/services/recruteurLba.service.test.ts

--- a/server/src/http/controllers/v3/jobs/jobs.controller.v3.test.ts
+++ b/server/src/http/controllers/v3/jobs/jobs.controller.v3.test.ts
@@ -740,9 +740,15 @@ describe("GET /v3/jobs/:id", () => {
     expect(validationResult.success).toBe(true)
   })
 
-  it("should return 404 Not Found if job does not exist", async () => {
+  it("should return error if job does not exist", async () => {
     // Générer un ID inexistant
-    const nonExistentId = new ObjectId()
+    const nonExistentId = new ObjectId().toString()
+
+    // Vérifier que l'ID n'existe pas en base
+    const jobExistsInJobsPartners = await getDbCollection("recruiters").findOne({ _id: new ObjectId(nonExistentId) })
+    const jobExistsInRecruiters = await getDbCollection("jobs_partners").findOne({ _id: new ObjectId(nonExistentId) })
+    expect(jobExistsInJobsPartners).toBeNull()
+    expect(jobExistsInRecruiters).toBeNull()
 
     // Effectuer la requête API avec un ID inexistant
     const response = await httpClient().inject({
@@ -761,7 +767,7 @@ describe("GET /v3/jobs/:id", () => {
     expect(data).toMatchObject({
       statusCode: 404,
       error: "Not Found",
-      message: `Aucune offre trouvée avec l'identifiant ${nonExistentId}`,
+      message: `Aucune offre d'emploi trouvée pour l'ID: ${nonExistentId.toString()}`,
     })
   })
 })

--- a/server/src/http/controllers/v3/jobs/jobs.controller.v3.test.ts
+++ b/server/src/http/controllers/v3/jobs/jobs.controller.v3.test.ts
@@ -1,13 +1,16 @@
 import dayjs from "dayjs"
 import { ObjectId } from "mongodb"
 import nock from "nock"
+import { NIVEAUX_POUR_LBA, RECRUITER_STATUS } from "shared/constants"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import { generateFeaturePropertyFixture } from "shared/fixtures/geolocation.fixture"
 import { generateJobsPartnersOfferPrivate } from "shared/fixtures/jobPartners.fixture"
+import { generateRecruiterFixture } from "shared/fixtures/recruiter.fixture"
 import { clichyFixture, generateReferentielCommuneFixtures, levalloisFixture, marseilleFixture, parisFixture } from "shared/fixtures/referentiel/commune.fixture"
-import { IGeoPoint } from "shared/models"
+import { generateReferentielRome } from "shared/fixtures/rome.fixture"
+import { IGeoPoint, IRecruiter, IReferentielRome, JOB_STATUS } from "shared/models"
 import { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
-import type { IJobOfferApiWriteV3Input } from "shared/routes/v3/jobs/jobs.routes.v3.model"
+import { zJobOfferApiReadV3, type IJobOfferApiWriteV3Input } from "shared/routes/v3/jobs/jobs.routes.v3.model"
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { getEtablissementFromGouvSafe } from "@/common/apis/apiEntreprise/apiEntreprise.client"
@@ -574,5 +577,191 @@ describe("PUT /jobs/:id", async () => {
 
     expect.soft(response.statusCode).toBe(403)
     expect(response.json()).toEqual({ error: "Forbidden", message: "Unauthorized", statusCode: 403 })
+  })
+})
+
+describe("GET /v3/jobs/:id", () => {
+  const jobPartnerId = new ObjectId()
+
+  const originalCreatedAt = new Date("2023-09-06T00:00:00.000+02:00")
+  const originalCreatedAtPlus2Months = new Date("2023-11-06T00:00:00.000+01:00")
+
+  const originalJob = generateJobsPartnersOfferPrivate({
+    _id: jobPartnerId,
+    created_at: originalCreatedAt,
+    offer_creation: originalCreatedAt,
+    offer_expiration: originalCreatedAtPlus2Months,
+  })
+
+  const lbaJob: IRecruiter = generateRecruiterFixture({
+    establishment_siret: "11000001500013",
+    establishment_raison_sociale: "ASSEMBLEE NATIONALE",
+    geopoint: parisFixture.centre,
+    status: RECRUITER_STATUS.ACTIF,
+    jobs: [
+      {
+        rome_code: ["M1602"],
+        rome_label: "Opérations administratives",
+        job_status: JOB_STATUS.ACTIVE,
+        job_level_label: NIVEAUX_POUR_LBA.INDIFFERENT,
+        job_creation_date: new Date("2021-01-01"),
+        job_expiration_date: new Date("2050-01-01"),
+      },
+    ],
+    address_detail: {
+      code_insee_localite: parisFixture.code,
+    },
+    address: parisFixture.nom,
+    phone: "0300000000",
+  })
+
+  const romes: IReferentielRome[] = [
+    generateReferentielRome({
+      rome: {
+        code_rome: "M1602",
+        intitule: "Opérations administratives",
+        code_ogr: "475",
+      },
+    }),
+    ...certificationFixtures["RNCP37098-46T31203"].domaines.rome.rncp.map(({ code, intitule }) => generateReferentielRome({ rome: { code_rome: code, intitule, code_ogr: "" } })),
+  ]
+
+  beforeEach(async () => {
+    await getDbCollection("referentiel.communes").insertMany(generateReferentielCommuneFixtures([parisFixture, clichyFixture, levalloisFixture, marseilleFixture]))
+    await getDbCollection("referentielromes").insertMany(romes)
+
+    await getDbCollection("jobs_partners").insertOne(originalJob)
+    await getDbCollection("recruiters").insertOne(lbaJob)
+  })
+
+  it("should return 401 if no api key provided", async () => {
+    const response = await httpClient().inject({ method: "GET", path: `/api/v3/jobs/${jobPartnerId}` })
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({ statusCode: 401, error: "Unauthorized", message: "Unable to parse token missing-bearer" })
+  })
+
+  it("should return 401 if api key is invalid", async () => {
+    const response = await httpClient().inject({ method: "GET", path: `/api/v3/jobs/${jobPartnerId}`, headers: { authorization: `Bearer ${fakeToken}` } })
+    expect.soft(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({ statusCode: 401, error: "Unauthorized", message: "Unable to parse token invalid-signature" })
+  })
+
+  it("should return valid jobOpportunity data from jobs_partners collection", async () => {
+    // Effectuer la requête API avec l'id de la collection jobs_partners
+    const response = await httpClient().inject({
+      method: "GET",
+      path: `/api/v3/jobs/${jobPartnerId}`,
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    // Vérifier que le statut HTTP est 200
+    expect(response.statusCode).toBe(200)
+
+    // Récupérer les données JSON de la réponse
+    const data = response.json()
+
+    // Vérifier que les données correspondent bien au schéma `zJobOfferApiReadV3`
+    // Conversion en date forcée car problème de typage avec les dates
+    const validationResult = zJobOfferApiReadV3.safeParse({
+      ...data,
+      offer: {
+        ...data.offer,
+        publication: {
+          ...data.offer?.publication,
+          creation: data.offer?.publication?.creation ? new Date(data.offer.publication.creation) : null,
+          expiration: data.offer?.publication?.expiration ? new Date(data.offer.publication.expiration) : null,
+        },
+      },
+    })
+
+    // Afficher les erreurs en cas d'échec de validation pour faciliter le debug
+    if (!validationResult.success) {
+      console.error("Validation errors:", validationResult.error.format())
+    }
+
+    // Assertion pour s'assurer que les données respectent bien le schéma
+    expect(validationResult.success).toBe(true)
+  })
+
+  it("should return valid jobOpportunity data from recruiters collection", async () => {
+    // Effectuer la requête API avec l'id de la collection recruiters
+    const jobId = lbaJob.jobs[0]._id
+    const response = await httpClient().inject({
+      method: "GET",
+      path: `/api/v3/jobs/${jobId}`,
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    // Vérifier que le statut HTTP est 200
+    expect(response.statusCode).toBe(200)
+
+    // Récupérer les données JSON de la réponse
+    const data = response.json()
+
+    // Vérifier que les données correspondent bien au schéma `zJobOfferApiReadV3`
+    // Conversion en date forcée car problème de typage avec les dates
+    const validationResult = zJobOfferApiReadV3.safeParse({
+      ...data,
+      contract: {
+        ...data.contract,
+        start: data.contract?.start ? new Date(data.contract.start) : null,
+      },
+      offer: {
+        ...data.offer,
+        publication: {
+          ...data.offer.publication,
+          creation: data.offer.publication?.creation ? new Date(data.offer.publication.creation) : null,
+          expiration: data.offer.publication?.expiration ? new Date(data.offer.publication.expiration) : null,
+        },
+      },
+    })
+
+    // Afficher les erreurs en cas d'échec de validation
+    if (!validationResult.success) {
+      console.error("❌ Validation errors detected:")
+
+      // Affichage formaté de toutes les erreurs
+      console.error("Errors:", JSON.stringify(validationResult.error.format(), null, 2))
+
+      // Boucle sur chaque champ en erreur pour un affichage plus clair
+      Object.entries(validationResult.error.format()).forEach(([field, issues]) => {
+        console.error(`🚨 Champ en erreur: ${field}`)
+        if (Array.isArray(issues)) {
+          issues.forEach((issue) => {
+            console.error(`   - Problème: ${issue}`)
+          })
+        } else {
+          console.error(`   - Problèmes détaillés:`, issues)
+        }
+      })
+    }
+
+    // Vérifier que la validation est bien passée
+    expect(validationResult.success).toBe(true)
+  })
+
+  it("should return 404 Not Found if job does not exist", async () => {
+    // Générer un ID inexistant
+    const nonExistentId = new ObjectId()
+
+    // Effectuer la requête API avec un ID inexistant
+    const response = await httpClient().inject({
+      method: "GET",
+      path: `/api/v3/jobs/${nonExistentId}`,
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    // Vérifier que le statut HTTP est 404
+    expect(response.statusCode).toBe(404)
+
+    // Récupérer les données JSON de la réponse
+    const data = response.json()
+
+    // Vérifier que le message d'erreur est correct
+    expect(data).toMatchObject({
+      statusCode: 404,
+      error: "Not Found",
+      message: `Aucune offre trouvée avec l'identifiant ${nonExistentId}`,
+    })
   })
 })

--- a/server/src/http/controllers/v3/jobs/jobs.controller.v3.ts
+++ b/server/src/http/controllers/v3/jobs/jobs.controller.v3.ts
@@ -1,9 +1,10 @@
+import { notFound } from "@hapi/boom"
 import { zRoutes } from "shared"
 
 import { getUserFromRequest } from "@/security/authenticationService"
 import { JobOpportunityRequestContext } from "@/services/jobs/jobOpportunity/JobOpportunityRequestContext"
 
-import { createJobOffer, findJobsOpportunities, updateJobOffer, upsertJobOffer } from "../../../../services/jobs/jobOpportunity/jobOpportunity.service"
+import { createJobOffer, findJobOpportunityById, findJobsOpportunities, updateJobOffer, upsertJobOffer } from "../../../../services/jobs/jobOpportunity/jobOpportunity.service"
 import { Server } from "../../../server"
 
 const config = {
@@ -61,4 +62,12 @@ export const jobsApiV3Routes = (server: Server) => {
       return res.status(200).send({ id })
     }
   )
+
+  server.get("/v3/jobs/:id", { schema: zRoutes.get["/v3/jobs/:id"], onRequest: server.auth(zRoutes.get["/v3/jobs/:id"]) }, async (req, res) => {
+    const result = await findJobOpportunityById(req.params.id, new JobOpportunityRequestContext(zRoutes.get["/v3/jobs/:id"], "api-apprentissage"))
+    if (!result) {
+      throw notFound(`Aucune offre trouvée avec l'identifiant ${req.params.id}`)
+    }
+    return res.send(result)
+  })
 }

--- a/server/src/http/controllers/v3/jobs/jobs.controller.v3.ts
+++ b/server/src/http/controllers/v3/jobs/jobs.controller.v3.ts
@@ -1,4 +1,3 @@
-import { notFound } from "@hapi/boom"
 import { zRoutes } from "shared"
 
 import { getUserFromRequest } from "@/security/authenticationService"
@@ -65,9 +64,6 @@ export const jobsApiV3Routes = (server: Server) => {
 
   server.get("/v3/jobs/:id", { schema: zRoutes.get["/v3/jobs/:id"], onRequest: server.auth(zRoutes.get["/v3/jobs/:id"]) }, async (req, res) => {
     const result = await findJobOpportunityById(req.params.id, new JobOpportunityRequestContext(zRoutes.get["/v3/jobs/:id"], "api-apprentissage"))
-    if (!result) {
-      throw notFound(`Aucune offre trouvée avec l'identifiant ${req.params.id}`)
-    }
     return res.send(result)
   })
 }

--- a/server/src/services/jobs/jobOpportunity/JobOpportunityRequestContext.ts
+++ b/server/src/services/jobs/jobOpportunity/JobOpportunityRequestContext.ts
@@ -4,6 +4,7 @@ import { IRouteSchema } from "shared/routes/common.routes"
 export const IJobOpportunityWarningMap = {
   FRANCE_TRAVAIL_API_ERROR: "Unable to retrieve job offers from France Travail API",
   JOB_OFFER_FORMATING_ERROR: "Some job offers are invalid and have been excluded due to unexpected errors.",
+  JOB_NOT_FOUND: "The job offer has not been found.",
   RECRUITERS_FORMATING_ERROR: "Some recruiters are invalid and have been excluded due to unexpected errors.",
 } as const satisfies Record<string, string>
 

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts
@@ -2228,7 +2228,7 @@ describe("findJobOpportunityById tests", () => {
         ...originalJob,
         contract_type: originalJob.contract_type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
         apply_url: originalJob.apply_url ?? `${config.publicUrl}/recherche?type=partner&itemId=${originalJob._id}`,
-        apply_recipient_id: `jobs_partners_${originalJob._id}`,
+        apply_recipient_id: originalJob.apply_email ? `partners_${originalJob._id}` : null,
       })
 
       // Vérifier que addWarning n'a pas été appelé car le job a été trouvé

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts
@@ -3,7 +3,7 @@ import { IApiAlternanceTokenData } from "api-alternance-sdk"
 import omit from "lodash-es/omit"
 import { ObjectId } from "mongodb"
 import nock from "nock"
-import { NIVEAUX_POUR_LBA, NIVEAUX_POUR_OFFRES_PE, RECRUITER_STATUS } from "shared/constants"
+import { NIVEAUX_POUR_LBA, NIVEAUX_POUR_OFFRES_PE, RECRUITER_STATUS, TRAINING_CONTRACT_TYPE } from "shared/constants"
 import { generateCfaFixture } from "shared/fixtures/cfa.fixture"
 import { generateJobsPartnersOfferPrivate } from "shared/fixtures/jobPartners.fixture"
 import { generateRecruiterFixture } from "shared/fixtures/recruiter.fixture"
@@ -12,7 +12,14 @@ import { generateReferentielRome } from "shared/fixtures/rome.fixture"
 import { generateUserWithAccountFixture } from "shared/fixtures/userWithAccount.fixture"
 import { IRecruiter, IReferentielRome, JOB_STATUS, JOB_STATUS_ENGLISH } from "shared/models"
 import { IJobsPartnersOfferPrivate, INiveauDiplomeEuropeen, JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
-import { zJobOfferApiWriteV3, zJobSearchApiV3Response, type IJobOfferApiWriteV3, type IJobOfferApiWriteV3Input } from "shared/routes/v3/jobs/jobs.routes.v3.model"
+import {
+  jobsRouteApiv3Converters,
+  zJobOfferApiReadV3,
+  zJobOfferApiWriteV3,
+  zJobSearchApiV3Response,
+  type IJobOfferApiWriteV3,
+  type IJobOfferApiWriteV3Input,
+} from "shared/routes/v3/jobs/jobs.routes.v3.model"
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { apiEntrepriseEtablissementFixture } from "@/common/apis/apiEntreprise/apiEntreprise.client.fixture"
@@ -22,9 +29,10 @@ import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { certificationFixtures } from "@/services/external/api-alternance/certification.fixture"
 import { useMongo } from "@tests/utils/mongo.test.utils"
 
+import config from "../../../config"
 import { FTJob } from "../../ftjob.service.types"
 
-import { createJobOffer, findJobsOpportunities, updateJobOffer } from "./jobOpportunity.service"
+import { createJobOffer, findJobsOpportunities, updateJobOffer, getJobsPartnersByIdAsJobOfferApi, getLbaJobByIdV2AsJobOfferApi } from "./jobOpportunity.service"
 import { JobOpportunityRequestContext } from "./JobOpportunityRequestContext"
 
 useMongo()
@@ -2114,5 +2122,173 @@ describe("updateJobOffer", () => {
     expect(job?.offer_status).toEqual(JOB_STATUS_ENGLISH.ANNULEE)
 
     expect(nock.isDone()).toBeTruthy()
+  })
+})
+
+describe("getJobsPartnersByIdAsJobOfferApi", () => {
+  const _id = new ObjectId()
+  const now = new Date("2025-02-28T00:00:00.000Z")
+  const identity = {
+    email: "mail@mailType.com",
+    organisation: "Some organisation",
+    habilitations: { "applications:write": false, "appointments:write": false, "jobs:write": true },
+  } as const satisfies IApiAlternanceTokenData
+  const originalCreatedAt = new Date("2023-09-06T00:00:00.000+02:00")
+  const originalCreatedAtPlus2Months = new Date("2023-11-06T00:00:00.000+01:00")
+
+  const originalJob = generateJobsPartnersOfferPrivate({
+    _id,
+    partner_label: identity.organisation,
+    created_at: originalCreatedAt,
+    offer_creation: originalCreatedAt,
+    offer_expiration: originalCreatedAtPlus2Months,
+  })
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+    await getDbCollection("jobs_partners").insertOne(originalJob)
+
+    return () => {
+      vi.useRealTimers()
+    }
+  })
+
+  it("should throw a job not found error on getJobsPartnersByIdAsJobOfferApi", async () => {
+    // Créer un contexte de requête mock
+    const context = {
+      addWarning: vi.fn(),
+    } as unknown as JobOpportunityRequestContext
+
+    // Utiliser un ID qui n'existe pas dans la base de données
+    const nonExistentId = new ObjectId()
+
+    // Vérifier que la fonction lance bien une erreur
+    await expect(getJobsPartnersByIdAsJobOfferApi(nonExistentId, context)).rejects.toThrow("Job not found")
+
+    // Vérifier que la méthode addWarning a été appelée avec le bon message
+    expect(context.addWarning).toHaveBeenCalledWith("JOB_NOT_FOUND")
+  })
+
+  it("should return a job offer with correct format on getJobsPartnersByIdAsJobOfferApi", async () => {
+    // Créer un contexte de requête mock
+    const context = {
+      addWarning: vi.fn(),
+    } as unknown as JobOpportunityRequestContext
+
+    // Mock de la fonction de conversion pour vérifier qu'elle est appelée avec les bons paramètres
+    const convertSpy = vi.spyOn(jobsRouteApiv3Converters, "convertToJobOfferApiReadV3")
+
+    // Appeler la fonction avec l'ID existant
+    const result = await getJobsPartnersByIdAsJobOfferApi(_id, context)
+
+    // Vérifier que la fonction de conversion a été appelée avec les bons paramètres
+    expect(convertSpy).toHaveBeenCalledWith({
+      ...originalJob,
+      contract_type: originalJob.contract_type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
+      apply_url: originalJob.apply_url ?? `${config.publicUrl}/recherche?type=partner&itemId=${originalJob._id}`,
+      apply_recipient_id: `jobs_partners_${originalJob._id}`,
+    })
+
+    // Vérifier que addWarning n'a pas été appelé car le job a été trouvé
+    expect(context.addWarning).not.toHaveBeenCalled()
+
+    // Vérifier que le résultat n'est pas null
+    expect(result).not.toBeNull()
+
+    // Utiliser le schéma Zod pour valider la structure
+    const validationResult = zJobOfferApiReadV3.safeParse(result)
+
+    // Si la validation échoue, afficher les erreurs pour faciliter le débogage
+    if (!validationResult.success) {
+      console.error("Validation errors:", validationResult.error.format())
+    }
+
+    // Vérifier que la validation a réussi
+    expect(validationResult.success).toBe(true)
+  })
+})
+
+describe("getLbaJobByIdV2AsJobOfferApi", () => {
+  const lbaJob: IRecruiter = generateRecruiterFixture({
+    establishment_siret: "11000001500013",
+    establishment_raison_sociale: "ASSEMBLEE NATIONALE",
+    geopoint: parisFixture.centre,
+    status: RECRUITER_STATUS.ACTIF,
+    jobs: [
+      {
+        rome_code: ["M1602"],
+        rome_label: "Opérations administratives",
+        job_status: JOB_STATUS.ACTIVE,
+        job_level_label: NIVEAUX_POUR_LBA.INDIFFERENT,
+        job_creation_date: new Date("2021-01-01"),
+        job_expiration_date: new Date("2050-01-01"),
+      },
+    ],
+    address_detail: {
+      code_insee_localite: parisFixture.code,
+    },
+    address: parisFixture.nom,
+    phone: "0300000000",
+  })
+
+  const romes: IReferentielRome[] = [
+    generateReferentielRome({
+      rome: {
+        code_rome: "M1602",
+        intitule: "Opérations administratives",
+        code_ogr: "475",
+      },
+    }),
+    ...certificationFixtures["RNCP37098-46T31203"].domaines.rome.rncp.map(({ code, intitule }) => generateReferentielRome({ rome: { code_rome: code, intitule, code_ogr: "" } })),
+  ]
+
+  beforeEach(async () => {
+    await getDbCollection("referentielromes").insertMany(romes)
+    await getDbCollection("recruiters").insertOne(lbaJob)
+  })
+
+  it("should throw a job not found error on getLbaJobByIdV2AsJobOfferApi", async () => {
+    // Créer un contexte de requête mock
+    const context = {
+      addWarning: vi.fn(),
+    } as unknown as JobOpportunityRequestContext
+
+    // Utiliser un ID qui n'existe pas dans la base de données
+    const nonExistentId = new ObjectId()
+
+    // Vérifier que la fonction lance bien une erreur
+    await expect(getLbaJobByIdV2AsJobOfferApi(nonExistentId, context)).rejects.toThrow("Job not found")
+
+    // Vérifier que la méthode addWarning a été appelée avec le bon message
+    expect(context.addWarning).toHaveBeenCalledWith("JOB_NOT_FOUND")
+  })
+
+  it("should return a job offer with correct format on getLbaJobByIdV2AsJobOfferApi", async () => {
+    // Créer un contexte de requête mock
+    const context = {
+      addWarning: vi.fn(),
+    } as unknown as JobOpportunityRequestContext
+
+    // Exécuter la fonction avec un ID existant
+    const jobId = lbaJob.jobs[0]._id
+    const result = await getLbaJobByIdV2AsJobOfferApi(jobId, context)
+
+    // Vérifier que addWarning n'a pas été appelé car le job a été trouvé
+    expect(context.addWarning).not.toHaveBeenCalled()
+
+    // Vérifier que le résultat n'est pas null
+    expect(result).not.toBeNull()
+
+    // Valider que le résultat correspond au schéma attendu
+    const validationResult = zJobOfferApiReadV3.safeParse(result)
+
+    // Afficher les erreurs en cas d'échec de validation
+    if (!validationResult.success) {
+      console.error("Validation errors:", validationResult.error.format())
+    }
+
+    // Vérifier que la validation a réussi
+    expect(validationResult.success).toBe(true)
   })
 })

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts
@@ -2403,7 +2403,7 @@ describe("findJobOpportunityById tests", () => {
       }
     })
 
-    it("should return null when no job is found on findJobOpportunityById", async () => {
+    it("should throw an error when no job is found on findJobOpportunityById", async () => {
       // Créer un contexte mock
       const context = {
         addWarning: vi.fn(),
@@ -2412,11 +2412,8 @@ describe("findJobOpportunityById tests", () => {
       // Utiliser un ID inexistant
       const nonExistentId = new ObjectId()
 
-      // Exécuter la fonction
-      const result = await findJobOpportunityById(nonExistentId, context)
-
-      // Vérifier que le résultat est bien `null`
-      expect(result).toBeNull()
+      // Vérifier que la fonction lance une erreur
+      await expect(findJobOpportunityById(nonExistentId, context)).rejects.toThrowError("Aucune offre d'emploi trouvée")
     })
 
     it("should find an offer from jobs_partners collection on findJobOpportunityById", async () => {

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -819,7 +819,7 @@ export async function upsertJobOffer(data: IJobOfferApiWriteV3, partner_label: s
   return upsertJobOfferPrivate({ data, partner_label, partnerJobIdIfNew: partner_job_id, requestedByEmail, current })
 }
 
-export async function findJobOpportunityById(id: ObjectId, context: JobOpportunityRequestContext): Promise<IJobOfferApiReadV3 | null> {
+export async function findJobOpportunityById(id: ObjectId, context: JobOpportunityRequestContext): Promise<IJobOfferApiReadV3> {
   try {
     // Exécuter les requêtes en parallèle puis récupérer la première offre trouvée
     const results = await Promise.allSettled([getLbaJobByIdV2AsJobOfferApi(id, context), getJobsPartnersByIdAsJobOfferApi(id, context)])

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -836,11 +836,11 @@ export async function findJobOpportunityById(id: ObjectId, context: JobOpportuni
     const err = internal("Erreur inattendue dans findJobOpportunityById", { id, error })
     logger.error(err)
     sentryCaptureException(err)
-    return null
+    throw new Error("Erreur inattendue dans findJobOpportunityById")
   }
 }
 
-function validateJobOffer(job: IJobOfferApiReadV3, id: ObjectId, context: JobOpportunityRequestContext): IJobOfferApiReadV3 | null {
+function validateJobOffer(job: IJobOfferApiReadV3, id: ObjectId, context: JobOpportunityRequestContext): IJobOfferApiReadV3 {
   const parsedJob = zJobOfferApiReadV3.safeParse(job)
 
   if (!parsedJob.success) {
@@ -849,10 +849,11 @@ function validateJobOffer(job: IJobOfferApiReadV3, id: ObjectId, context: JobOpp
       error: parsedJob.error.format(),
       id: id.toString(),
     })
+
     logger.error(error)
     context.addWarning("JOB_OFFER_FORMATING_ERROR")
     sentryCaptureException(error)
-    return null
+    throw new Error("Invalid job offer data")
   }
 
   return parsedJob.data

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -826,7 +826,7 @@ export async function findJobOpportunityById(id: ObjectId, context: JobOpportuni
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function getLbaJobByIdV2AsJobOfferApi(id: ObjectId, context: JobOpportunityRequestContext): Promise<IJobOfferApiReadV3 | null> {
+export async function getLbaJobByIdV2AsJobOfferApi(id: ObjectId, context: JobOpportunityRequestContext): Promise<IJobOfferApiReadV3 | null> {
   const job = await getLbaJobByIdV2AsJobResult({ id: id.toString(), caller: context?.caller })
 
   if (!job) {
@@ -842,7 +842,7 @@ async function getLbaJobByIdV2AsJobOfferApi(id: ObjectId, context: JobOpportunit
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function getJobsPartnersByIdAsJobOfferApi(id: ObjectId, context: JobOpportunityRequestContext): Promise<IJobOfferApiReadV3 | null> {
+export async function getJobsPartnersByIdAsJobOfferApi(id: ObjectId, context: JobOpportunityRequestContext): Promise<IJobOfferApiReadV3 | null> {
   const job = await getDbCollection("jobs_partners").findOne({ _id: id })
 
   if (!job) {

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -888,7 +888,7 @@ export async function getJobsPartnersByIdAsJobOfferApi(id: ObjectId, context: Jo
     ...job,
     contract_type: job.contract_type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
     apply_url: job.apply_url ?? `${config.publicUrl}/recherche?type=partner&itemId=${job._id}`,
-    apply_recipient_id: `jobs_partners_${job._id}`,
+    apply_recipient_id: job.apply_email ? `partners_${job._id}` : null,
   })
 
   return transformedJob

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -828,7 +828,7 @@ export async function findJobOpportunityById(id: ObjectId, context: JobOpportuni
 
     if (!foundJob) {
       logger.warn(`Aucune offre d'emploi trouvée pour l'ID: ${id.toString()}`, { context })
-      return null
+      throw notFound(`Aucune offre d'emploi trouvée pour l'ID: ${id.toString()}`)
     }
 
     return validateJobOffer(foundJob, id, context)

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -818,3 +818,9 @@ export async function upsertJobOffer(data: IJobOfferApiWriteV3, partner_label: s
   }
   return upsertJobOfferPrivate({ data, partner_label, partnerJobIdIfNew: partner_job_id, requestedByEmail, current })
 }
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function findJobOpportunityById(id: ObjectId, context: JobOpportunityRequestContext): Promise<IJobOfferApiReadV3 | null> {
+  //WIP
+  return null
+}

--- a/shared/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
+++ b/shared/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
@@ -8868,6 +8868,452 @@ Limite : 5 appel(s) / 1 seconde(s)
       },
     },
     "/v3/jobs/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Identifiant unique",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Identifiant unique",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "apply": {
+                      "properties": {
+                        "phone": {
+                          "description": "Téléphone de contact",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "recipient_id": {
+                          "description": "Identifiant permettant de candidaté via l'API, généré à la volé pour les offres LBA uniquement",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "url": {
+                          "description": "URL pour candidater",
+                          "format": "uri",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "url",
+                        "phone",
+                      ],
+                      "type": "object",
+                    },
+                    "contract": {
+                      "properties": {
+                        "duration": {
+                          "description": "Durée du contrat en mois",
+                          "minimum": 0,
+                          "type": [
+                            "integer",
+                            "null",
+                          ],
+                        },
+                        "remote": {
+                          "description": "Format de travail de l'offre",
+                          "enum": [
+                            "onsite",
+                            "remote",
+                            "hybrid",
+                          ],
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "start": {
+                          "description": "Date de début de contrat",
+                          "format": "date-time",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "type": {
+                          "description": "type de contrat, formaté à l'insertion",
+                          "items": {
+                            "enum": [
+                              "Apprentissage",
+                              "Professionnalisation",
+                            ],
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "duration",
+                        "type",
+                        "remote",
+                      ],
+                      "type": "object",
+                    },
+                    "identifier": {
+                      "properties": {
+                        "id": {
+                          "anyOf": [
+                            {
+                              "description": "Identifiant unique",
+                            },
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "Identifiant de l'offre",
+                        },
+                        "partner_job_id": {
+                          "description": "Identifiant d'origine de l'offre provenant du partenaire",
+                          "type": "string",
+                        },
+                        "partner_label": {
+                          "description": "Référence du partenaire",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "partner_label",
+                        "partner_job_id",
+                      ],
+                      "type": "object",
+                    },
+                    "offer": {
+                      "properties": {
+                        "access_conditions": {
+                          "description": "Conditions d'accès à l'offre",
+                          "items": {
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                        "description": {
+                          "description": "description de l'offre, soit définit par le partenaire, soit celle du ROME si pas suffisament grande",
+                          "type": "string",
+                        },
+                        "desired_skills": {
+                          "description": "Compétence attendues par le candidat pour l'offre",
+                          "items": {
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                        "opening_count": {
+                          "description": "Nombre de poste disponible",
+                          "type": "number",
+                        },
+                        "publication": {
+                          "properties": {
+                            "creation": {
+                              "description": "Date de creation de l'offre",
+                              "format": "date-time",
+                              "type": [
+                                "string",
+                                "null",
+                              ],
+                            },
+                            "expiration": {
+                              "description": "Date d'expiration de l'offre. Si pas présente, mettre à creation_date + 60j",
+                              "format": "date-time",
+                              "type": [
+                                "string",
+                                "null",
+                              ],
+                            },
+                          },
+                          "required": [
+                            "creation",
+                            "expiration",
+                          ],
+                          "type": "object",
+                        },
+                        "rome_codes": {
+                          "description": "Code rome de l'offre",
+                          "items": {
+                            "pattern": "^[A-Z]\\d{4}$",
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                        "status": {
+                          "description": "Status de l'offre (surtout utilisé pour les offres ajouté par API)",
+                          "enum": [
+                            "Active",
+                            "Filled",
+                            "Cancelled",
+                          ],
+                          "type": "string",
+                        },
+                        "target_diploma": {
+                          "properties": {
+                            "european": {
+                              "description": "Niveau de diplome visé en fin d'étude, transformé pour chaque partenaire",
+                              "enum": [
+                                "3",
+                                "4",
+                                "5",
+                                "6",
+                                "7",
+                              ],
+                              "type": "string",
+                            },
+                            "label": {
+                              "description": "Libellé du niveau de diplome",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "european",
+                            "label",
+                          ],
+                          "type": [
+                            "object",
+                            "null",
+                          ],
+                        },
+                        "title": {
+                          "description": "Titre de l'offre",
+                          "minLength": 3,
+                          "type": "string",
+                        },
+                        "to_be_acquired_skills": {
+                          "description": "Compétence acuqises durant l'alternance",
+                          "items": {
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "title",
+                        "rome_codes",
+                        "description",
+                        "target_diploma",
+                        "desired_skills",
+                        "to_be_acquired_skills",
+                        "access_conditions",
+                        "publication",
+                        "opening_count",
+                        "status",
+                      ],
+                      "type": "object",
+                    },
+                    "workplace": {
+                      "properties": {
+                        "brand": {
+                          "description": "Nom d'enseigne de l'établissement",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "description": {
+                          "description": "description de l'entreprise",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "domain": {
+                          "properties": {
+                            "idcc": {
+                              "description": "Identifiant convention collective",
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                            "naf": {
+                              "properties": {
+                                "code": {
+                                  "type": "string",
+                                },
+                                "label": {
+                                  "description": "Libelle NAF",
+                                  "type": [
+                                    "string",
+                                    "null",
+                                  ],
+                                },
+                              },
+                              "required": [
+                                "code",
+                                "label",
+                              ],
+                              "type": [
+                                "object",
+                                "null",
+                              ],
+                            },
+                            "opco": {
+                              "description": "Nom de l'OPCO",
+                              "enum": [
+                                "AFDAS",
+                                "AKTO / Opco entreprises et salariés des services à forte intensité de main d'oeuvre",
+                                "ATLAS",
+                                "Constructys",
+                                "L'Opcommerce",
+                                "OCAPIAT",
+                                "OPCO 2i",
+                                "Opco entreprises de proximité",
+                                "Opco Mobilités",
+                                "Opco Santé",
+                                "Uniformation, l'Opco de la Cohésion sociale",
+                                "inconnu",
+                                "OPCO multiple",
+                              ],
+                              "type": [
+                                "string",
+                                "null",
+                              ],
+                            },
+                          },
+                          "required": [
+                            "idcc",
+                            "opco",
+                            "naf",
+                          ],
+                          "type": "object",
+                        },
+                        "legal_name": {
+                          "description": "Nom légal de l'entreprise",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "location": {
+                          "properties": {
+                            "address": {
+                              "description": "Adresse de l'offre, provenant du SIRET ou du partenaire",
+                              "type": "string",
+                            },
+                            "geopoint": {
+                              "additionalProperties": false,
+                              "description": "Geolocalisation de l'offre",
+                              "properties": {
+                                "coordinates": {
+                                  "prefixItems": [
+                                    {
+                                      "maximum": 180,
+                                      "minimum": -180,
+                                      "type": "number",
+                                    },
+                                    {
+                                      "maximum": 90,
+                                      "minimum": -90,
+                                      "type": "number",
+                                    },
+                                  ],
+                                  "type": "array",
+                                },
+                                "type": {
+                                  "enum": [
+                                    "Point",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "coordinates",
+                                "type",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "address",
+                            "geopoint",
+                          ],
+                          "type": "object",
+                        },
+                        "name": {
+                          "description": "Nom customisé de l'entreprise",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "siret": {
+                          "description": "Le numéro de SIRET de l'établissement",
+                          "example": "78424186100011",
+                          "pattern": "^\\d{14}$",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "size": {
+                          "description": "Taille de l'entreprise",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "website": {
+                          "description": "Site web de l'entreprise",
+                          "format": "uri",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                      },
+                      "required": [
+                        "siret",
+                        "brand",
+                        "legal_name",
+                        "website",
+                        "name",
+                        "description",
+                        "size",
+                        "location",
+                        "domain",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "identifier",
+                    "workplace",
+                    "apply",
+                    "contract",
+                    "offer",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "",
+          },
+        },
+        "security": [
+          {
+            "api-apprentissage": [],
+          },
+        ],
+        "tags": [
+          "V3 - Jobs",
+        ],
+      },
       "put": {
         "parameters": [
           {

--- a/shared/routes/v3/jobs/jobs.routes.v3.ts
+++ b/shared/routes/v3/jobs/jobs.routes.v3.ts
@@ -3,7 +3,7 @@ import { zObjectId } from "zod-mongodb-schema"
 import { z } from "../../../helpers/zodWithOpenApi.js"
 import { IRoutesDef } from "../../common.routes.js"
 
-import { zJobOfferApiWriteV3, zJobSearchApiV3Query, zJobSearchApiV3Response } from "./jobs.routes.v3.model.js"
+import { zJobOfferApiReadV3, zJobOfferApiWriteV3, zJobSearchApiV3Query, zJobSearchApiV3Response } from "./jobs.routes.v3.model.js"
 
 export const zJobsRoutesV3 = {
   get: {
@@ -13,6 +13,24 @@ export const zJobsRoutesV3 = {
       querystring: zJobSearchApiV3Query,
       response: {
         "200": zJobSearchApiV3Response,
+      },
+      securityScheme: {
+        auth: "api-apprentissage",
+        access: null,
+        resources: {},
+      },
+      openapi: {
+        tags: ["V3 - Jobs"] as string[],
+      },
+    },
+    "/v3/jobs/:id": {
+      method: "get",
+      path: "/v3/jobs/:id",
+      params: z.object({
+        id: zObjectId,
+      }),
+      response: {
+        "200": zJobOfferApiReadV3,
       },
       securityScheme: {
         auth: "api-apprentissage",


### PR DESCRIPTION


- Ajout d'une route d'API getJobsById (v3) qui va récupérer depuis un identifiant une offre, soit depuis la collection **recruiters** (LbaJobs historiques) soit depuis la collection **jobs_partners**.

- Ajout de fonctions de transformations et tests unitaires.

⚠️ Certaines fonctions ne sont pas couvertes par des tests unitaires (optims todo)
⚠️ Dans les tests coté controller v3 problématique de parse des dates 👉🏼 forcé avant le parse

---
TODO List

- [x] Ajout route dans zJobsRoutesV3
- [x] Ajout du get dans jobs.controller.v3
- [x] Ajout fonction getLbaJobByIdV2AsJobOfferApi
- [x] Ajout tests fonction getLbaJobByIdV2AsJobOfferApi
- [x] Ajout fonction getJobsPartnersByIdAsJobOfferApi
- [x] Ajout tests getJobsPartnersByIdAsJobOfferApi
- [x] Ajout fonction findJobOpportunityById
- [x] Ajout tests findJobOpportunityById
- [x] Ajout tests jobs.controller.v3