### PR TITLE
fix: seed sh issue

### DIFF
--- a/.infra/files/scripts/seed.sh
+++ b/.infra/files/scripts/seed.sh
@@ -18,6 +18,7 @@ trap cleanup EXIT
 echo "{{ vault.SEED_GPG_PASSPHRASE }}" > "$PASSPHRASE"
 chmod 600 "$PASSPHRASE"
 
+rm "$SEED_ARCHIVE"
 gpg -d --batch --passphrase-file "$PASSPHRASE" -o "$SEED_ARCHIVE" "/opt/app/configs/mongodb/seed.gpg"
 chmod 600 "$SEED_ARCHIVE"
 


### PR DESCRIPTION
This pull request makes a minor change to the seed script by ensuring the seed archive file is removed before decrypting and recreating it. This helps prevent issues with leftover or corrupted files during the decryption process.