### PR TITLE
fix(lba-3160): bouton inactif car le lien sous jacent prend précédence

### DIFF
--- a/ui/app/(espace-pro)/_components/PopoverMenu.tsx
+++ b/ui/app/(espace-pro)/_components/PopoverMenu.tsx
@@ -68,7 +68,7 @@ export const PopoverMenu = ({
         iconId="fr-icon-settings-5-line"
         title={title}
       />
-      <Popper sx={{ zIndex: 1 }} open={open} anchorEl={anchorRef.current} role={undefined} placement="bottom-start" transition disablePortal>
+      <Popper sx={{ zIndex: 1000 }} open={open} anchorEl={anchorRef.current} role={undefined} placement="bottom-start" transition disablePortal>
         {({ TransitionProps, placement }) => (
           <Grow
             {...TransitionProps}


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?jql=assignee%20IN%20%28712020%3A9a003bb4-d766-4edc-b4ab-ecd6529e3353%2C%20empty%29&selectedIssue=LBA-3160