### PR TITLE
fix: memoire pour le job processor

### DIFF
--- a/.infra/docker-compose.production.yml
+++ b/.infra/docker-compose.production.yml
@@ -60,6 +60,7 @@ services:
     command: ["yarn", "cli", "job_processor:start"]
     environment:
       INSTANCE_ID: "runner-{% raw %}{{.Task.Slot}}{% endraw %}"
+      NODE_OPTIONS: "--max_old_space_size=1024"
     stop_grace_period: 5m
     volumes:
       - /opt/app/data/server:/data

--- a/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
+++ b/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
@@ -37,7 +37,7 @@ const importFormations = async () => {
           stats.failed++
         }
       }),
-      { parallel: 500 }
+      { parallel: 10 }
     )
 
     return stats

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,3 +1,5 @@
+import * as v8 from "v8"
+
 import { modelDescriptors } from "shared/models/models"
 
 import { configureDbSchemaValidation, connectToMongodb } from "@/common/utils/mongodbUtils"
@@ -11,6 +13,7 @@ process.on("uncaughtException", (err) => logger.error(err, "uncaughtException"))
 
 try {
   logger.warn("starting application")
+  logger.info("V8 Options:", v8.getHeapStatistics())
   await connectToMongodb(config.mongodb.uri)
   await configureDbSchemaValidation(modelDescriptors)
   await startCLI()


### PR DESCRIPTION
La mémoire allouée par docker doit être la même que celle définie dans les options du process node.

Par défaut, la mémoire allouée au job processor est de 550 Mo, ce qui ne correspond pas au 1 Go définis dans docker.

`require("v8").getHeapStatistics()` permet de lire les valeurs des paramètres node, y compris ceux par défaut.