### PR TITLE
fix: recruteur application using siret

### DIFF
--- a/server/src/http/controllers/v2/applications.controller.v2.test.ts
+++ b/server/src/http/controllers/v2/applications.controller.v2.test.ts
@@ -10,12 +10,14 @@ import { generateRecruiterFixture } from "shared/fixtures/recruiter.fixture"
 import { parisFixture } from "shared/fixtures/referentiel/commune.fixture"
 import { generateReferentielRome } from "shared/fixtures/rome.fixture"
 import { generateUserWithAccountFixture } from "shared/fixtures/userWithAccount.fixture"
+import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
 import { describe, expect, it, vi } from "vitest"
 
 import { s3WriteString } from "@/common/utils/awsUtils"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { buildUserForToken } from "@/services/application.service"
 import { generateApplicationReplyToken } from "@/services/appLinks.service"
+import { getRecipientID } from "@/services/jobs/jobOpportunity/jobOpportunity.service"
 import { useMongo } from "@tests/utils/mongo.test.utils"
 import { useServer } from "@tests/utils/server.test.utils"
 
@@ -44,7 +46,7 @@ const fakeToken = getApiApprentissageTestingTokenFromInvalidPrivateKey({
 })
 
 const recruteur = generateJobsPartnersOfferPrivate({
-  partner_label: LBA_ITEM_TYPE.RECRUTEURS_LBA,
+  partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
   workplace_siret: "11000001500013",
   workplace_legal_name: "ASSEMBLEE NATIONALE",
   workplace_brand: "ASSEMBLEE NATIONALE",
@@ -156,7 +158,7 @@ describe("POST /v2/application", () => {
       applicant_first_name: "Jean",
       applicant_last_name: "Dupont",
       applicant_phone: "0101010101",
-      recipient_id: `${JobCollectionName.partners}_${recruteur._id.toString()}`,
+      recipient_id: getRecipientID(JobCollectionName.recruteur, recruteur.workplace_siret!),
     }
 
     const response = await httpClient().inject({
@@ -223,7 +225,7 @@ describe("POST /v2/application", () => {
       applicant_first_name: "Jean",
       applicant_last_name: "Dupont",
       applicant_phone: "0101010101",
-      recipient_id: `recruiters_${job._id.toString()}`,
+      recipient_id: getRecipientID(JobCollectionName.recruiters, job._id.toString()),
     }
 
     const response = await httpClient().inject({

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -303,7 +303,6 @@ export const sendApplicationV2 = async ({
     if (recruiter.status !== RECRUITER_STATUS.ACTIF || job.job_status !== JOB_STATUS.ACTIVE || dayjs(job.job_expiration_date).add(1, "day").isBefore(dayjs())) {
       throw badRequest(BusinessErrorCodes.EXPIRED)
     }
-
     lbaJob = { type: LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, job, recruiter }
   }
   if (collectionName === JobCollectionName.partners) {
@@ -311,8 +310,14 @@ export const sendApplicationV2 = async ({
     if (!job) {
       throw badRequest(BusinessErrorCodes.NOTFOUND)
     }
-    const type = job.partner_label === JOBPARTNERS_LABEL.RECRUTEURS_LBA ? LBA_ITEM_TYPE.RECRUTEURS_LBA : LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES
-    lbaJob = { type, job, recruiter: null }
+    lbaJob = { type: LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES, job, recruiter: null }
+  }
+  if (collectionName === JobCollectionName.recruteur) {
+    const job = await getDbCollection("jobs_partners").findOne({ workplace_siret: jobId })
+    if (!job) {
+      throw badRequest(BusinessErrorCodes.NOTFOUND)
+    }
+    lbaJob = { type: LBA_ITEM_TYPE.RECRUTEURS_LBA, job, recruiter: null }
   }
 
   await checkUserApplicationCountV2(applicant._id, lbaJob, caller)

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -2,7 +2,7 @@ import Boom, { badRequest, internal, notFound } from "@hapi/boom"
 import { IApiAlternanceTokenData } from "api-alternance-sdk"
 import { DateTime } from "luxon"
 import { Document, Filter, ObjectId } from "mongodb"
-import { IGeoPoint, IJob, ILbaItemPartnerJob, JOB_STATUS_ENGLISH, assertUnreachable, parseEnum, translateJobStatus } from "shared"
+import { IGeoPoint, IJob, IJobCollectionName, ILbaItemPartnerJob, JOB_STATUS_ENGLISH, JobCollectionName, assertUnreachable, parseEnum, translateJobStatus } from "shared"
 import { NIVEAUX_POUR_LBA, NIVEAUX_POUR_OFFRES_PE, NIVEAU_DIPLOME_LABEL, TRAINING_CONTRACT_TYPE } from "shared/constants"
 import { LBA_ITEM_TYPE, allLbaItemType } from "shared/constants/lbaitem"
 import {
@@ -336,7 +336,7 @@ export const getJobsPartnersForApi = async ({ romes, geo, target_diploma_level, 
       ...j,
       contract_type: j.contract_type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
       apply_url: j.apply_url ?? `${config.publicUrl}/recherche?type=partner&itemId=${j._id}`,
-      apply_recipient_id: j.apply_email ? `partners_${j._id}` : null,
+      apply_recipient_id: j.apply_email ? getRecipientID(JobCollectionName.partners, j._id.toString()) : null,
     })
   )
 }
@@ -368,7 +368,7 @@ export const convertLbaCompanyToJobRecruiterApi = (recruteursLba: IJobsPartnersO
       apply: {
         url: `${config.publicUrl}/recherche?type=lba&itemId=${recruteurLba.workplace_siret}`,
         phone: recruteurLba.apply_phone,
-        recipient_id: recruteurLba.apply_email ? `partners_${recruteurLba._id}` : null,
+        recipient_id: recruteurLba.apply_email ? getRecipientID(JobCollectionName.recruteur, recruteurLba.workplace_siret!) : null,
       },
     })
   )
@@ -476,7 +476,7 @@ export const convertLbaRecruiterToJobOfferApi = (offresEmploiLba: IJobResult[]):
           apply: {
             url: `${config.publicUrl}/recherche?type=matcha&itemId=${job._id}`,
             phone: recruiter.phone ?? null,
-            recipient_id: `recruiters_${job._id}`,
+            recipient_id: getRecipientID(JobCollectionName.recruiters, job._id.toString()),
           },
         })
       )
@@ -899,4 +899,17 @@ export async function getJobsPartnersByIdAsJobOfferApi(id: ObjectId, context: Jo
   })
 
   return transformedJob
+}
+
+export const getRecipientID = (type: IJobCollectionName, id: string) => {
+  if (type === JobCollectionName.recruiters) {
+    return `recruiters_${id}`
+  }
+  if (type === JobCollectionName.partners) {
+    return `partners_${id}`
+  }
+  if (type === JobCollectionName.recruteur) {
+    return `recruteur_${id}`
+  }
+  assertUnreachable(type)
 }

--- a/server/src/services/recruteurLba.service.ts
+++ b/server/src/services/recruteurLba.service.ts
@@ -1,9 +1,11 @@
 import { badRequest, internal, notFound } from "@hapi/boom"
 import { Document, Filter, ObjectId } from "mongodb"
-import { ERecruteurLbaUpdateEventType, IApplication, IRecruteurLbaUpdateEvent } from "shared"
+import { ERecruteurLbaUpdateEventType, IApplication, IRecruteurLbaUpdateEvent, JobCollectionName } from "shared"
 import { LBA_ITEM_TYPE, LBA_ITEM_TYPE_OLD } from "shared/constants/lbaitem"
 import { IJobsPartnersOfferPrivate, IJobsPartnersRecruteurAlgoPrivate, JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
 import { ILbaCompanyForContactUpdate } from "shared/routes/updateLbaCompany.routes"
+
+import { getRecipientID } from "@/services/jobs/jobOpportunity/jobOpportunity.service"
 
 import { encryptMailWithIV } from "../common/utils/encryptString"
 import { IApiError, manageApiError } from "../common/utils/errorManager"
@@ -75,7 +77,7 @@ const transformCompany = ({
     applicationCount: applicationCount?.count || 0,
     url: null,
     token: generateApplicationToken({ company_siret: company.workplace_siret }),
-    recipient_id: `partners_${company._id.toString()}`,
+    recipient_id: getRecipientID(JobCollectionName.recruteur, company.workplace_siret),
   }
 
   return resultCompany
@@ -118,7 +120,7 @@ const transformCompanyWithMinimalData = ({
     ],
     applicationCount: applicationCount?.count || 0,
     token: generateApplicationToken({ company_siret: company.workplace_siret }),
-    recipient_id: `partners_${company._id.toString()}`,
+    recipient_id: getRecipientID(JobCollectionName.recruteur, company.workplace_siret),
   }
 
   return resultCompany


### PR DESCRIPTION
- jobs partners recruteur are reloaded every sunday : mongodb id is lost, but a company can still be present from an import to another