### PR TITLE
fix(sentry-3501): silence jwt expired error

### DIFF
--- a/server/src/http/middlewares/errorMiddleware.ts
+++ b/server/src/http/middlewares/errorMiddleware.ts
@@ -79,7 +79,10 @@ export function errorMiddleware(server: Server) {
 
     if (error.output.statusCode >= 500 || (request.url.startsWith("/api/emails/webhook") && error.output.statusCode >= 400)) {
       server.log.error(rawError)
-      captureException(rawError)
+      const errorMessage = rawError + ""
+      if (errorMessage !== "TokenExpiredError: jwt expired") {
+        captureException(rawError)
+      }
     }
 
     return reply.status(payload.statusCode).send(payload)


### PR DESCRIPTION
https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/3501/?project=4

**Description:**  
Modified the error handling middleware to prevent capturing JWT expired errors to Sentry. 

**Details:**
- Added a check to convert the raw error to a string message
- Wrapped the `captureException()` call in a conditional statement
- Only captures exceptions when the error message is NOT "TokenExpiredError: jwt expired"
- This prevents noisy/expected JWT expiration errors from being reported to Sentry monitoring
