### PR TITLE
fix: migration correction tagage candidatures spontanées

### DIFF
--- a/server/src/migrations/20250515112329-fix-applications-recruteurs-lba.ts
+++ b/server/src/migrations/20250515112329-fix-applications-recruteurs-lba.ts
@@ -1,0 +1,13 @@
+import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+
+export const up = async () => {
+  await getDbCollection("applications").updateMany(
+    { job_title: LBA_ITEM_TYPE.RECRUTEURS_LBA, job_origin: LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES },
+    { $set: { job_origin: LBA_ITEM_TYPE.RECRUTEURS_LBA } }
+  )
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false


### PR DESCRIPTION
Des candidatures spontanées entre mars et le 23 avril sont marquées par erreur comme candidatures à offres partenaires