### PR TITLE
fix: slow seed dump & restore

### DIFF
--- a/.bin/scripts/seed-update.sh
+++ b/.bin/scripts/seed-update.sh
@@ -45,6 +45,6 @@ yarn build:dev
 yarn cli migrations:up
 yarn cli recreate:indexes
 
-docker compose -f "$ROOT_DIR/docker-compose.yml" exec -it mongodb mongodump --uri "$TARGET_DB" --gzip --archive > "$SEED_GZ" 
+docker compose -f "$ROOT_DIR/docker-compose.yml" exec -it mongodb mongodump --uri "$TARGET_DB" --numParallelCollections=2 --gzip --archive > "$SEED_GZ" 
 rm -f "$SEED_GPG"
 gpg  -c --cipher-algo twofish --batch --passphrase-file "$PASSPHRASE" -o "$SEED_GPG" "$SEED_GZ"

--- a/.infra/files/configs/mongodb/seed.gpg
+++ b/.infra/files/configs/mongodb/seed.gpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a92b348fe8781882587d890626dec99fd4d61fd1bdaa93b6fd6b9fb7344211c
-size 190720657
+oid sha256:fc62794553f08a75aec2ce5bd35ddae9157321da630e9ca6e5dcf2586cbeb21f
+size 326893868

--- a/.infra/files/scripts/seed.sh
+++ b/.infra/files/scripts/seed.sh
@@ -31,6 +31,4 @@ cat "$SEED_ARCHIVE" | /opt/app/tools/docker-compose.sh exec -iT mongodb mongores
   --nsTo="$TARGET_DB.*" \
   --drop \
   --gzip \
-  --numInsertionWorkersPerCollection=1 \
-  --numParallelCollections=2 \
   "mongodb://__system:{{vault.MONGODB_KEYFILE}}@localhost:27017/?authSource=local&directConnection=true"

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: .infra/files/configs/mongodb/seed.gpg
-  checksum: 6511f0d6c229342fdd1214946c0bea2dc8f1fa6660590556e2a7e2daa3ae6ff6
+  checksum: 1d8570617be315cd9a6b423b927431afc05e5f07d76d98edf23550be1259d6b5
 - filename: .infra/vault/vault.yml
   checksum: 2cbdca4d4f6934e1564eca6b153bf8a68ec4a0d54e37036cf4e406f20cb6829b
   ignore_detectors:


### PR DESCRIPTION
This pull request updates the MongoDB seed data and optimizes the seed generation and restore scripts. The main focus is on improving the efficiency of the database dump process and updating related configuration files to reflect the new seed data.

**Seed Data Update:**

* Updated the MongoDB seed file `.infra/files/configs/mongodb/seed.gpg` to a new version with a larger size, indicating refreshed or expanded seed data.
* Updated the checksum for the seed file in `.talismanrc` to match the new seed data, ensuring integrity checks remain valid.

**Script Optimization:**

* Added the `--numParallelCollections=2` flag to the `mongodump` command in `.bin/scripts/seed-update.sh` to speed up the database dump process by parallelizing collection dumps.
* Removed parallelization and worker flags from the `mongores` command in `.infra/files/scripts/seed.sh`, likely to simplify or address issues in the restore process.

<!-- greptile_comment -->

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->