### PR TITLE
fix: github actions - use env instead of secret

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -15,10 +15,9 @@ on:
           - pentest
 
 jobs:
-
   npm-packages-check:
     runs-on: ubuntu-latest
-    secrets:
+    env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - name: Checkout project

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -69,7 +69,7 @@ jobs:
 
   npm-packages-check:
     runs-on: ubuntu-latest
-    secrets:
+    env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,9 @@ on:
         description: Code coverrage token
         required: true
 jobs:
-
   npm-packages-check:
     runs-on: ubuntu-latest
-    secrets:
+    env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - name: Checkout project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
   npm-packages-check:
     runs-on: ubuntu-latest
-    secrets:
+    env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - name: Checkout project


### PR DESCRIPTION
## 🔧 Changes Made

The `secrets:` keyword at job level is only valid when calling reusable workflows (with `uses:`). For regular jobs that run steps directly, secrets must be passed via `env:`.

## 📝 Files Modified

1. `.github/workflows/ci.yml` - Line 13
2. `.github/workflows/release.yml` - Line 14
3. `.github/workflows/_build.yml` - Line 21
4. `.github/workflows/_deploy.yml` - Line 72

## 🔄 Change Applied

**Before (incorrect):**
```yaml
npm-packages-check:
  runs-on: ubuntu-latest
  secrets:
    SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
  steps:
```

**After (correct):**
```yaml
npm-packages-check:
  runs-on: ubuntu-latest
  env:
    SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
  steps:
```

## ✅ Result

This resolves the "Unexpected value 'secrets'" errors that were blocking the workflows.