### PR TITLE
fix: coupure du cron du reminder parcoursup

### DIFF
--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -1,27 +1,35 @@
 import { addJob, initJobProcessor } from "job-processor"
 import { ObjectId } from "mongodb"
 
-import { updateSEO } from "./seo/updateSEO"
 import { anonymizeApplicantsAndApplications } from "./anonymization/anonymizeApplicantAndApplications"
 import { anonymizeApplications } from "./anonymization/anonymizeApplications"
 import anonymizeAppointments from "./anonymization/anonymizeAppointments"
 import anonymizeIndividual from "./anonymization/anonymizeIndividual"
+import { anonymizeReportedReasons } from "./anonymization/anonymizeReportedReasons"
 import { anonimizeUsersWithAccounts } from "./anonymization/anonymizeUserRecruteurs"
 import { anonymizeUsers } from "./anonymization/anonymizeUsers"
+import { removeBrevoContacts } from "./anonymization/removeBrevoContacts"
 import { processApplications } from "./applications/processApplications"
 import { processRecruiterIntentions } from "./applications/processRecruiterIntentions"
 import { recreateIndexes } from "./database/recreateIndexes"
 import { validateModels } from "./database/schemaValidation"
+import { updateDiplomeMetier } from "./diplomesMetiers/updateDiplomesMetiers"
 import { importCatalogueFormationJob } from "./formationsCatalogue/formationsCatalogue"
 import { updateParcoursupAndAffelnetInfoOnFormationCatalogue } from "./formationsCatalogue/updateParcoursupAndAffelnetInfoOnFormationCatalogue"
 import { generateFranceTravailAccess } from "./franceTravail/generateFranceTravailAccess"
 import { createJobsCollectionForMetabase } from "./metabase/metabaseJobsCollection"
 import { createRoleManagement360 } from "./metabase/metabaseRoleManagement360"
+import { create as createMigration, status as statusMigration, up as upMigration } from "./migrations/migrations"
+import { sendMiseEnRelation } from "./miseEnRelation/sendMiseEnRelation"
 import { expireJobsPartners } from "./offrePartenaire/expireJobsPartners"
+import { importers } from "./offrePartenaire/jobsPartners.importer"
 import { processJobPartnersForApi } from "./offrePartenaire/processJobPartnersForApi"
 import { processRecruteursLba } from "./offrePartenaire/recruteur-lba/processRecruteursLba"
+import { exportFileForAlgo } from "./partenaireExport/exportBlacklistAlgo"
 import { sendContactsToBrevo } from "./partenaireExport/exportContactsToBrevo"
 import { exportLbaJobsToS3 } from "./partenaireExport/exportJobsToS3"
+import { exportJobsToS3V2 } from "./partenaireExport/exportJobsToS3V2"
+import { exportRecruteursToBrevo } from "./partenaireExport/exportRecrutersToBrevo"
 import { exportJobsToFranceTravail } from "./partenaireExport/exportToFranceTravail"
 import { activateOptoutOnEtablissementAndUpdateReferrersOnETFA } from "./rdv/activateOptoutOnEtablissementAndUpdateReferrersOnETFA"
 import { eligibleTrainingsForAppointmentsHistoryWithCatalogue } from "./rdv/eligibleTrainingsForAppointmentsHistoryWithCatalogue"
@@ -42,25 +50,16 @@ import { opcoReminderJob } from "./recruiters/opcoReminderJob"
 import { recruiterOfferExpirationReminderJob } from "./recruiters/recruiterOfferExpirationReminderJob"
 import { resetApiKey } from "./recruiters/resetApiKey"
 import { updateSiretInfosInError } from "./recruiters/updateSiretInfosInErrorJob"
+import { updateSEO } from "./seo/updateSEO"
 import { SimpleJobDefinition, simpleJobDefinitions } from "./simpleJobDefinitions"
 import { updateBrevoBlockedEmails } from "./updateBrevoBlockedEmails/updateBrevoBlockedEmails"
 import { controlApplications } from "./verifications/controlApplications"
 import { controlAppointments } from "./verifications/controlAppointments"
-import { removeBrevoContacts } from "./anonymization/removeBrevoContacts"
-import { sendMiseEnRelation } from "./miseEnRelation/sendMiseEnRelation"
-import { create as createMigration, status as statusMigration, up as upMigration } from "./migrations/migrations"
-import { exportFileForAlgo } from "./partenaireExport/exportBlacklistAlgo"
-import { importers } from "./offrePartenaire/jobsPartners.importer"
-import { exportRecruteursToBrevo } from "./partenaireExport/exportRecrutersToBrevo"
-import { exportJobsToS3V2 } from "./partenaireExport/exportJobsToS3V2"
-import { updateDiplomeMetier } from "./diplomesMetiers/updateDiplomesMetiers"
-import { anonymizeReportedReasons } from "./anonymization/anonymizeReportedReasons"
-import { premiumActivatedReminder } from "./rdv/premiumActivatedReminder"
+import { generateSitemap } from "@/services/sitemap.service"
+import { updateReferentielCommune } from "@/services/referentiel/commune/commune.referentiel.service"
 import config from "@/config"
 import { getDatabase } from "@/common/utils/mongodbUtils"
 import { getLoggerWithContext, logger } from "@/common/logger"
-import { generateSitemap } from "@/services/sitemap.service"
-import { updateReferentielCommune } from "@/services/referentiel/commune/commune.referentiel.service"
 
 export async function setupJobProcessor() {
   logger.info("Setup job processor")
@@ -248,11 +247,11 @@ export async function setupJobProcessor() {
             handler: async () => inviteEtablissementAffelnetToPremiumFollowUp(),
             tag: "main",
           },
-          "Rappel aux établissements que le premium est activé (Parcoursup)": {
-            cron_string: "0 6 8-14 1 1",
-            handler: async () => premiumActivatedReminder(),
-            tag: "main",
-          },
+          // "Rappel aux établissements que le premium est activé (Parcoursup)": {
+          //   cron_string: "0 6 8-14 1 1",   // Warning : condition on Monday is not detected, job is run everyday between 8 and 14 Jan
+          //   handler: async () => premiumActivatedReminder(),
+          //   tag: "main",
+          // },
           "Creation de la collection rolemanagement360": {
             cron_string: "00 10,13,17 * * *",
             handler: createRoleManagement360,


### PR DESCRIPTION
La condition dans le cron sur le lundi uniquelent n'est pas interprétée par notre système. Du coup le job s'exécute tous les jours.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Disabled the Parcoursup premium reminder cron job that was executing daily instead of only on Mondays during January 8-14.

- The cron string `0 6 8-14 1 1` was interpreted as running every day between January 8-14 at 6 AM, because standard cron treats day-of-month and day-of-week as OR conditions when both are specified
- The job has been commented out with a clear warning explaining the issue
- A proper fix would require implementing the Monday-only logic within the handler function itself or restructuring the scheduling approach

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change correctly addresses the cron scheduling bug by commenting out the problematic job with clear documentation. No functional code was modified, only configuration was disabled to prevent the job from running incorrectly.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/jobs/jobs.ts | Commented out problematic Parcoursup premium reminder cron job with clear explanation of the issue |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->