### PR TITLE
feat: suppression erreur sentry inutile

### DIFF
--- a/server/src/services/lbajob.service.ts
+++ b/server/src/services/lbajob.service.ts
@@ -372,7 +372,7 @@ export const getLbaJobByIdV2AsJobResult = async ({ id, caller }: { id: string; c
     const rawJob = await getOffreAvecInfoMandataire(id)
 
     if (!rawJob) {
-      throw badRequest()
+      return null
     }
 
     if (caller) {


### PR DESCRIPTION
Probable cause de l'erreur sentry 30276 .
A ce niveau on ne peut pas savoir s'il y a une erreur ou non. Retour à null.