### PR TITLE
fix: classification.client.fixture.ts endpoint

### DIFF
--- a/server/src/common/apis/classification/classification.client.fixture.ts
+++ b/server/src/common/apis/classification/classification.client.fixture.ts
@@ -5,5 +5,5 @@ import type { IGetLabClassificationBatch } from "./classification.client"
 import config from "@/config"
 
 export function nockLabClassification(payload: IGetLabClassificationBatch, response: IClassificationLabBatchResponse) {
-  return nock(config.labonnealternanceLab.baseUrl).post("/scores", { items: payload }).reply(200, response)
+  return nock(config.labonnealternanceLab.baseUrl).post("/model/scores", { items: payload }).reply(200, response)
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

Fixed the endpoint path in the test fixture to match the actual API implementation. The fixture was mocking `/scores` but the real client uses `/model/scores` (line 33 in `classification.client.ts`).

- Corrected endpoint from `/scores` to `/model/scores` in `nockLabClassification` fixture
- This ensures test mocks align with the actual `getLabClassificationBatch` implementation

### Confidence Score: 5/5

- This PR is safe to merge with no risk
- The change is a simple one-line fix that corrects a test fixture to match the actual API endpoint being used in production code. The fix aligns the mock with the real implementation on line 33 of `classification.client.ts`, which uses `/model/scores`. No logic changes, no breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/common/apis/classification/classification.client.fixture.ts | 5/5 | Fixed endpoint path from `/scores` to `/model/scores` to match the actual API client implementation |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->