### PR TITLE
fix: preview seed

### DIFF
--- a/.infra/files/scripts/seed.sh
+++ b/.infra/files/scripts/seed.sh
@@ -25,4 +25,12 @@ chmod 600 "$SEED_ARCHIVE"
 echo "Dropping database $TARGET_DB if it exists..."
 /opt/app/tools/docker-compose.sh exec -iT mongodb mongosh "mongodb://__system:{{vault.MONGODB_KEYFILE}}@localhost:27017/$TARGET_DB?authSource=local&directConnection=true" --eval "db.dropDatabase()" || true
 
-cat "$SEED_ARCHIVE" | /opt/app/tools/docker-compose.sh exec -iT mongodb mongorestore --archive --nsFrom="labonnealternance.*" --nsTo="$TARGET_DB.*" --drop --gzip "mongodb://__system:{{vault.MONGODB_KEYFILE}}@localhost:27017/?authSource=local&directConnection=true"
+cat "$SEED_ARCHIVE" | /opt/app/tools/docker-compose.sh exec -iT mongodb mongorestore \
+  --archive \
+  --nsFrom="labonnealternance.*" \
+  --nsTo="$TARGET_DB.*" \
+  --drop \
+  --gzip \
+  --numInsertionWorkersPerCollection=1 \
+  --numParallelCollections=2 \
+  "mongodb://__system:{{vault.MONGODB_KEYFILE}}@localhost:27017/?authSource=local&directConnection=true"


### PR DESCRIPTION
This pull request makes a small but important change to the database seeding script to improve the performance and reliability of the MongoDB restore process.

- Database restore performance and reliability:
  * Updated the `mongorestore` command in `.infra/files/scripts/seed.sh` to use the `--numInsertionWorkersPerCollection=1` and `--numParallelCollections=2` options, which can help control resource usage and prevent issues with parallel restores.

<!-- greptile_comment -->

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->