### PR TITLE
fix: page avec slug

### DIFF
--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/[origin]/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/[origin]/page.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { useParams } from "next/navigation"
+import { Suspense } from "react"
+
+import { AUTHTYPE } from "@/common/contants"
+import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
+
+export default function CreationEntreprise() {
+  const { origin } = useParams() as { origin: string }
+  return (
+    <Suspense>
+      <CreationCompte type={AUTHTYPE.ENTREPRISE} origin={origin} isWidget={false} />
+    </Suspense>
+  )
+}


### PR DESCRIPTION
un lien sur 1j1s pointe sur une url qui n'est plus gérée et captant l'origin de la création d'offre.
--> ajout de la page nécessaire