### PR TITLE
feat: ajout d'une tâche d'analyse des paquets NPM dans les différentes pipelines

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -31,7 +31,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mission-apprentissage/mna-npm-check
-          path: mna-npm-check                                                                                                                                         
+          path: mna-npm-check
+
       - name: Analyze NPM dependancies
         run: mna-npm-check/npm-check.sh -p .
 

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -15,7 +15,29 @@ on:
           - pentest
 
 jobs:
+
+  npm-packages-check:
+    runs-on: ubuntu-latest
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Clone mna-npm-check repository
+        uses: actions/checkout@v4
+        with:
+          repository: mission-apprentissage/mna-npm-check
+          path: mna-npm-check                                                                                                                                         
+      - name: Analyze NPM dependancies
+        run: mna-npm-check/npm-check.sh -p .
+
   build:
+    if: ${{ success() }}
+    needs: ["npm-packages-check"]
     concurrency:
       group: "build-${{ github.workflow }}-${{ github.ref }}"
     permissions: write-all
@@ -33,7 +55,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --ignore-scripts
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -67,8 +67,40 @@ jobs:
         env:
           APP_VERSION: ${{ inputs.app_version }}
 
+  npm-packages-check:
+    runs-on: ubuntu-latest
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Clone mna-npm-check repository
+        uses: actions/checkout@v4
+        with:
+          repository: mission-apprentissage/mna-npm-check
+          path: mna-npm-check                                                                                                                                         
+      - name: Analyze NPM dependancies
+        run: mna-npm-check/npm-check.sh -p .
+
+      - name: Notify failure on Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notification_title: "Le déploiement ${{ inputs.app_version }} en ${{ inputs.environment }} a échoué"
+          message_format: "{emoji} *[${{ inputs.environment }}]* *{workflow}* {status_message} in <{repo_url}|{branch}> on <{commit_url}|{commit_sha}>. Suspected     traces of known attacks on the NPM supply chain!`"
+          notify_when: "failure"
+          mention_groups: "!channel"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
   deploy:
-    needs: version
+    if: ${{ success() }}
+    needs: ["version", "npm-packages-check"]
     name: Deploy ${{ needs.version.outputs.VERSION }} on ${{ inputs.environment }}
     runs-on: ubuntu-latest
     steps:
@@ -93,7 +125,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --ignore-scripts
 
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -82,21 +82,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mission-apprentissage/mna-npm-check
-          path: mna-npm-check                                                                                                                                         
+          path: mna-npm-check
+
       - name: Analyze NPM dependancies
         run: mna-npm-check/npm-check.sh -p .
-
-      - name: Notify failure on Slack
-        uses: ravsamhq/notify-slack-action@v2
-        if: always()
-        with:
-          status: ${{ job.status }}
-          notification_title: "Le déploiement ${{ inputs.app_version }} en ${{ inputs.environment }} a échoué"
-          message_format: "{emoji} *[${{ inputs.environment }}]* *{workflow}* {status_message} in <{repo_url}|{branch}> on <{commit_url}|{commit_sha}>. Suspected     traces of known attacks on the NPM supply chain!`"
-          notify_when: "failure"
-          mention_groups: "!channel"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   deploy:
     if: ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mission-apprentissage/mna-npm-check
-          path: mna-npm-check                                                                                                                                         
+          path: mna-npm-check
+
       - name: Analyze NPM dependancies
         run: mna-npm-check/npm-check.sh -p .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,29 @@ on:
         description: Code coverrage token
         required: true
 jobs:
+
+  npm-packages-check:
+    runs-on: ubuntu-latest
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Clone mna-npm-check repository
+        uses: actions/checkout@v4
+        with:
+          repository: mission-apprentissage/mna-npm-check
+          path: mna-npm-check                                                                                                                                         
+      - name: Analyze NPM dependancies
+        run: mna-npm-check/npm-check.sh -p .
+
   tests:
+    if: ${{ success() }}
+    needs: ["npm-packages-check"]
     timeout-minutes: 10
     name: "Tests"
     runs-on: ubuntu-latest
@@ -22,7 +44,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --ignore-scripts
 
       - name: Make sure to use same dependencies version across all packages
         run: yarn dedupe --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mission-apprentissage/mna-npm-check
-          path: mna-npm-check                                                                                                                                         
+          path: mna-npm-check
+
       - name: Analyze NPM dependancies
         run: mna-npm-check/npm-check.sh -p .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,28 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  npm-packages-check:
+    runs-on: ubuntu-latest
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Clone mna-npm-check repository
+        uses: actions/checkout@v4
+        with:
+          repository: mission-apprentissage/mna-npm-check
+          path: mna-npm-check                                                                                                                                         
+      - name: Analyze NPM dependancies
+        run: mna-npm-check/npm-check.sh -p .
+
   release:
+    if: ${{ success() }}
+    needs: ["npm-packages-check"]
     concurrency:
       group: "release-${{ github.workflow }}-${{ github.ref }}"
     permissions: write-all
@@ -30,7 +51,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --ignore-scripts
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -79,7 +100,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --ignore-scripts
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -118,7 +139,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --ignore-scripts
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -241,7 +262,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --ignore-scripts
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Ajout d'une tâche d'analyse des paquets NPM en amont des tâches de création des images **Docker** du projet, de déploiement du projet, et de tests.

Ce script parcourt l'ensemble des fichiers package.json du dépôt à la recherche de correspondances avec une liste préalabement télécharger de paquets dont les versions sont officiellement considérés comme compromises.

L'analyse prend également en compte la présence de fichier yarn.lock et package-lock.json pour évaluer le niveau de risque encouru.

Si l'analyse révèle des suspicions moyennes ou fortes de la présence de définitions de dépendances pouvant conduire à l'installation de paquets compromis, le script termine en erreur, et les tâches suivantes ne sont alors pas exécutées.