### PR TITLE
chore(doc): migration recruiters

### DIFF
--- a/docs/migration-temp/00-README.md
+++ b/docs/migration-temp/00-README.md
@@ -1,0 +1,55 @@
+# Décommissionnement de la Collection `recruiters`
+
+## Vue d'ensemble
+
+Ce dossier contient la documentation complète pour la migration de la collection `recruiters` vers `jobs_partners`.
+
+## Documents
+
+| Document                                             | Description                                    |
+| ---------------------------------------------------- | ---------------------------------------------- |
+| [01-overview.md](./01-overview.md)                   | Vue d'ensemble du projet, contexte et timeline |
+| [02-schema-migration.md](./02-schema-migration.md)   | Modifications du schéma jobs_partners          |
+| [03-file-changes.md](./03-file-changes.md)           | Liste détaillée des 57 fichiers à modifier     |
+| [04-background-jobs.md](./04-background-jobs.md)     | Migration des jobs background                  |
+| [05-feature-migration.md](./05-feature-migration.md) | Migration des fonctionnalités métier           |
+| [06-testing-rollback.md](./06-testing-rollback.md)   | Stratégie de tests et plan de rollback         |
+| [07-feature-flags.md](./07-feature-flags.md)         | Feature flags pour la transition progressive   |
+
+## Analyses Complémentaires
+
+| Dossier                                                    | Description                                                 |
+| ---------------------------------------------------------- | ----------------------------------------------------------- |
+| [establishment-id-analysis/](./establishment-id-analysis/) | Analyse de l'impact de la suppression de `establishment_id` |
+
+### Résultat de l'analyse `establishment_id`
+
+**Verdict : NE PAS SUPPRIMER `establishment_id`**
+
+- 🔴 Impact Server : 20+ fichiers, 10 endpoints API
+- 🔴 Impact UI : 11+ composants, 7 routes Next.js
+- 🔴 Liens Emails : URLs de délégation CFA seraient cassées
+- ✅ Recommandation : Garder `establishment_id` dans `jobs_partners` pour grouper les offres
+
+## Résumé Exécutif
+
+- **57 fichiers** impactés
+- **8 phases** de migration
+- **16 semaines** estimées
+- Synchronisation existante via `stream_processor` Docker service
+- Migration progressive avec feature flags et dual-read
+
+## État Actuel
+
+La synchronisation `recruiters` → `jobs_partners` existe déjà via :
+
+- Service Docker `stream_processor`
+- Change streams MongoDB dans `formulaire.service.ts` (lignes 889-1143)
+- Mapping des champs dans `upsertJobPartnersFromRecruiter()`
+
+## Prochaines Étapes
+
+1. Valider le plan avec l'équipe
+2. Créer les migrations de schéma
+3. Implémenter les corrections de sync
+4. Migrer les services par priorité

--- a/docs/migration-temp/00-README.md
+++ b/docs/migration-temp/00-README.md
@@ -6,15 +6,16 @@ Ce dossier contient la documentation complète pour la migration de la collectio
 
 ## Documents
 
-| Document                                             | Description                                    |
-| ---------------------------------------------------- | ---------------------------------------------- |
-| [01-overview.md](./01-overview.md)                   | Vue d'ensemble du projet, contexte et timeline |
-| [02-schema-migration.md](./02-schema-migration.md)   | Modifications du schéma jobs_partners          |
-| [03-file-changes.md](./03-file-changes.md)           | Liste détaillée des 57 fichiers à modifier     |
-| [04-background-jobs.md](./04-background-jobs.md)     | Migration des jobs background                  |
-| [05-feature-migration.md](./05-feature-migration.md) | Migration des fonctionnalités métier           |
-| [06-testing-rollback.md](./06-testing-rollback.md)   | Stratégie de tests et plan de rollback         |
-| [07-feature-flags.md](./07-feature-flags.md)         | Feature flags pour la transition progressive   |
+| Document                                                 | Description                                      |
+| -------------------------------------------------------- | ------------------------------------------------ |
+| [01-overview.md](./01-overview.md)                       | Vue d'ensemble du projet, contexte et timeline   |
+| [02-schema-migration.md](./02-schema-migration.md)       | Modifications du schéma jobs_partners            |
+| [03-file-changes.md](./03-file-changes.md)               | Liste détaillée des 57 fichiers à modifier       |
+| [04-background-jobs.md](./04-background-jobs.md)         | Migration des jobs background                    |
+| [05-feature-migration.md](./05-feature-migration.md)     | Migration des fonctionnalités métier             |
+| [06-testing-rollback.md](./06-testing-rollback.md)       | Stratégie de tests et plan de rollback           |
+| [07-feature-flags.md](./07-feature-flags.md)             | Feature flags pour la transition progressive     |
+| [08-ai-prompts-timeline.md](./08-ai-prompts-timeline.md) | Prompts IA pour tests/cleanup + timeline révisée |
 
 ## Analyses Complémentaires
 
@@ -35,7 +36,7 @@ Ce dossier contient la documentation complète pour la migration de la collectio
 
 - **57 fichiers** impactés
 - **8 phases** de migration
-- **16 semaines** estimées
+- **6-7 semaines** estimées (tests et cleanup générés par IA)
 - Synchronisation existante via `stream_processor` Docker service
 - Migration progressive avec feature flags et dual-read
 

--- a/docs/migration-temp/01-overview.md
+++ b/docs/migration-temp/01-overview.md
@@ -1,0 +1,185 @@
+# 01 - Vue d'ensemble du Décommissionnement
+
+## Contexte
+
+La collection `recruiters` gère actuellement les offres d'emploi en alternance (offres LBA). Elle est progressivement remplacée par la collection `jobs_partners` qui unifie toutes les sources d'offres (France Travail, partenaires, LBA).
+
+### Architecture Actuelle
+
+```
+┌─────────────────┐     Change Stream      ┌─────────────────┐
+│   recruiters    │ ───────────────────────▶│  jobs_partners  │
+│   (source)      │   stream_processor     │   (cible)       │
+└─────────────────┘                        └─────────────────┘
+        │                                          │
+        ▼                                          ▼
+   57 fichiers                              API v3/v4
+   (services, jobs,                         (lecture unifiée)
+    controllers)
+```
+
+### Service stream_processor
+
+**Configuration Docker** (`.infra/docker-compose.production.yml` lignes 82-110):
+
+- Image: `ghcr.io/mission-apprentissage/mna_lba_server`
+- Replicas: 1 (instance unique pour fiabilité change stream)
+- Commande: `yarn cli stream_processor:start`
+- Mémoire: 1GB
+- Health check: `/api/healthcheck` toutes les 60s
+
+### Logique de Synchronisation
+
+**Fichier:** `server/src/services/formulaire.service.ts` (lignes 889-1143)
+
+```typescript
+// Point d'entrée
+startRecruiterChangeStream(signal: AbortSignal)
+  ├── startChangeStream("recruiters", resumeToken, signal)
+  └── startChangeStream("anonymized_recruiters", resumeToken, signal)
+
+// Gestionnaire de changements
+onChange(change) {
+  switch (change.operationType) {
+    case "insert":
+    case "update":
+      await updateJobsPartnersFromRecruiterUpdate(change)
+      await storeResumeToken("recruiters", change._id)
+      break
+    case "invalidate":
+      // Restart après 10s sans token
+      break
+  }
+}
+
+// Mise à jour jobs_partners
+updateJobsPartnersFromRecruiterUpdate(change)
+  └── updateJobsPartnersFromRecruiterById(recruiterId)
+        └── upsertJobPartnersFromRecruiter(recruiter, job)
+```
+
+---
+
+## Statistiques d'Impact
+
+### Fichiers par Catégorie
+
+| Catégorie       | Nombre | % du total |
+| --------------- | ------ | ---------- |
+| Services        | 15     | 26%        |
+| Controllers     | 8      | 14%        |
+| Background Jobs | 18     | 32%        |
+| Tests           | 12     | 21%        |
+| Security        | 1      | 2%         |
+| Models          | 3      | 5%         |
+| **Total**       | **57** | 100%       |
+
+### Opérations par Type
+
+| Opération            | Occurrences |
+| -------------------- | ----------- |
+| `findOne()`          | 28          |
+| `find()`             | 19          |
+| `aggregate()`        | 8           |
+| `findOneAndUpdate()` | 15          |
+| `updateOne()`        | 7           |
+| `updateMany()`       | 4           |
+| `insertOne()`        | 6           |
+| `deleteOne()`        | 3           |
+| `deleteMany()`       | 4           |
+| `bulkWrite()`        | 1           |
+
+---
+
+## Timeline de Migration
+
+```
+Semaine 1-2:   [████] Schema Migration
+Semaine 3-4:   [████] Sync Fixes + Backfill
+Semaine 5-6:   [████████] Priority 1-2 Services
+Semaine 7-8:   [████████] Priority 3-4 Controllers
+Semaine 9-10:  [████████] Background Jobs
+Semaine 11-12: [████] Testing + Dual-Read
+Semaine 13-14: [████] Cutover
+Semaine 15-16: [████] Cleanup
+```
+
+### Jalons Clés
+
+| Jalon             | Semaine | Critères                              |
+| ----------------- | ------- | ------------------------------------- |
+| Schema Ready      | 1       | Nouveaux champs déployés              |
+| Sync Complete     | 2       | Backfill terminé, 0 écarts            |
+| Services Migrated | 8       | Tous services utilisent jobs_partners |
+| Jobs Migrated     | 10      | Tous jobs background migrés           |
+| Dual-Read Stable  | 12      | 0 erreurs pendant 2 semaines          |
+| Cutover           | 14      | recruiters reads désactivés           |
+| Cleanup Done      | 16      | Collection supprimée                  |
+
+---
+
+## Risques et Mitigations
+
+### Risques Techniques
+
+| Risque                       | Probabilité | Impact | Mitigation                        |
+| ---------------------------- | ----------- | ------ | --------------------------------- |
+| Perte données pendant sync   | Moyenne     | Élevé  | Resume tokens + backfill nocturne |
+| Performance dégradée         | Faible      | Moyen  | Index optimisés, batch processing |
+| Incompatibilité API          | Moyenne     | Élevé  | Dual-read + tests E2E             |
+| Token expiré (>24h downtime) | Faible      | Élevé  | Monitoring + alertes              |
+
+### Risques Organisationnels
+
+| Risque                   | Probabilité | Impact | Mitigation               |
+| ------------------------ | ----------- | ------ | ------------------------ |
+| Délais dépassés          | Moyenne     | Moyen  | Buffer 20% dans timeline |
+| Régression fonctionnelle | Moyenne     | Élevé  | Tests automatisés + QA   |
+| Rollback nécessaire      | Faible      | Moyen  | Plan rollback documenté  |
+
+---
+
+## Dépendances Externes
+
+### Collections MongoDB
+
+| Collection          | Relation                        |
+| ------------------- | ------------------------------- |
+| `userswithaccounts` | managed_by → \_id               |
+| `applications`      | job_id → jobs.\_id              |
+| `entreprises`       | establishment_siret → siret     |
+| `cfas`              | cfa_delegated_siret → siret     |
+| `rolemanagements`   | authorized_id → enterprise.\_id |
+| `referentielromes`  | rome_code → rome.code_rome      |
+| `unsubscribedofs`   | establishment_siret → siret     |
+| `resumetokens`      | collection → "recruiters"       |
+
+### Services Externes
+
+| Service            | Usage                                         |
+| ------------------ | --------------------------------------------- |
+| France Travail API | Engagement entreprise (is_disabled_elligible) |
+| Brevo              | Emails transactionnels                        |
+| Sentry             | Error tracking                                |
+
+---
+
+## Questions Non Résolues
+
+1. **Rétention backup:** Combien de temps conserver recruiters après cutover ?
+   - Suggestion: 3 mois minimum
+
+2. **Metabase:** Le job `metabaseJobsCollection` doit-il migrer vers jobs_partners ?
+   - Impact: Dashboards analytics
+
+3. **Historique:** Y a-t-il des besoins d'agrégation au niveau établissement ?
+   - À vérifier avec équipe data
+
+4. **API v3 format:** Faut-il adapter le format de réponse pour refléter jobs_partners ?
+   - Impact: Clients API existants
+
+5. **OPCO consistance:** Vérifier équivalence `recruiter.opco` ↔ `workplace_opco`
+   - Tests de non-régression requis
+
+6. **Délégations:** Confirmer sync bidirectionnel du tableau `delegations`
+   - Vérifier avec tests E2E

--- a/docs/migration-temp/02-schema-migration.md
+++ b/docs/migration-temp/02-schema-migration.md
@@ -1,0 +1,357 @@
+# 02 - Migration du Schéma
+
+## Comparaison des Schémas
+
+### Champs Actuels: recruiters vs jobs_partners
+
+#### Niveau Recruteur (recruiters)
+
+| Champ recruiters                                | Existe dans jobs_partners | Mapping                                            |
+| ----------------------------------------------- | ------------------------- | -------------------------------------------------- |
+| `_id`                                           | -                         | N/A (identifiant établissement)                    |
+| `establishment_id`                              | ❌                        | **À ajouter**                                      |
+| `establishment_siret`                           | ✅                        | `workplace_siret`                                  |
+| `establishment_raison_sociale`                  | ✅                        | `workplace_legal_name`                             |
+| `establishment_enseigne`                        | ✅                        | `workplace_brand`                                  |
+| `establishment_size`                            | ✅                        | `workplace_size`                                   |
+| `establishment_creation_date`                   | ❌                        | Non requis                                         |
+| `address`                                       | ✅                        | `workplace_address_label`                          |
+| `address_detail`                                | ✅                        | Déjà éclaté dans `workplace_address_*` (voir note) |
+| `address_detail.code_postal`                    | ✅                        | `workplace_address_zipcode`                        |
+| `address_detail.localite`                       | ✅                        | `workplace_address_city` (via `getCity()`)         |
+| `address_detail.numero_voie/type_voie/nom_voie` | ⚠️                        | `workplace_address_street_label` (toujours `null`) |
+| `geo_coordinates`                               | ✅                        | `workplace_geopoint`                               |
+| `geopoint`                                      | ✅                        | `workplace_geopoint`                               |
+| `is_delegated`                                  | ✅                        | `is_delegated`                                     |
+| `cfa_delegated_siret`                           | ✅                        | `cfa_siret`                                        |
+| `email`                                         | ✅                        | `apply_email`                                      |
+| `phone`                                         | ✅                        | `apply_phone`                                      |
+| `first_name`                                    | ❌                        | Via managed_by → user                              |
+| `last_name`                                     | ❌                        | Via managed_by → user                              |
+| `opco`                                          | ✅                        | `workplace_opco`                                   |
+| `idcc`                                          | ✅                        | `workplace_idcc`                                   |
+| `naf_code`                                      | ✅                        | `workplace_naf_code`                               |
+| `naf_label`                                     | ✅                        | `workplace_naf_label`                              |
+| `origin`                                        | ✅                        | `offer_origin`                                     |
+| `status`                                        | ❌                        | **À ajouter** (`recruiter_status`)                 |
+| `managed_by`                                    | ❌                        | **À ajouter**                                      |
+| `createdAt`                                     | ✅                        | `created_at`                                       |
+| `updatedAt`                                     | ✅                        | `updated_at`                                       |
+
+#### Niveau Job (recruiters.jobs[])
+
+| Champ jobs[]                 | Existe dans jobs_partners | Mapping                          |
+| ---------------------------- | ------------------------- | -------------------------------- |
+| `_id`                        | ✅                        | `_id` / `partner_job_id`         |
+| `rome_code`                  | ✅                        | `offer_rome_codes`               |
+| `rome_label`                 | ✅                        | Inclus dans `offer_title`        |
+| `rome_appellation_label`     | ✅                        | Inclus dans `offer_title`        |
+| `job_level_label`            | ✅                        | `offer_target_diploma`           |
+| `job_start_date`             | ✅                        | `contract_start`                 |
+| `job_description`            | ✅                        | `offer_description`              |
+| `job_employer_description`   | ❌                        | `workplace_description` (null)   |
+| `job_creation_date`          | ✅                        | `offer_creation`                 |
+| `job_expiration_date`        | ✅                        | `offer_expiration`               |
+| `job_update_date`            | ✅                        | `updated_at`                     |
+| `job_status`                 | ✅                        | `offer_status`                   |
+| `job_status_comment`         | ✅                        | `job_status_comment`             |
+| `job_type`                   | ✅                        | `contract_type`                  |
+| `job_duration`               | ✅                        | `contract_duration`              |
+| `job_rythm`                  | ✅                        | `contract_rythm`                 |
+| `job_count`                  | ✅                        | `offer_opening_count`            |
+| `is_multi_published`         | ✅                        | `offer_multicast`                |
+| `is_disabled_elligible`      | ✅                        | `contract_is_disabled_elligible` |
+| `delegations`                | ✅                        | `delegations`                    |
+| `job_delegation_count`       | ✅                        | `job_delegation_count`           |
+| `competences_rome`           | ✅                        | `offer_desired_skills`, etc.     |
+| `relance_mail_expiration_J7` | ❌                        | **À ajouter**                    |
+| `relance_mail_expiration_J1` | ❌                        | **À ajouter**                    |
+| `job_last_prolongation_date` | ❌                        | **À ajouter**                    |
+| `job_prolongation_count`     | ❌                        | **À ajouter**                    |
+| `offer_title_custom`         | ✅                        | `offer_title`                    |
+
+---
+
+## Nouveaux Champs à Ajouter
+
+### Fichier: `shared/src/models/jobsPartners.model.ts`
+
+```typescript
+// === CHAMPS À AJOUTER AU SCHÉMA ZJobsPartnersOfferPrivate ===
+
+// Gestion établissement/utilisateur
+managed_by: z.string().describe("ID de l'utilisateur gérant cette offre"),
+establishment_id: z.string().describe("Identifiant unique de l'établissement"),
+recruiter_status: z.nativeEnum(RECRUITER_STATUS).describe("Statut du recruteur: ACTIF, ARCHIVE, EN_ATTENTE_VALIDATION, etc."),
+
+// Tracking des rappels email
+relance_mail_expiration_J7: z.date().nullish().describe("Date d'envoi du rappel J-7"),
+relance_mail_expiration_J1: z.date().nullish().describe("Date d'envoi du rappel J-1"),
+
+// Tracking des prolongations
+job_last_prolongation_date: z.date().nullish().describe("Date de dernière prolongation"),
+job_prolongation_count: z.number().int().min(0).default(0).describe("Nombre de prolongations"),
+
+// Mise en relation
+mer_sent: z.date().nullish().describe("Date d'envoi de la mise en relation"),
+```
+
+### Import du type RECRUITER_STATUS
+
+```typescript
+import { RECRUITER_STATUS } from "shared/constants/recruteur"
+```
+
+---
+
+## Note sur `address_detail`
+
+⚠️ **`address_detail` n'a PAS besoin d'être ajouté** car ses sous-champs sont déjà mappés dans `jobs_partners` :
+
+| Champ `address_detail`                   | Champ `jobs_partners`            | Sync actuelle                    |
+| ---------------------------------------- | -------------------------------- | -------------------------------- |
+| (objet complet)                          | -                                | Non synchronisé en tant qu'objet |
+| `code_postal`                            | `workplace_address_zipcode`      | ✅ Synchronisé                   |
+| `localite`                               | `workplace_address_city`         | ✅ Synchronisé via `getCity()`   |
+| `numero_voie` + `type_voie` + `nom_voie` | `workplace_address_street_label` | ⚠️ Toujours `null`               |
+
+### Amélioration optionnelle
+
+Si besoin de `workplace_address_street_label`, ajouter dans `upsertJobPartnersFromRecruiter()` :
+
+```typescript
+workplace_address_street_label: recruiter.address_detail
+  ? [
+      recruiter.address_detail.numero_voie,
+      recruiter.address_detail.type_voie,
+      recruiter.address_detail.nom_voie
+    ].filter(Boolean).join(' ')
+  : null,
+```
+
+---
+
+## Nouveaux Index
+
+### Fichier: `shared/src/models/jobsPartners.model.ts`
+
+Ajouter dans la section `indexes`:
+
+```typescript
+// Index pour requêtes par utilisateur gestionnaire
+[[{ managed_by: 1 }, {}]],
+
+// Index pour requêtes par établissement
+[[{ establishment_id: 1 }, {}]],
+
+// Index pour job de rappel J-7
+[[{ relance_mail_expiration_J7: 1, offer_status: 1 }, {}]],
+
+// Index pour job de rappel J-1
+[[{ relance_mail_expiration_J1: 1, offer_status: 1 }, {}]],
+
+// Index pour requêtes par statut recruteur
+[[{ recruiter_status: 1 }, {}]],
+
+// Index composé pour dashboard recruteur
+[[{ managed_by: 1, offer_status: 1, offer_expiration: -1 }, {}]],
+```
+
+---
+
+## Script de Migration
+
+### Fichier: `server/src/migrations/20250XXX-add-recruiter-fields-to-jobs-partners.ts`
+
+```typescript
+import { Db } from "mongodb"
+
+export const up = async (db: Db) => {
+  // 1. Ajouter les nouveaux champs avec valeurs par défaut
+  // Note: address_detail n'est pas ajouté car déjà éclaté dans workplace_address_*
+  await db.collection("jobs_partners").updateMany(
+    { partner_label: "RECRUTEURS_LBA" },
+    {
+      $set: {
+        managed_by: null,
+        establishment_id: null,
+        recruiter_status: "Actif",
+        relance_mail_expiration_J7: null,
+        relance_mail_expiration_J1: null,
+        job_last_prolongation_date: null,
+        job_prolongation_count: 0,
+        mer_sent: null,
+      },
+    }
+  )
+
+  // 2. Créer les nouveaux index
+  await db.collection("jobs_partners").createIndex({ managed_by: 1 })
+  await db.collection("jobs_partners").createIndex({ establishment_id: 1 })
+  await db.collection("jobs_partners").createIndex({
+    relance_mail_expiration_J7: 1,
+    offer_status: 1,
+  })
+  await db.collection("jobs_partners").createIndex({
+    relance_mail_expiration_J1: 1,
+    offer_status: 1,
+  })
+  await db.collection("jobs_partners").createIndex({ recruiter_status: 1 })
+  await db.collection("jobs_partners").createIndex({
+    managed_by: 1,
+    offer_status: 1,
+    offer_expiration: -1,
+  })
+}
+
+export const down = async (db: Db) => {
+  // Supprimer les index
+  await db.collection("jobs_partners").dropIndex("managed_by_1")
+  await db.collection("jobs_partners").dropIndex("establishment_id_1")
+  await db.collection("jobs_partners").dropIndex("relance_mail_expiration_J7_1_offer_status_1")
+  await db.collection("jobs_partners").dropIndex("relance_mail_expiration_J1_1_offer_status_1")
+  await db.collection("jobs_partners").dropIndex("recruiter_status_1")
+  await db.collection("jobs_partners").dropIndex("managed_by_1_offer_status_1_offer_expiration_-1")
+
+  // Supprimer les champs
+  await db.collection("jobs_partners").updateMany(
+    { partner_label: "RECRUTEURS_LBA" },
+    {
+      $unset: {
+        managed_by: "",
+        establishment_id: "",
+        recruiter_status: "",
+        relance_mail_expiration_J7: "",
+        relance_mail_expiration_J1: "",
+        job_last_prolongation_date: "",
+        job_prolongation_count: "",
+        mer_sent: "",
+      },
+    }
+  )
+}
+```
+
+---
+
+## Job de Backfill
+
+### Fichier: `server/src/jobs/migrations/backfillJobsPartnersFromRecruiters.ts`
+
+```typescript
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { logger } from "@/common/logger"
+
+export const backfillJobsPartnersFromRecruiters = async () => {
+  const cursor = getDbCollection("recruiters").find({})
+
+  let processed = 0
+  let updated = 0
+  let errors = 0
+
+  for await (const recruiter of cursor) {
+    for (const job of recruiter.jobs) {
+      try {
+        // Note: address_detail n'est pas synchronisé car déjà éclaté dans workplace_address_*
+        const result = await getDbCollection("jobs_partners").updateOne(
+          { _id: job._id },
+          {
+            $set: {
+              managed_by: recruiter.managed_by,
+              establishment_id: recruiter.establishment_id,
+              recruiter_status: recruiter.status,
+              relance_mail_expiration_J7: job.relance_mail_expiration_J7 ?? null,
+              relance_mail_expiration_J1: job.relance_mail_expiration_J1 ?? null,
+              job_last_prolongation_date: job.job_last_prolongation_date ?? null,
+              job_prolongation_count: job.job_prolongation_count ?? 0,
+            },
+          }
+        )
+
+        if (result.modifiedCount > 0) updated++
+        processed++
+
+        if (processed % 1000 === 0) {
+          logger.info(`Backfill progress: ${processed} processed, ${updated} updated`)
+        }
+      } catch (error) {
+        errors++
+        logger.error(`Error backfilling job ${job._id}:`, error)
+      }
+    }
+  }
+
+  logger.info(`Backfill complete: ${processed} processed, ${updated} updated, ${errors} errors`)
+}
+```
+
+---
+
+## Mise à Jour de la Synchronisation
+
+### Fichier: `server/src/services/formulaire.service.ts`
+
+Modifier la fonction `upsertJobPartnersFromRecruiter` (ligne ~953):
+
+```typescript
+const upsertJobPartnersFromRecruiter = async (recruiter: IRecruiter, job: IJob) => {
+  const now = new Date()
+
+  // ... code existant ...
+
+  const partnerJobToUpsert: Partial<IJobsPartnersOfferPrivate> = {
+    // ... champs existants (workplace_address_* déjà synchronisés) ...
+
+    // === NOUVEAUX CHAMPS À AJOUTER ===
+    managed_by: recruiter.managed_by,
+    establishment_id: recruiter.establishment_id,
+    recruiter_status: recruiter.status,
+    relance_mail_expiration_J7: job.relance_mail_expiration_J7 ?? null,
+    relance_mail_expiration_J1: job.relance_mail_expiration_J1 ?? null,
+    job_last_prolongation_date: job.job_last_prolongation_date ?? null,
+    job_prolongation_count: job.job_prolongation_count ?? 0,
+    // Note: address_detail n'est pas ajouté car déjà éclaté dans workplace_address_*
+    // ================================
+  }
+
+  // ... reste du code ...
+}
+```
+
+---
+
+## Validation Post-Migration
+
+### Script de vérification
+
+```typescript
+const validateMigration = async () => {
+  // 1. Vérifier que tous les jobs LBA ont les nouveaux champs
+  const missingFields = await getDbCollection("jobs_partners").countDocuments({
+    partner_label: "RECRUTEURS_LBA",
+    $or: [{ managed_by: { $exists: false } }, { establishment_id: { $exists: false } }, { recruiter_status: { $exists: false } }],
+  })
+
+  if (missingFields > 0) {
+    throw new Error(`${missingFields} documents missing required fields`)
+  }
+
+  // 2. Vérifier la consistance avec recruiters
+  const recruitersCount = await getDbCollection("recruiters")
+    .aggregate([{ $unwind: "$jobs" }, { $match: { "jobs.job_status": "Active" } }, { $count: "total" }])
+    .toArray()
+
+  const jobsPartnersCount = await getDbCollection("jobs_partners").countDocuments({
+    partner_label: "RECRUTEURS_LBA",
+    offer_status: "Active",
+  })
+
+  const diff = Math.abs(recruitersCount[0]?.total - jobsPartnersCount)
+  if (diff > 10) {
+    // Tolérance de 10 pour les changements en cours
+    console.warn(`Discrepancy: recruiters=${recruitersCount[0]?.total}, jobs_partners=${jobsPartnersCount}`)
+  }
+
+  console.log("Migration validation complete")
+}
+```

--- a/docs/migration-temp/03-file-changes.md
+++ b/docs/migration-temp/03-file-changes.md
@@ -1,0 +1,352 @@
+# 03 - Liste Détaillée des Fichiers à Modifier
+
+## Résumé par Priorité
+
+| Priorité             | Fichiers | Description                        |
+| -------------------- | -------- | ---------------------------------- |
+| P1 - Critique        | 2        | Bloquant release                   |
+| P2 - Services Core   | 4        | Logique métier principale          |
+| P3 - Services User   | 6        | Gestion utilisateurs/organisations |
+| P4 - Controllers     | 5        | Endpoints API                      |
+| P5 - Background Jobs | 11       | Jobs automatisés                   |
+| P6 - Tests           | 12       | Tests unitaires/intégration        |
+| P7 - Autres          | 4        | Sitemap, obfuscation, etc.         |
+
+---
+
+## Priorité 1 - Critique (Bloquant Release)
+
+### 1.1 `server/src/security/authorisationService.ts`
+
+**Impact:** Vérifications d'autorisation pour toutes les opérations sur les offres.
+
+| Ligne   | Fonction                  | Changement                                    |
+| ------- | ------------------------- | --------------------------------------------- |
+| 119-162 | `getRecruitersResource()` | Lookup parallèle dans jobs_partners           |
+| 164-192 | `getJobsResource()`       | Changer de recruiters.jobs vers jobs_partners |
+| 326-333 | `canAccessRecruiter()`    | Utiliser managed_by depuis jobs_partners      |
+| 335-337 | `canAccessJob()`          | Utiliser jobs_partners directement            |
+
+**Code actuel:**
+
+```typescript
+// Ligne 128
+const recruiter = await getDbCollection("recruiters").findOne({ _id: new ObjectId(...) })
+
+// Ligne 174
+const recruiter = await getDbCollection("recruiters").findOne({ "jobs._id": id })
+```
+
+**Code cible:**
+
+```typescript
+// Nouveau
+const job = await getDbCollection("jobs_partners").findOne({ _id: new ObjectId(id) })
+const canAccess = job?.managed_by === userId || hasAdminAccess
+```
+
+---
+
+### 1.2 `server/src/services/lbajob.service.ts`
+
+**Impact:** Recherche géospatiale des offres LBA, cœur de la fonctionnalité de recherche.
+
+| Ligne   | Fonction                      | Changement                                               |
+| ------- | ----------------------------- | -------------------------------------------------------- |
+| 39-118  | `getJobs()`                   | Remplacer aggregation recruiters par query jobs_partners |
+| 217-240 | `getLbaJobById()`             | Query jobs_partners au lieu de recruiters                |
+| 427-441 | `addOffreDetailView()`        | Update jobs_partners directement                         |
+| 446-461 | `incrementLbaJobsViewCount()` | Update jobs_partners                                     |
+| 463-491 | `getLbaJobContactInfo()`      | Utiliser cfa\_\* fields depuis jobs_partners             |
+
+**Code actuel (ligne 92):**
+
+```typescript
+const recruiters = await getDbCollection("recruiters")
+  .aggregate<IRecruiter>([
+    { $geoNear: { near: { type: "Point", coordinates }, ... } },
+    // ... stages complexes avec $unwind sur jobs
+  ])
+  .toArray()
+```
+
+**Code cible:**
+
+```typescript
+const jobs = await getDbCollection("jobs_partners")
+  .aggregate<IJobsPartnersOfferPrivate>([
+    { $geoNear: { near: { type: "Point", coordinates }, distanceField: "distance", ... } },
+    { $match: { partner_label: "RECRUTEURS_LBA", offer_status: "Active" } },
+    // Aggregation simplifiée - pas de $unwind nécessaire
+  ])
+  .toArray()
+```
+
+---
+
+## Priorité 2 - Services Core
+
+### 2.1 `server/src/services/formulaire.service.ts`
+
+**Impact:** Service principal CRUD pour les recruteurs et offres. **40+ opérations**.
+
+| Ligne   | Fonction                                              | Type   | Changement                                      |
+| ------- | ----------------------------------------------------- | ------ | ----------------------------------------------- |
+| 109-122 | `getOffreAvecInfoMandataire()`                        | READ   | Query jobs_partners                             |
+| 132-144 | `getFormulaires()`                                    | READ   | Dual-read puis jobs_partners                    |
+| 154-252 | `createJob()`                                         | WRITE  | Écrire dans jobs_partners (+ sync)              |
+| 257-348 | `createJobDelegations()`                              | WRITE  | Update jobs_partners                            |
+| 355-358 | `checkOffreExists()`                                  | READ   | Query jobs_partners                             |
+| 365     | `getFormulaire()`                                     | READ   | Query jobs_partners groupé par establishment_id |
+| 367-380 | `getFormulaireWithRomeDetail()`                       | READ   | Query jobs_partners + join referentielromes     |
+| 387-405 | `createFormulaire()`                                  | WRITE  | Créer entrée(s) dans jobs_partners              |
+| 410     | `deleteFormulaire()`                                  | DELETE | Update offer_status dans jobs_partners          |
+| 415-421 | `updateFormulaire()`                                  | UPDATE | Update jobs_partners par establishment_id       |
+| 428-446 | `archiveFormulaire()`                                 | UPDATE | Update recruiter_status dans jobs_partners      |
+| 453-460 | `activateRecruiter()`                                 | UPDATE | Update recruiter_status                         |
+| 466-470 | `archiveDelegatedFormulaire()`                        | UPDATE | Update par cfa_siret                            |
+| 476-487 | `getOffre()` / `getOffreWithRomeDetail()`             | READ   | Query jobs_partners                             |
+| 492-519 | `createOffre()` / `updateOffre()`                     | WRITE  | Update jobs_partners                            |
+| 527-545 | `patchOffre()`                                        | UPDATE | Update jobs_partners                            |
+| 547-557 | `updateJobDelegation()`                               | UPDATE | Update delegations                              |
+| 564-603 | `provideOffre()` / `cancelOffre()`                    | UPDATE | Update offer_status                             |
+| 610-650 | `extendOffre()` / `activateAndExtendOffre()`          | UPDATE | Update expiration + prolongation fields         |
+| 656-674 | `checkForJobActivations()`                            | UPDATE | Update offer_status en batch                    |
+| 679-700 | `getJob()` / `getJobWithRomeDetail()`                 | READ   | Query jobs_partners                             |
+| 774-796 | `getJobFromRecruiter()` / `getFormulaireFromUserId()` | READ   | Query par managed_by                            |
+| 869-873 | `validateUserEmailFromJobId()`                        | READ   | Utiliser managed_by                             |
+| 884-887 | `updateCfaManagedRecruiter()`                         | UPDATE | Update jobs_partners                            |
+
+**Stages d'aggregation à migrer (lignes 58-104):**
+
+```typescript
+// Ces stages deviennent obsolètes car jobs_partners a déjà les champs aplatis
+const romeDetailAndCandidatureCountAggregateStage = [...]
+export const romeDetailAggregateStages = [...]
+```
+
+---
+
+### 2.2 `server/src/services/application.service.ts`
+
+**Impact:** Gestion des candidatures, lien avec les offres.
+
+| Ligne | Fonction                          | Changement                   |
+| ----- | --------------------------------- | ---------------------------- |
+| 810   | Lookup recruiter par job_id       | Query jobs_partners          |
+| 1249  | `findOne({ "jobs._id": job_id })` | Query jobs_partners par \_id |
+| 1338  | Lookup recruiter                  | Query jobs_partners          |
+
+---
+
+### 2.3 `server/src/services/userRecruteur.service.ts`
+
+**Impact:** Transformation données recruteur pour l'interface.
+
+| Ligne | Fonction                     | Changement                          |
+| ----- | ---------------------------- | ----------------------------------- |
+| 254   | Check email uniqueness       | Query jobs_partners                 |
+| 272   | `updateMany({ managed_by })` | Update jobs_partners par managed_by |
+| 386   | `findOne({ managed_by })`    | Query jobs_partners                 |
+
+---
+
+### 2.4 `server/src/services/etablissement.service.ts`
+
+**Impact:** Gestion des délégations CFA.
+
+| Ligne | Fonction                                                | Changement           |
+| ----- | ------------------------------------------------------- | -------------------- |
+| 536   | `findOne({ cfa_delegated_siret, establishment_siret })` | Query jobs_partners  |
+| 551   | `findOneAndUpdate()`                                    | Update jobs_partners |
+
+---
+
+## Priorité 3 - Services User/Organisation
+
+### 3.1 `server/src/services/organization.service.ts`
+
+| Ligne | Fonction                              | Changement                              |
+| ----- | ------------------------------------- | --------------------------------------- |
+| 95    | `updateMany({ establishment_siret })` | Update workplace\_\* dans jobs_partners |
+| 114   | `find({ establishment_siret })`       | Query jobs_partners                     |
+
+---
+
+### 3.2 `server/src/services/userWithAccount.service.ts`
+
+| Ligne | Fonction               | Changement                         |
+| ----- | ---------------------- | ---------------------------------- |
+| 87    | `find({ managed_by })` | Query jobs_partners par managed_by |
+
+---
+
+### 3.3 `server/src/services/user.service.ts`
+
+| Ligne | Fonction      | Changement                    |
+| ----- | ------------- | ----------------------------- |
+| 59    | `aggregate()` | Aggreger depuis jobs_partners |
+
+---
+
+### 3.4 `server/src/services/roleManagement.service.ts`
+
+| Ligne | Fonction    | Changement          |
+| ----- | ----------- | ------------------- |
+| 335   | `findOne()` | Query jobs_partners |
+
+---
+
+## Priorité 4 - Controllers
+
+### 4.1 `server/src/http/controllers/formulaire.controller.ts`
+
+| Ligne | Endpoint                            | Changement                 |
+| ----- | ----------------------------------- | -------------------------- |
+| 174   | GET formulaire par establishment_id | Query jobs_partners groupé |
+| 240   | GET formulaire                      | Query jobs_partners        |
+
+---
+
+### 4.2 `server/src/http/controllers/jobs.controller.ts`
+
+| Ligne | Endpoint                                  | Changement          |
+| ----- | ----------------------------------------- | ------------------- |
+| 55    | `findOne({ establishment_siret, email })` | Query jobs_partners |
+
+---
+
+### 4.3 `server/src/http/controllers/v2/jobs.controller.v2.ts`
+
+| Ligne | Endpoint         | Changement          |
+| ----- | ---------------- | ------------------- |
+| 32-38 | Lookup recruiter | Query jobs_partners |
+| 50-61 | Lookup recruiter | Query jobs_partners |
+
+---
+
+### 4.4 `server/src/http/controllers/etablissementRecruteur.controller.ts`
+
+| Ligne | Endpoint            | Changement          |
+| ----- | ------------------- | ------------------- |
+| 185   | `find()` recruiters | Query jobs_partners |
+
+---
+
+### 4.5 `server/src/http/controllers/user.controller.ts`
+
+| Ligne | Endpoint                                   | Changement            |
+| ----- | ------------------------------------------ | --------------------- |
+| 174   | `updateMany({ establishment_siret })` OPCO | Update workplace_opco |
+
+---
+
+## Priorité 5 - Background Jobs
+
+Voir document séparé: [04-background-jobs.md](./04-background-jobs.md)
+
+---
+
+## Priorité 6 - Tests
+
+### Tests à mettre à jour
+
+| Fichier                                                                  | Raison            |
+| ------------------------------------------------------------------------ | ----------------- |
+| `server/src/services/formulaire.service.test.ts`                         | Service principal |
+| `server/src/services/application.service.test.ts`                        | Lookups job       |
+| `server/src/services/jobs/jobOpportunity/jobOpportunity.service.test.ts` | Queries           |
+| `server/src/http/controllers/formulaire.controller.test.ts`              | API responses     |
+| `server/src/http/controllers/etablissementRecruteur.controller.test.ts`  | Operations        |
+| `server/src/http/controllers/v3/jobs/jobs.controller.v3.test.ts`         | Job operations    |
+| `server/src/http/controllers/v2/applications.controller.v2.test.ts`      | Application flows |
+| `server/tests/utils/user.test.utils.ts`                                  | Test utilities    |
+| `server/src/jobs/offrePartenaire/detectDuplicateJobPartners.test.ts`     | Job tests         |
+
+### Fixtures à migrer
+
+Tous les tests qui créent des `recruiters` doivent être adaptés pour créer des `jobs_partners`:
+
+```typescript
+// Avant
+await getDbCollection("recruiters").insertOne(recruiter)
+
+// Après
+await getDbCollection("jobs_partners").insertMany(recruiter.jobs.map((job) => transformRecruiterJobToJobsPartners(recruiter, job)))
+```
+
+---
+
+## Priorité 7 - Autres
+
+### 7.1 `server/src/services/sitemap.service.ts`
+
+| Ligne | Fonction            | Changement                 |
+| ----- | ------------------- | -------------------------- |
+| 22    | `find()` recruiters | Query jobs_partners actifs |
+
+---
+
+### 7.2 `server/src/jobs/database/obfuscateCollections.ts`
+
+| Ligne   | Fonction               | Changement                      |
+| ------- | ---------------------- | ------------------------------- |
+| 190-211 | Obfuscation recruiters | Supprimer, garder jobs_partners |
+
+---
+
+### 7.3 `server/src/jobs/anonymization/anonymizeIndividual.ts`
+
+Adapter pour anonymiser dans jobs_partners au lieu de recruiters.
+
+---
+
+### 7.4 `server/src/jobs/oneTimeJob/addNafDataToCacheEntreprise.ts`
+
+| Ligne | Fonction                               | Changement          |
+| ----- | -------------------------------------- | ------------------- |
+| 28    | `findOne({ establishment_siret })` NAF | Query jobs_partners |
+
+---
+
+## Checklist de Migration par Fichier
+
+```markdown
+## Services (15 fichiers)
+
+- [ ] formulaire.service.ts (40+ changements)
+- [ ] lbajob.service.ts (5 changements)
+- [ ] application.service.ts (3 changements)
+- [ ] userRecruteur.service.ts (3 changements)
+- [ ] etablissement.service.ts (2 changements)
+- [ ] organization.service.ts (2 changements)
+- [ ] userWithAccount.service.ts (1 changement)
+- [ ] user.service.ts (1 changement)
+- [ ] roleManagement.service.ts (1 changement)
+- [ ] sitemap.service.ts (1 changement)
+- [ ] partnerJob.service.ts (vérifier compatibilité)
+- [ ] appLinks.service.ts (vérifier)
+- [ ] catalogue.service.ts (vérifier)
+- [ ] rome.service.ts (vérifier)
+- [ ] trafficSource.service.ts (vérifier)
+
+## Security (1 fichier)
+
+- [ ] authorisationService.ts (4 changements critiques)
+
+## Controllers (5 fichiers)
+
+- [ ] formulaire.controller.ts (2 changements)
+- [ ] jobs.controller.ts (1 changement)
+- [ ] jobs.controller.v2.ts (2 changements)
+- [ ] etablissementRecruteur.controller.ts (1 changement)
+- [ ] user.controller.ts (1 changement)
+
+## Jobs (voir doc séparé)
+
+- [ ] 11 jobs à migrer
+
+## Tests (12 fichiers)
+
+- [ ] 9 fichiers de tests à mettre à jour
+```

--- a/docs/migration-temp/04-background-jobs.md
+++ b/docs/migration-temp/04-background-jobs.md
@@ -1,0 +1,483 @@
+# 04 - Migration des Background Jobs
+
+## Vue d'ensemble
+
+| Catégorie       | Nombre | Action                     |
+| --------------- | ------ | -------------------------- |
+| À réécrire      | 7      | Adapter pour jobs_partners |
+| À déprécier     | 3      | Supprimer après migration  |
+| À mettre à jour | 4      | Modifications mineures     |
+
+---
+
+## Jobs à Réécrire
+
+### 4.1 `server/src/jobs/recruiters/recruiterOfferExpirationReminderJob.ts`
+
+**Fonction:** Envoie des emails de rappel J-7 et J-1 avant expiration des offres.
+
+**Logique actuelle:**
+
+```typescript
+// Ligne 27
+const recruiters = await getDbCollection("recruiters")
+  .find({
+    "jobs.job_status": JOB_STATUS.ACTIVE,
+    "jobs.job_expiration_date": { $gt: now },
+    $or: [{ "jobs.relance_mail_expiration_J7": null }, { "jobs.relance_mail_expiration_J1": null }],
+  })
+  .toArray()
+
+// Pour chaque job, envoie email puis update
+await getDbCollection("recruiters").findOneAndUpdate({ "jobs._id": job._id }, { $set: { "jobs.$.relance_mail_expiration_J7": now } })
+```
+
+**Nouvelle logique:**
+
+```typescript
+// Query jobs_partners directement
+const jobsJ7 = await getDbCollection("jobs_partners")
+  .find({
+    partner_label: "RECRUTEURS_LBA",
+    offer_status: "Active",
+    offer_expiration: {
+      $gte: dayjs().add(6, "days").toDate(),
+      $lte: dayjs().add(7, "days").toDate(),
+    },
+    relance_mail_expiration_J7: null,
+  })
+  .toArray()
+
+// Grouper par managed_by pour envoyer un seul email par utilisateur
+const jobsByUser = groupBy(jobsJ7, "managed_by")
+
+for (const [userId, jobs] of Object.entries(jobsByUser)) {
+  const user = await getDbCollection("userswithaccounts").findOne({ _id: new ObjectId(userId) })
+  if (!user) continue
+
+  await sendExpirationReminderEmail(user, jobs, "J7")
+
+  // Update en batch
+  await getDbCollection("jobs_partners").updateMany({ _id: { $in: jobs.map((j) => j._id) } }, { $set: { relance_mail_expiration_J7: new Date() } })
+}
+
+// Même logique pour J1
+```
+
+**Champs requis dans jobs_partners:**
+
+- `relance_mail_expiration_J7` (nouveau)
+- `relance_mail_expiration_J1` (nouveau)
+- `managed_by` (nouveau)
+
+---
+
+### 4.2 `server/src/jobs/recruiters/cancelOfferJob.ts`
+
+**Fonction:** Annule automatiquement les offres expirées.
+
+**Logique actuelle:**
+
+```typescript
+// Ligne 12
+const formulaires = await getFormulaires({ "jobs.job_status": JOB_STATUS.ACTIVE }, {}, { limit: 1000 })
+
+for (const formulaire of formulaires) {
+  for (const job of formulaire.jobs) {
+    if (job.job_expiration_date < now) {
+      await cancelOffre(job._id)
+    }
+  }
+}
+```
+
+**Nouvelle logique:**
+
+```typescript
+// Update en batch directement
+const result = await getDbCollection("jobs_partners").updateMany(
+  {
+    partner_label: "RECRUTEURS_LBA",
+    offer_status: "Active",
+    offer_expiration: { $lt: new Date() },
+  },
+  {
+    $set: {
+      offer_status: "Cancelled",
+      updated_at: new Date(),
+    },
+  }
+)
+
+logger.info(`Cancelled ${result.modifiedCount} expired offers`)
+```
+
+---
+
+### 4.3 `server/src/jobs/recruiters/fixJobExpirationDateJob.ts`
+
+**Fonction:** Corrige les dates d'expiration invalides (trop lointaines).
+
+**Logique actuelle:**
+
+```typescript
+// Ligne 12
+const recruiters = await getDbCollection("recruiters")
+  .find({
+    "jobs.job_expiration_date": { $gt: latestExpirationDate },
+  })
+  .toArray()
+```
+
+**Nouvelle logique:**
+
+```typescript
+const result = await getDbCollection("jobs_partners").updateMany(
+  {
+    partner_label: "RECRUTEURS_LBA",
+    offer_expiration: { $gt: latestExpirationDate },
+  },
+  {
+    $set: { offer_expiration: latestExpirationDate },
+  }
+)
+```
+
+---
+
+### 4.4 `server/src/jobs/recruiters/updateMissingStartDateJob.ts`
+
+**Fonction:** Corrige les offres sans date de début.
+
+**Logique actuelle:**
+
+```typescript
+// Ligne 7
+const recruiters = await getDbCollection("recruiters")
+  .find({
+    "jobs.job_start_date": null,
+  })
+  .toArray()
+```
+
+**Nouvelle logique:**
+
+```typescript
+const jobsWithoutStartDate = await getDbCollection("jobs_partners")
+  .find({
+    partner_label: "RECRUTEURS_LBA",
+    contract_start: null,
+    offer_status: "Active",
+  })
+  .toArray()
+
+// Logique de correction...
+await getDbCollection("jobs_partners").updateOne({ _id: job._id }, { $set: { contract_start: estimatedStartDate } })
+```
+
+---
+
+### 4.5 `server/src/jobs/recruiters/fixRecruiterDataValidationJob.ts`
+
+**Fonction:** Corrige les données invalides dans les recruteurs.
+
+**Changements:**
+
+- Query jobs_partners au lieu de recruiters
+- Adapter les validations aux champs jobs_partners
+- Update directement dans jobs_partners
+
+---
+
+### 4.6 `server/src/jobs/recruiters/updateSiretInfosInErrorJob.ts`
+
+**Fonction:** Met à jour les infos SIRET pour les recruteurs en erreur.
+
+**Logique actuelle:**
+
+```typescript
+// Ligne 76
+const recruiters = await getDbCollection("recruiters")
+  .find({
+    status: RECRUITER_STATUS.EN_ATTENTE_VALIDATION,
+  })
+  .toArray()
+```
+
+**Nouvelle logique:**
+
+```typescript
+// Grouper par establishment_id pour éviter les doublons
+const jobsInError = await getDbCollection("jobs_partners")
+  .aggregate([
+    {
+      $match: {
+        partner_label: "RECRUTEURS_LBA",
+        recruiter_status: "EN_ATTENTE_VALIDATION",
+      },
+    },
+    {
+      $group: {
+        _id: "$establishment_id",
+        workplace_siret: { $first: "$workplace_siret" },
+        jobs: { $push: "$_id" },
+      },
+    },
+  ])
+  .toArray()
+
+// Pour chaque établissement, vérifier et mettre à jour
+for (const establishment of jobsInError) {
+  const siretInfo = await fetchSiretInfo(establishment.workplace_siret)
+
+  if (siretInfo.valid) {
+    await getDbCollection("jobs_partners").updateMany(
+      { establishment_id: establishment._id },
+      {
+        $set: {
+          workplace_legal_name: siretInfo.raison_sociale,
+          workplace_address_label: siretInfo.address,
+          recruiter_status: "ACTIF",
+        },
+      }
+    )
+  }
+}
+```
+
+---
+
+### 4.7 `server/src/jobs/miseEnRelation/sendMiseEnRelation.ts`
+
+**Fonction:** Envoie les mises en relation entreprise-candidat.
+
+**Changement:**
+
+```typescript
+// Ligne 157 - Actuel
+await getDbCollection("recruiters").updateOne(...)
+
+// Nouveau
+await getDbCollection("jobs_partners").updateOne(
+  { _id: jobId },
+  { $set: { mer_sent: new Date() } }
+)
+```
+
+---
+
+## Jobs à Déprécier
+
+### 4.8 `server/src/jobs/recruiters/removeDuplicatesRecruiters.ts`
+
+**Fonction:** Détecte et fusionne les recruteurs en doublon.
+
+**Raison de dépréciation:**
+
+- La logique de duplication change avec jobs_partners
+- Les doublons sont gérés différemment (par partner_label + partner_job_id)
+- Le job `detectDuplicateJobPartners.ts` existe déjà
+
+**Action:** Supprimer après migration complète.
+
+---
+
+### 4.9 `server/src/jobs/offrePartenaire/lbaJobToJobsPartners.ts`
+
+**Fonction:** Synchronisation batch des offres LBA vers jobs_partners.
+
+**Raison de dépréciation:**
+
+- Remplacé par écriture directe dans jobs_partners
+- Le change stream devient obsolète quand on écrit directement
+
+**Action:** Garder temporairement comme fallback, supprimer après cutover.
+
+---
+
+### 4.10 Stream Processor (Change Stream)
+
+**Fichiers:**
+
+- `server/src/services/formulaire.service.ts` (lignes 1069-1143)
+- `server/src/http/StreamProcessorServer.ts`
+- `.infra/docker-compose.production.yml` (service stream_processor)
+
+**Raison de dépréciation:**
+
+- Plus nécessaire quand les écritures vont directement dans jobs_partners
+
+**Action:**
+
+1. Phase 1: Garder actif pendant dual-write
+2. Phase 2: Désactiver après validation
+3. Phase 3: Supprimer le code et le service Docker
+
+---
+
+## Jobs à Mettre à Jour
+
+### 4.11 `server/src/jobs/database/obfuscateCollections.ts`
+
+**Changements:**
+
+```typescript
+// Supprimer (lignes 190-211)
+const recruitersToObfuscate = await getDbCollection("recruiters")
+  .find({
+    first_name: { $ne: "prenom" },
+  })
+  .toArray()
+
+// Garder uniquement l'obfuscation jobs_partners
+const jobsToObfuscate = await getDbCollection("jobs_partners")
+  .find({
+    partner_label: "RECRUTEURS_LBA",
+    // Critères d'obfuscation
+  })
+  .toArray()
+```
+
+---
+
+### 4.12 `server/src/jobs/anonymization/anonymizeIndividual.ts`
+
+**Changements:**
+
+- Anonymiser dans jobs_partners au lieu de recruiters
+- Adapter les champs (first_name → contact dans managed_by lookup)
+
+---
+
+### 4.13 `server/src/jobs/anonymization/anonimizeUsersWithAccounts.ts`
+
+**Changements:**
+
+- Quand un user est anonymisé, anonymiser ses offres dans jobs_partners
+
+```typescript
+// Nouveau
+await getDbCollection("jobs_partners").updateMany(
+  { managed_by: userId },
+  {
+    $set: {
+      apply_email: "anonymized@example.com",
+      apply_phone: null,
+    },
+  }
+)
+```
+
+---
+
+### 4.14 `server/src/jobs/oneTimeJob/analyzeClosedCompanies.ts`
+
+**Changements:**
+
+```typescript
+// Ligne 8 - Actuel
+const recruiters = await getDbCollection("recruiters").find({...}).toArray()
+
+// Nouveau
+const activeJobs = await getDbCollection("jobs_partners").find({
+  partner_label: "RECRUTEURS_LBA",
+  offer_status: "Active"
+}).toArray()
+```
+
+---
+
+## Nouveau Job à Créer
+
+### 4.15 `server/src/jobs/migrations/syncRecruiterStatusToJobsPartners.ts`
+
+**Fonction:** Propagation du statut recruteur vers toutes ses offres.
+
+```typescript
+/**
+ * Quand le statut d'un recruteur change (ACTIF → ARCHIVE),
+ * il faut mettre à jour toutes ses offres dans jobs_partners
+ */
+export const syncRecruiterStatusToJobsPartners = async () => {
+  // Trouver les incohérences
+  const mismatches = await getDbCollection("recruiters")
+    .aggregate([
+      { $unwind: "$jobs" },
+      {
+        $lookup: {
+          from: "jobs_partners",
+          localField: "jobs._id",
+          foreignField: "_id",
+          as: "partner_job",
+        },
+      },
+      { $unwind: "$partner_job" },
+      {
+        $match: {
+          $expr: {
+            $ne: ["$status", "$partner_job.recruiter_status"],
+          },
+        },
+      },
+    ])
+    .toArray()
+
+  for (const mismatch of mismatches) {
+    await getDbCollection("jobs_partners").updateOne({ _id: mismatch.jobs._id }, { $set: { recruiter_status: mismatch.status } })
+  }
+
+  logger.info(`Synced ${mismatches.length} recruiter statuses`)
+}
+```
+
+---
+
+## Planning de Migration des Jobs
+
+| Semaine | Jobs                                | Action                      |
+| ------- | ----------------------------------- | --------------------------- |
+| 8       | recruiterOfferExpirationReminderJob | Réécrire pour jobs_partners |
+| 8       | cancelOfferJob                      | Réécrire pour jobs_partners |
+| 9       | fixJobExpirationDateJob             | Réécrire pour jobs_partners |
+| 9       | updateMissingStartDateJob           | Réécrire pour jobs_partners |
+| 9       | fixRecruiterDataValidationJob       | Réécrire pour jobs_partners |
+| 9       | updateSiretInfosInErrorJob          | Réécrire pour jobs_partners |
+| 10      | sendMiseEnRelation                  | Adapter update              |
+| 10      | obfuscateCollections                | Supprimer partie recruiters |
+| 10      | anonymizeIndividual                 | Adapter pour jobs_partners  |
+| 14      | removeDuplicatesRecruiters          | Déprécier                   |
+| 14      | lbaJobToJobsPartners                | Déprécier                   |
+| 16      | Stream Processor                    | Supprimer service           |
+
+---
+
+## Checklist Jobs
+
+```markdown
+## À Réécrire
+
+- [ ] recruiterOfferExpirationReminderJob.ts
+- [ ] cancelOfferJob.ts
+- [ ] fixJobExpirationDateJob.ts
+- [ ] updateMissingStartDateJob.ts
+- [ ] fixRecruiterDataValidationJob.ts
+- [ ] updateSiretInfosInErrorJob.ts
+- [ ] sendMiseEnRelation.ts
+
+## À Déprécier
+
+- [ ] removeDuplicatesRecruiters.ts
+- [ ] lbaJobToJobsPartners.ts
+- [ ] Stream Processor (formulaire.service.ts + Docker)
+
+## À Mettre à Jour
+
+- [ ] obfuscateCollections.ts
+- [ ] anonymizeIndividual.ts
+- [ ] anonimizeUsersWithAccounts.ts
+- [ ] analyzeClosedCompanies.ts
+
+## Nouveau
+
+- [ ] syncRecruiterStatusToJobsPartners.ts (créer)
+```

--- a/docs/migration-temp/05-feature-migration.md
+++ b/docs/migration-temp/05-feature-migration.md
@@ -1,0 +1,538 @@
+# 05 - Migration des Fonctionnalités Métier
+
+## Vue d'ensemble des Fonctionnalités
+
+| Fonctionnalité        | Complexité | Dépendances            |
+| --------------------- | ---------- | ---------------------- |
+| Rappels email (J1/J7) | Moyenne    | Schema migration       |
+| Prolongation offres   | Faible     | Schema migration       |
+| Statut recruteur      | Moyenne    | Schema + propagation   |
+| Gestion utilisateur   | Élevée     | Authorization refactor |
+| Délégation CFA        | Moyenne    | Jobs_partners fields   |
+| Recherche géospatiale | Moyenne    | Index optimization     |
+
+---
+
+## 5.1 Rappels Email d'Expiration (J1/J7)
+
+### Fonctionnement Actuel
+
+1. Job `recruiterOfferExpirationReminderJob` tourne quotidiennement
+2. Query: offres actives avec `relance_mail_expiration_J7: null` et expiration dans 7 jours
+3. Envoie email de rappel au recruteur
+4. Update `jobs.$.relance_mail_expiration_J7 = now`
+5. Même logique pour J-1
+
+### Modèle de Données Actuel
+
+```typescript
+// Dans recruiters.jobs[]
+{
+  job_expiration_date: Date,
+  relance_mail_expiration_J7: Date | null,
+  relance_mail_expiration_J1: Date | null,
+}
+```
+
+### Migration vers jobs_partners
+
+**1. Ajouter champs au schéma:**
+
+```typescript
+// jobsPartners.model.ts
+relance_mail_expiration_J7: z.date().nullish(),
+relance_mail_expiration_J1: z.date().nullish(),
+```
+
+**2. Mettre à jour la sync:**
+
+```typescript
+// formulaire.service.ts - upsertJobPartnersFromRecruiter
+relance_mail_expiration_J7: job.relance_mail_expiration_J7 ?? null,
+relance_mail_expiration_J1: job.relance_mail_expiration_J1 ?? null,
+```
+
+**3. Réécrire le job:**
+
+```typescript
+// recruiterOfferExpirationReminderJob.ts
+const sendJ7Reminders = async () => {
+  const targetDate = dayjs().add(7, "days").startOf("day")
+
+  const jobs = await getDbCollection("jobs_partners")
+    .find({
+      partner_label: "RECRUTEURS_LBA",
+      offer_status: "Active",
+      offer_expiration: {
+        $gte: targetDate.toDate(),
+        $lt: targetDate.add(1, "day").toDate(),
+      },
+      relance_mail_expiration_J7: null,
+    })
+    .toArray()
+
+  // Grouper par utilisateur gestionnaire
+  const jobsByUser = groupBy(jobs, "managed_by")
+
+  for (const [userId, userJobs] of Object.entries(jobsByUser)) {
+    const user = await getDbCollection("userswithaccounts").findOne({
+      _id: new ObjectId(userId),
+    })
+
+    if (!user) {
+      logger.warn(`User ${userId} not found for J7 reminder`)
+      continue
+    }
+
+    // Envoyer un seul email avec toutes les offres
+    await sendExpirationReminderEmail({
+      to: user.email,
+      jobs: userJobs,
+      daysRemaining: 7,
+    })
+
+    // Marquer comme envoyé
+    await getDbCollection("jobs_partners").updateMany({ _id: { $in: userJobs.map((j) => j._id) } }, { $set: { relance_mail_expiration_J7: new Date() } })
+  }
+}
+```
+
+**4. Index pour performance:**
+
+```javascript
+{ relance_mail_expiration_J7: 1, offer_status: 1, offer_expiration: 1 }
+```
+
+---
+
+## 5.2 Prolongation des Offres
+
+### Fonctionnement Actuel
+
+```typescript
+// formulaire.service.ts - extendOffre
+await getDbCollection("recruiters").findOneAndUpdate(
+  { "jobs._id": id },
+  {
+    $set: {
+      "jobs.$.job_expiration_date": addExpirationPeriod(dayjs()).toDate(),
+      "jobs.$.job_last_prolongation_date": now,
+      "jobs.$.job_update_date": now,
+      "jobs.$.relance_mail_expiration_J7": null, // Reset
+      "jobs.$.relance_mail_expiration_J1": null, // Reset
+    },
+    $inc: { "jobs.$.job_prolongation_count": 1 },
+  }
+)
+```
+
+### Migration vers jobs_partners
+
+**1. Ajouter champs:**
+
+```typescript
+job_last_prolongation_date: z.date().nullish(),
+job_prolongation_count: z.number().int().min(0).default(0),
+```
+
+**2. Nouvelle implémentation:**
+
+```typescript
+export const extendOffre = async (id: IJob["_id"]): Promise<IJobsPartnersOfferPrivate> => {
+  const now = new Date()
+  const newExpiration = addExpirationPeriod(dayjs()).toDate()
+
+  const job = await getDbCollection("jobs_partners").findOneAndUpdate(
+    { _id: id, partner_label: "RECRUTEURS_LBA" },
+    {
+      $set: {
+        offer_expiration: newExpiration,
+        job_last_prolongation_date: now,
+        updated_at: now,
+        relance_mail_expiration_J7: null,
+        relance_mail_expiration_J1: null,
+      },
+      $inc: { job_prolongation_count: 1 },
+    },
+    { returnDocument: "after" }
+  )
+
+  if (!job) {
+    throw notFound(`Job with id=${id} not found`)
+  }
+
+  return job
+}
+```
+
+---
+
+## 5.3 Gestion du Statut Recruteur
+
+### Modèle Actuel
+
+```typescript
+// recruiters
+{
+  status: "Actif" | "Archive" | "En attente validation" | ...,
+  jobs: [
+    { job_status: "Active" | "Pourvue" | "Annulée" | "En attente" }
+  ]
+}
+```
+
+**Logique:**
+
+- Quand `recruiter.status` change, cela affecte la visibilité de toutes ses offres
+- `archiveFormulaire()` met `status = ARCHIVE` et annule tous les jobs
+
+### Migration vers jobs_partners
+
+**1. Nouveau champ:**
+
+```typescript
+recruiter_status: z.nativeEnum(RECRUITER_STATUS),
+```
+
+**2. Fonction de propagation:**
+
+```typescript
+export const updateRecruiterStatus = async (establishmentId: string, newStatus: RECRUITER_STATUS) => {
+  // Update toutes les offres de cet établissement
+  const result = await getDbCollection("jobs_partners").updateMany(
+    {
+      partner_label: "RECRUTEURS_LBA",
+      establishment_id: establishmentId,
+    },
+    {
+      $set: {
+        recruiter_status: newStatus,
+        updated_at: new Date(),
+      },
+    }
+  )
+
+  // Si archivage, annuler aussi les offres actives
+  if (newStatus === RECRUITER_STATUS.ARCHIVE) {
+    await getDbCollection("jobs_partners").updateMany(
+      {
+        partner_label: "RECRUTEURS_LBA",
+        establishment_id: establishmentId,
+        offer_status: "Active",
+      },
+      {
+        $set: {
+          offer_status: "Cancelled",
+          offer_expiration: new Date(),
+        },
+      }
+    )
+  }
+
+  return result.modifiedCount
+}
+```
+
+**3. Adapter `getOfferStatus()`:**
+
+```typescript
+function getOfferStatus(jobStatus: JOB_STATUS, recruiterStatus: RECRUITER_STATUS): JOB_STATUS_ENGLISH {
+  // Si recruteur non actif, l'offre est annulée
+  if (recruiterStatus !== RECRUITER_STATUS.ACTIF) {
+    return JOB_STATUS_ENGLISH.ANNULEE
+  }
+  // ... logique existante
+}
+```
+
+---
+
+## 5.4 Gestion Utilisateur (managed_by)
+
+### Modèle Actuel
+
+```typescript
+// recruiters
+{
+  managed_by: "userId", // ObjectId as string
+  // L'utilisateur peut avoir plusieurs recruiters
+}
+
+// Queries courantes
+getDbCollection("recruiters").find({ managed_by: userId })
+getDbCollection("recruiters").findOne({ "jobs._id": jobId })
+  .then(r => r.managed_by) // Pour vérifier ownership
+```
+
+### Migration vers jobs_partners
+
+**1. Nouveau champ:**
+
+```typescript
+managed_by: z.string().describe("User ID managing this offer"),
+```
+
+**2. Index:**
+
+```javascript
+{ managed_by: 1, offer_status: 1, offer_expiration: -1 }
+```
+
+**3. Queries typiques:**
+
+```typescript
+// Obtenir toutes les offres d'un utilisateur
+const getUserOffers = async (userId: string) => {
+  return getDbCollection("jobs_partners")
+    .find({
+      partner_label: "RECRUTEURS_LBA",
+      managed_by: userId,
+    })
+    .toArray()
+}
+
+// Grouper par établissement pour l'affichage dashboard
+const getUserEstablishments = async (userId: string) => {
+  return getDbCollection("jobs_partners")
+    .aggregate([
+      {
+        $match: {
+          partner_label: "RECRUTEURS_LBA",
+          managed_by: userId,
+        },
+      },
+      {
+        $group: {
+          _id: "$establishment_id",
+          workplace_siret: { $first: "$workplace_siret" },
+          workplace_legal_name: { $first: "$workplace_legal_name" },
+          recruiter_status: { $first: "$recruiter_status" },
+          jobs: { $push: "$$ROOT" },
+          activeJobsCount: {
+            $sum: { $cond: [{ $eq: ["$offer_status", "Active"] }, 1, 0] },
+          },
+        },
+      },
+    ])
+    .toArray()
+}
+
+// Vérifier ownership pour autorisation
+const canUserAccessJob = async (userId: string, jobId: ObjectId) => {
+  const job = await getDbCollection("jobs_partners").findOne({
+    _id: jobId,
+    partner_label: "RECRUTEURS_LBA",
+  })
+
+  return job?.managed_by === userId
+}
+```
+
+**4. Adapter authorisationService.ts:**
+
+```typescript
+// Actuel
+const recruiter = await getDbCollection("recruiters").findOne({ "jobs._id": jobId })
+const canAccess = recruiter?.managed_by === userId
+
+// Nouveau
+const job = await getDbCollection("jobs_partners").findOne({ _id: jobId })
+const canAccess = job?.managed_by === userId
+```
+
+---
+
+## 5.5 Délégation CFA
+
+### Modèle Actuel
+
+```typescript
+// recruiters (entreprise déléguant au CFA)
+{
+  is_delegated: true,
+  cfa_delegated_siret: "12345678901234",
+  // Contact = CFA, pas l'entreprise
+}
+
+// recruiters.jobs[].delegations[]
+{
+  siret_code: "98765432109876",
+  email: "cfa@example.com"
+}
+```
+
+### Migration vers jobs_partners
+
+**Champs existants (déjà synchronisés):**
+
+```typescript
+is_delegated: boolean,
+cfa_siret: string | null,
+cfa_legal_name: string | null,
+cfa_apply_phone: string | null,
+cfa_apply_email: string | null,
+cfa_address_label: string | null,
+delegations: IDelegation[],
+job_delegation_count: number,
+```
+
+**Vérifications nécessaires:**
+
+1. **Contact info:** Quand `is_delegated = true`, les champs `apply_email` et `apply_phone` pointent vers le CFA
+2. **Délégations:** Le tableau `delegations` contient les CFAs à qui l'offre a été partagée
+
+**Fonctions à adapter:**
+
+```typescript
+// Obtenir le contact pour une offre
+const getOfferContactInfo = (job: IJobsPartnersOfferPrivate) => {
+  if (job.is_delegated) {
+    return {
+      email: job.cfa_apply_email,
+      phone: job.cfa_apply_phone,
+      name: job.cfa_legal_name,
+    }
+  }
+  return {
+    email: job.apply_email,
+    phone: job.apply_phone,
+    name: job.workplace_legal_name,
+  }
+}
+
+// Créer une délégation
+const createDelegation = async (jobId: ObjectId, delegation: IDelegation) => {
+  await getDbCollection("jobs_partners").updateOne(
+    { _id: jobId },
+    {
+      $push: { delegations: delegation },
+      $inc: { job_delegation_count: 1 },
+      $set: { updated_at: new Date() },
+    }
+  )
+}
+```
+
+---
+
+## 5.6 Recherche Géospatiale
+
+### Modèle Actuel
+
+```typescript
+// recruiters - Index 2dsphere sur geopoint
+// Aggregation avec $geoNear sur recruiters puis $unwind sur jobs
+```
+
+### Migration vers jobs_partners
+
+**Index existant:**
+
+```javascript
+{
+  workplace_geopoint: "2dsphere"
+}
+```
+
+**Nouvelle query:**
+
+```typescript
+const searchJobsByLocation = async (params: {
+  latitude: number
+  longitude: number
+  radius: number // en mètres
+  romes?: string[]
+  status?: string
+}) => {
+  const pipeline: any[] = [
+    {
+      $geoNear: {
+        near: {
+          type: "Point",
+          coordinates: [params.longitude, params.latitude],
+        },
+        distanceField: "distance",
+        maxDistance: params.radius,
+        spherical: true,
+        query: {
+          partner_label: "RECRUTEURS_LBA",
+          offer_status: params.status || "Active",
+          ...(params.romes && { offer_rome_codes: { $in: params.romes } }),
+        },
+      },
+    },
+    {
+      $project: {
+        _id: 1,
+        offer_title: 1,
+        workplace_legal_name: 1,
+        workplace_address_label: 1,
+        workplace_geopoint: 1,
+        distance: 1,
+        offer_rome_codes: 1,
+        contract_type: 1,
+        contract_start: 1,
+        offer_description: 1,
+      },
+    },
+    { $limit: 100 },
+  ]
+
+  return getDbCollection("jobs_partners").aggregate(pipeline).toArray()
+}
+```
+
+**Avantages:**
+
+- Plus de `$unwind` sur jobs (chaque offre = 1 document)
+- Query plus simple et performante
+- Même index 2dsphere
+
+---
+
+## Matrice de Compatibilité API
+
+| Endpoint            | Champs retournés (actuel) | Source après migration           |
+| ------------------- | ------------------------- | -------------------------------- |
+| GET /jobs/:id       | recruiter + job fusionnés | jobs_partners direct             |
+| GET /jobs/search    | Liste de jobs             | jobs_partners aggregation        |
+| POST /jobs          | Crée recruiter + job      | Crée jobs_partners               |
+| PUT /jobs/:id       | Update job dans recruiter | Update jobs_partners             |
+| DELETE /jobs/:id    | Archive job               | Update offer_status              |
+| GET /formulaire/:id | Recruiter avec jobs       | Aggregation par establishment_id |
+
+**Transformation de réponse:**
+
+Pour maintenir la compatibilité, créer un mapper:
+
+```typescript
+const mapJobsPartnersToLegacyJob = (job: IJobsPartnersOfferPrivate): IJobLegacy => ({
+  _id: job._id,
+  rome_code: job.offer_rome_codes,
+  rome_label: job.offer_title, // Approximation
+  job_status: mapStatusToLegacy(job.offer_status),
+  job_type: job.contract_type,
+  job_start_date: job.contract_start,
+  job_duration: job.contract_duration,
+  job_description: job.offer_description,
+  job_creation_date: job.offer_creation,
+  job_expiration_date: job.offer_expiration,
+  // ... autres champs
+})
+
+const mapJobsPartnersToLegacyRecruiter = (jobs: IJobsPartnersOfferPrivate[]): IRecruiterLegacy => {
+  const first = jobs[0]
+  return {
+    establishment_id: first.establishment_id,
+    establishment_siret: first.workplace_siret,
+    establishment_raison_sociale: first.workplace_legal_name,
+    email: first.apply_email,
+    phone: first.apply_phone,
+    address: first.workplace_address_label,
+    geopoint: first.workplace_geopoint,
+    status: mapRecruiterStatus(first.recruiter_status),
+    managed_by: first.managed_by,
+    jobs: jobs.map(mapJobsPartnersToLegacyJob),
+  }
+}
+```

--- a/docs/migration-temp/06-testing-rollback.md
+++ b/docs/migration-temp/06-testing-rollback.md
@@ -1,0 +1,617 @@
+# 06 - Stratégie de Tests et Plan de Rollback
+
+## Stratégie de Tests
+
+### 6.1 Tests Unitaires à Modifier
+
+| Fichier                          | Changements               | Priorité |
+| -------------------------------- | ------------------------- | -------- |
+| `formulaire.service.test.ts`     | Toutes les fonctions CRUD | P1       |
+| `application.service.test.ts`    | Lookups job               | P2       |
+| `jobOpportunity.service.test.ts` | Queries recherche         | P2       |
+| `lbajob.service.test.ts`         | Recherche géospatiale     | P1       |
+| `userRecruteur.service.test.ts`  | Gestion utilisateur       | P3       |
+
+### 6.2 Tests d'Intégration à Modifier
+
+| Fichier                                     | Changements              | Priorité |
+| ------------------------------------------- | ------------------------ | -------- |
+| `formulaire.controller.test.ts`             | Endpoints API formulaire | P1       |
+| `jobs.controller.v3.test.ts`                | Endpoints jobs v3        | P1       |
+| `etablissementRecruteur.controller.test.ts` | Endpoints établissement  | P2       |
+| `applications.controller.v2.test.ts`        | Flux candidature         | P2       |
+
+### 6.3 Tests E2E Cypress
+
+**Scénarios critiques à couvrir:**
+
+```typescript
+// cypress/e2e/recruiter-flow.cy.ts
+
+describe("Recruiter Job Management", () => {
+  it("should create a new job offer", () => {
+    // 1. Login as recruiter
+    // 2. Navigate to job creation
+    // 3. Fill form and submit
+    // 4. Verify job appears in jobs_partners
+    // 5. Verify job appears in search results
+  })
+
+  it("should extend a job offer", () => {
+    // 1. Login as recruiter
+    // 2. Find expiring job
+    // 3. Click extend
+    // 4. Verify new expiration date
+    // 5. Verify prolongation_count incremented
+  })
+
+  it("should archive a recruiter and cancel all jobs", () => {
+    // 1. Login as admin
+    // 2. Archive recruiter
+    // 3. Verify recruiter_status = ARCHIVE in all jobs
+    // 4. Verify offer_status = Cancelled
+    // 5. Verify jobs not visible in search
+  })
+
+  it("should handle CFA delegation", () => {
+    // 1. Login as entreprise
+    // 2. Create delegated job
+    // 3. Verify is_delegated = true
+    // 4. Verify cfa_* fields populated
+    // 5. Verify contact info points to CFA
+  })
+})
+```
+
+---
+
+### 6.4 Nouveaux Tests Requis
+
+#### Test de Consistance (Temporaire)
+
+```typescript
+// server/src/tests/migration/dataConsistency.test.ts
+
+describe("Recruiters to Jobs Partners Data Consistency", () => {
+  it("should have matching job counts", async () => {
+    const recruitersJobCount = await getDbCollection("recruiters")
+      .aggregate([{ $unwind: "$jobs" }, { $match: { "jobs.job_status": "Active" } }, { $count: "total" }])
+      .toArray()
+
+    const jobsPartnersCount = await getDbCollection("jobs_partners").countDocuments({
+      partner_label: "RECRUTEURS_LBA",
+      offer_status: "Active",
+    })
+
+    expect(jobsPartnersCount).toBe(recruitersJobCount[0]?.total ?? 0)
+  })
+
+  it("should have all new fields populated for LBA jobs", async () => {
+    const missingFields = await getDbCollection("jobs_partners").countDocuments({
+      partner_label: "RECRUTEURS_LBA",
+      $or: [{ managed_by: { $exists: false } }, { managed_by: null }, { establishment_id: { $exists: false } }, { establishment_id: null }],
+    })
+
+    expect(missingFields).toBe(0)
+  })
+
+  it("should have consistent managed_by values", async () => {
+    // Vérifier que managed_by dans jobs_partners correspond à recruiters
+    const sample = await getDbCollection("jobs_partners").find({ partner_label: "RECRUTEURS_LBA" }).limit(100).toArray()
+
+    for (const job of sample) {
+      const recruiter = await getDbCollection("recruiters").findOne({ "jobs._id": job._id })
+
+      expect(job.managed_by).toBe(recruiter?.managed_by)
+    }
+  })
+})
+```
+
+#### Test d'Autorisation
+
+```typescript
+// server/src/security/authorisationService.test.ts
+
+describe("Authorization with jobs_partners", () => {
+  it("should allow owner to access their job", async () => {
+    const userId = new ObjectId()
+    const job = await createTestJob({ managed_by: userId.toString() })
+
+    const canAccess = await canUserAccessJob(userId.toString(), job._id)
+    expect(canAccess).toBe(true)
+  })
+
+  it("should deny non-owner access to job", async () => {
+    const ownerId = new ObjectId()
+    const otherId = new ObjectId()
+    const job = await createTestJob({ managed_by: ownerId.toString() })
+
+    const canAccess = await canUserAccessJob(otherId.toString(), job._id)
+    expect(canAccess).toBe(false)
+  })
+
+  it("should allow admin access to any job", async () => {
+    const adminId = new ObjectId()
+    const job = await createTestJob({ managed_by: new ObjectId().toString() })
+
+    // Setup admin role
+    await createAdminRole(adminId)
+
+    const canAccess = await canUserAccessJob(adminId.toString(), job._id)
+    expect(canAccess).toBe(true)
+  })
+})
+```
+
+#### Test des Rappels Email
+
+```typescript
+// server/src/jobs/recruiters/recruiterOfferExpirationReminderJob.test.ts
+
+describe("Expiration Reminder Job with jobs_partners", () => {
+  it("should send J7 reminder for expiring jobs", async () => {
+    // Setup: créer job expirant dans 7 jours
+    const job = await createTestJob({
+      offer_expiration: dayjs().add(7, "days").toDate(),
+      relance_mail_expiration_J7: null,
+    })
+
+    await runExpirationReminderJob()
+
+    // Verify email sent
+    expect(mockMailer.sendEmail).toHaveBeenCalled()
+
+    // Verify field updated
+    const updated = await getDbCollection("jobs_partners").findOne({ _id: job._id })
+    expect(updated?.relance_mail_expiration_J7).not.toBeNull()
+  })
+
+  it("should not send reminder if already sent", async () => {
+    const job = await createTestJob({
+      offer_expiration: dayjs().add(7, "days").toDate(),
+      relance_mail_expiration_J7: new Date(), // Already sent
+    })
+
+    await runExpirationReminderJob()
+
+    expect(mockMailer.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it("should group reminders by user", async () => {
+    const userId = new ObjectId().toString()
+
+    // Créer 3 jobs pour le même utilisateur
+    await createTestJob({ managed_by: userId, offer_expiration: dayjs().add(7, "days").toDate() })
+    await createTestJob({ managed_by: userId, offer_expiration: dayjs().add(7, "days").toDate() })
+    await createTestJob({ managed_by: userId, offer_expiration: dayjs().add(7, "days").toDate() })
+
+    await runExpirationReminderJob()
+
+    // Un seul email pour les 3 jobs
+    expect(mockMailer.sendEmail).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+---
+
+### 6.5 Fixtures de Test
+
+```typescript
+// server/tests/fixtures/jobsPartners.fixture.ts
+
+import { ObjectId } from "mongodb"
+import type { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
+
+export const createTestJobPartner = async (overrides: Partial<IJobsPartnersOfferPrivate> = {}): Promise<IJobsPartnersOfferPrivate> => {
+  const now = new Date()
+  const jobId = new ObjectId()
+
+  const job: IJobsPartnersOfferPrivate = {
+    _id: jobId,
+    partner_label: "RECRUTEURS_LBA",
+    partner_job_id: jobId.toString(),
+
+    // Nouveaux champs
+    managed_by: new ObjectId().toString(),
+    establishment_id: randomUUID(),
+    recruiter_status: "ACTIF",
+    address_detail: null,
+    relance_mail_expiration_J7: null,
+    relance_mail_expiration_J1: null,
+    job_last_prolongation_date: null,
+    job_prolongation_count: 0,
+
+    // Champs existants
+    offer_title: "Test Job",
+    offer_description: "Test description",
+    offer_rome_codes: ["M1805"],
+    offer_status: "Active",
+    offer_creation: now,
+    offer_expiration: dayjs(now).add(2, "months").toDate(),
+    offer_target_diploma: null,
+    offer_desired_skills: [],
+    offer_to_be_acquired_skills: [],
+    offer_opening_count: 1,
+    offer_multicast: true,
+    offer_origin: "lba",
+
+    workplace_siret: "12345678901234",
+    workplace_legal_name: "Test Company",
+    workplace_brand: null,
+    workplace_address_label: "1 rue Test, 75001 Paris",
+    workplace_address_zipcode: "75001",
+    workplace_address_city: "Paris",
+    workplace_geopoint: { type: "Point", coordinates: [2.3522, 48.8566] },
+    workplace_size: null,
+    workplace_opco: null,
+    workplace_idcc: null,
+    workplace_naf_code: null,
+    workplace_naf_label: null,
+
+    apply_email: "test@example.com",
+    apply_phone: "0123456789",
+
+    contract_type: ["Apprentissage"],
+    contract_start: dayjs(now).add(1, "month").toDate(),
+    contract_duration: 12,
+    contract_rythm: null,
+    contract_remote: null,
+    contract_is_disabled_elligible: false,
+
+    is_delegated: false,
+    cfa_siret: null,
+    cfa_legal_name: null,
+    cfa_apply_email: null,
+    cfa_apply_phone: null,
+    cfa_address_label: null,
+    delegations: [],
+    job_delegation_count: 0,
+    job_status_comment: null,
+
+    created_at: now,
+    updated_at: now,
+
+    ...overrides,
+  }
+
+  await getDbCollection("jobs_partners").insertOne(job)
+  return job
+}
+
+export const cleanupTestJobPartners = async () => {
+  await getDbCollection("jobs_partners").deleteMany({
+    partner_label: "RECRUTEURS_LBA",
+    offer_title: { $regex: /^Test/ },
+  })
+}
+```
+
+---
+
+## Plan de Rollback
+
+### 7.1 Feature Flags
+
+```typescript
+// server/src/config.ts
+
+export const featureFlags = {
+  // Phase 1: Dual-write (écrire dans les deux collections)
+  DUAL_WRITE_ENABLED: process.env.DUAL_WRITE_ENABLED === "true",
+
+  // Phase 2: Read from jobs_partners
+  USE_JOBS_PARTNERS_READ: process.env.USE_JOBS_PARTNERS_READ === "true",
+
+  // Phase 3: Write only to jobs_partners
+  JOBS_PARTNERS_ONLY: process.env.JOBS_PARTNERS_ONLY === "true",
+
+  // Emergency: Force recruiters read (bypass all)
+  FORCE_RECRUITERS_READ: process.env.FORCE_RECRUITERS_READ === "true",
+}
+```
+
+### 7.2 Utilisation des Feature Flags
+
+```typescript
+// server/src/services/formulaire.service.ts
+
+export const getOffre = async (id: string | ObjectId) => {
+  // Emergency bypass
+  if (featureFlags.FORCE_RECRUITERS_READ) {
+    return getOffreFromRecruiters(id)
+  }
+
+  // Normal flow
+  if (featureFlags.USE_JOBS_PARTNERS_READ) {
+    const job = await getDbCollection("jobs_partners").findOne({
+      _id: new ObjectId(id.toString()),
+    })
+
+    if (job) return transformToRecruiterFormat(job)
+
+    // Fallback si pas trouvé (pendant migration)
+    if (!featureFlags.JOBS_PARTNERS_ONLY) {
+      return getOffreFromRecruiters(id)
+    }
+
+    return null
+  }
+
+  return getOffreFromRecruiters(id)
+}
+
+const getOffreFromRecruiters = async (id: string | ObjectId) => {
+  return getDbCollection("recruiters").findOne({
+    "jobs._id": new ObjectId(id.toString()),
+  })
+}
+```
+
+### 7.3 Scénarios de Rollback
+
+#### Scénario 1: Erreurs de lecture
+
+**Symptômes:**
+
+- 500 errors sur endpoints /jobs/\*
+- Logs: "Job not found in jobs_partners"
+
+**Actions:**
+
+```bash
+# 1. Activer fallback recruiters
+kubectl set env deployment/lba-server USE_JOBS_PARTNERS_READ=false
+
+# 2. Vérifier les erreurs
+kubectl logs -l app=lba-server --tail=100 | grep "not found"
+
+# 3. Investiguer la sync
+yarn cli check:sync-status
+```
+
+#### Scénario 2: Données incohérentes
+
+**Symptômes:**
+
+- Offres manquantes dans les résultats de recherche
+- Données obsolètes affichées
+
+**Actions:**
+
+```bash
+# 1. Forcer lecture depuis recruiters
+kubectl set env deployment/lba-server FORCE_RECRUITERS_READ=true
+
+# 2. Relancer le backfill
+yarn cli jobs:run backfillJobsPartnersFromRecruiters
+
+# 3. Vérifier la consistance
+yarn cli check:data-consistency
+
+# 4. Réactiver progressivement
+kubectl set env deployment/lba-server FORCE_RECRUITERS_READ=false
+```
+
+#### Scénario 3: Performance dégradée
+
+**Symptômes:**
+
+- Latence élevée sur recherche
+- Timeouts fréquents
+
+**Actions:**
+
+```bash
+# 1. Vérifier les index
+yarn cli db:check-indexes jobs_partners
+
+# 2. Analyser les queries lentes
+yarn cli db:slow-queries
+
+# 3. Si index manquant
+yarn cli migrations:up
+
+# 4. Si toujours lent, rollback temporaire
+kubectl set env deployment/lba-server USE_JOBS_PARTNERS_READ=false
+```
+
+#### Scénario 4: Problème de change stream
+
+**Symptômes:**
+
+- Nouvelles offres non synchronisées
+- Stream processor en erreur
+
+**Actions:**
+
+```bash
+# 1. Vérifier le stream processor
+kubectl logs -l app=stream-processor --tail=100
+
+# 2. Vérifier le resume token
+yarn cli check:resume-token recruiters
+
+# 3. Redémarrer le stream processor
+kubectl rollout restart deployment/stream-processor
+
+# 4. Si token expiré, reset
+yarn cli reset:resume-token recruiters
+yarn cli jobs:run fullSync
+```
+
+---
+
+### 7.4 Checklist de Rollback
+
+```markdown
+## Rollback Rapide (< 5 min)
+
+- [ ] Activer FORCE_RECRUITERS_READ=true
+- [ ] Vérifier que le site fonctionne
+- [ ] Notifier l'équipe
+
+## Rollback Standard (< 30 min)
+
+- [ ] Désactiver USE_JOBS_PARTNERS_READ
+- [ ] Vérifier les endpoints critiques
+- [ ] Analyser les logs d'erreur
+- [ ] Créer ticket d'investigation
+
+## Rollback Complet (< 2h)
+
+- [ ] Désactiver tous les feature flags
+- [ ] Réactiver stream processor
+- [ ] Lancer sync complète recruiters → jobs_partners
+- [ ] Vérifier consistance données
+- [ ] Planifier post-mortem
+```
+
+---
+
+### 7.5 Monitoring et Alertes
+
+#### Métriques à Surveiller
+
+```typescript
+// server/src/common/metrics.ts
+
+export const migrationMetrics = {
+  // Nombre de lectures jobs_partners vs recruiters
+  jobsPartnersReads: new Counter({
+    name: "jobs_partners_reads_total",
+    help: "Total reads from jobs_partners collection",
+  }),
+
+  recruitersReads: new Counter({
+    name: "recruiters_reads_total",
+    help: "Total reads from recruiters collection",
+  }),
+
+  // Fallbacks (indicateur de problème)
+  fallbacksToRecruiters: new Counter({
+    name: "fallbacks_to_recruiters_total",
+    help: "Times we fell back to recruiters collection",
+  }),
+
+  // Latence par source
+  readLatency: new Histogram({
+    name: "collection_read_latency_seconds",
+    help: "Read latency by collection",
+    labelNames: ["collection"],
+  }),
+
+  // Erreurs
+  syncErrors: new Counter({
+    name: "sync_errors_total",
+    help: "Errors during recruiters to jobs_partners sync",
+  }),
+}
+```
+
+#### Alertes Recommandées
+
+```yaml
+# alerting/migration-alerts.yml
+
+groups:
+  - name: recruiters-migration
+    rules:
+      # Trop de fallbacks = problème de données
+      - alert: HighFallbackRate
+        expr: rate(fallbacks_to_recruiters_total[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High fallback rate to recruiters collection"
+
+      # Stream processor down
+      - alert: StreamProcessorDown
+        expr: up{job="stream-processor"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Stream processor is down"
+
+      # Sync errors
+      - alert: SyncErrors
+        expr: rate(sync_errors_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Errors during data sync"
+
+      # Data inconsistency
+      - alert: DataInconsistency
+        expr: abs(recruiters_active_jobs_count - jobs_partners_active_jobs_count) > 100
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Data inconsistency between collections"
+```
+
+---
+
+### 7.6 Communications
+
+#### Template: Début de Migration
+
+```markdown
+## [Migration] Décommissionnement collection recruiters
+
+**Date:** [DATE]
+**Durée estimée:** 16 semaines
+
+### Ce qui change
+
+- Les offres d'emploi LBA seront progressivement lues depuis `jobs_partners`
+- Aucun impact utilisateur attendu
+
+### Actions requises
+
+- [ ] Équipe data: Mettre à jour les dashboards Metabase
+- [ ] Équipe support: Être vigilant sur les tickets liés aux offres
+
+### Rollback
+
+Feature flags en place pour rollback rapide si nécessaire.
+
+### Contact
+
+@tech-lead pour toute question
+```
+
+#### Template: Incident de Migration
+
+```markdown
+## [Incident] Problème migration recruiters
+
+**Début:** [TIMESTAMP]
+**Impact:** [DESCRIPTION]
+**Sévérité:** P1/P2/P3
+
+### Actions en cours
+
+1. [ACTION 1]
+2. [ACTION 2]
+
+### Rollback effectué
+
+- [ ] Oui / [ ] Non
+- Détails: [...]
+
+### Prochaine mise à jour
+
+Dans [X] minutes
+
+### Historique
+
+- [TIMESTAMP] - Détection du problème
+- [TIMESTAMP] - Investigation démarrée
+- [TIMESTAMP] - ...
+```

--- a/docs/migration-temp/07-feature-flags.md
+++ b/docs/migration-temp/07-feature-flags.md
@@ -1,0 +1,447 @@
+# 07 - Feature Flags pour la Transition Progressive
+
+## Principe de Base
+
+Les feature flags sont des **interrupteurs conditionnels** dans le code qui permettent d'activer/désactiver des fonctionnalités sans redéploiement.
+
+```typescript
+// Exemple simple
+if (config.USE_JOBS_PARTNERS_READ) {
+  return readFromJobsPartners(id)
+} else {
+  return readFromRecruiters(id)
+}
+```
+
+---
+
+## Stratégie en 4 Phases
+
+### Vue d'ensemble
+
+```
+PHASE 1: SYNC COMPLET
+├── Stream processor: ✅ ACTIF
+├── Écriture: recruiters uniquement (sync automatique)
+├── Lecture: recruiters uniquement
+└── Objectif: S'assurer que TOUS les champs sont synchronisés
+
+PHASE 2: DUAL-READ
+├── Stream processor: ✅ ACTIF
+├── Écriture: recruiters (sync automatique)
+├── Lecture: jobs_partners (primary) + recruiters (fallback)
+└── Objectif: Valider que jobs_partners contient les bonnes données
+
+PHASE 3: ÉCRITURE DIRECTE
+├── Stream processor: ❌ COUPÉ
+├── Écriture: jobs_partners (direct) + recruiters (backup optionnel)
+├── Lecture: jobs_partners uniquement
+└── Objectif: L'application écrit directement dans jobs_partners
+
+PHASE 4: CLEANUP
+├── Stream processor: ❌ SUPPRIMÉ
+├── Écriture: jobs_partners uniquement
+├── Lecture: jobs_partners uniquement
+└── Objectif: Supprimer recruiters
+```
+
+### Diagrammes par Phase
+
+```
+PHASE 1: SYNC COMPLET (stream processor ACTIF)
+┌─────────────────────────────────────────────────────────────────────┐
+│                                                                     │
+│  Application ──WRITE──→ recruiters ──Stream Processor──→ jobs_partners
+│                                            (actif)                  │
+│  READ ←─────────────────── recruiters                               │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+
+PHASE 2: DUAL-READ (stream processor ACTIF)
+┌─────────────────────────────────────────────────────────────────────┐
+│                                                                     │
+│  Application ──WRITE──→ recruiters ──Stream Processor──→ jobs_partners
+│                                            (actif)                  │
+│  READ ←─────────────────── jobs_partners (primary)                  │
+│  READ ←─────────────────── recruiters (fallback si non trouvé)      │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+
+PHASE 3: ÉCRITURE DIRECTE (stream processor COUPÉ)
+┌─────────────────────────────────────────────────────────────────────┐
+│                                                                     │
+│  Application ──WRITE──→ jobs_partners (direct)                      │
+│             ──WRITE──→ recruiters (backup temporaire, optionnel)    │
+│                                                                     │
+│  READ ←─────────────────── jobs_partners                            │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+
+PHASE 4: CLEANUP
+┌─────────────────────────────────────────────────────────────────────┐
+│                                                                     │
+│  Application ──WRITE──→ jobs_partners                               │
+│  READ ←─────────────────── jobs_partners                            │
+│                                                                     │
+│  recruiters: SUPPRIMÉ                                               │
+│  stream_processor: SUPPRIMÉ                                         │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Implémentation des Feature Flags
+
+### Configuration
+
+```typescript
+// server/src/config.ts
+
+export const migrationFlags = {
+  /**
+   * PHASE 2: Active la lecture depuis jobs_partners
+   * - true: Lire depuis jobs_partners (fallback recruiters si non trouvé)
+   * - false: Lire depuis recruiters uniquement
+   */
+  USE_JOBS_PARTNERS_READ: process.env.USE_JOBS_PARTNERS_READ === "true",
+
+  /**
+   * PHASE 3: Active l'écriture directe dans jobs_partners
+   * - true: Écrire directement dans jobs_partners
+   * - false: Écrire dans recruiters (sync via stream processor)
+   */
+  USE_JOBS_PARTNERS_WRITE: process.env.USE_JOBS_PARTNERS_WRITE === "true",
+
+  /**
+   * PHASE 3: Garde une copie dans recruiters (backup)
+   * - true: Écrire aussi dans recruiters (dual-write)
+   * - false: Écrire uniquement dans jobs_partners
+   */
+  KEEP_RECRUITERS_BACKUP: process.env.KEEP_RECRUITERS_BACKUP === "true",
+
+  /**
+   * URGENCE: Force le retour à recruiters
+   * - true: Ignorer tous les autres flags, utiliser recruiters
+   * - false: Comportement normal selon les autres flags
+   */
+  FORCE_RECRUITERS_FALLBACK: process.env.FORCE_RECRUITERS_FALLBACK === "true",
+}
+```
+
+### Utilisation dans les Services
+
+#### Lecture (GET)
+
+```typescript
+// server/src/services/formulaire.service.ts
+
+export const getOffre = async (id: ObjectId): Promise<IJob | null> => {
+  // URGENCE: Bypass total
+  if (migrationFlags.FORCE_RECRUITERS_FALLBACK) {
+    return getOffreFromRecruiters(id)
+  }
+
+  // PHASE 2+: Lecture depuis jobs_partners
+  if (migrationFlags.USE_JOBS_PARTNERS_READ) {
+    const job = await getDbCollection("jobs_partners").findOne({
+      _id: id,
+      partner_label: "RECRUTEURS_LBA",
+    })
+
+    if (job) {
+      return transformJobsPartnersToLegacy(job)
+    }
+
+    // Fallback vers recruiters (Phase 2 uniquement)
+    if (!migrationFlags.USE_JOBS_PARTNERS_WRITE) {
+      logger.warn(`Job ${id} not found in jobs_partners, fallback to recruiters`)
+      metrics.fallbackCount.inc()
+      return getOffreFromRecruiters(id)
+    }
+
+    return null
+  }
+
+  // PHASE 1: Lecture depuis recruiters
+  return getOffreFromRecruiters(id)
+}
+
+const getOffreFromRecruiters = async (id: ObjectId): Promise<IJob | null> => {
+  const recruiter = await getDbCollection("recruiters").findOne({
+    "jobs._id": id,
+  })
+  return recruiter?.jobs.find((j) => j._id.equals(id)) ?? null
+}
+```
+
+#### Écriture (CREATE/UPDATE)
+
+```typescript
+// server/src/services/formulaire.service.ts
+
+export const createOffre = async (establishmentId: string, data: IJobCreate): Promise<IJob> => {
+  // PHASE 3+: Écriture directe dans jobs_partners
+  if (migrationFlags.USE_JOBS_PARTNERS_WRITE) {
+    const job = await createOffreInJobsPartners(establishmentId, data)
+
+    // Backup optionnel dans recruiters (Phase 3 transitoire)
+    if (migrationFlags.KEEP_RECRUITERS_BACKUP) {
+      try {
+        await createOffreInRecruiters(establishmentId, data)
+      } catch (error) {
+        logger.error("Failed to backup in recruiters", error)
+        // Ne pas bloquer - jobs_partners est la source de vérité
+      }
+    }
+
+    return job
+  }
+
+  // PHASE 1-2: Écriture dans recruiters (sync via stream processor)
+  return createOffreInRecruiters(establishmentId, data)
+}
+
+export const updateOffre = async (id: ObjectId, data: Partial<IJob>): Promise<IJob> => {
+  if (migrationFlags.USE_JOBS_PARTNERS_WRITE) {
+    const job = await updateOffreInJobsPartners(id, data)
+
+    if (migrationFlags.KEEP_RECRUITERS_BACKUP) {
+      try {
+        await updateOffreInRecruiters(id, data)
+      } catch (error) {
+        logger.error("Failed to backup update in recruiters", error)
+      }
+    }
+
+    return job
+  }
+
+  return updateOffreInRecruiters(id, data)
+}
+```
+
+---
+
+## Configuration par Phase
+
+### Phase 1 - Sync Complet
+
+```bash
+# .env.production
+USE_JOBS_PARTNERS_READ=false
+USE_JOBS_PARTNERS_WRITE=false
+KEEP_RECRUITERS_BACKUP=false
+FORCE_RECRUITERS_FALLBACK=false
+```
+
+**Actions:**
+
+- Stream processor actif
+- Ajouter les champs manquants à la sync
+- Lancer le backfill complet
+- Vérifier la consistance des données
+
+### Phase 2 - Dual-Read
+
+```bash
+# .env.production
+USE_JOBS_PARTNERS_READ=true    # ← Activé
+USE_JOBS_PARTNERS_WRITE=false
+KEEP_RECRUITERS_BACKUP=false
+FORCE_RECRUITERS_FALLBACK=false
+```
+
+**Actions:**
+
+- Monitorer les fallbacks (devrait être ~0)
+- Comparer les latences
+- Vérifier les réponses API
+
+### Phase 3 - Écriture Directe
+
+```bash
+# .env.production - Étape 3a (avec backup)
+USE_JOBS_PARTNERS_READ=true
+USE_JOBS_PARTNERS_WRITE=true   # ← Activé
+KEEP_RECRUITERS_BACKUP=true    # ← Backup actif
+FORCE_RECRUITERS_FALLBACK=false
+```
+
+```bash
+# .env.production - Étape 3b (sans backup, stream processor coupé)
+USE_JOBS_PARTNERS_READ=true
+USE_JOBS_PARTNERS_WRITE=true
+KEEP_RECRUITERS_BACKUP=false   # ← Backup désactivé
+FORCE_RECRUITERS_FALLBACK=false
+```
+
+**Actions:**
+
+- Couper le stream processor (après 3a validé)
+- Monitorer les erreurs d'écriture
+- Vérifier que recruiters n'est plus mis à jour
+
+### Phase 4 - Cleanup
+
+```bash
+# .env.production
+USE_JOBS_PARTNERS_READ=true
+USE_JOBS_PARTNERS_WRITE=true
+KEEP_RECRUITERS_BACKUP=false
+FORCE_RECRUITERS_FALLBACK=false
+```
+
+**Actions:**
+
+- Supprimer le code de fallback
+- Supprimer le stream processor
+- Drop collection recruiters
+
+---
+
+## Monitoring et Métriques
+
+### Métriques à Collecter
+
+```typescript
+// server/src/common/metrics.ts
+
+export const migrationMetrics = {
+  // Compteur de lectures par source
+  reads: new Counter({
+    name: "migration_reads_total",
+    labelNames: ["source"], // "jobs_partners" | "recruiters"
+  }),
+
+  // Compteur de fallbacks (Phase 2)
+  fallbacks: new Counter({
+    name: "migration_fallbacks_total",
+    help: "Number of times we fell back to recruiters",
+  }),
+
+  // Latence par source
+  readLatency: new Histogram({
+    name: "migration_read_latency_seconds",
+    labelNames: ["source"],
+  }),
+
+  // Erreurs d'écriture
+  writeErrors: new Counter({
+    name: "migration_write_errors_total",
+    labelNames: ["target"], // "jobs_partners" | "recruiters"
+  }),
+
+  // Incohérences détectées
+  inconsistencies: new Counter({
+    name: "migration_inconsistencies_total",
+  }),
+}
+```
+
+### Alertes Recommandées
+
+```yaml
+# alertmanager/migration-alerts.yml
+groups:
+  - name: migration
+    rules:
+      # Trop de fallbacks = problème de sync
+      - alert: HighFallbackRate
+        expr: rate(migration_fallbacks_total[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Fallback rate too high during migration"
+
+      # Erreurs d'écriture jobs_partners
+      - alert: JobsPartnersWriteErrors
+        expr: rate(migration_write_errors_total{target="jobs_partners"}[5m]) > 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Errors writing to jobs_partners"
+
+      # Latence dégradée
+      - alert: HighReadLatency
+        expr: histogram_quantile(0.95, migration_read_latency_seconds{source="jobs_partners"}) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+```
+
+---
+
+## Procédure de Rollback
+
+### Rollback Rapide (< 1 minute)
+
+```bash
+# Activer le bypass d'urgence
+kubectl set env deployment/lba-server FORCE_RECRUITERS_FALLBACK=true
+
+# Vérifier
+kubectl logs -l app=lba-server --tail=10 | grep "fallback"
+```
+
+### Rollback Phase 3 → Phase 2
+
+```bash
+# 1. Désactiver l'écriture directe
+kubectl set env deployment/lba-server USE_JOBS_PARTNERS_WRITE=false
+
+# 2. Réactiver le backup
+kubectl set env deployment/lba-server KEEP_RECRUITERS_BACKUP=false
+
+# 3. Redémarrer le stream processor
+kubectl scale deployment/stream-processor --replicas=1
+
+# 4. Lancer un sync de rattrapage
+kubectl exec -it deploy/lba-server -- yarn cli jobs:run backfillJobsPartners
+```
+
+### Rollback Phase 2 → Phase 1
+
+```bash
+# Désactiver la lecture depuis jobs_partners
+kubectl set env deployment/lba-server USE_JOBS_PARTNERS_READ=false
+```
+
+---
+
+## Checklist par Phase
+
+### Phase 1 ✓
+
+- [ ] Champs manquants ajoutés au schéma jobs_partners
+- [ ] Migration DB exécutée
+- [ ] Backfill complet lancé
+- [ ] Vérification: count recruiters.jobs == count jobs_partners (LBA)
+- [ ] Stream processor stable depuis 1 semaine
+
+### Phase 2 ✓
+
+- [ ] `USE_JOBS_PARTNERS_READ=true` activé
+- [ ] Fallback rate < 0.1%
+- [ ] Latence jobs_partners ≤ latence recruiters
+- [ ] Tests E2E passent
+- [ ] Stable depuis 2 semaines
+
+### Phase 3 ✓
+
+- [ ] `USE_JOBS_PARTNERS_WRITE=true` activé
+- [ ] `KEEP_RECRUITERS_BACKUP=true` (temporaire)
+- [ ] Vérifier dual-write fonctionne
+- [ ] Couper stream processor
+- [ ] `KEEP_RECRUITERS_BACKUP=false`
+- [ ] Stable depuis 2 semaines
+
+### Phase 4 ✓
+
+- [ ] Supprimer code fallback
+- [ ] Supprimer stream processor
+- [ ] Drop collection recruiters
+- [ ] Drop collection anonymized_recruiters
+- [ ] Nettoyer les feature flags

--- a/docs/migration-temp/08-ai-prompts-timeline.md
+++ b/docs/migration-temp/08-ai-prompts-timeline.md
@@ -1,0 +1,297 @@
+# 08 - Prompts IA et Timeline Révisée
+
+## Timeline Révisée: 6-7 Semaines
+
+| Semaine | Phase               | Tâches                                        |
+| ------- | ------------------- | --------------------------------------------- |
+| 1       | Schema + Sync       | Migration DB, fix sync, backfill              |
+| 2-3     | Code (Priorité 1-3) | Services critiques, authorization, formulaire |
+| 4       | Code (Priorité 4-5) | Controllers, jobs background                  |
+| 5       | Dual-read           | Activation, monitoring, fixes                 |
+| 6       | Cutover             | Bascule complète vers jobs_partners           |
+| 7       | Cleanup (IA)        | Suppression code legacy, tests finaux         |
+
+**Hypothèses:**
+
+- Tests générés par IA en parallèle du développement
+- Cleanup automatisé par IA
+- 1-2 développeurs
+- Rollback testé avant cutover
+
+---
+
+## Prompt 1: Génération des Tests
+
+````markdown
+# Contexte
+
+Je migre la collection MongoDB `recruiters` vers `jobs_partners` dans un projet Node.js/TypeScript avec Fastify et Vitest.
+
+## Fichiers de référence
+
+- Schéma source: `shared/src/models/recruiter.model.ts`
+- Schéma cible: `shared/src/models/jobsPartners.model.ts`
+- Service principal: `server/src/services/formulaire.service.ts`
+- Tests existants: `server/src/services/formulaire.service.test.ts`
+
+## Mapping des champs
+
+| Source (recruiters)            | Cible (jobs_partners)      |
+| ------------------------------ | -------------------------- |
+| recruiter.managed_by           | managed_by                 |
+| recruiter.establishment_id     | establishment_id           |
+| recruiter.status               | recruiter_status           |
+| job.relance_mail_expiration_J7 | relance_mail_expiration_J7 |
+| job.relance_mail_expiration_J1 | relance_mail_expiration_J1 |
+| job.job_last_prolongation_date | job_last_prolongation_date |
+| job.job_prolongation_count     | job_prolongation_count     |
+
+## Tâche
+
+Génère des tests Vitest pour:
+
+1. **Tests de consistance données** - Vérifie que les données dans `jobs_partners` correspondent à `recruiters`
+2. **Tests des services migrés** - Teste les fonctions qui lisent/écrivent dans `jobs_partners`
+3. **Tests de régression API** - Vérifie que les endpoints retournent les mêmes données qu'avant
+
+### Format attendu
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+
+describe("Migration recruiters → jobs_partners", () => {
+  // Tests ici
+})
+```
+````
+
+### Fonctions à tester
+
+1. `getOffre(id)` - Lecture d'une offre
+2. `createOffre(establishmentId, data)` - Création d'offre
+3. `updateOffre(id, data)` - Mise à jour
+4. `getFormulaires(query)` - Liste des formulaires
+5. `archiveFormulaire(establishmentId)` - Archivage
+
+Génère les tests complets avec mocks MongoDB et assertions.
+
+````
+
+---
+
+## Prompt 2: Cleanup du Code Legacy
+
+```markdown
+# Contexte
+
+La migration `recruiters` → `jobs_partners` est terminée. Je dois nettoyer le code legacy.
+
+## État actuel
+
+- Toutes les lectures viennent de `jobs_partners`
+- Toutes les écritures vont dans `jobs_partners`
+- La collection `recruiters` n'est plus utilisée
+- Le stream processor est arrêté
+
+## Fichiers à nettoyer
+
+### Services (supprimer code recruiters)
+
+- `server/src/services/formulaire.service.ts`
+  - Supprimer: `upsertJobPartnersFromRecruiter()` (lignes 889-1143)
+  - Supprimer: `startRecruiterChangeStream()`
+  - Supprimer: imports et références à la collection `recruiters`
+
+- `server/src/services/application.service.ts`
+  - Supprimer: lookups vers `recruiters`
+  - Garder: lookups vers `jobs_partners`
+
+### Jobs à supprimer
+
+- `server/src/jobs/offrePartenaire/lbaJobToJobsPartners.ts` (plus nécessaire)
+- `server/src/jobs/recruiters/removeDuplicatesRecruiters.ts` (obsolète)
+
+### Jobs à modifier
+
+- `server/src/jobs/database/obfuscateCollections.ts`
+  - Supprimer: `obfuscateRecruiter()`
+  - Garder: obfuscation de `jobs_partners`
+
+### Feature flags à supprimer
+
+Dans `server/src/config.ts`:
+```typescript
+// SUPPRIMER ces flags
+USE_JOBS_PARTNERS_READ: true,
+USE_JOBS_PARTNERS_WRITE: true,
+KEEP_RECRUITERS_BACKUP: false,
+FORCE_RECRUITERS_FALLBACK: false,
+````
+
+### Modèles
+
+- `shared/src/models/recruiter.model.ts` - Marquer comme deprecated ou supprimer
+- `shared/src/models/anonymizedRecruiters.model.ts` - Supprimer
+
+## Tâche
+
+Pour chaque fichier listé:
+
+1. Identifie le code à supprimer (références à `recruiters`, `getDbCollection("recruiters")`)
+2. Vérifie qu'aucune dépendance ne reste
+3. Génère le diff de suppression
+4. Liste les imports à nettoyer
+
+### Format de sortie
+
+Pour chaque fichier:
+
+```
+## fichier.ts
+
+### À supprimer
+- Lignes X-Y: description
+- Fonction `nomFonction`: raison
+
+### Imports à retirer
+- import { X } from "..."
+
+### Vérifications
+- [ ] Aucune référence restante à recruiters
+- [ ] Tests passent après suppression
+```
+
+````
+
+---
+
+## Prompt 3: Génération Migration DB
+
+```markdown
+# Contexte
+
+Projet Node.js/TypeScript avec MongoDB. Je dois créer une migration pour ajouter des champs à `jobs_partners`.
+
+## Nouveaux champs à ajouter
+
+```typescript
+// Pour les offres LBA (partner_label: "RECRUTEURS_LBA")
+managed_by: string | null           // ID utilisateur gestionnaire
+establishment_id: string | null     // UUID établissement
+recruiter_status: string            // "Actif" | "Archivé" | "En attente de validation"
+relance_mail_expiration_J7: Date | null
+relance_mail_expiration_J1: Date | null
+job_last_prolongation_date: Date | null
+job_prolongation_count: number      // default: 0
+mer_sent: Date | null
+````
+
+## Nouveaux index
+
+```typescript
+{ managed_by: 1 }
+{ establishment_id: 1 }
+{ relance_mail_expiration_J7: 1, offer_status: 1 }
+{ relance_mail_expiration_J1: 1, offer_status: 1 }
+{ recruiter_status: 1 }
+{ managed_by: 1, offer_status: 1, offer_expiration: -1 }
+```
+
+## Format migration existant
+
+```typescript
+// server/src/migrations/20250XXX-nom-migration.ts
+import { Db } from "mongodb"
+
+export const up = async (db: Db) => {
+  // Migration
+}
+
+export const down = async (db: Db) => {
+  // Rollback
+}
+```
+
+## Tâche
+
+Génère:
+
+1. Le fichier de migration complet
+2. Un script de backfill pour populer les champs depuis `recruiters`
+3. Un script de validation post-migration
+
+````
+
+---
+
+## Prompt 4: Vérification Consistance
+
+```markdown
+# Contexte
+
+Migration `recruiters` → `jobs_partners` en cours. Je dois vérifier la consistance des données.
+
+## Vérifications requises
+
+1. **Comptage** - Nombre de jobs dans recruiters == nombre dans jobs_partners (pour LBA)
+2. **Champs critiques** - Tous les champs obligatoires sont remplis
+3. **Références** - managed_by pointe vers un user existant
+4. **Géolocalisation** - workplace_geopoint est valide
+
+## Tâche
+
+Génère un script de vérification qui:
+
+1. Compare les counts entre collections
+2. Identifie les documents avec champs manquants
+3. Vérifie l'intégrité référentielle
+4. Génère un rapport JSON avec:
+   - Total documents vérifiés
+   - Erreurs par type
+   - Liste des _id problématiques
+
+### Format sortie
+
+```typescript
+interface ConsistencyReport {
+  timestamp: Date
+  recruiters_jobs_count: number
+  jobs_partners_lba_count: number
+  discrepancy: number
+  missing_fields: { field: string; count: number }[]
+  invalid_references: { _id: string; field: string }[]
+  invalid_geopoints: string[]
+}
+````
+
+````
+
+---
+
+## Checklist Utilisation Prompts
+
+| Étape | Prompt | Quand |
+|-------|--------|-------|
+| Semaine 1 | Prompt 3 (Migration DB) | Début migration |
+| Semaine 2-4 | Prompt 1 (Tests) | Après chaque service migré |
+| Semaine 5 | Prompt 4 (Consistance) | Avant activation dual-read |
+| Semaine 7 | Prompt 2 (Cleanup) | Après cutover validé |
+
+---
+
+## Commandes de Validation
+
+```bash
+# Vérifier consistance
+yarn cli jobs:run validateMigrationConsistency
+
+# Lancer tests migration
+yarn test --grep "Migration recruiters"
+
+# Vérifier aucune référence recruiters restante
+grep -r "getDbCollection.*recruiters" server/src --include="*.ts" | grep -v ".test.ts"
+
+# Compter références
+grep -r "recruiters" server/src --include="*.ts" | wc -l
+````

--- a/docs/migration-temp/09-decision-matrix.md
+++ b/docs/migration-temp/09-decision-matrix.md
@@ -1,0 +1,117 @@
+# 09 - Matrice de Décision: Migrer ou Non?
+
+## Pour et Contre
+
+| Critère                 | ✅ FAIRE la migration                               | ❌ NE PAS FAIRE                                            |
+| ----------------------- | --------------------------------------------------- | ---------------------------------------------------------- |
+| **Architecture**        | 1 collection unifiée, plus simple                   | 2 collections + sync = complexité maintenue                |
+| **Maintenance**         | Code simplifié, moins de bugs potentiels            | Connaissance existante de l'équipe sur le code actuel      |
+| **Performance**         | 1 document = 1 job (requêtes directes)              | jobs[] embedded = lectures groupées par établissement      |
+| **Consistance données** | Source unique de vérité                             | Risque permanent d'incohérence recruiters ↔ jobs_partners |
+| **Stream processor**    | Supprimé = moins d'infra à maintenir                | Fonctionne actuellement, pourquoi toucher?                 |
+| **Dette technique**     | Réduite significativement                           | Accumulée, explosion future possible                       |
+| **Coût immédiat**       | 6-7 semaines dev, 57 fichiers à risque              | 0 effort, 0 risque immédiat                                |
+| **Risque régression**   | Élevé pendant transition                            | Nul                                                        |
+| **Valeur utilisateur**  | Aucune visible directement                          | Idem                                                       |
+| **Évolutivité**         | Facilite ajout de nouveaux partenaires              | Modèle recruiter spécifique, difficile à étendre           |
+| **Onboarding devs**     | 1 modèle à comprendre                               | 2 modèles + sync à expliquer                               |
+| **Rollback**            | Complexe si problème post-cutover                   | N/A                                                        |
+| **Monitoring**          | Simplifié (1 collection)                            | 2 collections + stream à surveiller                        |
+| **Coût infra**          | Réduit (moins de stockage, pas de stream processor) | Actuel maintenu                                            |
+
+---
+
+## Scénarios de Décision
+
+| Si...                                  | Alors...                               |
+| -------------------------------------- | -------------------------------------- |
+| Équipe stable, temps disponible        | ✅ Migrer maintenant                   |
+| Roadmap chargée, features prioritaires | ❌ Reporter                            |
+| Bugs fréquents liés à la sync          | ✅ Migrer (urgence technique)          |
+| Sync stable depuis 6+ mois             | ❌ Pas urgent                          |
+| Nouveaux partenaires à intégrer        | ✅ Migrer (uniformiser le modèle)      |
+| Turnover équipe prévu                  | ❌ Éviter migration pendant transition |
+
+---
+
+## Analyse Coût/Bénéfice
+
+### Coûts de la Migration
+
+| Poste             | Estimation                |
+| ----------------- | ------------------------- |
+| Développement     | 6-7 semaines (1-2 devs)   |
+| Tests & QA        | Inclus (générés par IA)   |
+| Risque régression | Moyen (57 fichiers)       |
+| Indisponibilité   | ~0 (dual-read progressif) |
+
+### Coûts de NE PAS Migrer (par an)
+
+| Poste                        | Estimation       |
+| ---------------------------- | ---------------- |
+| Maintenance stream processor | ~2-4 semaines/an |
+| Debug incohérences données   | ~1-2 semaines/an |
+| Onboarding nouveaux devs     | +1 jour/dev      |
+| Dette technique accumulée    | Exponentielle    |
+
+---
+
+## Risques
+
+### Si Migration
+
+| Risque              | Probabilité | Impact   | Mitigation                          |
+| ------------------- | ----------- | -------- | ----------------------------------- |
+| Régression API      | Moyenne     | Élevé    | Dual-read, tests E2E                |
+| Perte de données    | Faible      | Critique | Backup recruiters 1 mois            |
+| Rollback nécessaire | Faible      | Moyen    | Feature flags, procédure documentée |
+| Dépassement délai   | Moyenne     | Faible   | Timeline conservatrice              |
+
+### Si Pas de Migration
+
+| Risque                 | Probabilité | Impact     | Mitigation          |
+| ---------------------- | ----------- | ---------- | ------------------- |
+| Incohérence données    | Moyenne     | Moyen      | Monitoring, alertes |
+| Panne stream processor | Faible      | Élevé      | Redondance, alertes |
+| Code inmaintenable     | Certaine    | Long terme | Aucune              |
+| Blocage évolution      | Moyenne     | Élevé      | Refacto partiel     |
+
+---
+
+## Recommandation
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                                                             │
+│   RECOMMANDATION: ✅ MIGRER                                 │
+│                                                             │
+│   Timing: Période calme (post-release, début de sprint)    │
+│   Priorité: Moyenne (pas urgente, mais nécessaire)         │
+│   Équipe: 1-2 devs dédiés pendant 6-7 semaines             │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Justification
+
+1. **Dette technique croissante** - Le coût de maintenance augmente avec le temps
+2. **Sync déjà en place** - 80% du travail de mapping est fait
+3. **Risque maîtrisé** - Dual-read + feature flags permettent rollback
+4. **ROI positif** - Économie maintenance > coût migration après ~1 an
+
+### Trigger Idéal
+
+- Post-release majeure
+- Début de trimestre
+- Équipe au complet
+- Pas de deadline feature critique
+
+---
+
+## Checklist Pré-Décision
+
+- [ ] Équipe informée et alignée
+- [ ] Pas de release majeure dans les 8 prochaines semaines
+- [ ] Monitoring actuel de la sync OK
+- [ ] Backup strategy validée
+- [ ] Rollback procedure testée

--- a/docs/migration-temp/establishment-id-analysis/01-README.md
+++ b/docs/migration-temp/establishment-id-analysis/01-README.md
@@ -1,0 +1,152 @@
+# Analyse de `establishment_id` - Impact sur le Décommissionnement de `recruiters`
+
+## Résumé Exécutif
+
+Cette analyse évalue la possibilité de **supprimer `establishment_id`** et de le remplacer par `_id` dans le cadre de la migration de la collection `recruiters` vers `jobs_partners`.
+
+### Verdict : **NE PAS SUPPRIMER** `establishment_id`
+
+| Critère          | Impact        | Détail                                  |
+| ---------------- | ------------- | --------------------------------------- |
+| **Server**       | 🔴 Élevé      | 20+ fichiers, 10 endpoints API          |
+| **UI**           | 🔴 Élevé      | 11+ composants, 7 routes Next.js        |
+| **Liens Emails** | 🔴 Critique   | URLs de délégation CFA seraient cassées |
+| **Sécurité**     | 🟡 Régression | UUIDs plus sûrs que ObjectIds dans URLs |
+
+---
+
+## Documents de cette Analyse
+
+| Document                                                             | Description                                  |
+| -------------------------------------------------------------------- | -------------------------------------------- |
+| [02-server-impact.md](./02-server-impact.md)                         | Impact côté serveur - 20+ fichiers détaillés |
+| [03-ui-impact.md](./03-ui-impact.md)                                 | Impact côté UI - 11+ composants, 7 routes    |
+| [04-migration-recommendations.md](./04-migration-recommendations.md) | Recommandations et plan d'action             |
+
+---
+
+## Qu'est-ce que `establishment_id` ?
+
+```typescript
+// Dans recruiters collection
+{
+  _id: ObjectId("..."),           // Identifiant MongoDB interne
+  establishment_id: "a1b2c3d4-...", // UUID externe pour URLs/API
+  establishment_siret: "12345678901234",
+  jobs: [...]
+}
+```
+
+| Propriété      | `_id`                   | `establishment_id`             |
+| -------------- | ----------------------- | ------------------------------ |
+| **Format**     | ObjectId (24 chars hex) | UUID v4 (36 chars avec tirets) |
+| **Génération** | MongoDB automatique     | `randomUUID()` dans le code    |
+| **Visibilité** | Interne uniquement      | URLs, API, emails              |
+| **Sécurité**   | Séquentiel, devinable   | Aléatoire, sécurisé            |
+
+---
+
+## Pourquoi `establishment_id` existe ?
+
+1. **Sécurité des URLs** : Les UUIDs sont impossibles à deviner contrairement aux ObjectIds séquentiels
+2. **Identifiant externe** : Utilisé dans les liens envoyés par email aux CFAs
+3. **Groupement** : Permet de regrouper les offres d'un même établissement
+4. **Historique** : Séparation entre identifiant technique (MongoDB) et identifiant métier
+
+---
+
+## Impact de la Suppression
+
+### Côté Server (20+ fichiers)
+
+```
+Controllers:     5 fichiers  (formulaire, jobs v1/v2)
+Services:        8 fichiers  (formulaire, user, roleManagement...)
+Security:        1 fichier   (authorisationService)
+Jobs:            4 fichiers  (anonymization, metabase, export...)
+Tests:           3 fichiers
+```
+
+### Côté UI (11+ composants)
+
+```
+API Functions:   7 fonctions (api.ts)
+React Components: 12 composants
+Next.js Routes:  7 pages dynamiques [establishment_id]
+Route Builders:  7 fonctions (routes.utils.ts)
+```
+
+### Liens Emails Impactés
+
+```
+/espace-pro/proposition/formulaire/{establishment_id}/offre/{job_id}/siret/{siret}
+/espace-pro/cfa/entreprise/{establishment_id}
+/espace-pro/mise-en-relation/{establishment_id}/{job_id}
+```
+
+---
+
+## Recommandation : Garder `establishment_id`
+
+### Dans `jobs_partners`
+
+```typescript
+// Nouveau schéma jobs_partners
+{
+  _id: ObjectId("..."),              // ID unique de l'offre
+  establishment_id: "a1b2c3d4-...",  // UUID groupant les offres
+  managed_by: "user-id",             // Utilisateur gestionnaire
+  // ... autres champs
+}
+```
+
+### Patterns de Requête
+
+```typescript
+// Obtenir toutes les offres d'un établissement
+const jobs = await getDbCollection("jobs_partners")
+  .find({
+    establishment_id: establishmentId,
+    partner_label: "RECRUTEURS_LBA",
+  })
+  .toArray()
+
+// Obtenir une offre spécifique
+const job = await getDbCollection("jobs_partners").findOne({
+  _id: jobId,
+})
+```
+
+### Avantages
+
+- ✅ Aucun breaking change
+- ✅ Liens emails existants fonctionnent
+- ✅ Sécurité maintenue (UUIDs dans URLs)
+- ✅ Migration simplifiée
+
+---
+
+## Actions Requises
+
+1. **Ajouter `establishment_id` au schéma `jobs_partners`**
+2. **Synchroniser depuis `recruiters` pendant la migration**
+3. **Créer l'index** `{ establishment_id: 1 }`
+4. **Adapter les endpoints** pour query par `establishment_id`
+
+Voir [04-migration-recommendations.md](./04-migration-recommendations.md) pour le plan détaillé.
+
+---
+
+## Bug Identifié
+
+⚠️ **Incohérence dans le code** :
+
+```typescript
+// shared/src/models/recruiter.model.ts - Définition
+establishment_id: z.string().default(() => new ObjectId().toString())
+
+// server/src/services/formulaire.service.ts - Implémentation réelle
+establishment_id: randomUUID() // ← C'est celui-ci qui est utilisé
+```
+
+La définition du modèle dit `ObjectId().toString()` mais l'implémentation utilise `randomUUID()`. Ce n'est pas bloquant car les deux sont des strings uniques, mais cela devrait être corrigé pour la cohérence.

--- a/docs/migration-temp/establishment-id-analysis/02-server-impact.md
+++ b/docs/migration-temp/establishment-id-analysis/02-server-impact.md
@@ -1,0 +1,777 @@
+# Server-Side Usage of `establishment_id`
+
+This document provides a comprehensive analysis of how `establishment_id` is used throughout the La Bonne Alternance server-side codebase.
+
+## Table of Contents
+
+1. [Definition and Generation](#1-definition-and-generation)
+2. [Database Index](#2-database-index)
+3. [API Endpoints Using establishment_id](#3-api-endpoints-using-establishment_id)
+4. [Service Functions Querying by establishment_id](#4-service-functions-querying-by-establishment_id)
+5. [URLs and Links in Emails](#5-urls-and-links-in-emails)
+6. [Authorization System](#6-authorization-system)
+7. [Complete File List](#7-complete-file-list)
+
+---
+
+## 1. Definition and Generation
+
+### Schema Definition
+
+**File:** `/shared/src/models/recruiter.model.ts` (lines 18-24)
+
+The `establishment_id` field is defined as a string field in the `ZRecruiterWritable` Zod schema:
+
+```typescript
+const ZRecruiterWritable = z.object({
+  establishment_id: z
+    .string()
+    .default(() => new ObjectId().toString())
+    .describe("Identifiant de formulaire unique")
+    .openapi({
+      default: "Random UUID",
+    }),
+  // ... other fields
+})
+```
+
+### Actual Generation
+
+**File:** `/server/src/services/formulaire.service.ts` (line 394)
+
+The actual generation happens in the `createFormulaire` function:
+
+```typescript
+export const createFormulaire = async (payload: Partial<Omit<IRecruiter, "_id" | "establishment_id" | "createdAt" | "updatedAt">>, managedBy: string): Promise<IRecruiter> => {
+  const recruiter: IRecruiter = {
+    ...payload,
+    managed_by: managedBy,
+    _id: new ObjectId(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    establishment_id: randomUUID(), // <-- Uses crypto.randomUUID()
+    status: RECRUITER_STATUS.ACTIF,
+    // ... other fields
+  }
+  await getDbCollection("recruiters").insertOne(recruiter)
+  return recruiter
+}
+```
+
+### BUG: Schema/Implementation Mismatch
+
+There is an inconsistency between the schema and the actual implementation:
+
+| Location                                       | Method                      | Result                                 |
+| ---------------------------------------------- | --------------------------- | -------------------------------------- |
+| Schema default (`recruiter.model.ts` line 20)  | `new ObjectId().toString()` | MongoDB ObjectId string (24 hex chars) |
+| Actual code (`formulaire.service.ts` line 394) | `randomUUID()`              | UUID v4 format (36 chars with dashes)  |
+| OpenAPI documentation                          | Claims "Random UUID"        | Correct for actual behavior            |
+
+**Example values:**
+
+- ObjectId: `507f1f77bcf86cd799439011`
+- UUID: `550e8400-e29b-41d4-a716-446655440000`
+
+This mismatch could cause issues if code relies on the format of `establishment_id`.
+
+---
+
+## 2. Database Index
+
+**File:** `/shared/src/models/recruiter.model.ts` (line 117)
+
+```typescript
+export default {
+  zod: ZRecruiter,
+  indexes: [
+    [{ geopoint: "2dsphere", status: 1, "jobs.job_status": 1, "jobs.rome_code": 1, "jobs.job_expiration_date": 1 }, {}],
+    [{ establishment_id: 1 }, {}], // <-- establishment_id index
+    [{ establishment_siret: 1 }, {}],
+    [{ cfa_delegated_siret: 1 }, {}],
+    [{ email: 1, establishment_siret: 1 }, { unique: true }],
+    // ... more indexes
+  ],
+  collectionName,
+}
+```
+
+### Index Analysis
+
+| Property  | Value                       |
+| --------- | --------------------------- |
+| Index Key | `{ establishment_id: 1 }`   |
+| Direction | Ascending                   |
+| Unique    | **No** (empty options `{}`) |
+| Sparse    | No                          |
+
+### Potential Issue
+
+The `establishment_id` is used as a unique identifier for formulaires throughout the codebase, but the index is **not unique**. This could potentially allow duplicate values. The uniqueness appears to be enforced only by the application logic (generating UUIDs), not at the database level.
+
+Compare with `email + establishment_siret` which has `{ unique: true }`.
+
+---
+
+## 3. API Endpoints Using establishment_id
+
+### GET Endpoints
+
+#### GET `/formulaire/:establishment_id`
+
+**File:** `/server/src/http/controllers/formulaire.controller.ts` (lines 40-52)
+
+```typescript
+server.get(
+  "/formulaire/:establishment_id",
+  {
+    schema: zRoutes.get["/formulaire/:establishment_id"],
+    onRequest: [server.auth(zRoutes.get["/formulaire/:establishment_id"])],
+  },
+  async (req, res) => {
+    const { establishment_id } = req.params
+    const recruiterOpt = await getFormulaireWithRomeDetailAndApplicationCount({ establishment_id })
+    if (!recruiterOpt) {
+      throw notFound(`pas de formulaire avec establishment_id=${establishment_id}`)
+    }
+    return res.status(200).send(recruiterOpt)
+  }
+)
+```
+
+**Purpose:** Retrieve a formulaire by its establishment_id (authenticated via cookie session).
+
+---
+
+#### GET `/formulaire/:establishment_id/by-token`
+
+**File:** `/server/src/http/controllers/formulaire.controller.ts` (lines 55-67)
+
+```typescript
+server.get(
+  "/formulaire/:establishment_id/by-token",
+  {
+    schema: zRoutes.get["/formulaire/:establishment_id/by-token"],
+    onRequest: [server.auth(zRoutes.get["/formulaire/:establishment_id/by-token"])],
+  },
+  async (req, res) => {
+    const { establishment_id } = req.params
+    const recruiterOpt = await getFormulaireWithRomeDetailAndApplicationCount({ establishment_id })
+    if (!recruiterOpt) {
+      throw notFound(`pas de formulaire avec establishment_id=${establishment_id}`)
+    }
+    return res.status(200).send(recruiterOpt)
+  }
+)
+```
+
+**Purpose:** Retrieve a formulaire using access token authentication (for depot simplifie flow).
+
+---
+
+#### GET `/formulaire/delegation/:establishment_id`
+
+**File:** `/server/src/http/controllers/formulaire.controller.ts` (lines 74-87)
+
+```typescript
+server.get(
+  "/formulaire/delegation/:establishment_id",
+  {
+    schema: zRoutes.get["/formulaire/delegation/:establishment_id"],
+    onRequest: [server.auth(zRoutes.get["/formulaire/delegation/:establishment_id"])],
+  },
+  async (req, res) => {
+    const result = await getFormulaireWithRomeDetail({ establishment_id: req.params.establishment_id })
+    if (!result) {
+      throw badRequest()
+    }
+    return res.status(200).send(result)
+  }
+)
+```
+
+**Purpose:** Retrieve formulaire data for delegation view (CFA viewing company offer details).
+
+---
+
+#### GET `/v1/jobs/establishment`
+
+**File:** `/server/src/http/controllers/jobs.controller.ts` (lines 45-62)
+
+```typescript
+server.get(
+  "/v1/jobs/establishment",
+  {
+    schema: zRoutes.get["/v1/jobs/establishment"],
+    config,
+    onRequest: server.auth(zRoutes.get["/v1/jobs/establishment"]),
+  },
+  async (req, res) => {
+    const { establishment_siret, email } = req.query
+
+    const establishment = await getDbCollection("recruiters").findOne({ establishment_siret, email })
+
+    if (!establishment) {
+      return res.status(400).send({ error: true, message: "Establishment not found" })
+    }
+
+    return res.status(200).send(establishment.establishment_id)
+  }
+)
+```
+
+**Purpose:** API v1 - Retrieve establishment_id by SIRET and email (returns the establishment_id as response).
+
+---
+
+#### GET `/v2/jobs/establishment`
+
+**File:** `/server/src/http/controllers/v2/jobs.controller.v2.ts` (lines 22-39)
+
+```typescript
+server.get(
+  "/v2/jobs/establishment",
+  {
+    schema: zRoutes.get["/v2/jobs/establishment"],
+    config,
+    onRequest: server.auth(zRoutes.get["/v2/jobs/establishment"]),
+  },
+  async (req, res) => {
+    const { establishment_siret, email } = req.query
+
+    const establishment = await getDbCollection("recruiters").findOne({ establishment_siret, email })
+
+    if (!establishment) {
+      return res.status(400).send({ error: true, message: "Establishment not found" })
+    }
+
+    return res.status(200).send(establishment.establishment_id)
+  }
+)
+```
+
+**Purpose:** API v2 - Same as v1, retrieve establishment_id by SIRET and email.
+
+---
+
+### POST Endpoints
+
+#### POST `/formulaire/:establishment_id/offre`
+
+**File:** `/server/src/http/controllers/formulaire.controller.ts` (lines 165-224)
+
+```typescript
+server.post(
+  "/formulaire/:establishment_id/offre",
+  {
+    schema: zRoutes.post["/formulaire/:establishment_id/offre"],
+    onRequest: [server.auth(zRoutes.post["/formulaire/:establishment_id/offre"])],
+    bodyLimit: 5 * 1024 ** 2, // 5MB
+  },
+  async (req, res) => {
+    const { establishment_id } = req.params
+    const user = getUserFromRequest(req, zRoutes.post["/formulaire/:establishment_id/offre"]).value
+    const recruiter = await getDbCollection("recruiters").findOne({ establishment_id })
+    if (!recruiter) {
+      throw badRequest("/formulaire/:establishment_id/offre - L'entreprise n'existe pas")
+    }
+    // ... create job logic
+    const updatedFormulaire = await createJob({
+      job: {
+        /* job fields */
+      },
+      user,
+      establishment_id,
+      source: getSourceFromCookies(req),
+    })
+    // ...
+  }
+)
+```
+
+**Purpose:** Create a new job offer for a formulaire (authenticated user).
+
+---
+
+#### POST `/formulaire/:establishment_id/offre/by-token`
+
+**File:** `/server/src/http/controllers/formulaire.controller.ts` (lines 226-293)
+
+```typescript
+server.post(
+  "/formulaire/:establishment_id/offre/by-token",
+  {
+    schema: zRoutes.post["/formulaire/:establishment_id/offre/by-token"],
+    onRequest: [server.auth(zRoutes.post["/formulaire/:establishment_id/offre/by-token"])],
+    bodyLimit: 5 * 1024 ** 2, // 5MB
+  },
+  async (req, res) => {
+    const { establishment_id } = req.params
+    const tokenUser = getUserFromRequest(req, zRoutes.post["/formulaire/:establishment_id/offre/by-token"]).value
+    // ... validation and job creation using establishment_id
+  }
+)
+```
+
+**Purpose:** Create a new job offer using access token (depot simplifie flow).
+
+---
+
+#### POST `/formulaire/:establishment_id/informations`
+
+**File:** `/server/src/http/controllers/formulaire.controller.ts` (lines 322-340)
+
+```typescript
+server.post(
+  // this route is for CFA only
+  "/formulaire/:establishment_id/informations",
+  {
+    schema: zRoutes.post["/formulaire/:establishment_id/informations"],
+    onRequest: [server.auth(zRoutes.post["/formulaire/:establishment_id/informations"])],
+  },
+  async (req, res) => {
+    const user = getUserFromRequest(req, zRoutes.post["/formulaire/:establishment_id/informations"]).value
+    const { establishment_id } = req.params
+    const { email, phone } = req.body
+
+    validateDelegatedCompanyPhoneAndEmail(user, phone, email)
+
+    await updateCfaManagedRecruiter(establishment_id, req.body)
+
+    return res.status(200).send({ ok: true })
+  }
+)
+```
+
+**Purpose:** Update company information for CFA-delegated recruiters.
+
+---
+
+#### POST `/v1/jobs/:establishmentId`
+
+**File:** `/server/src/http/controllers/jobs.controller.ts` (lines 126-150)
+
+```typescript
+server.post(
+  "/v1/jobs/:establishmentId",
+  {
+    schema: zRoutes.post["/v1/jobs/:establishmentId"],
+    onRequest: server.auth(zRoutes.post["/v1/jobs/:establishmentId"]),
+    config,
+  },
+  async (req, res) => {
+    const { establishmentId } = req.params
+    const { body } = req
+    // Check if entity exists
+    const establishmentExists = await getFormulaire({ establishment_id: establishmentId })
+
+    if (!establishmentExists) {
+      return res.status(400).send({ error: true, message: "Establishment does not exist" })
+    }
+    // ... create job using establishment_id
+    const updatedRecruiter = await createOffre(establishmentId, job)
+    return res.status(201).send(updatedRecruiter)
+  }
+)
+```
+
+**Purpose:** API v1 - Create a job offer for an establishment (OPCO API).
+
+---
+
+### DELETE Endpoints
+
+#### DELETE `/formulaire/:establishment_id`
+
+**File:** `/server/src/http/controllers/formulaire.controller.ts` (lines 130-139)
+
+```typescript
+server.delete(
+  "/formulaire/:establishment_id",
+  {
+    schema: zRoutes.delete["/formulaire/:establishment_id"],
+    onRequest: [server.auth(zRoutes.delete["/formulaire/:establishment_id"])],
+  },
+  async (req, res) => {
+    await archiveFormulaireByEstablishmentId(req.params.establishment_id)
+    return res.status(200).send({})
+  }
+)
+```
+
+**Purpose:** Archive (soft delete) a formulaire and all its job offers.
+
+---
+
+## 4. Service Functions Querying by establishment_id
+
+### formulaire.service.ts
+
+**File:** `/server/src/services/formulaire.service.ts`
+
+#### createJob() - Line 168
+
+```typescript
+export const createJob = async ({
+  job,
+  establishment_id,
+  user,
+  source,
+}: {
+  job: IJobCreate
+  establishment_id: string
+  user: IUserWithAccount
+  source?: ITrackingCookies
+}): Promise<IRecruiter> => {
+  // ...
+  const recruiter = await getDbCollection("recruiters").findOne({ establishment_id: establishment_id })
+  if (!recruiter) {
+    throw internal(`recruiter with establishment_id=${establishment_id} not found`)
+  }
+  // ...
+}
+```
+
+---
+
+#### updateFormulaire() - Line 416
+
+```typescript
+export const updateFormulaire = async (establishment_id: IRecruiter["establishment_id"], payload: UpdateFilter<IRecruiter>): Promise<IRecruiter> => {
+  const recruiter = await getDbCollection("recruiters").findOneAndUpdate({ establishment_id }, { $set: { ...payload, updatedAt: new Date() } }, { returnDocument: "after" })
+  if (!recruiter) {
+    throw internal("Recruiter not found")
+  }
+  return recruiter
+}
+```
+
+---
+
+#### archiveFormulaireByEstablishmentId() - Line 429
+
+```typescript
+export const archiveFormulaireByEstablishmentId = async (id: IRecruiter["establishment_id"]) => {
+  const recruiter = await getDbCollection("recruiters").findOne({ establishment_id: id })
+  if (!recruiter) {
+    throw internal("Recruiter not found")
+  }
+  await archiveFormulaire(recruiter)
+}
+```
+
+---
+
+#### createOffre() - Line 494
+
+```typescript
+export async function createOffre(establishment_id: IRecruiter["establishment_id"], payload: UpdateFilter<IJob>): Promise<IRecruiter> {
+  const recruiter = await getDbCollection("recruiters").findOneAndUpdate(
+    { establishment_id },
+    { $push: { jobs: { ...payload, _id: new ObjectId() } } },
+    { returnDocument: "after" }
+  )
+  if (!recruiter) {
+    throw internal("Recruiter not found")
+  }
+  return recruiter
+}
+```
+
+---
+
+#### updateCfaManagedRecruiter() - Line 884
+
+```typescript
+export const updateCfaManagedRecruiter = async (establishment_id: string, payload: Partial<IRecruiter>) => {
+  const recruiter = await getDbCollection("recruiters").findOneAndUpdate({ establishment_id }, { $set: { ...payload, updatedAt: new Date() } }, { returnDocument: "after" })
+  return recruiter
+}
+```
+
+---
+
+### userRecruteur.service.ts
+
+**File:** `/server/src/services/userRecruteur.service.ts` (lines 106-108)
+
+```typescript
+if (formulaire) {
+  const { establishment_id } = formulaire
+  Object.assign(entrepriseFields, { establishment_id })
+}
+```
+
+Used to include `establishment_id` in the `IUserRecruteur` object when building user recruteur data.
+
+---
+
+### user.service.ts
+
+**File:** `/server/src/services/user.service.ts` (line 60)
+
+```typescript
+const recruiters = await getDbCollection("recruiters")
+  .find({ managed_by: { $in: userIds }, opco }, { projection: { establishment_id: 1, origin: 1, jobs: 1, managed_by: 1, _id: 0 } })
+  .toArray()
+```
+
+Retrieves recruiters with `establishment_id` in projection for OPCO user data.
+
+---
+
+### roleManagement.service.ts
+
+**File:** `/server/src/services/roleManagement.service.ts` (line 158)
+
+```typescript
+const recruiter = await getFormulaireFromUserIdOrError(user._id.toString())
+return { ...commonFields, establishment_siret: siret, establishment_id: recruiter.establishment_id }
+```
+
+Returns `establishment_id` as part of public user recruteur properties.
+
+---
+
+## 5. URLs and Links in Emails
+
+### appLinks.service.ts
+
+**File:** `/server/src/services/appLinks.service.ts`
+
+#### createViewDelegationLink() - Lines 150-181
+
+```typescript
+export function createViewDelegationLink(email: string, establishment_id: string, job_id: string, siret_formateur: string) {
+  const token = generateAccessToken(
+    { type: "cfa", email, siret: siret_formateur },
+    [
+      generateScope({
+        schema: zRoutes.get["/formulaire/delegation/:establishment_id"],
+        options: {
+          params: { establishment_id: establishment_id },
+          querystring: undefined,
+        },
+      }),
+      generateScope({
+        schema: zRoutes.patch["/formulaire/offre/:jobId/delegation/view"],
+        options: {
+          params: { jobId: job_id },
+          querystring: { siret_formateur },
+        },
+      }),
+    ],
+    { expiresIn: "30d" }
+  )
+
+  return `${config.publicUrl}/espace-pro/proposition/formulaire/${establishment_id}/offre/${job_id}/siret/${siret_formateur}?token=${token}`
+}
+```
+
+**Purpose:** Creates a link for CFAs to view delegation details. The `establishment_id` is embedded in:
+
+- The URL path
+- The access token scope parameters
+
+---
+
+#### generateDepotSimplifieToken() - Lines 365-395
+
+```typescript
+export function generateDepotSimplifieToken(user: IUserWithAccountForAccessToken, establishment_id: string) {
+  return generateAccessToken(
+    user,
+    [
+      generateScope({
+        schema: zRoutes.get["/formulaire/:establishment_id/by-token"],
+        options: {
+          params: { establishment_id },
+          querystring: undefined,
+        },
+      }),
+      generateScope({
+        schema: zRoutes.post["/formulaire/:establishment_id/offre/by-token"],
+        options: {
+          params: { establishment_id },
+          querystring: undefined,
+        },
+      }),
+      // ... more scopes
+    ],
+    { expiresIn: "2h" }
+  )
+}
+```
+
+**Purpose:** Generates a token for the "depot simplifie" (simplified job posting) flow, with `establishment_id` in the scope parameters.
+
+---
+
+#### createMERInvitationLink() - Lines 459-488
+
+```typescript
+export function createMERInvitationLink(user: IUserWithAccount, jobId: string, establishmentId: string): string {
+  const token = generateAccessToken(
+    userWithAccountToUserForToken(user),
+    [
+      generateScope({
+        schema: zRoutes.post["/formulaire/offre/:jobId/delegation/by-token"],
+        options: {
+          params: { jobId },
+          querystring: undefined,
+        },
+      }),
+      generateScope({
+        schema: zRoutes.get["/formulaire/:establishment_id/by-token"],
+        options: {
+          params: { establishment_id: establishmentId },
+          querystring: undefined,
+        },
+      }),
+    ],
+    { expiresIn: "30d" }
+  )
+
+  return `${config.publicUrl}/espace-pro/mise-en-relation/${establishmentId}/${jobId}?token=${encodeURIComponent(token)}`
+}
+```
+
+**Purpose:** Creates an invitation link for "Mise en Relation" (connecting companies with CFAs).
+
+---
+
+## 6. Authorization System
+
+### authorisationService.ts
+
+**File:** `/server/src/security/authorisationService.ts` (lines 131-136)
+
+The authorization system uses `establishment_id` to identify recruiter resources for access control:
+
+```typescript
+async function getRecruitersResource<S extends WithSecurityScheme>(schema: S, req: IRequest): Promise<Resources["recruiters"]> {
+  if (!schema.securityScheme.resources.recruiter) {
+    return []
+  }
+
+  const recruiters: IRecruiter[] = (
+    await Promise.all(
+      schema.securityScheme.resources.recruiter.map(async (recruiterDef): Promise<IRecruiter[]> => {
+        if ("_id" in recruiterDef) {
+          // ... handle _id case
+        }
+        if ("establishment_id" in recruiterDef) {
+          return getDbCollection("recruiters")
+            .find({
+              establishment_id: getAccessResourcePathValue(recruiterDef.establishment_id, req),
+            })
+            .toArray()
+        }
+        // ... other cases
+      })
+    )
+  ).flatMap((_) => _)
+  // ...
+}
+```
+
+### Route Security Scheme Examples
+
+From `/shared/src/routes/formulaire.route.ts`:
+
+```typescript
+"/formulaire/:establishment_id": {
+  // ...
+  securityScheme: {
+    auth: "cookie-session",
+    access: { some: ["recruiter:manage", "recruiter:add_job"] },
+    resources: {
+      recruiter: [{ establishment_id: { type: "params", key: "establishment_id" } }],
+    },
+  },
+}
+```
+
+The security scheme uses `establishment_id` from route params to:
+
+1. Identify which recruiter resource is being accessed
+2. Check if the authenticated user has permission to access that specific recruiter
+
+---
+
+## 7. Complete File List
+
+The following 21 files in the server codebase reference `establishment_id`:
+
+### Controllers (4 files)
+
+| File                                                                | Description                        |
+| ------------------------------------------------------------------- | ---------------------------------- |
+| `/server/src/http/controllers/formulaire.controller.ts`             | Main formulaire CRUD operations    |
+| `/server/src/http/controllers/jobs.controller.ts`                   | Jobs API v1 endpoints              |
+| `/server/src/http/controllers/v2/jobs.controller.v2.ts`             | Jobs API v2 endpoints              |
+| `/server/src/http/controllers/etablissementRecruteur.controller.ts` | Establishment recruteur operations |
+
+### Services (6 files)
+
+| File                                              | Description                     |
+| ------------------------------------------------- | ------------------------------- |
+| `/server/src/services/formulaire.service.ts`      | Core formulaire business logic  |
+| `/server/src/services/userRecruteur.service.ts`   | User recruteur management       |
+| `/server/src/services/user.service.ts`            | User data management            |
+| `/server/src/services/appLinks.service.ts`        | Magic link and token generation |
+| `/server/src/services/roleManagement.service.ts`  | Role and permission management  |
+| `/server/src/services/formulaire.service.test.ts` | Formulaire service tests        |
+
+### Security (2 files)
+
+| File                                           | Description                              |
+| ---------------------------------------------- | ---------------------------------------- |
+| `/server/src/security/accessTokenService.ts`   | Access token handling (authorized paths) |
+| `/server/src/security/authorisationService.ts` | Authorization and access control         |
+
+### Jobs/Background Tasks (5 files)
+
+| File                                                           | Description                                                  |
+| -------------------------------------------------------------- | ------------------------------------------------------------ |
+| `/server/src/jobs/anonymization/anonimizeUsersWithAccounts.ts` | User anonymization (includes establishment_id in projection) |
+| `/server/src/jobs/anonymization/anonymizeIndividual.ts`        | Individual record anonymization                              |
+| `/server/src/jobs/recruiters/updateSiretInfosInErrorJob.ts`    | SIRET info correction job                                    |
+| `/server/src/jobs/partenaireExport/exportJobsToS3.ts`          | S3 export (excludes establishment_id)                        |
+| `/server/src/jobs/metabase/metabaseJobsCollection.ts`          | Metabase jobs collection aggregation                         |
+| `/server/src/jobs/miseEnRelation/sendMiseEnRelation.ts`        | Mise en relation email job                                   |
+
+### Tests (2 files)
+
+| File                                                                     | Description      |
+| ------------------------------------------------------------------------ | ---------------- |
+| `/server/tests/utils/user.test.utils.ts`                                 | Test utilities   |
+| `/server/src/http/controllers/etablissementRecruteur.controller.test.ts` | Controller tests |
+
+### Snapshots (1 file)
+
+| File                                                                 | Description    |
+| -------------------------------------------------------------------- | -------------- |
+| `/server/src/services/__snapshots__/formulaire.service.test.ts.snap` | Test snapshots |
+
+---
+
+## Summary
+
+The `establishment_id` field is a critical identifier in the La Bonne Alternance system:
+
+1. **Unique Identifier**: Acts as the primary public identifier for recruiters/formulaires (distinct from MongoDB `_id`)
+
+2. **API Parameter**: Used extensively in REST API routes as a URL parameter
+
+3. **Token Scope**: Embedded in access tokens to control which formulaires a token can access
+
+4. **Email Links**: Included in various magic links sent via email
+
+5. **Authorization**: Key resource identifier for the permission system
+
+### Key Concerns
+
+1. **Format Inconsistency**: Schema default uses ObjectId format, but actual code uses UUID format
+2. **Non-Unique Index**: Database index is not unique, relying on application logic for uniqueness
+3. **Exposed in URLs**: As a public identifier, it's visible in URLs and tokens

--- a/docs/migration-temp/establishment-id-analysis/03-ui-impact.md
+++ b/docs/migration-temp/establishment-id-analysis/03-ui-impact.md
@@ -1,0 +1,620 @@
+# UI-Side Usage of `establishment_id` in La Bonne Alternance
+
+This document provides a comprehensive analysis of how `establishment_id` is used throughout the UI codebase (Next.js frontend) of La Bonne Alternance.
+
+---
+
+## 1. React Components Using `establishment_id`
+
+The following 12 components directly use `establishment_id`:
+
+### 1.1 MiseEnRelation.tsx
+
+**File:** `/ui/app/(espace-pro)/_components/MiseEnRelation.tsx`
+
+| Line | Usage                                                                                          |
+| ---- | ---------------------------------------------------------------------------------------------- |
+| 127  | Component prop definition: `{ establishment_id, job_id, token }`                               |
+| 134  | Query enabled condition: `enabled: !!establishment_id`                                         |
+| 135  | API call: `getFormulaireByToken(establishment_id, token)` or `getFormulaire(establishment_id)` |
+
+```typescript
+export default function MiseEnRelation({ establishment_id, job_id, token }: { establishment_id: string; job_id: string; token?: string }) {
+  // ...
+  const { data: formulaire, isLoading: isFormulaireLoading } = useQuery({
+    queryKey: ["formulaire"],
+    enabled: !!establishment_id,
+    queryFn: () => (token ? getFormulaireByToken(establishment_id, token) : getFormulaire(establishment_id)),
+  })
+```
+
+---
+
+### 1.2 DetailEntreprise.tsx
+
+**File:** `/ui/app/(espace-pro)/espace-pro/(connected)/_components/DetailEntreprise.tsx`
+
+| Line | Usage                                                                                   |
+| ---- | --------------------------------------------------------------------------------------- |
+| 107  | API call in mutation: `updateEntrepriseCFA(userRecruteur.establishment_id, {...})`      |
+| 153  | Route navigation: `PAGES.dynamic.backCfaPageEntreprise(userRecruteur.establishment_id)` |
+| 309  | Building offer edition URL: `establishment_id: userRecruteur.establishment_id`          |
+
+```typescript
+if (user.type === AUTHTYPE.CFA) {
+  const { email, first_name, last_name, phone } = values
+  await updateEntrepriseCFA(userRecruteur.establishment_id, { email, first_name, last_name, phone })
+}
+```
+
+---
+
+### 1.3 CfaHomeEntrepriseMenu.tsx
+
+**File:** `/ui/app/(espace-pro)/espace-pro/(connected)/_components/CfaHomeEntrepriseMenu.tsx`
+
+| Line | Usage                                                                                           |
+| ---- | ----------------------------------------------------------------------------------------------- |
+| 20   | Navigation link building: `PAGES.dynamic.backCfaPageEntreprise(row.establishment_id).getPath()` |
+
+```typescript
+const actions: PopoverMenuAction[] = [
+  {
+    label: "Voir les offres",
+    ariaLabel: `Voir les offres de l'entreprise ${row.establishment_raison_sociale}`,
+    link: PAGES.dynamic.backCfaPageEntreprise(row.establishment_id).getPath(),
+    type: "link",
+  },
+  // ...
+]
+```
+
+---
+
+### 1.4 ListeOffres.tsx
+
+**File:** `/ui/app/(espace-pro)/espace-pro/(connected)/_components/ListeOffres.tsx`
+
+| Line | Usage                                                                                      |
+| ---- | ------------------------------------------------------------------------------------------ |
+| 20   | Component prop: `establishment_id: string`                                                 |
+| 28   | Query enabled condition: `enabled: !!establishment_id`                                     |
+| 29   | API call: `getFormulaire(establishment_id)`                                                |
+| 46   | Route building: `offreUpsert({ offerId, establishment_id, userType: user.type })`          |
+| 50   | Route building for creation: `offreUpsert({ offerId: "creation", establishment_id, ... })` |
+| 61   | Route building for modification: `modificationEntreprise(user.type, establishment_id)`     |
+
+```typescript
+export default function ListeOffres({ hideModify = false, showStats = false, establishment_id }: { hideModify?: boolean; showStats?: boolean; establishment_id: string }) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["offre-liste"],
+    enabled: !!establishment_id,
+    queryFn: () => getFormulaire(establishment_id),
+  })
+```
+
+---
+
+### 1.5 FormulaireEditionOffre.tsx
+
+**File:** `/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffre.tsx`
+
+| Line | Usage                                              |
+| ---- | -------------------------------------------------- |
+| 23   | Optional prop: `establishment_id?: string`         |
+| 75   | Guard check: `if (!establishment_id) return <></>` |
+
+```typescript
+export const FormulaireEditionOffre = ({ offre, establishment_id, handleSave }: { offre?: IJobJson; establishment_id?: string; handleSave?: (values: any) => void }) => {
+  // ...
+  if (!establishment_id) return <></>
+```
+
+---
+
+### 1.6 UpsertOffre.tsx
+
+**File:** `/ui/app/(espace-pro)/espace-pro/(connected)/_components/UpsertOffre.tsx`
+
+| Line | Usage                                                                   |
+| ---- | ----------------------------------------------------------------------- |
+| 11   | Component prop: `establishment_id: string`                              |
+| 31   | API call for creating offers: `createOffre(establishment_id, values)`   |
+| 41   | Passed to FormulaireEditionOffre: `establishment_id={establishment_id}` |
+
+```typescript
+export default function UpsertOffre({ establishment_id, job_id, onSuccess }: { establishment_id: string; job_id?: string; onSuccess: () => void }) {
+  // ...
+  await createOffre(establishment_id, values)
+```
+
+---
+
+### 1.7 BackEntrepriseUpsertOffre.tsx
+
+**File:** `/ui/app/(espace-pro)/espace-pro/(connected)/_components/BackEntrepriseUpsertOffre.tsx`
+
+| Line | Usage                                                                                   |
+| ---- | --------------------------------------------------------------------------------------- |
+| 12   | Component prop: `establishment_id: string`                                              |
+| 18   | Breadcrumb route building: `offreUpsert({ establishment_id, offerId: job_id, ... })`    |
+| 20   | Passed to UpsertOffre: `establishment_id={establishment_id}`                            |
+| 22   | Success redirect: `successEditionOffre({ userType: user.type, establishment_id, ... })` |
+
+```typescript
+export function BackEntrepriseUpsertOffre({ establishment_id, job_id }: { establishment_id: string; job_id?: string }) {
+```
+
+---
+
+### 1.8 ConfirmationSuppressionEntreprise.tsx
+
+**File:** `/ui/app/(espace-pro)/espace-pro/(connected)/_components/ConfirmationSuppressionEntreprise.tsx`
+
+| Line | Usage                                                              |
+| ---- | ------------------------------------------------------------------ |
+| 13   | Interface prop: `establishment_id: string`                         |
+| 17   | Destructured from props: `const { ..., establishment_id } = props` |
+| 21   | API call: `archiveFormulaire(establishment_id)`                    |
+
+```typescript
+interface ConfirmationSuppressionEntrepriseProps {
+  isOpen: boolean
+  onClose: () => void
+  establishment_raison_sociale?: string
+  establishment_id: string
+}
+
+export function ConfirmationSuppressionEntreprise(props: ConfirmationSuppressionEntrepriseProps) {
+  const { isOpen, onClose, establishment_raison_sociale, establishment_id } = props
+  // ...
+  const SupprimerFormulaire = () => {
+    archiveFormulaire(establishment_id)
+```
+
+---
+
+### 1.9 CfaHome.tsx (ListeEntreprise)
+
+**File:** `/ui/app/(espace-pro)/espace-pro/(connected)/_components/CfaHome.tsx`
+
+| Line | Usage                                                                                       |
+| ---- | ------------------------------------------------------------------------------------------- |
+| 118  | Table cell accessor: `const { ..., establishment_id, ... } = data[id]`                      |
+| 124  | Link building: `PAGES.dynamic.backCfaPageEntreprise(establishment_id).getPath()`            |
+| 137  | Link building (fallback): `PAGES.dynamic.backCfaPageEntreprise(establishment_id).getPath()` |
+| 208  | Confirmation modal prop: `establishment_id={currentEntreprise.establishment_id}`            |
+
+```typescript
+const { establishment_raison_sociale, establishment_siret, establishment_id, opco } = data[id]
+return (
+  <Box sx={{ display: "flex", flexDirection: "column" }}>
+    <Link
+      underline="hover"
+      href={PAGES.dynamic.backCfaPageEntreprise(establishment_id).getPath()}
+```
+
+---
+
+### 1.10 DepotSimplifieCreationOffre.tsx
+
+**File:** `/ui/app/(espace-pro-creation-compte)/_components/DepotSimplifieCreationOffre.tsx`
+
+| Line | Usage                                                                                     |
+| ---- | ----------------------------------------------------------------------------------------- |
+| 14   | Extracted from search params: `const { ..., establishment_id } = useSearchParamsRecord()` |
+| 18   | API call: `createOffreByToken(establishment_id, values, token)`                           |
+| 42   | Passed to FormulaireEditionOffre: `establishment_id={establishment_id}`                   |
+
+```typescript
+export function DepotSimplifieCreationOffre() {
+  const router = useRouter()
+  const { displayBanner, userId, establishment_id } = useSearchParamsRecord()
+  // ...
+  const { recruiter: formulaire, token: jobToken } = await createOffreByToken(establishment_id, values, token)
+```
+
+---
+
+### 1.11 InformationCreationCompte.tsx
+
+**File:** `/ui/app/(espace-pro-creation-compte)/_components/InformationCreationCompte/InformationCreationCompte.tsx`
+
+| Line    | Usage                                                                                                               |
+| ------- | ------------------------------------------------------------------------------------------------------------------- |
+| 214-215 | Redirecting with establishment_id: `espaceProCreationOffre({ establishment_id: formulaire.establishment_id, ... })` |
+
+```typescript
+router.push(
+  PAGES.dynamic
+    .espaceProCreationOffre({
+      establishment_id: formulaire.establishment_id,
+      type,
+      email: user.email,
+      // ...
+    })
+    .getPath()
+)
+```
+
+---
+
+### 1.12 ExportButton/ExportButtonNew.tsx
+
+**File:** `/ui/components/espace_pro/ExportButton/ExportButtonNew.tsx`
+
+Uses `establishment_id` for export functionality (based on grep results).
+
+---
+
+## 2. API Calls in `ui/utils/api.ts`
+
+The following 7 functions use `establishment_id` as a parameter:
+
+| Function               | Line    | Endpoint                                            | Parameter Usage                                 |
+| ---------------------- | ------- | --------------------------------------------------- | ----------------------------------------------- |
+| `getDelegationDetails` | 32      | `GET /formulaire/delegation/:establishment_id`      | `params: { establishment_id }`                  |
+| `getFormulaire`        | 34      | `GET /formulaire/:establishment_id`                 | `params: { establishment_id }`                  |
+| `getFormulaireByToken` | 35-36   | `GET /formulaire/:establishment_id/by-token`        | `params: { establishment_id }`                  |
+| `archiveFormulaire`    | 38      | `DELETE /formulaire/:establishment_id`              | `params: { establishment_id }`                  |
+| `createOffre`          | 44-45   | `POST /formulaire/:establishment_id/offre`          | `params: { establishment_id }`                  |
+| `createOffreByToken`   | 46-47   | `POST /formulaire/:establishment_id/offre/by-token` | `params: { establishment_id }`                  |
+| `updateEntrepriseCFA`  | 114-116 | `POST /formulaire/:establishment_id/informations`   | `params: { establishment_id: establishmentId }` |
+
+### Detailed API Function Signatures
+
+```typescript
+// Line 32-33
+export const getDelegationDetails = async (establishment_id: string, token: string) =>
+  apiGet("/formulaire/delegation/:establishment_id", { params: { establishment_id }, headers: { authorization: `Bearer ${token}` } })
+
+// Line 34
+export const getFormulaire = async (establishment_id: string) => apiGet("/formulaire/:establishment_id", { params: { establishment_id } })
+
+// Line 35-36
+export const getFormulaireByToken = async (establishment_id: string, token: string) =>
+  apiGet("/formulaire/:establishment_id/by-token", { params: { establishment_id }, headers: { authorization: `Bearer ${token}` } })
+
+// Line 38
+export const archiveFormulaire = async (establishment_id: string) => apiDelete("/formulaire/:establishment_id", { params: { establishment_id } })
+
+// Line 44-45
+export const createOffre = async (establishment_id: string, newOffre: IJobCreate) =>
+  apiPost("/formulaire/:establishment_id/offre", { params: { establishment_id }, body: newOffre })
+
+// Line 46-47
+export const createOffreByToken = async (establishment_id: string, newOffre: IJobCreate, token: string) =>
+  apiPost("/formulaire/:establishment_id/offre/by-token", { params: { establishment_id }, body: newOffre, headers: { authorization: `Bearer ${token}` } })
+
+// Line 114-116
+export const updateEntrepriseCFA = async (establishmentId: string, values: IBody<IRoutes["post"]["/formulaire/:establishment_id/informations"]>) => {
+  await apiPost("/formulaire/:establishment_id/informations", { params: { establishment_id: establishmentId }, body: values })
+}
+```
+
+---
+
+## 3. URL Routes from `routes.utils.ts`
+
+**File:** `/ui/utils/routes.utils.ts`
+
+The following route builders use `establishment_id`:
+
+### 3.1 `modificationEntreprise` (Lines 276-281)
+
+```typescript
+modificationEntreprise: (userType: string, establishment_id?: string): IPage => ({
+  getPath: () => (userType === "CFA" ? `/espace-pro/cfa/entreprise/${establishment_id}/informations` : "/espace-pro/entreprise/compte"),
+  // ...
+})
+```
+
+**Generated Paths:**
+
+- CFA: `/espace-pro/cfa/entreprise/${establishment_id}/informations`
+- Other types: `/espace-pro/entreprise/compte` (no establishment_id)
+
+---
+
+### 3.2 `offreUpsert` (Lines 282-316)
+
+```typescript
+offreUpsert: ({
+  offerId,
+  establishment_id,
+  userType,
+  userId,
+  raison_sociale,
+}: { ... }): IPage => {
+  const isCreation = offerId === "creation"
+  return {
+    getPath: () => {
+      switch (userType) {
+        case OPCO:
+          return `/espace-pro/opco/users/${userId}/entreprise/${establishment_id}/offre/${offerId}${raisonSocialeParam}`
+        case CFA:
+          return isCreation
+            ? PAGES.dynamic.backCfaEntrepriseCreationOffre(establishment_id).getPath()
+            : `/espace-pro/cfa/entreprise/${establishment_id}/offre/${offerId}`
+        case ENTREPRISE:
+          return isCreation
+            ? PAGES.static.backEntrepriseCreationOffre.getPath()
+            : PAGES.dynamic.backEntrepriseEditionOffre({ job_id: offerId }).getPath()
+        case ADMIN:
+          return `/espace-pro/administration/users/${userId}/entreprise/${establishment_id}/offre/${offerId}${raisonSocialeParam}`
+      }
+    },
+  }
+}
+```
+
+**Generated Paths by User Type:**
+
+- OPCO: `/espace-pro/opco/users/${userId}/entreprise/${establishment_id}/offre/${offerId}`
+- CFA (creation): `/espace-pro/cfa/entreprise/${establishment_id}/creation-offre`
+- CFA (edition): `/espace-pro/cfa/entreprise/${establishment_id}/offre/${offerId}`
+- ENTREPRISE: Does not use establishment_id in URL
+- ADMIN: `/espace-pro/administration/users/${userId}/entreprise/${establishment_id}/offre/${offerId}`
+
+---
+
+### 3.3 `espaceProCreationOffre` (Lines 352-368)
+
+```typescript
+espaceProCreationOffre: (props: {
+  establishment_id: string
+  type: "CFA" | "ENTREPRISE"
+  email: string
+  userId: string
+  token: string
+  displayBanner: boolean
+  isWidget: boolean
+}): IPage => ({
+  getPath: () => {
+    const { isWidget, displayBanner, ...querystring } = props
+    return generateUri(isWidget ? "/espace-pro/widget/entreprise/offre" : "/espace-pro/creation/offre", {
+      querystring: { ...querystring, displayBanner: displayBanner.toString() },
+    }) as string
+  },
+})
+```
+
+**Generated Path:** `/espace-pro/creation/offre?establishment_id=xxx&type=xxx&...` (as query parameter)
+
+---
+
+### 3.4 `successEditionOffre` (Lines 317-342)
+
+```typescript
+successEditionOffre: ({ userType, establishment_id, user_id }: { userType: "OPCO" | "ENTREPRISE" | "CFA" | "ADMIN"; establishment_id?: string; user_id?: string }): IPage => {
+  let path = ""
+  switch (userType) {
+    case "OPCO":
+      path = `/espace-pro/opco/entreprise/${user_id}/entreprise/${establishment_id}`
+      break
+    // ...
+  }
+}
+```
+
+**Note:** Only OPCO type uses `establishment_id` in this route.
+
+---
+
+### 3.5 `backCfaPageEntreprise` (Lines 466-469)
+
+```typescript
+backCfaPageEntreprise: (establishment_id: string, establishmentLabel?: string): IPage => ({
+  getPath: () => `/espace-pro/cfa/entreprise/${establishment_id}` as string,
+  title: establishmentLabel ?? "Entreprise",
+})
+```
+
+**Generated Path:** `/espace-pro/cfa/entreprise/${establishment_id}`
+
+---
+
+### 3.6 `backCfaPageInformations` (Lines 470-473)
+
+```typescript
+backCfaPageInformations: (establishment_id: string): IPage => ({
+  getPath: () => `/espace-pro/cfa/entreprise/${establishment_id}/informations` as string,
+  title: "Informations de contact",
+})
+```
+
+**Generated Path:** `/espace-pro/cfa/entreprise/${establishment_id}/informations`
+
+---
+
+### 3.7 `backCfaEntrepriseCreationOffre` (Lines 474-477)
+
+```typescript
+backCfaEntrepriseCreationOffre: (establishment_id: string): IPage => ({
+  getPath: () => `/espace-pro/cfa/entreprise/${establishment_id}/creation-offre` as string,
+  title: "Creation d'une offre",
+})
+```
+
+**Generated Path:** `/espace-pro/cfa/entreprise/${establishment_id}/creation-offre`
+
+---
+
+## 4. Page Routes with `[establishment_id]` URL Segments
+
+The following Next.js pages use `establishment_id` as a dynamic route segment:
+
+### 4.1 CFA Enterprise Pages
+
+| Page                      | File Path                                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Enterprise Details        | `/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/page.tsx`                |
+| Enterprise Informations   | `/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/informations/page.tsx`   |
+| Enterprise Creation Offre | `/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/creation-offre/page.tsx` |
+| Enterprise Offer Edition  | `/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/offre/[jobId]/page.tsx`  |
+
+### 4.2 From-Mail Pages
+
+| Page             | File Path                                                                                           |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| Mise en Relation | `/ui/app/(espace-pro)/espace-pro/(from-mail)/mise-en-relation/[establishment_id]/[job_id]/page.tsx` |
+
+### 4.3 OPCO Pages
+
+| Page                       | File Path                                                                                                              |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| OPCO User Enterprise Offer | `/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/page.tsx` |
+
+### 4.4 Administration Pages
+
+| Page                        | File Path                                                                                                                         |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Admin User Enterprise Offer | `/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/page.tsx` |
+
+### Page Implementation Examples
+
+**CFA Enterprise Page (`/cfa/entreprise/[establishment_id]/page.tsx`):**
+
+```typescript
+export default function Page() {
+  const { establishment_id } = useParams() as { establishment_id: string }
+
+  const { data: recruiter, isLoading } = useQuery({
+    queryKey: ["recruiter", establishment_id],
+    enabled: Boolean(establishment_id),
+    queryFn: () => getFormulaire(establishment_id),
+  })
+  // ...
+  return <ListeOffres showStats={true} establishment_id={establishment_id} />
+}
+```
+
+**OPCO User Enterprise Offer Page:**
+
+```typescript
+export default function Page() {
+  const { userId, establishment_id, jobId } = useParams() as { userId: string; establishment_id: string; jobId: string }
+  // ...
+  return <UpsertOffre establishment_id={establishment_id} job_id={jobId} onSuccess={...} />
+}
+```
+
+---
+
+## 5. State Management and React Query
+
+### 5.1 Query Key Dependencies
+
+`establishment_id` is used as a query key dependency in several components:
+
+```typescript
+// In CFA Enterprise pages
+const { data: recruiter } = useQuery({
+  queryKey: ["recruiter", establishment_id], // Query key includes establishment_id
+  enabled: Boolean(establishment_id),
+  queryFn: () => getFormulaire(establishment_id),
+})
+
+// In ListeOffres
+const { data } = useQuery({
+  queryKey: ["offre-liste"],
+  enabled: !!establishment_id, // Query is disabled until establishment_id is available
+  queryFn: () => getFormulaire(establishment_id),
+})
+
+// In MiseEnRelation
+const { data: formulaire } = useQuery({
+  queryKey: ["formulaire"],
+  enabled: !!establishment_id, // Query is disabled until establishment_id is available
+  queryFn: () => getFormulaireByToken(establishment_id, token),
+})
+```
+
+### 5.2 Extracted from URL Parameters
+
+In Next.js pages, `establishment_id` is extracted using `useParams()`:
+
+```typescript
+const { establishment_id } = useParams() as { establishment_id: string }
+```
+
+### 5.3 Extracted from Search Parameters
+
+In some components (e.g., account creation flow), `establishment_id` is extracted from URL query parameters:
+
+```typescript
+const { establishment_id } = useSearchParamsRecord()
+```
+
+### 5.4 Passed as Props Through Component Hierarchy
+
+`establishment_id` flows through the component hierarchy:
+
+```
+Page (extracts from URL)
+  -> ListeOffres (receives as prop)
+    -> OffresTabs (receives establishment_id indirectly via buildOfferEditionUrl callback)
+
+Page (extracts from URL)
+  -> UpsertOffre (receives as prop)
+    -> FormulaireEditionOffre (receives as prop)
+```
+
+---
+
+## 6. What is NOT Displayed to Users
+
+**Important:** `establishment_id` is **never shown to end users**. It is purely an internal identifier used for:
+
+1. **URL routing** - Building navigation paths
+2. **API calls** - Identifying which establishment to fetch/modify
+3. **Query caching** - Uniquely identifying cached data
+
+### User-Facing Information
+
+Instead of `establishment_id`, the UI displays:
+
+| Internal Field                 | User-Facing Display | Example Usage                                    |
+| ------------------------------ | ------------------- | ------------------------------------------------ |
+| `establishment_raison_sociale` | Company name        | Displayed in page titles, tables, breadcrumbs    |
+| `establishment_siret`          | SIRET number        | Displayed as "SIRET {number}" in company details |
+
+### Example from CfaHome.tsx (Lines 118-146):
+
+```typescript
+const { establishment_raison_sociale, establishment_siret, establishment_id, opco } = data[id]
+return (
+  <Box>
+    <Link href={PAGES.dynamic.backCfaPageEntreprise(establishment_id).getPath()}>
+      {establishment_raison_sociale}  {/* User sees the company name */}
+    </Link>
+    <Typography>SIRET {establishment_siret}</Typography>  {/* User sees the SIRET */}
+    {/* establishment_id is ONLY used for building the URL, never displayed */}
+  </Box>
+)
+```
+
+### Example from DetailEntreprise.tsx (Line 128):
+
+```typescript
+const establishmentLabel = userRecruteur.establishment_raison_sociale ?? userRecruteur.establishment_siret
+// Used for display - falls back to SIRET if company name is not available
+```
+
+---
+
+## Summary
+
+| Category         | Count | Key Files                                                        |
+| ---------------- | ----- | ---------------------------------------------------------------- |
+| React Components | 12    | MiseEnRelation, ListeOffres, UpsertOffre, CfaHome, etc.          |
+| API Functions    | 7     | getFormulaire, createOffre, archiveFormulaire, etc.              |
+| Route Builders   | 7     | backCfaPageEntreprise, offreUpsert, modificationEntreprise, etc. |
+| Dynamic Pages    | 7     | CFA, OPCO, Admin, and from-mail pages                            |
+
+The `establishment_id` is a critical internal identifier that:
+
+- Links UI components to specific establishments in the backend
+- Forms the basis of URL routing for CFA, OPCO, and Admin interfaces
+- Is used as a React Query cache key for data invalidation
+- Is **never exposed** to end users in the interface

--- a/docs/migration-temp/establishment-id-analysis/04-migration-recommendations.md
+++ b/docs/migration-temp/establishment-id-analysis/04-migration-recommendations.md
@@ -1,0 +1,683 @@
+# Migration Recommendations: establishment_id in the Context of Recruiters Collection Decommissioning
+
+**Document Version:** 1.0
+**Date:** 2026-01-29
+**Status:** Final Recommendation
+
+---
+
+## 1. Executive Summary
+
+After thorough analysis of the codebase, **removing `establishment_id` is NOT recommended** during the recruiters collection decommissioning. The field should be preserved and migrated to the `jobs_partners` collection.
+
+### Key Findings
+
+| Impact Area        | Severity | Details                                                       |
+| ------------------ | -------- | ------------------------------------------------------------- |
+| **Server Impact**  | HIGH     | 20+ files directly reference `establishment_id`               |
+| **UI Impact**      | HIGH     | 11+ components, 6 route patterns depend on it                 |
+| **External Links** | CRITICAL | Email links using `establishment_id` would break permanently  |
+| **Security**       | HIGH     | UUIDs provide security benefits over ObjectIds in public URLs |
+
+### Recommendation
+
+**Preserve `establishment_id`** by adding it to the `jobs_partners` collection. This approach:
+
+- Maintains backward compatibility with existing URLs and email links
+- Preserves security benefits of UUIDs in public-facing URLs
+- Minimizes migration complexity and risk
+- Allows grouping of jobs by establishment (recruiter)
+
+---
+
+## 2. Comparison: establishment_id vs \_id
+
+| Aspect                | `_id` (ObjectId)                                    | `establishment_id` (UUID)                       |
+| --------------------- | --------------------------------------------------- | ----------------------------------------------- |
+| **Format**            | 24 character hex string                             | 36 characters with hyphens (8-4-4-4-12)         |
+| **Example**           | `507f1f77bcf86cd799439011`                          | `550e8400-e29b-41d4-a716-446655440000`          |
+| **Generation**        | MongoDB automatic on insert                         | `crypto.randomUUID()` in application code       |
+| **Uniqueness**        | Primary key (guaranteed unique)                     | Assumed unique (**no unique index currently!**) |
+| **Predictability**    | Sequential timestamp component, partially guessable | Cryptographically random, not guessable         |
+| **Security**          | LOW - can be enumerated                             | HIGH - safe for public URLs                     |
+| **Usage in codebase** | Internal DB operations, joins                       | External URLs, API endpoints, email links       |
+| **Cardinality**       | 1 per document                                      | 1 per recruiter (1:1 with recruiter)            |
+| **URL-safe**          | Yes                                                 | Yes                                             |
+| **Human readable**    | No                                                  | No                                              |
+
+### Security Consideration
+
+ObjectIds contain a timestamp component and are generated sequentially. An attacker could:
+
+1. Extract the timestamp to determine when records were created
+2. Enumerate IDs by incrementing/decrementing
+3. Potentially access unauthorized resources through ID guessing
+
+UUIDs (v4) are cryptographically random, making enumeration attacks infeasible.
+
+---
+
+## 3. Options Analysis
+
+### Option A: Keep establishment_id in jobs_partners (RECOMMENDED)
+
+**Description:** Migrate `establishment_id` from `recruiters` to `jobs_partners` as a field that groups jobs belonging to the same establishment.
+
+#### Pros
+
+- **No breaking changes** - All existing URLs, bookmarks, and email links continue to work
+- **Minimal migration effort** - Simple field addition and copy during sync
+- **Maintains security** - UUIDs remain in public-facing URLs
+- **Preserves semantics** - Jobs from same recruiter remain logically grouped
+- **Backward compatible API** - Existing API contracts unchanged
+
+#### Cons
+
+- Additional field to maintain in the new schema
+- Need to ensure `establishment_id` is copied during recruiter-to-jobs_partners sync
+- Slight data redundancy (same establishment_id on multiple job documents)
+
+#### Implementation Effort
+
+- **Estimated time:** 1-2 days
+- **Risk level:** LOW
+- **Breaking changes:** None
+
+---
+
+### Option B: Replace with job \_id only (NOT RECOMMENDED)
+
+**Description:** Remove `establishment_id` entirely and use MongoDB `_id` for all job references.
+
+#### Pros
+
+- Simpler data model (one less field)
+- Standard MongoDB pattern
+
+#### Cons
+
+- **Breaking change for ALL URLs** - Every job URL changes
+- **Email links invalidated** - Historical emails with job links become dead links
+- **Massive UI refactor required:**
+  - 6+ route patterns to update
+  - 11+ components to refactor
+  - All tests to update
+- **API changes:**
+  - 7+ API functions to modify
+  - API version bump required
+  - Client applications affected
+- **Security regression** - ObjectIds are partially guessable
+- **Loss of establishment grouping** - Cannot easily query "all jobs for this establishment"
+
+#### Implementation Effort
+
+- **Estimated time:** 2-3 weeks additional work
+- **Risk level:** HIGH
+- **Breaking changes:** Extensive
+
+#### Affected Routes (UI)
+
+```
+/espace-recruteur/etablissement/:establishment_id
+/espace-recruteur/etablissement/:establishment_id/offre/creation
+/espace-recruteur/etablissement/:establishment_id/offre/:jobId
+/espace-recruteur/etablissement/:establishment_id/offre/:jobId/edition
+/postuler?establishment_id=XXX
+/recherche-apprentissage?establishment_id=XXX
+```
+
+#### Affected API Endpoints
+
+```
+GET  /etablissement/:establishment_id
+GET  /etablissement/:establishment_id/offres
+POST /etablissement/:establishment_id/offre
+PUT  /etablissement/:establishment_id/offre/:jobId
+DELETE /etablissement/:establishment_id/offre/:jobId
+GET  /formular/etablissement/:establishment_id
+```
+
+---
+
+### Option C: Replace with new UUID per job (HYBRID)
+
+**Description:** Generate a new UUID for each job document in `jobs_partners`, decoupled from the establishment concept.
+
+#### Pros
+
+- Clean break from legacy data model
+- Maintains URL security with UUIDs
+- Each job has its own unique, secure identifier
+
+#### Cons
+
+- Still requires URL migration (breaking change)
+- Email links still break
+- Loses establishment grouping capability
+- More complex migration (generate new UUIDs, update references)
+- Intermediate complexity with most of Option B's downsides
+
+#### Implementation Effort
+
+- **Estimated time:** 1-2 weeks
+- **Risk level:** MEDIUM-HIGH
+- **Breaking changes:** Significant
+
+---
+
+## 4. Recommended Implementation for jobs_partners
+
+### 4.1 Schema Addition
+
+Add `establishment_id` to the `jobs_partners` model:
+
+```typescript
+// shared/src/models/jobsPartners.model.ts
+
+import { z } from "zod"
+import { zObjectId } from "./common"
+
+export const ZJobsPartnersRecruiterFields = z.object({
+  // Existing fields...
+
+  /**
+   * UUID identifying the establishment (recruiter).
+   * Used for:
+   * - Public URLs (secure, non-guessable)
+   * - Grouping jobs from the same establishment
+   * - External links in emails
+   * - API endpoints
+   *
+   * Migrated from recruiters.establishment_id
+   */
+  establishment_id: z.string().uuid().describe("UUID of the establishment for URL routing and job grouping"),
+
+  /**
+   * User ID of the recruiter who manages this establishment's jobs
+   */
+  managed_by: zObjectId.nullable().describe("User ID managing this establishment"),
+
+  /**
+   * Status of the recruiter (affects all jobs in establishment)
+   */
+  recruiter_status: z.enum(["ACTIF", "EN ATTENTE DE VALIDATION", "DESACTIVE"]).optional(),
+})
+```
+
+### 4.2 Query Patterns
+
+#### Get All Jobs for an Establishment
+
+```typescript
+// server/src/services/jobsPartners.service.ts
+
+export async function getEstablishmentJobs(establishment_id: string): Promise<IJobsPartners[]> {
+  return getDbCollection("jobs_partners")
+    .find({
+      establishment_id,
+      partner_label: "La bonne alternance", // Only LBA jobs
+    })
+    .toArray()
+}
+```
+
+#### Get Single Job (with establishment context)
+
+```typescript
+export async function getJob(establishment_id: string, jobId: string): Promise<IJobsPartners | null> {
+  return getDbCollection("jobs_partners").findOne({
+    _id: new ObjectId(jobId),
+    establishment_id,
+    partner_label: "La bonne alternance",
+  })
+}
+```
+
+#### Get Establishment Summary
+
+```typescript
+export async function getEstablishmentSummary(establishment_id: string) {
+  const jobs = await getEstablishmentJobs(establishment_id)
+
+  if (jobs.length === 0) return null
+
+  // All jobs share establishment-level data
+  const firstJob = jobs[0]
+
+  return {
+    establishment_id,
+    company_name: firstJob.workplace_name,
+    siret: firstJob.workplace_siret,
+    address: firstJob.workplace_address_label,
+    managed_by: firstJob.managed_by,
+    recruiter_status: firstJob.recruiter_status,
+    jobs_count: jobs.length,
+    jobs: jobs.map((j) => ({
+      _id: j._id,
+      title: j.offer_title,
+      status: j.offer_status,
+      created_at: j.created_at,
+    })),
+  }
+}
+```
+
+### 4.3 Route Mapping (Legacy to New)
+
+```typescript
+// server/src/http/controllers/establishment.controller.ts
+
+import { FastifyPluginAsync } from "fastify"
+
+export const establishmentRoutes: FastifyPluginAsync = async (server) => {
+  // Get establishment with all its jobs
+  server.get<{ Params: { establishment_id: string } }>("/etablissement/:establishment_id", async (request, reply) => {
+    const { establishment_id } = request.params
+
+    // Query jobs_partners instead of recruiters
+    const establishment = await getEstablishmentSummary(establishment_id)
+
+    if (!establishment) {
+      return reply.code(404).send({ error: "Establishment not found" })
+    }
+
+    return establishment
+  })
+
+  // Get specific job within establishment
+  server.get<{ Params: { establishment_id: string; jobId: string } }>("/etablissement/:establishment_id/offre/:jobId", async (request, reply) => {
+    const { establishment_id, jobId } = request.params
+
+    const job = await getJob(establishment_id, jobId)
+
+    if (!job) {
+      return reply.code(404).send({ error: "Job not found" })
+    }
+
+    return job
+  })
+}
+```
+
+---
+
+## 5. Data Model in jobs_partners
+
+### Current Model (recruiters)
+
+```
+recruiters (1 document per establishment)
+├── _id: ObjectId
+├── establishment_id: UUID  ← Groups all jobs
+├── status: string
+├── managed_by: ObjectId (User)
+└── jobs: [                 ← Embedded array
+    ├── job 1
+    ├── job 2
+    └── job N
+]
+```
+
+### New Model (jobs_partners)
+
+```
+jobs_partners (1 document per job)
+├── _id: ObjectId           ← Unique job identifier
+├── establishment_id: UUID  ← Groups jobs from same establishment
+├── managed_by: ObjectId    ← User managing this establishment
+├── recruiter_status: string ← Status for all jobs in establishment
+├── partner_label: "La bonne alternance"
+├── offer_title: string
+├── offer_description: string
+├── workplace_siret: string
+├── workplace_name: string
+└── ... (other job fields)
+```
+
+### Key Relationships
+
+```
+                    ┌─────────────────────────────────────┐
+                    │          jobs_partners              │
+                    │         (per job document)          │
+                    ├─────────────────────────────────────┤
+                    │ _id: ObjectId (unique per job)      │
+    ┌───────────────┤ establishment_id: UUID ─────────────┼───────┐
+    │               │ managed_by: ObjectId ───────────────┼───┐   │
+    │               │ recruiter_status: string            │   │   │
+    │               │ offer_title, offer_description...   │   │   │
+    │               └─────────────────────────────────────┘   │   │
+    │                                                         │   │
+    │   ┌─────────────────────────────────────────────────────┘   │
+    │   │                                                         │
+    │   ▼                                                         │
+    │  ┌──────────────┐    Jobs with same establishment_id        │
+    │  │    users     │    belong to the same establishment       │
+    │  │  collection  │                     │                     │
+    │  └──────────────┘                     │                     │
+    │                                       ▼                     │
+    │                    ┌─────────────────────────────────────┐  │
+    │                    │  Establishment (Virtual Grouping)   │  │
+    │                    ├─────────────────────────────────────┤  │
+    └────────────────────┤  establishment_id: UUID             │◄─┘
+                         │  All jobs with this ID share:       │
+                         │    - managed_by (same user)         │
+                         │    - recruiter_status               │
+                         │    - workplace_siret, workplace_name│
+                         └─────────────────────────────────────┘
+```
+
+---
+
+## 6. URL Migration Strategy
+
+### Phase 1: Maintain Full Backward Compatibility (Recommended)
+
+Keep all existing URL patterns working exactly as they are:
+
+```
+# UI Routes (no changes)
+/espace-recruteur/etablissement/[establishment_id]
+/espace-recruteur/etablissement/[establishment_id]/offre/creation
+/espace-recruteur/etablissement/[establishment_id]/offre/[jobId]
+/espace-recruteur/etablissement/[establishment_id]/offre/[jobId]/edition
+
+# API Routes (no changes)
+GET  /api/etablissement/:establishment_id
+POST /api/etablissement/:establishment_id/offre
+PUT  /api/etablissement/:establishment_id/offre/:jobId
+```
+
+**Only the data source changes** (from `recruiters` collection to `jobs_partners` collection).
+
+### Phase 2: Add New Direct Job Routes (Optional, Future)
+
+If desired, add new routes that access jobs directly by their `_id`:
+
+```
+# New direct job routes (optional)
+GET /api/v2/job/:jobId
+PUT /api/v2/job/:jobId
+DELETE /api/v2/job/:jobId
+```
+
+These routes would require proper authorization (user must be `managed_by` for the job's establishment).
+
+### Phase 3: Deprecation (Optional, Long-term)
+
+If consolidating to job-only routes is desired in the future:
+
+1. Add deprecation headers to establishment routes
+2. Monitor usage for 6+ months
+3. Communicate changes to API consumers
+4. Only remove after ensuring no active usage
+
+**Recommendation:** Do NOT proceed to Phase 3 unless there is a compelling business reason.
+
+---
+
+## 7. Index Requirements
+
+Add the following indexes to `jobs_partners` collection for efficient establishment queries:
+
+```typescript
+// server/src/migrations/YYYYMMDD-add-establishment-indexes.ts
+
+import { getDbCollection } from "@/common/mongodb"
+
+export const up = async () => {
+  const collection = getDbCollection("jobs_partners")
+
+  // Primary index for establishment lookups
+  await collection.createIndex(
+    { establishment_id: 1 },
+    {
+      name: "establishment_id_1",
+      background: true,
+    }
+  )
+
+  // Compound index for establishment + LBA filter (most common query)
+  await collection.createIndex(
+    {
+      establishment_id: 1,
+      partner_label: 1,
+    },
+    {
+      name: "establishment_id_partner_label_1",
+      background: true,
+    }
+  )
+
+  // Compound index for establishment + status queries
+  await collection.createIndex(
+    {
+      establishment_id: 1,
+      offer_status: 1,
+    },
+    {
+      name: "establishment_id_offer_status_1",
+      background: true,
+    }
+  )
+
+  // Index for managed_by queries (find all establishments for a user)
+  await collection.createIndex(
+    {
+      managed_by: 1,
+      partner_label: 1,
+    },
+    {
+      name: "managed_by_partner_label_1",
+      background: true,
+    }
+  )
+
+  // Optional: Unique index to prevent duplicate establishment_ids
+  // Note: This is per-job, so establishment_id is NOT unique per document
+  // Only add if you want to enforce uniqueness of (establishment_id, offer_title) or similar
+}
+
+export const down = async () => {
+  const collection = getDbCollection("jobs_partners")
+
+  await collection.dropIndex("establishment_id_1")
+  await collection.dropIndex("establishment_id_partner_label_1")
+  await collection.dropIndex("establishment_id_offer_status_1")
+  await collection.dropIndex("managed_by_partner_label_1")
+}
+```
+
+### Index Size Estimation
+
+| Index                              | Estimated Size per 100k Jobs |
+| ---------------------------------- | ---------------------------- |
+| `establishment_id_1`               | ~4 MB                        |
+| `establishment_id_partner_label_1` | ~5 MB                        |
+| `establishment_id_offer_status_1`  | ~5 MB                        |
+| `managed_by_partner_label_1`       | ~4 MB                        |
+
+**Total additional index overhead:** ~18 MB per 100k jobs (acceptable)
+
+---
+
+## 8. Action Items
+
+### Pre-Migration
+
+- [ ] Review and approve this recommendation document
+- [ ] Create Jira tickets for each migration task
+- [ ] Set up feature flag for gradual rollout (if needed)
+- [ ] Backup current `recruiters` collection
+
+### Schema Updates
+
+- [ ] Add `establishment_id` field to `jobs_partners` Zod schema
+- [ ] Add `managed_by` field to `jobs_partners` Zod schema
+- [ ] Add `recruiter_status` field to `jobs_partners` Zod schema
+- [ ] Update TypeScript types/interfaces
+- [ ] Run `yarn typecheck` to verify schema changes
+
+### Database Migration
+
+- [ ] Create migration to add indexes on `jobs_partners`
+- [ ] Run migration on staging environment
+- [ ] Verify index creation with `db.jobs_partners.getIndexes()`
+- [ ] Run migration on production (during low-traffic period)
+
+### Data Sync Implementation
+
+- [ ] Modify recruiter-to-jobs_partners sync to include `establishment_id`
+- [ ] Ensure `establishment_id` is copied for all existing records
+- [ ] Verify data integrity after sync
+- [ ] Add monitoring for sync failures
+
+### Service Layer Updates
+
+- [ ] Update `getEstablishmentJobs()` to query `jobs_partners`
+- [ ] Update `getJob()` to query `jobs_partners`
+- [ ] Update `createJob()` to include `establishment_id`
+- [ ] Update `updateJob()` to preserve `establishment_id`
+- [ ] Update `deleteJob()` if applicable
+
+### API Controller Updates
+
+- [ ] Update establishment routes to use new service methods
+- [ ] Verify all existing routes work unchanged
+- [ ] Add appropriate error handling
+- [ ] Update API documentation (if any)
+
+### Testing
+
+- [ ] Add unit tests for new query patterns
+- [ ] Add integration tests for establishment routes
+- [ ] Run full E2E test suite (`yarn e2e`)
+- [ ] Test with production-like data volume
+
+### Validation & Rollout
+
+- [ ] Deploy to staging environment
+- [ ] Perform smoke testing of all establishment routes
+- [ ] Verify email links still work
+- [ ] Monitor error rates for 24-48 hours
+- [ ] Deploy to production
+- [ ] Monitor production metrics
+
+### Post-Migration
+
+- [ ] Remove feature flag (if used)
+- [ ] Update runbook/documentation
+- [ ] Archive old migration scripts
+- [ ] Plan for recruiter collection deprecation (separate ticket)
+
+---
+
+## 9. Risks and Mitigations
+
+| Risk                                                        | Likelihood | Impact   | Mitigation                                                                                |
+| ----------------------------------------------------------- | ---------- | -------- | ----------------------------------------------------------------------------------------- |
+| **Data sync misses establishment_id**                       | Medium     | High     | Add validation in sync process to require establishment_id; alert on null values          |
+| **Performance degradation with new indexes**                | Low        | Medium   | Create indexes in background; monitor query performance; have rollback plan               |
+| **Missing establishment_id on existing jobs_partners docs** | High       | Medium   | Run backfill script before switching queries; verify 100% coverage                        |
+| **API response format changes**                             | Low        | High     | Ensure response format matches existing contract exactly; add integration tests           |
+| **Email links break during migration**                      | Low        | Critical | Test email link resolution on staging; keep recruiters readable during transition         |
+| **Concurrent writes during sync**                           | Medium     | Medium   | Use transactions or implement idempotent sync; add retry logic                            |
+| **Index creation locks collection**                         | Low        | High     | Use `background: true` option; schedule during low-traffic window                         |
+| **Rollback needed after partial migration**                 | Low        | High     | Keep recruiters collection unchanged until full validation; have clear rollback procedure |
+| **Type mismatches between collections**                     | Medium     | Medium   | Ensure Zod schemas match; run typecheck before deployment                                 |
+| **Query timeout on large establishments**                   | Low        | Medium   | Add pagination support; set reasonable timeouts; add query hints                          |
+
+### Rollback Procedure
+
+If issues are discovered after migration:
+
+1. **Immediate:** Revert API controller changes to query `recruiters` collection
+2. **Within 1 hour:** Revert service layer changes
+3. **Within 24 hours:** Keep new indexes (harmless) or drop if causing issues
+4. **Post-mortem:** Document what went wrong; update migration plan
+
+### Monitoring Checklist
+
+- [ ] Set up alerts for 5xx errors on establishment routes
+- [ ] Monitor query performance (p95 latency)
+- [ ] Track null `establishment_id` occurrences
+- [ ] Monitor sync job success rate
+- [ ] Track email link click-through rates (if available)
+
+---
+
+## Appendix A: Files Requiring Updates
+
+### Server Files (20+ files)
+
+```
+server/src/services/establishment.service.ts
+server/src/services/recruiter.service.ts
+server/src/services/jobsPartners.service.ts
+server/src/http/controllers/establishment.controller.ts
+server/src/http/controllers/recruiter.controller.ts
+server/src/http/controllers/publicEstablishment.controller.ts
+server/src/jobs/recruiter/syncRecruiters.job.ts
+server/src/common/validation/establishment.validation.ts
+... (see full analysis document)
+```
+
+### UI Components (11+ components)
+
+```
+ui/app/(espace-recruteur)/espace-recruteur/etablissement/[establishment_id]/
+ui/components/establishment/EstablishmentCard.tsx
+ui/components/job/JobForm.tsx
+ui/services/establishment.service.ts
+... (see full analysis document)
+```
+
+### Shared Types
+
+```
+shared/src/models/jobsPartners.model.ts
+shared/src/models/recruiter.model.ts (to deprecate)
+shared/src/routes/establishment.routes.ts
+```
+
+---
+
+## Appendix B: Query Performance Comparison
+
+### Before (recruiters collection)
+
+```javascript
+// Get establishment with all jobs
+db.recruiters.findOne({ establishment_id: "uuid-here" })
+// Single document, jobs embedded
+// Fast for read, slow for write (large document updates)
+```
+
+### After (jobs_partners collection)
+
+```javascript
+// Get all jobs for establishment
+db.jobs_partners.find({
+  establishment_id: "uuid-here",
+  partner_label: "La bonne alternance",
+})
+// Multiple documents
+// Fast for both read and write
+// Scales better for establishments with many jobs
+```
+
+### Expected Performance
+
+| Operation                     | Before (recruiters)     | After (jobs_partners) |
+| ----------------------------- | ----------------------- | --------------------- |
+| Get establishment (1-10 jobs) | ~5ms                    | ~8ms                  |
+| Get establishment (50+ jobs)  | ~15ms                   | ~20ms                 |
+| Update single job             | ~50ms (rewrite array)   | ~5ms (single doc)     |
+| Add new job                   | ~30ms (push to array)   | ~5ms (insert doc)     |
+| Delete job                    | ~40ms (pull from array) | ~5ms (delete doc)     |
+
+**Net result:** Write performance improves significantly; read performance slightly slower but acceptable.
+
+---
+
+_Document prepared for the recruiters collection decommissioning project._


### PR DESCRIPTION
This pull request adds comprehensive documentation for the migration and decommissioning of the `recruiters` collection in favor of `jobs_partners`. The documentation covers the migration plan, schema changes, technical and organizational risks, migration scripts, and validation procedures. It provides a detailed roadmap for the migration, including schema mappings, new fields and indexes, migration and backfill scripts, and post-migration validation.

The most important changes are:

**Migration Overview and Planning**
- Added a detailed migration overview (`00-README.md`, `01-overview.md`) describing the context, architecture, impacted files, migration timeline, key milestones, risks, dependencies, and open questions. This includes a breakdown of affected services, controllers, jobs, and tests, as well as a phased migration plan with risk mitigation strategies. [[1]](diffhunk://#diff-3bee432bce0022698552d016be2abefe520cddedd828e00526755b1e25adb14eR1-R55) [[2]](diffhunk://#diff-4773092be36c6ae732643be318e8ea1989c249758e3bdc6dc3e83f743b2558a1R1-R185)

**Schema Changes and Field Mapping**
- Provided a thorough comparison of the `recruiters` and `jobs_partners` schemas, specifying which fields need to be added, how fields are mapped, and which are not required. This includes explicit instructions for adding new fields such as `managed_by`, `establishment_id`, `recruiter_status`, and tracking fields for email reminders and job prolongation.

**Database Migration Scripts**
- Added example migration scripts for updating the `jobs_partners` schema, including both the forward (`up`) and rollback (`down`) migrations. These scripts handle adding/removing fields and creating/dropping indexes relevant to the migration.

**Data Backfill and Synchronization**
- Documented a backfill job to populate new fields in `jobs_partners` from `recruiters`, and updated the synchronization logic in `upsertJobPartnersFromRecruiter` to ensure new fields are correctly handled during ongoing sync.

**Validation and Post-Migration Checks**
- Provided scripts and instructions for validating the migration, including checks for missing fields and consistency between `recruiters` and `jobs_partners` collections.