### PR TITLE
fix: use node22 for ui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,8 @@ ENV __SENTRY_EXCLUDE_REPLAY_WORKER__=true
 RUN --mount=type=cache,target=/app/ui/.next/cache yarn --cwd ui build
 
 # Production image, copy all the files and run next
-FROM node:24-slim AS ui
+# locked to node 22 for now (20251120) : https://github.com/vercel/next.js/discussions/75995 en node24
+FROM node:22-slim AS ui 
 WORKDIR /app
 
 RUN apt-get update \


### PR DESCRIPTION
https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/undefined/events/24c07981db074e02826fd77dbfc7018b/

 📅 Chronologie de l'apparition du bug

  v1.671.0 (17 sept 2025)  → Node.js 24 installé
           ↓
  v1.703.0 (31 oct 2025)   → Next.js 16.0.1 installé  ⚠️
           ↓
  v1.710.x                 → Première occurrence de l'erreur selon Sentry
           ↓
  v1.711.4 (20 nov 2025)   → Version actuelle avec l'erreur

  🎯 Diagnostic confirmé

  L'erreur est apparue directement après la mise à jour vers Next.js 16 (v1.703.0). Voici pourquoi :

  La combinaison problématique :
  - ✅ Node.js 24 installé depuis septembre → fonctionnait avec Next.js 15
  - ⚠️ Next.js 16.0.1 installé en octobre → incompatibilité avec Node.js 24
  - 💥 Résultat : erreurs de streaming transformAlgorithm is not a function

  Pourquoi ça n'est pas apparu immédiatement ?

  L'erreur est intermittente et ne se produit que dans certaines conditions :
  1. Page avec streaming SSR (votre page de détail d'offre fait un await apiGet())
  2. Connexions fermées prématurément (bots, health checks, timeouts)
  3. État corrompu du stream après plusieurs heures de fonctionnement

  🔧 Solutions par ordre de priorité

  Solution 1 : Downgrade Node.js à la v22 LTS (recommandé)