### PR TITLE
fix: UI fix layout

### DIFF
--- a/ui/app/(espace-pro)/_components/PublicHeader.tsx
+++ b/ui/app/(espace-pro)/_components/PublicHeader.tsx
@@ -1,8 +1,8 @@
-"use client"
 import { Header as DsfrHeader, HeaderQuickAccessItem } from "@codegouvfr/react-dsfr/Header"
 import { useMemo } from "react"
 import { IUserRecruteurPublic } from "shared"
 
+import { AuthWatcher } from "@/app/_components/AuthWatcher"
 import { DsfrHeaderProps } from "@/app/_components/Header"
 
 import { PAGES } from "../../../utils/routes.utils"
@@ -46,5 +46,14 @@ export function PublicHeader({ user, hideConnectionButton = false }: { user?: IU
     }
   }, [user, hideConnectionButton])
 
-  return <DsfrHeader {...props} />
+  return (
+    <>
+      <AuthWatcher user={user} />
+      <DsfrHeader {...props} />
+    </>
+  )
+}
+
+export const PublicHeaderSimple = () => {
+  return <DsfrHeader {...DsfrHeaderProps} />
 }

--- a/ui/app/(espace-pro)/_components/PublicHeader.tsx
+++ b/ui/app/(espace-pro)/_components/PublicHeader.tsx
@@ -4,8 +4,7 @@ import { IUserRecruteurPublic } from "shared"
 
 import { AuthWatcher } from "@/app/_components/AuthWatcher"
 import { DsfrHeaderProps } from "@/app/_components/Header"
-
-import { PAGES } from "../../../utils/routes.utils"
+import { PAGES } from "@/utils/routes.utils"
 
 export function PublicHeader({ user, hideConnectionButton = false }: { user?: IUserRecruteurPublic; hideConnectionButton?: boolean }) {
   const props = useMemo(() => {
@@ -54,6 +53,6 @@ export function PublicHeader({ user, hideConnectionButton = false }: { user?: IU
   )
 }
 
-export const PublicHeaderSimple = () => {
+export const PublicHeaderStatic = () => {
   return <DsfrHeader {...DsfrHeaderProps} />
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx
@@ -3,6 +3,7 @@ import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 
 import { ConnectedHeader } from "@/app/(espace-pro)/espace-pro/(connected)/_components/ConnectedHeader"
+import { AuthWatcher } from "@/app/_components/AuthWatcher"
 import { Footer } from "@/app/_components/Footer"
 import { getSession } from "@/utils/getSession"
 
@@ -20,6 +21,7 @@ export default async function EspaceProConnecteLayout({ children }: PropsWithChi
       <ConnectedHeader user={user} />
       <Box sx={{ marginBottom: fr.spacing("4w") }}>{children}</Box>
       <Footer />
+      <AuthWatcher user={user} />
     </UserContextProvider>
   )
 }

--- a/ui/app/(rdva)/premium/[id]/page.tsx
+++ b/ui/app/(rdva)/premium/[id]/page.tsx
@@ -5,9 +5,9 @@ import { useSearchParams } from "next/navigation"
 import { useEffect, useState } from "react"
 import { IEtablissementJson } from "shared"
 
+import Layout from "@/components/espace_pro/Layout"
 import { apiGet, apiPost } from "@/utils/api.utils"
 
-import { Layout } from "../../../../components/espace_pro"
 import { SuccessCircle } from "../../../../theme/components/icons"
 
 type IPremiumEtablissement = {

--- a/ui/app/(rdva)/premium/affelnet/[id]/page.tsx
+++ b/ui/app/(rdva)/premium/affelnet/[id]/page.tsx
@@ -5,9 +5,9 @@ import { useSearchParams } from "next/navigation"
 import { useEffect, useState } from "react"
 import { IEtablissementJson } from "shared"
 
+import Layout from "@/components/espace_pro/Layout"
 import { apiGet, apiPost } from "@/utils/api.utils"
 
-import { Layout } from "../../../../../components/espace_pro"
 import { SuccessCircle } from "../../../../../theme/components/icons"
 
 type IAffelnetEtablissement = {

--- a/ui/app/_components/AuthWatcher.tsx
+++ b/ui/app/_components/AuthWatcher.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useEffect, useMemo } from "react"
+import type { IUserRecruteurPublic } from "shared"
+
+export function AuthWatcher({ user }: { user: IUserRecruteurPublic | null }) {
+  const router = useRouter()
+
+  const isBroadcastChannelDefined = typeof BroadcastChannel !== "undefined"
+  const channel = useMemo(() => (isBroadcastChannelDefined ? new BroadcastChannel("auth") : null), [isBroadcastChannelDefined])
+
+  useEffect(() => {
+    if (!channel) {
+      return
+    }
+
+    const currentId = user?._id ?? null
+    channel.postMessage(currentId)
+
+    const listener = (event: BroadcastChannelEventMap["message"]) => {
+      if (event.data !== currentId) {
+        router.refresh()
+      }
+    }
+
+    channel.addEventListener("message", listener)
+
+    return () => {
+      channel.removeEventListener("message", listener)
+    }
+  }, [channel, user, router])
+
+  return null
+}

--- a/ui/app/error.tsx
+++ b/ui/app/error.tsx
@@ -1,14 +1,14 @@
 "use client"
 import { Box } from "@mui/material"
 
-import { PublicHeaderSimple } from "@/app/(espace-pro)/_components/PublicHeader"
+import { PublicHeaderStatic } from "@/app/(espace-pro)/_components/PublicHeader"
 import { ErrorComponent, type ErrorProps } from "@/app/_components/ErrorComponent"
 import { Footer } from "@/app/_components/Footer"
 
 export default function ErrorPage(props: ErrorProps) {
   return (
     <Box sx={{ minHeight: "100vh", display: "grid", gridTemplateRows: "max-content 1fr min-content" }}>
-      <PublicHeaderSimple />
+      <PublicHeaderStatic />
       <ErrorComponent {...props} />
       <Footer />
     </Box>

--- a/ui/app/error.tsx
+++ b/ui/app/error.tsx
@@ -1,14 +1,14 @@
 "use client"
 import { Box } from "@mui/material"
 
-import { PublicHeader } from "@/app/(espace-pro)/_components/PublicHeader"
+import { PublicHeaderSimple } from "@/app/(espace-pro)/_components/PublicHeader"
 import { ErrorComponent, type ErrorProps } from "@/app/_components/ErrorComponent"
 import { Footer } from "@/app/_components/Footer"
 
 export default function ErrorPage(props: ErrorProps) {
   return (
     <Box sx={{ minHeight: "100vh", display: "grid", gridTemplateRows: "max-content 1fr min-content" }}>
-      <PublicHeader user={null} hideConnectionButton={true} />
+      <PublicHeaderSimple />
       <ErrorComponent {...props} />
       <Footer />
     </Box>

--- a/ui/app/not-found.tsx
+++ b/ui/app/not-found.tsx
@@ -2,14 +2,14 @@
 
 import { Box, Container } from "@mui/material"
 
-import { PublicHeader } from "@/app/(espace-pro)/_components/PublicHeader"
+import { PublicHeaderSimple } from "@/app/(espace-pro)/_components/PublicHeader"
 import { Footer } from "@/app/_components/Footer"
 import NotFound from "@/app/_components/NotFound"
 
-export default function yo() {
+export default function NotFoundPage() {
   return (
     <Box sx={{ minHeight: "100vh", display: "grid", gridTemplateRows: "max-content 1fr min-content" }}>
-      <PublicHeader user={null} hideConnectionButton={true} />
+      <PublicHeaderSimple />
       <Container maxWidth="xl">
         <NotFound />
       </Container>

--- a/ui/app/not-found.tsx
+++ b/ui/app/not-found.tsx
@@ -2,14 +2,14 @@
 
 import { Box, Container } from "@mui/material"
 
-import { PublicHeaderSimple } from "@/app/(espace-pro)/_components/PublicHeader"
+import { PublicHeaderStatic } from "@/app/(espace-pro)/_components/PublicHeader"
 import { Footer } from "@/app/_components/Footer"
 import NotFound from "@/app/_components/NotFound"
 
 export default function NotFoundPage() {
   return (
     <Box sx={{ minHeight: "100vh", display: "grid", gridTemplateRows: "max-content 1fr min-content" }}>
-      <PublicHeaderSimple />
+      <PublicHeaderStatic />
       <Container maxWidth="xl">
         <NotFound />
       </Container>

--- a/ui/components/espace_pro/Layout/Header.tsx
+++ b/ui/components/espace_pro/Layout/Header.tsx
@@ -9,6 +9,7 @@ import { RiAccountCircleLine } from "react-icons/ri"
 import InfoBanner from "@/components/InfoBanner/InfoBanner"
 import { useAuth } from "@/context/UserContext"
 import { apiGet } from "@/utils/api.utils"
+import { PAGES } from "@/utils/routes.utils"
 
 import { AUTHTYPE } from "../../../common/contants"
 import { LogoContext } from "../../../context/contextLogo"
@@ -16,7 +17,7 @@ import { LockFill } from "../../../theme/components/icons"
 import { LbaNew } from "../../../theme/components/logos"
 import LogoAkto from "../assets/images/akto"
 
-const Header = () => {
+const Header = ({ onLogout }: { onLogout: () => void }) => {
   const { organisation } = useContext(LogoContext)
   const { user } = useAuth()
 
@@ -24,7 +25,8 @@ const Header = () => {
 
   const handleLogout = async () => {
     await apiGet("/auth/logout", {})
-    router.push("/")
+    router.push(PAGES.static.home.getPath())
+    onLogout()
   }
 
   return (

--- a/ui/components/espace_pro/Layout/index.tsx
+++ b/ui/components/espace_pro/Layout/index.tsx
@@ -23,12 +23,15 @@ export default function Layout({
   adminPage?: EAdminPages
   displayNavigationMenu?: boolean
 }) {
+  const handleLogout = async () => {
+    "use server"
+  }
   return (
     <Container maxW="full" p="0">
       <Flex direction="column" h="100vh">
         {!widget && (
           <Box as="header">
-            {header && <Header />}
+            {header && <Header onLogout={handleLogout} />}
             {displayNavigationMenu && <NavigationMenu rdva={rdva} />}
             {adminPage && <NavigationAdmin currentPage={adminPage} />}
           </Box>

--- a/ui/components/espace_pro/index.ts
+++ b/ui/components/espace_pro/index.ts
@@ -7,7 +7,6 @@ import CustomInput from "./CustomInput"
 import DropdownCombobox from "./DropdownCombobox"
 import InfoPopover from "./InfoPopover"
 import InfoTooltip from "./InfoToolTip"
-import Layout from "./Layout"
 import LoadingEmptySpace from "./LoadingEmptySpace"
 import TableNew from "./TableNew"
 import UserValidationHistory from "./UserValidationHistory"
@@ -21,7 +20,6 @@ export {
   DropdownCombobox,
   InfoPopover,
   InfoTooltip,
-  Layout,
   LoadingEmptySpace,
   TableNew,
   UserValidationHistory,


### PR DESCRIPTION
Version simplifiée de https://github.com/mission-apprentissage/labonnealternance/pull/1999

Les parties techniques importantes :

* La "server action" suivante permet de déclencher un réaffichage de la layout même si l'action est vide.
https://github.com/mission-apprentissage/labonnealternance/pull/2001/files#diff-ff6dfa68de03ca789cd4d070d9cf59d9632329705f287809a02c24b9e8ee262dR27

documentation des "server actions" : https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations

* Le composant "AuthWatcher" permet de détecter de publier systématiquement l'id du user connecté et de le diffuser aux autres onglets. Ce n'est pas indispensable mais ça permet de déclencher un rafraîchessement de la page au moment du changement de connexion, en temps réel.