### PR TITLE
fix(lba-2649): utilisation Enseigne inconnue pour Monster lorsque nom d'entreprise pas renseigné

### DIFF
--- a/server/src/jobs/offrePartenaire/monster/monsterMapper.ts
+++ b/server/src/jobs/offrePartenaire/monster/monsterMapper.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from "mongodb"
+import { UNKNOWN_COMPANY } from "shared/constants/lbaitem"
 import { TRAINING_CONTRACT_TYPE } from "shared/constants/recruteur"
 import dayjs from "shared/helpers/dayjs"
 import { extensions } from "shared/helpers/zodHelpers/zodPrimitives"
@@ -75,7 +76,7 @@ export const monsterJobToJobsPartners = (job: IMonsterJob): IComputedJobsPartner
       .add(2, "months")
       .toDate(),
 
-    workplace_name: CompanyName,
+    workplace_name: CompanyName === "myJob.company" ? UNKNOWN_COMPANY : CompanyName,
     workplace_siret: siretParsing.success ? siretParsing.data : null,
     workplace_address_zipcode: JobPostalCode || null,
     workplace_address_city: JobCity,


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?assignee=712020%3A9a003bb4-d766-4edc-b4ab-ecd6529e3353%2Cunassigned&selectedIssue=LBA-2649