### PR TITLE
fix: seed

### DIFF
--- a/.infra/files/configs/mongodb/seed.gpg
+++ b/.infra/files/configs/mongodb/seed.gpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b97816c99fd8c6d134bf0747da5ef300be6e9bf40679ff84495a83c8f071b9ba
-size 191337370
+oid sha256:6a92b348fe8781882587d890626dec99fd4d61fd1bdaa93b6fd6b9fb7344211c
+size 190720657

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: .infra/files/configs/mongodb/seed.gpg
-  checksum: 52d05262812b46b0b884fb31a942f9c121b9cf1b4bc48c6edeb359ce616589fa
+  checksum: 6511f0d6c229342fdd1214946c0bea2dc8f1fa6660590556e2a7e2daa3ae6ff6
 - filename: .infra/vault/vault.yml
   checksum: 2cbdca4d4f6934e1564eca6b153bf8a68ec4a0d54e37036cf4e406f20cb6829b
   ignore_detectors:


### PR DESCRIPTION
This pull request updates the MongoDB seed file and its related configuration to ensure the correct version is tracked and ignored by security scanning tools.

File updates and configuration:

* Updated the `.infra/files/configs/mongodb/seed.gpg` file to a new version, changing its hash and size.
* Updated the corresponding checksum in `.talismanrc` to match the new version of the seed file, ensuring it continues to be ignored by Talisman.

<!-- greptile_comment -->

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->