### PR TITLE
fix(lba3362): sentry config

### DIFF
--- a/server/src/common/sentry/sentry.fastify.ts
+++ b/server/src/common/sentry/sentry.fastify.ts
@@ -54,6 +54,10 @@ function extractUserData(request: FastifyRequest): UserData {
 }
 
 export function initSentryFastify(app: Server) {
+  // Setup official Fastify error handler
+  Sentry.setupFastifyErrorHandler(app)
+
+  // Custom user data hook
   app.addHook("onRequest", async (request, _reply) => {
     const scope = Sentry.getIsolationScope()
     scope

--- a/server/src/common/sentry/sentry.ts
+++ b/server/src/common/sentry/sentry.ts
@@ -5,6 +5,17 @@ import config from "@/config"
 
 function getOptions(): Sentry.NodeOptions {
   return {
+    beforeSend(event, hint) {
+      // Filter out 4xx errors from Boom
+      const error = hint.originalException
+      if (error && typeof error === "object" && "isBoom" in error && error.isBoom) {
+        const statusCode = (error as any).output?.statusCode
+        if (statusCode && statusCode < 500) {
+          return null // Don't send to Sentry
+        }
+      }
+      return event
+    },
     tracesSampler: (samplingContext) => {
       // Continue trace decision, if there is any parentSampled information
       if (samplingContext.parentSampled != null) {


### PR DESCRIPTION
- https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3362

## Résumé des changements

### sentry.fastify.ts

Ajout de `Sentry.setupFastifyErrorHandler(app)` pour utiliser l'intégration officielle Fastify, avec conservation du hook custom pour les données utilisateur.

### sentry.ts

Ajout d'un filtre `beforeSend` qui ignore toutes les erreurs Boom avec statusCode < 500. Les erreurs 4xx (badRequest, unauthorized, notFound, etc.) ne seront plus envoyées à Sentry.