### PR TITLE
feat(lba-3441): enable classification upate api

### DIFF
--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -392,7 +392,7 @@ export async function setupJobProcessor() {
           return [
             command,
             {
-              handler: async () => fct(),
+              handler: async (job) => fct(job.payload),
             },
           ]
         })

--- a/server/src/jobs/simpleJobDefinitions.ts
+++ b/server/src/jobs/simpleJobDefinitions.ts
@@ -70,7 +70,7 @@ import { processScheduledRecruiterIntentions } from "@/services/application.serv
 import { generateSitemap } from "@/services/sitemap.service"
 
 type SimpleJobDefinition = {
-  fct: () => Promise<unknown>
+  fct: (payload?: any) => Promise<unknown>
   description: string
 }
 

--- a/shared/src/routes/classification.routes.ts
+++ b/shared/src/routes/classification.routes.ts
@@ -21,4 +21,22 @@ export const zClassificationRoute = {
       securityScheme: null,
     },
   },
+  post: {
+    "/classification": {
+      method: "post",
+      path: "/classification",
+      body: z.object({
+        partner_job_ids: z.string().array().min(1, "Il faut au moins un id à mettre à jour"),
+        classification: z.enum(["cfa", "entreprise", "entreprise_cfa"]),
+      }),
+      response: {
+        200: z.object({ response: z.literal("Les mises à jour vont être traité par le serveur"), time: z.coerce.date() }),
+      },
+      securityScheme: {
+        auth: "api-key",
+        access: null,
+        resources: {},
+      },
+    },
+  },
 } as const satisfies IRoutesDef

--- a/shared/src/routes/index.ts
+++ b/shared/src/routes/index.ts
@@ -93,6 +93,7 @@ const zRoutesPost2 = {
   ...zRecruiterRoutes.post,
   ...zApplicationRoutesV2.post,
   ...zAppointmentsRouteV2.post,
+  ...zClassificationRoute.post,
 }
 
 const zRoutesPost3 = {


### PR DESCRIPTION
- https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3441

## Nouvelle route POST `/classification` (shared + server)

### shared/src/routes/classification.routes.ts

Ajout du schéma de la route POST avec body `{ partner_job_ids: string[], classification: "cfa" | "entreprise" | "entreprise_cfa" }`, réponse `{ response: string, time: Date }` et sécurité par authentification API key.

### shared/src/routes/index.ts

Export de la nouvelle route POST.

## Implémentation du controller (classification.controller.ts)

Nouvelle fonction `updateClassificationAndSynchronise` qui effectue les opérations suivantes :

1. Met à jour `human_verification` dans `cache_classification` pour les jobs sélectionnés
2. Récupère les jobs où `classification ≠ human_verification`
3. Pour chaque job mal classifié, si présent dans `jobs_partners` met le statut à `ANNULEE`, si présent dans `computed_jobs_partners` reset les erreurs
4. Lance le job `fillComputedJobsPartners` avec un filtre sur les IDs concernés

## Support du payload pour les simple jobs (jobs.ts + simpleJobDefinitions.ts)

Le handler passe maintenant `job.payload` aux fonctions, et le type `SimpleJobDefinition.fct` accepte un payload optionnel.