### PR TITLE
fix(lba-3380): Nextjs stream error - transformAlgorithm is not a function

### DIFF
--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
@@ -8,6 +8,13 @@ import JobDetailRendererClient from "./JobDetailRendererClient"
 import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { apiGet } from "@/utils/api.utils"
 
+// Désactive le streaming SSR pour éviter l'erreur "transformAlgorithm is not a function"
+// avec Next.js 16 quand les connexions sont interrompues (healthchecks, timeouts, etc.)
+// Voir: https://github.com/vercel/next.js/discussions/75995
+// Context: PRs #2474-2479, Sentry issue https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/6/
+export const dynamic = "force-dynamic"
+export const revalidate = 300 // Cache ISR pendant 5 minutes
+
 const typeToJobMap = {
   [LBA_ITEM_TYPE.RECRUTEURS_LBA]: "ILbaItemLbaCompanyJson",
   [LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA]: "ILbaItemPartnerJobJson",


### PR DESCRIPTION
- https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3380

## 🐛 Problème

Erreur récurrente sur Sentry lors de l'affichage des pages d'offres d'emploi :
- `transformAlgorithm is not a function`
- Causée par l'interruption des streams SSR de Next.js 16 (healthchecks Docker, timeouts réseau, etc.)
- Voir discussion : https://github.com/vercel/next.js/discussions/75995

## 🔍 Contexte

Suite aux PRs #2474-2479 qui ont tenté différentes approches :
- **#2474** : Downgrade Node 22
- **#2475** : Ajout endpoint healthcheck (insuffisant)

**Le vrai problème :** streaming SSR de Next.js 16 incompatible avec les interruptions de connexion en production.

## ✅ Solution

Ajout de configurations sur la page `ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx` :

```typescript
export const dynamic = "force-dynamic"
export const revalidate = 300 // Cache ISR pendant 5 minutes
```

**Bénéfices :**
- ✅ Désactive le streaming SSR qui causait les erreurs
- ✅ Cache ISR de 5 minutes pour réduire la charge serveur
- ✅ Données à jour avec un délai max de 5 minutes (acceptable pour des offres d'emploi)

## 📊 Impact

- **Performance :** Cache ISR améliore les temps de réponse pour les offres populaires
- **Serveur :** Charge réduite grâce au cache (vs force-no-store)
- **SEO :** Aucun impact négatif (toujours du SSR)

--> Prévoir un passage à node 24 si correction succès après 2-3 semaines 