### PR TITLE
fix: disable image optimisation

### DIFF
--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -86,6 +86,7 @@ const nextConfig = {
     dirs: ["."],
   },
   images: {
+    unoptimized: true,
     // Tout changement d'image devra passer par un changement de nom de fichier
     // pour être pris en compte par le cache
     minimumCacheTTL: 31 * 24 * 3_600, // 31 jours


### PR DESCRIPTION
Desactive l'optim image pour valider la cause

https://github.com/vercel/next.js/issues/44685