### PR TITLE
fix(lbac-3381): fix sentry 419: formation not found

### DIFF
--- a/server/src/services/formation.service.ts
+++ b/server/src/services/formation.service.ts
@@ -1,10 +1,10 @@
-import { badRequest } from "@hapi/boom"
-import dayjs from "shared/helpers/dayjs"
+import { badRequest, notFound } from "@hapi/boom"
 import { chain } from "lodash-es"
-import { assertUnreachable } from "shared"
 import type { IFormationCatalogue, ILbaItemFormation2 } from "shared"
+import { assertUnreachable } from "shared"
 import { LBA_ITEM_TYPE, LBA_ITEM_TYPE_OLD } from "shared/constants/lbaitem"
 import { referrers } from "shared/constants/referers"
+import dayjs from "shared/helpers/dayjs"
 import type { INiveauDiplomeEuropeen } from "shared/models/jobsPartners.model"
 
 import { isEmailBlacklisted } from "./application.service"
@@ -760,7 +760,7 @@ export const getFormationQuery = async ({ id }: { id: string }): Promise<{ resul
 export const getFormationDetailByCleME = async (id: string): Promise<ILbaItemFormation2> => {
   const formation = await getDbCollection("formationcatalogues").findOne({ cle_ministere_educatif: id })
   if (!formation) {
-    throw badRequest("Formation not found")
+    throw notFound("Formation not found")
   }
   const priseDeRendezVous = await getDbCollection("eligible_trainings_for_appointments").findOne({
     cle_ministere_educatif: formation.cle_ministere_educatif,

--- a/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
+++ b/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
@@ -4,12 +4,23 @@ import { redirect } from "next/navigation"
 
 import TrainingDetailRendererClient from "./TrainingDetailRendererClient"
 import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
-import { apiGet } from "@/utils/api.utils"
+import { ApiError, apiGet } from "@/utils/api.utils"
+
+async function getFormationOption(id: string) {
+  try {
+    const formation = await apiGet("/_private/formations/:id", { params: { id } })
+    return formation
+  } catch (err) {
+    if (err && err instanceof ApiError && err.context.statusCode === 404) {
+      return null
+    }
+  }
+}
 
 export async function generateMetadata({ params }): Promise<Metadata> {
   const { id } = await params
   const idParam = decodeURIComponent(id)
-  const formation = await apiGet("/_private/formations/:id", { params: { id: idParam } })
+  const formation = await getFormationOption(idParam)
 
   if (!formation) return { title: "Offre de formation introuvable" }
 
@@ -21,7 +32,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
 export default async function FormationPage({ params, searchParams }: { params: Promise<{ id: string }>; searchParams: Promise<Record<string, string>> }) {
   const { id } = await params
   const idParam = decodeURIComponent(id)
-  const formation = await apiGet("/_private/formations/:id", { params: { id: idParam } })
+  const formation = await getFormationOption(idParam)
   if (!formation) redirect("/404")
 
   return (

--- a/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
+++ b/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
@@ -14,6 +14,7 @@ async function getFormationOption(id: string) {
     if (err && err instanceof ApiError && err.context.statusCode === 404) {
       return null
     }
+    throw err
   }
 }
 


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?jql=assignee%20%3D%20712020%3A805c2bc3-b985-42ea-9088-d8d83d9b3925&selectedIssue=LBA-3381


* Added import of ApiError alongside apiGet.
* Introduced helper function getFormationOption(id):
* Calls apiGet("/_private/formations/:id", { params: { id } }).
* Catches errors and returns null when the API responds 404.
* Replaced direct apiGet calls with getFormationOption(idParam) in:
** generateMetadata — now returns a "formation introuvable" title when helper returns null.
** FormationPage — now redirects to /404 when helper returns null.
* No changes to the fetched data shape or other logic; primary change is centralized 404-aware fetching and error handling.