### PR TITLE
fix(lba-2785): association value legit à option cachée

### DIFF
--- a/ui/components/espace_pro/CreationRecruteur/OpcoSelect.tsx
+++ b/ui/components/espace_pro/CreationRecruteur/OpcoSelect.tsx
@@ -4,7 +4,9 @@ import { OPCOS_LABEL } from "shared/constants/index"
 export const OpcoSelect = ({ name, onChange, value }) => {
   return (
     <Select variant="outline" size="md" name={name} mr={3} onChange={(e) => onChange?.(e.target.value)} value={value}>
-      <option hidden>Sélectionnez un OPCO</option>
+      <option value={OPCOS_LABEL.UNKNOWN_OPCO} hidden>
+        Sélectionnez un OPCO
+      </option>
       <option value={OPCOS_LABEL.AFDAS}>AFDAS</option>
       <option value={OPCOS_LABEL.AKTO}>AKTO</option>
       <option value={OPCOS_LABEL.ATLAS}>ATLAS</option>


### PR DESCRIPTION
Des cas où l'opco enregistré est "Sélectionnez un OPCO" apparaissent ponctuellement en db.
L'option de select qui contient ce texte est normalement cachée et associée à aucune valeur, c'est donc le texte qui est pris.
Association de cette option à la valeur "inconnu" qui est legit