### PR TITLE
fix: performances UI

### DIFF
--- a/.infra/docker-compose.production.yml
+++ b/.infra/docker-compose.production.yml
@@ -86,7 +86,7 @@ services:
       resources:
         limits:
           memory: 768m
-      replicas: 2
+      replicas: 4
     env_file: .env_ui
     environment:
       NODE_OPTIONS: "--max_old_space_size=768"

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -6,6 +6,11 @@ import createWithBundleAnalyzer from "@next/bundle-analyzer"
 import { withSentryConfig } from "@sentry/nextjs"
 import { Config } from "next-recompose-plugins"
 
+const cacheControls = {
+  month: "public, max-age=2592000, immutable",
+  year: "public, max-age=31536000, immutable",
+}
+
 const withBundleAnalyzer = createWithBundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 })
@@ -81,6 +86,9 @@ const nextConfig = {
     dirs: ["."],
   },
   images: {
+    // Tout changement d'image devra passer par un changement de nom de fichier
+    // pour être pris en compte par le cache
+    minimumCacheTTL: 31 * 24 * 3_600, // 31 jours
     localPatterns: [
       {
         pathname: "/images/**",
@@ -130,6 +138,32 @@ const nextConfig = {
       {
         source: "/espace-pro/widget/:slug*",
         headers: [
+          {
+            key: "Content-Security-Policy",
+            value: inline(contentSecurityPolicy),
+          },
+        ],
+      },
+      {
+        source: "/:slug(favicon\\.ico|favicon|styles)/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: cacheControls.month,
+          },
+          {
+            key: "Content-Security-Policy",
+            value: inline(contentSecurityPolicy),
+          },
+        ],
+      },
+      {
+        source: "/:slug(assets|fonts|images|ressources)/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: cacheControls.year,
+          },
           {
             key: "Content-Security-Policy",
             value: inline(contentSecurityPolicy),


### PR DESCRIPTION
Le serveur UI fait plus de compute qu'avant la refonte. Il doit maintenant générer dynamiquement toutes les pages (pratiquement). Il faut donc augmenter ses ressources.

Par ailleurs par default aucun cache sur le dossier public, ce qui solicite inutilement le serveur. Ajout de cache à 1an, en cas de changement de fichier il faudra donc changer le nom de fichier pour forcer une invalidation de cache.