### PR TITLE
fix: logger

### DIFF
--- a/server/src/common/apis/franceTravail/franceTravail.client.ts
+++ b/server/src/common/apis/franceTravail/franceTravail.client.ts
@@ -238,7 +238,7 @@ export async function* getAllFTJobsByDepartments(departement: string): AsyncGene
         // code region or departement not found
         break
       }
-      logger.error("Error while fetching jobs", error)
+      logger.error(error, "Error while fetching jobs")
     }
   }
 }

--- a/server/src/common/utils/ftpUtils.ts
+++ b/server/src/common/utils/ftpUtils.ts
@@ -17,7 +17,7 @@ class FTPClient {
       await this.client.access(options)
     } catch (error) {
       sentryCaptureException(error)
-      logger.error("FTP connection failed", error)
+      logger.error(error, "FTP connection failed")
     }
   }
 
@@ -47,7 +47,7 @@ class FTPClient {
       logger.info(`File successfully downloaded.`)
     } catch (error) {
       sentryCaptureException(error)
-      logger.error("Download failed:", error)
+      logger.error(error, "Download failed:")
     }
   }
 }

--- a/server/src/jobs/database/obfuscateCollections.ts
+++ b/server/src/jobs/database/obfuscateCollections.ts
@@ -29,7 +29,7 @@ async function reduceModel(model: CollectionName, limit = 20000) {
       await Promise.all(chunks.map(async (chunk) => await getDbCollection(model).deleteMany({ _id: { $in: chunk } })))
     }
   } catch (err) {
-    logger.error("Error reducing collection", err)
+    logger.error(err, "Error reducing collection")
   }
 }
 

--- a/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
+++ b/server/src/jobs/formationsCatalogue/formationsCatalogue.ts
@@ -63,7 +63,7 @@ export const importCatalogueFormationJob = async () => {
 
             stats.created++
           } catch (e) {
-            logger.error("Erreur enregistrement de formation", e)
+            logger.error(e, "Erreur enregistrement de formation")
             stats.failed++
           }
 

--- a/server/src/jobs/offrePartenaire/france-travail/classifyJobsFranceTravail.ts
+++ b/server/src/jobs/offrePartenaire/france-travail/classifyJobsFranceTravail.ts
@@ -133,7 +133,7 @@ export const classifyFranceTravailJobs = async () => {
 
         callback()
       } catch (err: any) {
-        logger.error("Erreur de classification d’un batch France Travail", err)
+        logger.error(err, "Erreur de classification d'un batch France Travail")
         callback(err)
       }
     },

--- a/server/src/jobs/offrePartenaire/importFromStreamInCsv.ts
+++ b/server/src/jobs/offrePartenaire/importFromStreamInCsv.ts
@@ -47,7 +47,7 @@ export const importFromStreamInCsv = async ({
       (err) => {
         logger.info(`${offerInsertCount} offers inserted`)
         if (err) {
-          logger.error("Pipeline failed.", err)
+          logger.error(err, "Pipeline failed.")
           reject(err)
         } else {
           logger.info("Pipeline succeeded.")

--- a/server/src/jobs/offrePartenaire/importFromStreamInXml.ts
+++ b/server/src/jobs/offrePartenaire/importFromStreamInXml.ts
@@ -68,7 +68,7 @@ export const importFromStreamInXml = async ({
     pipeline(stream, xmlToJsonTransform, (err) => {
       logger.info(`${offerInsertCount} offers inserted`)
       if (err) {
-        logger.error("Pipeline failed.", err)
+        logger.error(err, "Pipeline failed.")
         reject(err)
       } else {
         logger.info("Pipeline succeeded.")

--- a/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
@@ -39,7 +39,7 @@ const removePredictionFile = async () => {
     logger.info("Deleting downloaded file from assets")
     await unlinkSync(PREDICTION_FILE_PATH)
   } catch (err) {
-    logger.error("Error removing company algo file", err)
+    logger.error(err, "Error removing company algo file")
   }
 }
 
@@ -70,7 +70,7 @@ const getRecruteursLbaFileFromS3 = async ({ from, to }: { from: Stream.Readable;
     await pipeline(from, writeStream)
     logger.info("File transfer completed successfully")
   } catch (error) {
-    logger.error("Error during file transfer:", error)
+    logger.error(error, "Error during file transfer:")
     throw error
   }
 }

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -212,7 +212,7 @@ export const sendApplication = async ({
       await getDbCollection("applications").insertOne(application)
       return { result: "ok", message: "messages sent" }
     } catch (err) {
-      logger.error("Error sending application", err)
+      logger.error(err, "Error sending application")
       sentryCaptureException(err)
       if (newApplication?.caller) {
         await manageApiError({
@@ -1060,7 +1060,7 @@ export const deleteApplicationCvFile = async (application: IApplication) => {
 
 const getRecruteurEmailSubject = (application: IApplication, applicant: IApplicant) => {
   const { job_origin } = application
-  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+
   switch (job_origin) {
     case LBA_ITEM_TYPE.RECRUTEURS_LBA:
       return `Candidature spontanée en alternance ${application.company_name}`
@@ -1265,7 +1265,6 @@ const getJobOrCompanyFromApplication = async (application: IApplication) => {
   let job: IJobsPartnersOfferPrivate | null = null
   const { job_id, company_siret } = application
 
-  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
   switch (application.job_origin) {
     case LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA: {
       recruiter = await getDbCollection("recruiters").findOne({ "jobs._id": job_id })

--- a/server/src/services/openai/openai.service.ts
+++ b/server/src/services/openai/openai.service.ts
@@ -54,7 +54,7 @@ export const sendOpenAIMessages = async ({
 
     const json: OpenAI.Chat.Completions.ChatCompletion = (await response.json()) as any
     if ("error" in json) {
-      logger.error("Error from OpenAI", json.error)
+      logger.error(json.error, "Error from OpenAI")
       return null
     }
     if (!json.choices.length || !json.choices[0].message || !json.choices[0].message) {


### PR DESCRIPTION
# Documentation Node.js sur `util.inspect` et le problème rencontré

## Changements dans Node.js v24

D'après la documentation officielle de Node.js, voici les changements pertinents dans `util.inspect` entre v22 et v24.

### Inspection plus défensive des erreurs (commit `8cb3b77039`)

Node.js v24 a ajouté du code plus défensif lors de l'inspection d'objets erreur. Cela inclut l'ajout de blocs try-catch lors de l'accès aux propriétés des erreurs, une meilleure gestion des cas où les getters d'erreurs peuvent lever des exceptions, et une amélioration de la gestion des erreurs provenant de différents realms.

### Marquage des propriétés spéciales (commit `748d4f6430`)

Les propriétés spéciales sont maintenant marquées différemment lors de l'inspection, par exemple `[byteLength]` au lieu de `byteLength`.

## Le code source problématique

Dans `lib/internal/util/inspect.js` de Node.js, la fonction `formatProperty` contient ce code :

```javascript
desc ||= ObjectGetOwnPropertyDescriptor(value, key) ||
  { value: value[key], enumerable: true };
```

Le problème est que si `value` est `undefined`, l'accès à `value[key]` échouera avec l'erreur :

```
Cannot read properties of undefined (reading 'value')
```

## Pourquoi cela affecte bunyan ?

Lorsque bunyan appelle `logger.error(message, err)` au lieu de `logger.error(err, message)`, voici ce qui se passe :

Bunyan utilise l'overload `error(format: any, ...params: any[])`, ce qui déclenche un appel à `util.format(message, err)`. Cette fonction appelle ensuite `util.inspect(err)` en interne pour inspecter l'objet `err`. Dans Node.js v24, si `err` a une structure inattendue, `formatProperty` essaie d'accéder à `value[key]` où `value` peut être `undefined`.

## Références officielles

- Node.js v24.0.0 Release Notes : https://nodejs.org/en/blog/release/v24.0.0
- Node.js v24 Changelog : https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V24.md
- util.inspect API Documentation : https://nodejs.org/api/util.html#utilinspectobject-options
- Commit "use more defensive code when inspecting error objects" : https://github.com/nodejs/node/commit/8cb3b77039

## Le changement clé (commit 8cb3b77039)

Dans Node.js v22 et versions antérieures, le code était moins défensif et plus tolérant aux structures d'erreur inhabituelles. Dans Node.js v24, le code est devenu plus strict avec l'ajout de blocs try-catch :

```javascript
try {
  if (desc && desc.value !== undefined) {
    // ...
  }
} catch {
  // Gestion des erreurs
}
```

## Conclusion

Node.js v24 a rendu `util.inspect` plus strict et plus défensif, ce qui expose des bugs qui étaient silencieux dans les versions précédentes. Le mauvais ordre des paramètres dans `logger.error()` fonctionnait "par hasard" dans Node.js v22, mais échoue dans Node.js v24.

## Recommandation officielle

Toujours utiliser l'ordre correct pour bunyan :

```javascript
// ✅ CORRECT
logger.error(err, "message")

// ❌ INCORRECT
logger.error("message", err)
```