### PR TITLE
feat: changement adresse api-adresse

### DIFF
--- a/server/src/http/controllers/v3/jobs/jobs.controller.v3.test.ts
+++ b/server/src/http/controllers/v3/jobs/jobs.controller.v3.test.ts
@@ -307,7 +307,7 @@ describe("POST /jobs", async () => {
 
     vi.mocked(getEtablissementFromGouvSafe).mockResolvedValue(apiEntrepriseEtablissementFixture.dinum)
 
-    nock("https://api-adresse.data.gouv.fr:443")
+    nock("https://data.geopf.fr:443/geocodage")
       .get("/search")
       .query({ q: "20 AVENUE DE SEGUR, 75007 PARIS", limit: "1" })
       .reply(200, {
@@ -470,7 +470,7 @@ describe("PUT /jobs/:id", async () => {
 
     vi.mocked(getEtablissementFromGouvSafe).mockResolvedValue(apiEntrepriseEtablissementFixture.dinum)
 
-    nock("https://api-adresse.data.gouv.fr:443")
+    nock("https://data.geopf.fr:443/geocodage")
       .get("/search")
       .query({ q: "20 AVENUE DE SEGUR, 75007 PARIS", limit: "1" })
       .reply(200, {

--- a/server/src/jobs/offrePartenaire/fillLocationInfosForPartners.test.ts
+++ b/server/src/jobs/offrePartenaire/fillLocationInfosForPartners.test.ts
@@ -78,7 +78,7 @@ describe("fillLocationInfosForPartners", () => {
       },
     ])
 
-    nock("https://api-adresse.data.gouv.fr:443")
+    nock("https://data.geopf.fr:443/geocodage")
       .get("/search")
       .query({ q: "1T IMPASSE PASSOIR CLICHY", limit: "1" })
       .reply(200, {

--- a/server/src/services/geolocation.service.ts
+++ b/server/src/services/geolocation.service.ts
@@ -9,7 +9,7 @@ import { getGeolocationFromCache, saveGeolocationInCache } from "./cacheGeolocat
 import getApiClient from "@/common/apis/client"
 import { sentryCaptureException } from "@/common/utils/sentryUtils"
 
-const API_ADRESSE_URL = "https://api-adresse.data.gouv.fr"
+const API_ADRESSE_URL = "https://data.geopf.fr/geocodage"
 
 const client = getApiClient({ timeout: 2_000 })
 const startCharRegex = () => new RegExp("[0-9a-zA-Z]")
@@ -174,7 +174,7 @@ export const addressDetailToStreetLabel = (address: IAdresseV3): string | null =
 }
 
 export const getBulkGeoLocation = async (form: FormData) => {
-  return await client.post("https://api-adresse.data.gouv.fr/search/csv/", form, {
+  return await client.post("https://data.geopf.fr/geocodage/search/csv/", form, {
     headers: {
       ...form.getHeaders(),
     },

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -39,7 +39,7 @@ const contentSecurityPolicy = `
   script-src-attr 'none';
   connect-src 'self'
               https://catalogue-apprentissage.intercariforef.org
-              https://api-adresse.data.gouv.fr
+              https://data.geopf.fr
               https://api.mapbox.com
               https://stats.beta.gouv.fr
               https://stats.data.gouv.fr

--- a/ui/services/baseAdresse.ts
+++ b/ui/services/baseAdresse.ts
@@ -44,7 +44,7 @@ export async function searchAddress(value: string, type?: string, signal?: Abort
     }
     if (type) filter = "&type=" + type
 
-    const addressURL = `https://api-adresse.data.gouv.fr/search/?limit=${limit}&q=${term}${filter}`
+    const addressURL = `https://data.geopf.fr/geocodage/search/?limit=${limit}&q=${term}${filter}`
 
     try {
       const response = await fetch(addressURL, { signal })
@@ -79,7 +79,7 @@ export async function searchAddress(value: string, type?: string, signal?: Abort
 }
 
 export const fetchAddressFromCoordinates = async (coordinates: Coordinates, type?: string, signal?: AbortSignal): Promise<IAddressItem[]> => {
-  const addressURL = `https://api-adresse.data.gouv.fr/reverse/?lat=${coordinates[1]}&lon=${coordinates[0]}${type ? "&type=" + type : ""}`
+  const addressURL = `https://data.geopf.fr/geocodage/reverse/?lat=${coordinates[1]}&lon=${coordinates[0]}${type ? "&type=" + type : ""}`
 
   try {
     const response = await fetch(addressURL, { signal })


### PR DESCRIPTION
L'URL [api-adresse.data.gouv.fr](http://api-adresse.data.gouv.fr/) va etre decommissionnee. Merci d'utiliser l'URL de la Geoplateforme https://data.geopf.fr/geocodage/