### PR TITLE
fix(lba-3250): masquage des checkbox et correction de la perte de scope formation/métier

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
@@ -64,17 +64,19 @@ export function CandidatRechercheForm({ rechercheParams }: { rechercheParams: IR
     <RechercheForm onSubmit={onSubmit} rechercheParams={rechercheParams}>
       <RechercheInputsLayout
         viewTypeCheckboxs={
-          <RechercheResultTypeCheckbox
-            checked={checkedItemTypes}
-            rechercheResults={rechercheResults}
-            onChange={(newValues) =>
-              navigateToRecherchePage({
-                displayEntreprises: newValues.includes(UserItemTypes.EMPLOI),
-                displayPartenariats: newValues.includes(UserItemTypes.EMPLOI) && newValues.includes(UserItemTypes.FORMATIONS),
-                displayFormations: newValues.includes(UserItemTypes.FORMATIONS),
-              })
-            }
-          />
+          !rechercheParams.viewType && (
+            <RechercheResultTypeCheckbox
+              checked={checkedItemTypes}
+              rechercheResults={rechercheResults}
+              onChange={(newValues) =>
+                navigateToRecherchePage({
+                  displayEntreprises: newValues.includes(UserItemTypes.EMPLOI),
+                  displayPartenariats: newValues.includes(UserItemTypes.EMPLOI) && newValues.includes(UserItemTypes.FORMATIONS),
+                  displayFormations: newValues.includes(UserItemTypes.FORMATIONS),
+                })
+              }
+            />
+          )
         }
         metierInput={<RechercheMetierAutocomplete />}
         lieuInput={<RechercheLieuAutocomplete />}

--- a/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
@@ -71,7 +71,6 @@ export function CandidatRechercheForm({ rechercheParams }: { rechercheParams: IR
               onChange={(newValues) =>
                 navigateToRecherchePage({
                   displayEntreprises: newValues.includes(UserItemTypes.EMPLOI),
-                  displayPartenariats: newValues.includes(UserItemTypes.EMPLOI) && newValues.includes(UserItemTypes.FORMATIONS),
                   displayFormations: newValues.includes(UserItemTypes.FORMATIONS),
                 })
               }

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
@@ -263,16 +263,16 @@ export function parseRecherchePageParams(search: ReadonlyURLSearchParams | URLSe
   }
 }
 
-export function detectModeFromParams({ displayFilters, displayEntreprises, displayPartenariats, displayFormations }: IRecherchePageParams): IRechercheMode {
+export function detectModeFromParams({ displayFilters, displayEntreprises, displayFormations }: IRecherchePageParams): IRechercheMode {
   if (displayFilters) {
     return IRechercheMode.DEFAULT
   }
 
-  if (!displayEntreprises && !displayPartenariats && displayFormations) {
+  if (!displayEntreprises && displayFormations) {
     return IRechercheMode.FORMATIONS_ONLY
   }
 
-  if (displayEntreprises && displayPartenariats && !displayFormations) {
+  if (displayEntreprises && !displayFormations) {
     return IRechercheMode.JOBS_ONLY
   }
 


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?jql=assignee%20IN%20%28712020%3A9a003bb4-d766-4edc-b4ab-ecd6529e3353%2C%20empty%29&selectedIssue=LBA-3250

deux sujets traités ici : 
- ne pas permettre la modification de scope formation / métier sur les points d'entrées spécifiques
- corriger un saut de scope vers /recherche lors de la modification des paramètres de recherche (par exemple en modifiant le rayon de recherche)