### PR TITLE
fix(lba-3560): copy file locally before restoring

### DIFF
--- a/.infra/files/scripts/seed.sh
+++ b/.infra/files/scripts/seed.sh
@@ -4,27 +4,20 @@ set -euo pipefail
 
 readonly TARGET_DB=${1:?"Merci de préciser le nom de la base de donnée cible"}
 shift
-readonly SEED_ARCHIVE=$(mktemp seed_archive.XXXXXXXXXX)
 readonly PASSPHRASE=$(mktemp passphrase.XXXXXXXXXX)
-readonly CONTAINER_SEED_PATH="/tmp/seed_archive_$(date +%s)"
-
-# Get MongoDB container ID
-readonly MONGODB_CONTAINER=$(/opt/app/tools/docker-compose.sh ps -q mongodb)
+# Decrypt to mounted volume so MongoDB container can access it directly
+readonly SEED_ARCHIVE="/opt/app/configs/mongodb/seed_archive_$(date +%s)"
+readonly CONTAINER_SEED_PATH="/etc/mongod/$(basename "$SEED_ARCHIVE")"
 
 cleanup() {
-  # Clean up local files
   shred -f -n 10 -u "$SEED_ARCHIVE" "$PASSPHRASE" 2>/dev/null || true
-  # Clean up file in container
-  docker exec "$MONGODB_CONTAINER" rm -f "$CONTAINER_SEED_PATH" 2>/dev/null || true
 }
 
 trap cleanup EXIT
 
 echo "{{ vault.SEED_GPG_PASSPHRASE }}" > "$PASSPHRASE"
-
 chmod 600 "$PASSPHRASE"
 
-rm -r "$SEED_ARCHIVE"
 gpg -d --batch --passphrase-file "$PASSPHRASE" -o "$SEED_ARCHIVE" "/opt/app/configs/mongodb/seed.gpg"
 chmod 600 "$SEED_ARCHIVE"
 
@@ -32,11 +25,7 @@ chmod 600 "$SEED_ARCHIVE"
 echo "Dropping database $TARGET_DB if it exists..."
 /opt/app/tools/docker-compose.sh exec -T mongodb mongosh "mongodb://__system:{{vault.MONGODB_KEYFILE}}@localhost:27017/$TARGET_DB?authSource=local&directConnection=true" --eval "db.dropDatabase()" || true
 
-# Copy seed archive into container to avoid pipe/socket issues
-echo "Copying seed archive to MongoDB container..."
-docker cp "$SEED_ARCHIVE" "$MONGODB_CONTAINER:$CONTAINER_SEED_PATH"
-
-# Restore from local file in container
+# Restore from file accessible via mounted volume
 echo "Restoring database $TARGET_DB..."
 /opt/app/tools/docker-compose.sh exec -T mongodb mongorestore \
   --archive="$CONTAINER_SEED_PATH" \

--- a/.infra/files/scripts/seed.sh
+++ b/.infra/files/scripts/seed.sh
@@ -6,7 +6,7 @@ readonly TARGET_DB=${1:?"Merci de préciser le nom de la base de donnée cible"}
 shift
 readonly PASSPHRASE=$(mktemp passphrase.XXXXXXXXXX)
 # Decrypt to mounted volume so MongoDB container can access it directly
-readonly SEED_ARCHIVE="/opt/app/configs/mongodb/seed_archive_$(date +%s)"
+readonly SEED_ARCHIVE="$(mktemp -p /opt/app/configs/mongodb/ seed-XXXXXXXXXX)"
 readonly CONTAINER_SEED_PATH="/etc/mongod/$(basename "$SEED_ARCHIVE")"
 
 cleanup() {

--- a/.infra/files/scripts/seed.sh
+++ b/.infra/files/scripts/seed.sh
@@ -6,12 +6,19 @@ readonly TARGET_DB=${1:?"Merci de préciser le nom de la base de donnée cible"}
 shift
 readonly SEED_ARCHIVE=$(mktemp seed_archive.XXXXXXXXXX)
 readonly PASSPHRASE=$(mktemp passphrase.XXXXXXXXXX)
+readonly CONTAINER_SEED_PATH="/tmp/seed_archive_$(date +%s)"
 
-delete_cleartext() {
-  shred -f -n 10 -u "$SEED_ARCHIVE" "$PASSPHRASE"
+# Get MongoDB container ID
+readonly MONGODB_CONTAINER=$(/opt/app/tools/docker-compose.sh ps -q mongodb)
+
+cleanup() {
+  # Clean up local files
+  shred -f -n 10 -u "$SEED_ARCHIVE" "$PASSPHRASE" 2>/dev/null || true
+  # Clean up file in container
+  docker exec "$MONGODB_CONTAINER" rm -f "$CONTAINER_SEED_PATH" 2>/dev/null || true
 }
 
-trap delete_cleartext EXIT
+trap cleanup EXIT
 
 echo "{{ vault.SEED_GPG_PASSPHRASE }}" > "$PASSPHRASE"
 
@@ -23,10 +30,16 @@ chmod 600 "$SEED_ARCHIVE"
 
 # Drop the entire database before restore to avoid duplicate key errors
 echo "Dropping database $TARGET_DB if it exists..."
-/opt/app/tools/docker-compose.sh exec -iT mongodb mongosh "mongodb://__system:{{vault.MONGODB_KEYFILE}}@localhost:27017/$TARGET_DB?authSource=local&directConnection=true" --eval "db.dropDatabase()" || true
+/opt/app/tools/docker-compose.sh exec -T mongodb mongosh "mongodb://__system:{{vault.MONGODB_KEYFILE}}@localhost:27017/$TARGET_DB?authSource=local&directConnection=true" --eval "db.dropDatabase()" || true
 
-cat "$SEED_ARCHIVE" | /opt/app/tools/docker-compose.sh exec -iT mongodb mongorestore \
-  --archive \
+# Copy seed archive into container to avoid pipe/socket issues
+echo "Copying seed archive to MongoDB container..."
+docker cp "$SEED_ARCHIVE" "$MONGODB_CONTAINER:$CONTAINER_SEED_PATH"
+
+# Restore from local file in container
+echo "Restoring database $TARGET_DB..."
+/opt/app/tools/docker-compose.sh exec -T mongodb mongorestore \
+  --archive="$CONTAINER_SEED_PATH" \
   --nsFrom="labonnealternance.*" \
   --nsTo="$TARGET_DB.*" \
   --drop \


### PR DESCRIPTION
This pull request improves the reliability and security of the MongoDB database seeding process in the `seed.sh` script. The main changes involve copying the seed archive directly into the MongoDB container to avoid issues with pipes and sockets, updating the cleanup process to remove temporary files both locally and in the container, and simplifying the restore command.

**Improvements to seed archive handling:**

* The seed archive is now copied directly into the MongoDB container at a unique path (`/tmp/seed_archive_<timestamp>`) before restoring, which avoids issues with pipes or sockets during the restore process.
* The `mongorestore` command has been updated to restore from the file inside the container, rather than streaming from the host.

**Enhanced cleanup and reliability:**

* A new `cleanup` function ensures that both the local temporary files and the seed archive inside the container are securely deleted after the script finishes, improving security and preventing leftover files.
* The script now retrieves the MongoDB container ID dynamically and uses it for all subsequent Docker operations, making the script more robust.