### PR TITLE
fix(lba-2713): gestion des erreurs de chargement de formulaire

### DIFF
--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/proposition/formulaire/[idFormulaire]/offre/[jobId]/siret/[siretFormateur]/PropositionOffreId.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/proposition/formulaire/[idFormulaire]/offre/[jobId]/siret/[siretFormateur]/PropositionOffreId.tsx
@@ -18,7 +18,7 @@ import { PAGES } from "@/utils/routes.utils"
 export function PropositionOffreId({ idFormulaire, jobId, siretFormateur, token }: { idFormulaire: string; jobId: string; siretFormateur: string; token: string }) {
   const toast = useToast()
 
-  const formulaireQuery = useQuery({
+  const { isError, data: formulaire } = useQuery({
     queryKey: ["getFormulaire", idFormulaire, token],
     queryFn: () => getDelegationDetails(idFormulaire, token),
     enabled: Boolean(idFormulaire && token),
@@ -30,7 +30,10 @@ export function PropositionOffreId({ idFormulaire, jobId, siretFormateur, token 
     enabled: Boolean(jobId && siretFormateur && token),
   })
 
-  const formulaire = formulaireQuery?.data
+  if (isError) {
+    throw new Error("Une erreur est survenue lors de la récupération des informations de l'entreprise.")
+  }
+
   const job = (formulaire?.jobs as IJobJson[])?.find((job) => job._id === jobId)
 
   /**


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?assignee=712020%3A9a003bb4-d766-4edc-b4ab-ecd6529e3353&selectedIssue=LBA-2713

les liens problématiques fonctionnent correctement mais les tokens sont morts suite aux changements de secret.

Petite modification pour faire apparaître la page d'erreur dans le cas d'un des deux liens qui sinon reste en spinner infini