### PR TITLE
fix(lbac-3561): fix pièce jointes dans les mails

### DIFF
--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -1103,7 +1103,8 @@ export const processApplicationEmails = {
       attachments: [
         {
           filename: application.applicant_attachment_name,
-          path: attachmentContent,
+          content: attachmentContent,
+          encoding: "base64",
         },
       ],
     })

--- a/server/src/services/mailer.service.ts
+++ b/server/src/services/mailer.service.ts
@@ -3,7 +3,7 @@ import { promisify } from "util"
 import type { Data } from "ejs"
 import ejs from "ejs"
 import mjml from "mjml"
-import type { Transporter } from "nodemailer"
+import type { Transporter, SendMailOptions } from "nodemailer"
 import nodemailer from "nodemailer"
 import type { Address } from "nodemailer/lib/mailer"
 import type SMTPTransport from "nodemailer/lib/smtp-transport"
@@ -11,6 +11,8 @@ import nodemailerHtmlToText from "nodemailer-html-to-text"
 
 import config from "@/config"
 import { startSentryPerfRecording } from "@/common/utils/sentryUtils"
+
+type Attachment = Exclude<SendMailOptions["attachments"], undefined>[number]
 
 const htmlToText = nodemailerHtmlToText.htmlToText
 const renderFile: (path: string, data: Data) => Promise<string> = promisify(ejs.renderFile)
@@ -60,13 +62,13 @@ const createMailer = () => {
       cc = undefined,
       attachments,
     }: {
+      from?: string | Address
       to: string
       subject: string
       template: string
       data: object
-      from?: string | Address
       cc?: string
-      attachments?: object[]
+      attachments?: Attachment[]
     }): Promise<{ messageId: string; accepted?: string[] }> => {
       const html = await renderEmail(template, data)
       let mail


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?jql=assignee%20%3D%20712020%3A805c2bc3-b985-42ea-9088-d8d83d9b3925&selectedIssue=LBA-3561

Les pièces jointes étaient envoyées en utilisant une data url, ce qui est limité en taille.
J'ai modifié pour utiliser une méthode plus classique