### PR TITLE
fix(lba-2717): Bloc téléphone affiché à tort dans l'email de réponse d'un CFA à un candidat

### DIFF
--- a/server/static/templates/mail-reponse-cfa.mjml.ejs
+++ b/server/static/templates/mail-reponse-cfa.mjml.ejs
@@ -113,11 +113,14 @@
               <br />
               <br />
 
+              <% if (data.cfa_phone) { %>
               Téléphone
               <br />
               <span style="font-weight: 700;"><%= data.cfa_phone %></span>
               <br />
               <br />
+              <% } %>
+              
               Pensez à vous présenter et à redonner le contexte de vos échanges dans votre message afin que le destinataire puisse vous répondre au mieux.
             </mj-text>
           </mj-column>


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?jql=assignee%20IN%20%28712020%3A9a003bb4-d766-4edc-b4ab-ecd6529e3353%2C%20empty%29&selectedIssue=LBA-2717