### PR TITLE
fix(lba-3483): maj texte sur fiche formation

### DIFF
--- a/ui/app/(candidat)/formation/[id]/[intitule-formation]/TrainingDetailRendererClient.tsx
+++ b/ui/app/(candidat)/formation/[id]/[intitule-formation]/TrainingDetailRendererClient.tsx
@@ -264,7 +264,7 @@ function TrainingDetail({ training }: { training: ILbaItemFormation2Json }) {
       {IJStats.isFetched && <StatsInserJeunes stats={IJStats.data} />}
       <Box sx={{ pb: "0px", mt: fr.spacing("3w"), position: "relative", background: "white", padding: "16px 24px", maxWidth: "970px", mx: { xs: 0, md: "auto" } }}>
         <Typography variant="h4" sx={{ mb: 2, color: fr.colors.decisions.text.actionHigh.blueFrance.default }}>
-          Quelques informations l'établissement
+          Quelques informations sur l'établissement
         </Typography>
 
         <ItemLocalisation item={training} />

--- a/ui/app/(editorial)/a-propos/page.tsx
+++ b/ui/app/(editorial)/a-propos/page.tsx
@@ -178,7 +178,7 @@ export default function APropos() {
                   }}
                 >
                   Vous pouvez consulter nos{" "}
-                  <DsfrLink href="/stats" aria-label="Accès aux statistiques">
+                  <DsfrLink href="/statistiques" aria-label="Accès aux statistiques">
                     statistiques
                   </DsfrLink>
                 </Typography>


### PR DESCRIPTION
This pull request contains minor corrections to the user interface, focusing on improving clarity and accuracy in text and navigation.

- Content and Text Corrections:
  * Fixed a typo in the heading within `TrainingDetailRendererClient.tsx` to correctly read "Quelques informations sur l'établissement". ([ui/app/(candidat)/formation/[id]/[intitule-formation]/TrainingDetailRendererClient.tsxL267-R267](diffhunk://#diff-7774a509db4805ad519a19fe7e142638dde03c84744dc7add5f64120dc5964caL267-R267))

- Navigation and Link Updates:
  * Updated the statistics page link in the "À propos" page to point to `/statistiques` instead of `/stats` for consistency with the actual route.