### PR TITLE
fix(lbac-3367): userswithaccounts: clean last_action_date

### DIFF
--- a/server/src/http/controllers/etablissementRecruteur.controller.ts
+++ b/server/src/http/controllers/etablissementRecruteur.controller.ts
@@ -238,6 +238,7 @@ export default (server: Server) => {
               phone,
               email: formatedEmail,
               origin,
+              last_action_date: new Date(),
             },
             is_email_checked: false,
             organization: { type: CFA, cfa },

--- a/server/src/jobs/anonymization/anonymizeUserRecruteurs.ts
+++ b/server/src/jobs/anonymization/anonymizeUserRecruteurs.ts
@@ -31,7 +31,7 @@ const recruiterProjection: Partial<Record<keyof IRecruiter, 1>> = {
 
 const anonymize = async () => {
   const fromDate = dayjs().subtract(2, "years").toDate()
-  const userWithAccountQuery = { $or: [{ last_action_date: { $lte: fromDate } }, { last_action_date: null, createdAt: { $lte: fromDate } }] }
+  const userWithAccountQuery = { last_action_date: { $lte: fromDate } }
   const usersToAnonymize = await getDbCollection("userswithaccounts").find(userWithAccountQuery).toArray()
   const userIds = usersToAnonymize.map(({ _id }) => _id.toString())
   const recruiterQuery = { managed_by: { $in: userIds } } //TODO: à mettre à jour quand multi compte

--- a/server/src/migrations/20251204025232-fill-last-action-date.ts
+++ b/server/src/migrations/20251204025232-fill-last-action-date.ts
@@ -1,0 +1,12 @@
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+
+export const up = async () => {
+  await getDbCollection("userswithaccounts").updateMany(
+    // @ts-expect-error
+    { last_action_date: null },
+    [{ $set: { last_action_date: "$updatedAt" } }]
+  )
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/server/src/services/etablissement.service.ts
+++ b/server/src/services/etablissement.service.ts
@@ -555,7 +555,7 @@ export const entrepriseOnboardingWorkflow = {
 
     let validated = false
     const { user: managingUser } = await createOrganizationUser({
-      userFields: { first_name, last_name, phone: phone ?? "", origin, email: formatedEmail },
+      userFields: { first_name, last_name, phone: phone ?? "", origin, email: formatedEmail, last_action_date: new Date() },
       is_email_checked: false,
       organization: { type: ENTREPRISE, entreprise },
     })

--- a/server/src/services/userWithAccount.service.ts
+++ b/server/src/services/userWithAccount.service.ts
@@ -49,7 +49,7 @@ export const createUser2IfNotExist = async (
       first_name,
       last_name,
       phone: phone ?? "",
-      last_action_date: last_action_date ?? new Date(),
+      last_action_date,
       origin,
       status,
       createdAt: now,

--- a/shared/src/fixtures/userWithAccount.fixture.ts
+++ b/shared/src/fixtures/userWithAccount.fixture.ts
@@ -22,6 +22,7 @@ export function generateUserWithAccountFixture(data: Partial<IUserWithAccount> =
 
     createdAt: new Date("2021-01-28T15:00:00.000Z"),
     updatedAt: new Date("2021-01-28T15:00:00.000Z"),
+    last_action_date: new Date("2021-01-28T15:00:00.000Z"),
 
     ...data,
   }

--- a/shared/src/models/userWithAccount.model.ts
+++ b/shared/src/models/userWithAccount.model.ts
@@ -38,7 +38,7 @@ export const ZUserWithAccount = z
     last_name: z.string(),
     email: z.string().email(),
     phone: extensions.phone(),
-    last_action_date: z.date().nullish(),
+    last_action_date: z.date(),
     createdAt: z.date(),
     updatedAt: z.date(),
   })

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/gestionDesAdministrateurs.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/gestionDesAdministrateurs.tsx
@@ -94,8 +94,8 @@ export default function GestionDesAdministrateurs() {
           {
             Header: "Actif",
             id: "last_connection",
-            accessor: ({ last_action_date: date }) => {
-              return date ? dayjs(date).format("DD/MM/YYYY") : "Jamais"
+            accessor: ({ last_action_date }) => {
+              return dayjs(last_action_date).format("DD/MM/YYYY")
             },
           },
         ]}


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?jql=assignee%20%3D%20712020%3A805c2bc3-b985-42ea-9088-d8d83d9b3925&selectedIssue=LBA-3367

- New migration
  - server/src/migrations/20251204025232-fill-last-action-date.ts
    - Fills null last_action_date with updatedAt for all userswithaccounts documents.

- Model & fixtures
  - shared/src/models/userWithAccount.model.ts
    - last_action_date changed from optional/nullish to required z.date().
  - shared/src/fixtures/userWithAccount.fixture.ts
    - Adds last_action_date to fixture data.

- Creation / onboarding changes
  - server/src/http/controllers/etablissementRecruteur.controller.ts
    - Sets last_action_date: new Date() when creating recruiter user.
  - server/src/services/etablissement.service.ts
    - Sets last_action_date: new Date() when creating entreprise user via onboarding.
  - server/src/services/userWithAccount.service.ts
    - createUser2IfNotExist: stops defaulting last_action_date to new Date(); now uses provided value.

- Anonymization job
  - server/src/jobs/anonymization/anonymizeUserRecruteurs.ts
    - Query tightened: only anonymize users where last_action_date <= fromDate (removed null branch).

- UI change
  - ui/app/.../gestionDesAdministrateurs.tsx
    - Table accessor simplified to always format last_action_date (assumes non-null).
