### PR TITLE
fix: logger error declaration

### DIFF
--- a/server/src/jobs/offrePartenaire/fillFieldsForPartnersFactory.ts
+++ b/server/src/jobs/offrePartenaire/fillFieldsForPartnersFactory.ts
@@ -144,7 +144,7 @@ export const fillFieldsForPartnersFactory = async <SourceFields extends keyof IC
       } catch (err) {
         counters.error += documents.length
         const newError = internal(`error lors du traitement d'un groupe de documents`)
-        logger.error(newError.message, err)
+        logger.error(err, newError.message)
         sentryCaptureException(newError)
 
         await getDbCollection("computed_jobs_partners").bulkWrite(

--- a/server/src/jobs/offrePartenaire/importFromComputedToJobsPartners.ts
+++ b/server/src/jobs/offrePartenaire/importFromComputedToJobsPartners.ts
@@ -125,7 +125,7 @@ export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter
         const newError = internal(
           `error converting computed_job_partner to job_partner, partner_label=${computedJobPartner.partner_label} partner_job_id=${computedJobPartner.partner_job_id}`
         )
-        logger.error(newError.message, err)
+        logger.error(err, newError.message)
         newError.cause = err
         sentryCaptureException(newError)
         callback(null)

--- a/server/src/jobs/offrePartenaire/rawToComputedJobsPartners.ts
+++ b/server/src/jobs/offrePartenaire/rawToComputedJobsPartners.ts
@@ -63,7 +63,7 @@ export const rawToComputedJobsPartners = async <ZodInput extends AnyZodObject>({
         } catch (err) {
           counters.error++
           const newError = internal(`error converting raw job to partner_label job for id=${document._id} partner_label=${partnerLabel}`)
-          logger.error(newError.message, err)
+          logger.error(err, newError.message)
           newError.cause = err
           sentryCaptureException(newError)
         }

--- a/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
@@ -188,7 +188,7 @@ export const importRecruteurLbaToComputed = async () => {
         } catch (err) {
           counters.error++
           const newError = internal(`error converting raw job to partner_label job for id=${document._id} partner_label=${partnerLabel}`)
-          logger.error(newError.message, err)
+          logger.error(err, newError.message)
           logger.error(JSON.stringify(err))
           newError.cause = err
           sentryCaptureException(newError)


### PR DESCRIPTION
## Cause racine

L'erreur était causée par un **ordre incorrect des paramètres** dans les appels à `logger.error()`. Après votre récente mise à jour des dépendances (commit `8a3f86434` du 7 novembre 2025), qui a mis à jour `@types/node` de `20.17.30` à `24.10.0`, l'inspection interne des erreurs par le logger bunyan est devenue plus stricte.

Bunyan attend : `logger.error(err, "message")` (erreur en premier, message en second)  
Mais le code avait : `logger.error("message", err)` (message en premier, erreur en second)

Lorsque bunyan a tenté d'inspecter l'objet erreur dans la mauvaise position, il a échoué en essayant de lire une propriété `value` qui n'existait pas, causant l'erreur `"Cannot read properties of undefined (reading 'value')"`.

## Fichiers corrigés

J'ai corrigé les 4 occurrences de ce bug :

1. `server/src/jobs/offrePartenaire/rawToComputedJobsPartners.ts:66`
2. `server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts:191`
3. `server/src/jobs/offrePartenaire/fillFieldsForPartnersFactory.ts:147`
4. `server/src/jobs/offrePartenaire/importFromComputedToJobsPartners.ts:128`

Tous les appels à logger.error utilisent maintenant l'ordre correct : `logger.error(err, newError.message)`.

## Pourquoi le typecheck n'a pas détecté l'erreur ?

Bunyan définit plusieurs **overloads** pour la méthode `error()` avec des signatures très permissives :

```typescript
error(error: Error, ...params: any[]): void;
error(obj: Object, ...params: any[]): void;
error(format: any, ...params: any[]): void;
```

Le problème
1. Ordre correct : logger.error(err, "message")
- Correspond à : error(error: Error, ...params: any[])
- L'erreur est traitée spécialement avec un champ err dans les logs
2. Ordre incorrect : logger.error("message", err)
- Correspond aussi à : error(format: any, ...params: any[])
- TypeScript accepte car any accepte tout type
- Bunyan essaie de formater avec util.format() au lieu de traiter l'erreur spécialement

## Conséquence
TypeScript ne peut pas détecter l'erreur car les deux ordres sont techniquement valides selon les types. Cependant :
- L'ordre correct (err en premier) utilise une logique spéciale pour les objets Error
- L'ordre incorrect (string en premier) utilise util.format() qui a échoué avec les nouvelles versions de Node.js lors de l'inspection de certaines structures d'erreur

C'est un bug de runtime qui n'est pas détectable au niveau des types à cause de l'utilisation de any dans les signatures.