### PR TITLE
fix: classification endpoint

### DIFF
--- a/server/src/services/cacheClassification.service.ts
+++ b/server/src/services/cacheClassification.service.ts
@@ -31,7 +31,7 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
   })
 
   if (!notFoundJobs.length) {
-    return cachedClassifications.map((cached) => cached?.classification ?? null)
+    return cachedClassifications.map((cached) => (cached?.human_verification ? cached.human_verification : (cached?.classification ?? null)))
   }
 
   const classificationPayload = notFoundJobs.map((job) => ({


### PR DESCRIPTION
## classification.controller.ts

### Sécurité de l'API

Ajout de la vérification du scope utilisateur : seuls les utilisateurs avec `scope: "classification"` peuvent utiliser l'endpoint POST `/classification`. Import de `ICredential` et `unauthorized` pour la validation.

### Amélioration du traitement des jobs

- Ajout de la mise à jour de `updated_at` lors de l'annulation d'offres dans `jobs_partners`
- Ajout du reset du flag `validated: false` dans `computed_jobs_partners` (en plus de `business_error` et `errors`)
- Optimisation : utilisation de `Promise.all()` pour paralléliser les mises à jour de `jobs_partners` et `computed_jobs_partners`

### Correction de bug

Ajout du job `importFromComputedToJobsPartners` qui était manquant, avec le payload correct `{ partner_job_id: { $in: filteredScopeIds } }`. Ce job permet de réimporter les offres modifiées depuis `computed_jobs_partners` vers `jobs_partners`.

## cacheClassification.service.ts

### Priorisation de la vérification humaine

Si une classification a été vérifiée manuellement (`human_verification`), elle est maintenant retournée en priorité plutôt que la classification automatique. Logique : `human_verification || classification || null`.