### PR TITLE
fix(lbac-3440): unification fonction de build de job url

### DIFF
--- a/server/src/jobs/offrePartenaire/fillLbaUrl.ts
+++ b/server/src/jobs/offrePartenaire/fillLbaUrl.ts
@@ -3,9 +3,9 @@ import { COMPUTED_ERROR_SOURCE } from "shared/models/jobsPartnersComputed.model"
 import type { Filter } from "mongodb"
 import type { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
 import { fillFieldsForPartnersFactory } from "./fillFieldsForPartnersFactory"
-import { buildUrlLba } from "./importFromComputedToJobsPartners"
+import { builLbaUrlFromJob } from "@/services/jobs/jobOpportunity/jobOpportunity.service"
 
-const sourceFields = ["workplace_siret", "_id", "partner_label", "offer_title"] as const satisfies (keyof IJobsPartnersOfferPrivate)[]
+const sourceFields = ["workplace_siret", "_id", "partner_label", "offer_title", "workplace_naf_label"] as const satisfies (keyof IJobsPartnersOfferPrivate)[]
 
 export const fillLbaUrl = async ({ addedMatchFilter }: { addedMatchFilter?: Filter<IJobsPartnersOfferPrivate> } = {}) => {
   const filledFields = ["lba_url"] as const satisfies (keyof IJobsPartnersOfferPrivate)[]
@@ -17,10 +17,10 @@ export const fillLbaUrl = async ({ addedMatchFilter }: { addedMatchFilter?: Filt
     addedMatchFilter,
     getData: async (documents) => {
       return documents.map((document) => {
-        const { _id, partner_label, workplace_siret, offer_title } = document
+        const { _id, partner_label, workplace_siret, offer_title, workplace_naf_label } = document
         const result: Pick<IJobsPartnersOfferPrivate, (typeof filledFields)[number] | "_id"> = {
           _id,
-          lba_url: buildUrlLba(partner_label, _id.toString(), workplace_siret ?? null, offer_title ?? undefined),
+          lba_url: builLbaUrlFromJob({ _id, partner_label, workplace_siret, offer_title, workplace_naf_label }),
         }
         return result
       })

--- a/server/src/jobs/offrePartenaire/importFromComputedToJobsPartners.ts
+++ b/server/src/jobs/offrePartenaire/importFromComputedToJobsPartners.ts
@@ -3,8 +3,6 @@ import { pipeline } from "stream/promises"
 import { internal } from "@hapi/boom"
 import type { Filter } from "mongodb"
 import { TRAINING_CONTRACT_TYPE } from "shared/constants/index"
-import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
-import { getDirectJobPath } from "shared/metier/lbaitemutils"
 import { JOB_STATUS_ENGLISH } from "shared/models/index"
 import type { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
 import type { IComputedJobsPartners } from "shared/models/jobsPartnersComputed.model"
@@ -14,18 +12,6 @@ import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { sentryCaptureException } from "@/common/utils/sentryUtils"
 import { notifyToSlack } from "@/common/utils/slackUtils"
 import { limitStream } from "@/common/utils/streamUtils"
-import config from "@/config"
-
-export const buildUrlLba = (type: string, id: string, siret: string | null, title?: string) => {
-  switch (type) {
-    case LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA:
-      return `${config.publicUrl}${getDirectJobPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, id, title)}`
-    case LBA_ITEM_TYPE.RECRUTEURS_LBA:
-      return `${config.publicUrl}${getDirectJobPath(LBA_ITEM_TYPE.RECRUTEURS_LBA, siret!, title)}`
-    default:
-      return `${config.publicUrl}${getDirectJobPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES, id, title)}`
-  }
-}
 
 export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter<IComputedJobsPartners>, shouldNotifySlack = true) => {
   logger.info(`import dans jobs_partners commencé`)

--- a/server/src/jobs/partenaireExport/exportToFranceTravail.ts
+++ b/server/src/jobs/partenaireExport/exportToFranceTravail.ts
@@ -6,7 +6,6 @@ import { promisify } from "util"
 import { stringify } from "csv-stringify"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import { RECRUITER_STATUS } from "shared/constants/recruteur"
-import { getDirectJobPath } from "shared/metier/lbaitemutils"
 import { JOB_STATUS } from "shared/models/index"
 
 import dayjs from "shared/helpers/dayjs"
@@ -16,7 +15,7 @@ import { getDepartmentByZipCode } from "@/common/territoires"
 import { asyncForEach } from "@/common/utils/asyncUtils"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { notifyToSlack } from "@/common/utils/slackUtils"
-import config from "@/config"
+import { buildLbaUrl } from "@/services/jobs/jobOpportunity/jobOpportunity.service"
 
 const pipelineAsync = promisify(pipeline)
 
@@ -52,7 +51,7 @@ const formatData = (offre) => {
     Par_ref_offre: `${ntcCle}-${offre.jobId.toString()}`,
     Par_cle: "LABONNEALTERNANCE",
     Par_nom: "LABONNEALTERNANCE",
-    Par_URL_offre: `${config.publicUrl}${getDirectJobPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, offre.jobId.toString(), offre.rome_detail.rome.intitule)}`,
+    Par_URL_offre: buildLbaUrl(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, offre.jobId.toString(), offre.rome_detail.rome.intitule),
     Code_rome: offre.rome_code[0],
     Code_OGR: appellation.code_ogr,
     Libelle_metier_OGR: appellation.libelle,

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -14,7 +14,7 @@ import { LBA_ITEM_TYPE, UNKNOWN_COMPANY } from "shared/constants/lbaitem"
 import { CFA, ENTREPRISE, RECRUITER_STATUS } from "shared/constants/recruteur"
 import { prepareMessageForMail, removeUrlsFromText } from "shared/helpers/common"
 import dayjs from "shared/helpers/dayjs"
-import { getDirectJobPath } from "shared/metier/lbaitemutils"
+import { buildJobUrlPath } from "shared/metier/lbaitemutils"
 import type { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
 import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
 import type { ITrackingCookies } from "shared/models/trafficSources.model"
@@ -30,6 +30,7 @@ import mailer from "./mailer.service"
 import { validateCaller } from "./queryValidator.service"
 import { saveApplicationTrafficSourceIfAny } from "./trafficSource.service"
 import { validateUserWithAccountEmail } from "./userWithAccount.service"
+import { buildLbaUrl } from "./jobs/jobOpportunity/jobOpportunity.service"
 import { logger } from "@/common/logger"
 import { s3Delete, s3ReadAsString, s3WriteString } from "@/common/utils/awsUtils"
 import { manageApiError } from "@/common/utils/errorManager"
@@ -397,7 +398,7 @@ const buildUrlsOfDetail = (application: IApplication, utm?: { utm_source?: strin
   const defaultUtm = { utm_source: "lba", utm_medium: "email", utm_campaign: "je-candidate" }
   const { utm_campaign, utm_medium, utm_source } = { ...defaultUtm, ...utm }
   const idInUrl = job_origin === LBA_ITEM_TYPE.RECRUTEURS_LBA ? company_siret! : job_id!.toString()
-  const urlWithoutUtm = `${publicUrl}${getDirectJobPath(job_origin, idInUrl, job_title ?? undefined)}`
+  const urlWithoutUtm = buildLbaUrl(job_origin, idInUrl, job_title ?? null)
 
   const searchParams = new URLSearchParams()
   searchParams.append("utm_source", utm_source)
@@ -498,7 +499,7 @@ const buildRecruiterEmailUrlsAndParameters = async (application: IApplication) =
   }
 
   if (application.job_id) {
-    urls.jobUrl = `${config.publicUrl}${getDirectJobPath(application.job_origin, application.job_id.toString())}${utmRecruiterData}`
+    urls.jobUrl = `${config.publicUrl}${buildJobUrlPath(application.job_origin, application.job_id.toString())}${utmRecruiterData}`
     urls.jobProvidedUrl = createProvidedJobLink(userForToken, application.job_id.toString(), application.job_origin, utmRecruiterData)
     urls.cancelJobUrl = createCancelJobLink(userForToken, application.job_id.toString(), application.job_origin, utmRecruiterData)
   }

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -23,6 +23,7 @@ import type {
 } from "shared/routes/v3/jobs/jobs.routes.v3.model"
 import { JOB_PUBLISHING_STATUS, jobsRouteApiv3Converters, zJobOfferApiReadV3, zJobRecruiterApiReadV3 } from "shared/routes/v3/jobs/jobs.routes.v3.model"
 
+import { buildJobUrlPath } from "shared/metier/lbaitemutils"
 import type { JobOpportunityRequestContext } from "./JobOpportunityRequestContext"
 import { logger } from "@/common/logger"
 import type { IApiError } from "@/common/utils/errorManager"
@@ -501,12 +502,12 @@ export const getJobsPartnersForApi = async ({
     : [JOBPARTNERS_LABEL.RECRUTEURS_LBA, JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA]
   const jobsPartners = await getJobsPartnersFromDB({ romes, geo, target_diploma_level, partners_to_exclude: partnersToExclude, opco, departements, elligibleHandicapFilter: false })
 
-  return jobsPartners.map((j) =>
+  return jobsPartners.map((job) =>
     jobsRouteApiv3Converters.convertToJobOfferApiReadV3({
-      ...j,
-      contract_type: j.contract_type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
-      apply_url: getApplyUrl(j),
-      apply_recipient_id: j.apply_email ? getRecipientID(JobCollectionName.partners, j._id.toString()) : null,
+      ...job,
+      contract_type: job.contract_type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
+      apply_url: buildApplyUrlFromJob(job),
+      apply_recipient_id: job.apply_email ? getRecipientID(JobCollectionName.partners, job._id.toString()) : null,
     })
   )
 }
@@ -536,7 +537,7 @@ export const convertLbaCompanyToJobRecruiterApi = (recruteursLba: IJobsPartnersO
         },
       },
       apply: {
-        url: buildApplyUrl(recruteurLba.workplace_siret!, recruteurLba.workplace_legal_name!, LBA_ITEM_TYPE.RECRUTEURS_LBA),
+        url: buildLbaUrl(LBA_ITEM_TYPE.RECRUTEURS_LBA, recruteurLba._id, recruteurLba.workplace_siret, recruteurLba.workplace_legal_name!),
         phone: recruteurLba.apply_phone,
         recipient_id: recruteurLba.apply_email ? getRecipientID(JobCollectionName.partners, recruteurLba._id.toString()) : null,
       },
@@ -684,12 +685,12 @@ async function findLbaJobOpportunities({ romes, geo, target_diploma_level, depar
     elligibleHandicapFilter: false,
   })
 
-  return jobsPartners.map((j) =>
+  return jobsPartners.map((job) =>
     jobsRouteApiv3Converters.convertToJobOfferApiReadV3({
-      ...j,
-      contract_type: j.contract_type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
-      apply_url: getApplyUrl(j),
-      apply_recipient_id: j.apply_email ? getRecipientID(JobCollectionName.partners, j._id.toString()) : null,
+      ...job,
+      contract_type: job.contract_type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
+      apply_url: buildApplyUrlFromJob(job),
+      apply_recipient_id: job.apply_email ? getRecipientID(JobCollectionName.partners, job._id.toString()) : null,
     })
   )
 }
@@ -990,7 +991,7 @@ export const jobsPartnersToApiV3Read = (job: IJobsPartnersOfferPrivate): IJobOff
   jobsRouteApiv3Converters.convertToJobOfferApiReadV3({
     ...job,
     contract_type: job.contract_type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
-    apply_url: getApplyUrl(job),
+    apply_url: buildApplyUrlFromJob(job),
     apply_recipient_id: job.apply_email ? `partners_${job._id}` : null,
     is_delegated: job.is_delegated ?? false,
   })
@@ -1038,7 +1039,7 @@ const computedJobsPartnersToPublishing = (job: IComputedJobsPartners): IJobOffer
   }
 }
 
-export const getJobTypeFromPartnerLabel = (jobType: JOBPARTNERS_LABEL): LBA_ITEM_TYPE => {
+const getJobTypeFromPartnerLabel = (jobType: JOBPARTNERS_LABEL): LBA_ITEM_TYPE => {
   if (jobType === JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA) {
     return LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA
   } else if (jobType === JOBPARTNERS_LABEL.RECRUTEURS_LBA) {
@@ -1048,17 +1049,31 @@ export const getJobTypeFromPartnerLabel = (jobType: JOBPARTNERS_LABEL): LBA_ITEM
   }
 }
 
-export const buildApplyUrl = (jobId: string, jobTitle: string, jobType: LBA_ITEM_TYPE): string => {
-  return `${config.publicUrl}/emploi/${jobType}/${jobId}/${encodeURIComponent(jobTitle)}`
+export const buildLbaUrl = (type: LBA_ITEM_TYPE, objectId: string | ObjectId, siret: string | null, title?: string): string => {
+  const id = objectId.toString()
+  switch (type) {
+    case LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA:
+      return `${config.publicUrl}${buildJobUrlPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, id, title)}`
+    case LBA_ITEM_TYPE.RECRUTEURS_LBA:
+      return `${config.publicUrl}${buildJobUrlPath(LBA_ITEM_TYPE.RECRUTEURS_LBA, siret!, title)}`
+    default:
+      return `${config.publicUrl}${buildJobUrlPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES, id, title)}`
+  }
 }
 
-export const getApplyUrl = (job: IJobsPartnersOfferPrivate): string => {
+export const builLbaUrlFromJob = (job: Pick<IJobsPartnersOfferPrivate, "partner_label" | "_id" | "workplace_siret" | "offer_title" | "workplace_naf_label">): string => {
+  const jobType = getJobTypeFromPartnerLabel(job.partner_label as JOBPARTNERS_LABEL)
+  const title = jobType === LBA_ITEM_TYPE.RECRUTEURS_LBA ? job.workplace_naf_label : job.offer_title
+  return buildLbaUrl(jobType, job._id, job.workplace_siret, title ?? undefined)
+}
+
+export const buildApplyUrlFromJob = (
+  job: Pick<IJobsPartnersOfferPrivate, "partner_label" | "apply_url" | "_id" | "workplace_siret" | "offer_title" | "workplace_naf_label">
+): string => {
   if (job.apply_url) {
     return job.apply_url
   }
-  const jobType = getJobTypeFromPartnerLabel(job.partner_label as JOBPARTNERS_LABEL)
-
-  return `${config.publicUrl}/emploi/${jobType}/${jobType === LBA_ITEM_TYPE.RECRUTEURS_LBA ? job.workplace_siret : job._id}/${encodeURIComponent(jobType === LBA_ITEM_TYPE.RECRUTEURS_LBA ? job.workplace_naf_label! : job.offer_title)}`
+  return builLbaUrlFromJob(job)
 }
 
 export const getRecipientID = (type: IJobCollectionName, id: string) => {

--- a/server/src/services/sitemap.service.ts
+++ b/server/src/services/sitemap.service.ts
@@ -1,7 +1,6 @@
 import { ObjectId } from "mongodb"
 import { RECRUITER_STATUS } from "shared/constants/index"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
-import { buildJobUrl } from "shared/metier/lbaitemutils"
 import type { IJob, IRecruiter } from "shared/models/index"
 import { JOB_STATUS } from "shared/models/index"
 import type { ISitemap } from "shared/models/sitemap.model"
@@ -9,10 +8,10 @@ import { hashcode } from "shared/utils/index"
 import { generateSitemapFromUrlEntries } from "shared/utils/sitemapUtils"
 
 import dayjs from "shared/helpers/dayjs"
+import { buildLbaUrl } from "./jobs/jobOpportunity/jobOpportunity.service"
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { notifyToSlack } from "@/common/utils/slackUtils"
-import config from "@/config"
 
 type AggregateRecruiter = Pick<Omit<IRecruiter, "jobs">, "updatedAt"> & {
   jobs: Pick<IJob, "job_update_date" | "_id" | "rome_label" | "rome_appellation_label" | "offer_title_custom">
@@ -35,11 +34,11 @@ const generateSitemapXml = async () => {
       const { job_update_date, _id, rome_label, rome_appellation_label, offer_title_custom } = job
       const lastMod = job_update_date && dayjs(updatedAt).isBefore(job_update_date) ? job_update_date : updatedAt
       const jobTitle = offer_title_custom ?? rome_appellation_label ?? rome_label
-      const url = `${config.publicUrl}${buildJobUrl(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, _id.toString(), jobTitle ?? undefined)}`
+      const url = buildLbaUrl(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, _id, jobTitle ?? null)
       return {
         loc: url,
         lastmod: lastMod,
-        changefreq: "daily",
+        changefreq: "daily" as const,
       }
     })
   )

--- a/shared/src/metier/lbaitemutils.test.ts
+++ b/shared/src/metier/lbaitemutils.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest"
 
 import { LBA_ITEM_TYPE } from "../constants/lbaitem.js"
 
-import { buildJobUrl, buildTrainingUrl, getDirectJobPath } from "./lbaitemutils.js"
+import { buildJobUrlPath, buildTrainingUrl } from "./lbaitemutils.js"
 
 describe("lbautils", () => {
   describe("buildJobUrl", () => {
     it("should build a job URL", () => {
-      expect(buildJobUrl(LBA_ITEM_TYPE.RECRUTEURS_LBA, "123", "Job Title")).toBe("/emploi/recruteurs_lba/123/job-title")
+      expect(buildJobUrlPath(LBA_ITEM_TYPE.RECRUTEURS_LBA, "123", "Job Title")).toBe("/emploi/recruteurs_lba/123/job-title")
     })
   })
 
@@ -19,11 +19,11 @@ describe("lbautils", () => {
 
   describe("getDirectJobPath", () => {
     it("should build a direct job path", () => {
-      expect(getDirectJobPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, "123")).toBe("/emploi/offres_emploi_lba/123/offre")
+      expect(buildJobUrlPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, "123")).toBe("/emploi/offres_emploi_lba/123/offre")
     })
 
     it("should build a direct job path with title", () => {
-      expect(getDirectJobPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, "123", "titre de l'offre")).toBe("/emploi/offres_emploi_lba/123/titre-de-l-offre")
+      expect(buildJobUrlPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, "123", "titre de l'offre")).toBe("/emploi/offres_emploi_lba/123/titre-de-l-offre")
     })
   })
 })

--- a/shared/src/metier/lbaitemutils.ts
+++ b/shared/src/metier/lbaitemutils.ts
@@ -1,7 +1,7 @@
 import type { LBA_ITEM_TYPE } from "../constants/lbaitem.js"
 import { toKebabCase } from "../utils/stringUtils.js"
 
-export const buildJobUrl = (type: LBA_ITEM_TYPE, id: string, title?: string | undefined) => {
+export const buildJobUrlPath = (type: LBA_ITEM_TYPE, id: string, title?: string | undefined) => {
   title = title || "offre"
   return `/emploi/${type}/${encodeURIComponent(id)}/${toKebabCase(title)}`
 }
@@ -9,5 +9,3 @@ export const buildJobUrl = (type: LBA_ITEM_TYPE, id: string, title?: string | un
 export const buildTrainingUrl = (id: string, title: string) => {
   return `/formation/${encodeURIComponent(id)}/${toKebabCase(title)}`
 }
-
-export const getDirectJobPath = buildJobUrl

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabsMenu.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabsMenu.tsx
@@ -8,7 +8,7 @@ import { useState } from "react"
 import { JOB_STATUS } from "shared"
 import { AUTHTYPE } from "shared/constants/index"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
-import { buildJobUrl } from "shared/metier/lbaitemutils"
+import { buildJobUrlPath } from "shared/metier/lbaitemutils"
 
 import type { PopoverMenuAction } from "@/app/(espace-pro)/_components/PopoverMenu"
 import { PopoverMenu } from "@/app/(espace-pro)/_components/PopoverMenu"
@@ -48,7 +48,7 @@ export const OffresTabsMenu = ({
           ariaLabel: `Lien vers les formations pour l'offre ${offerTitle} - nouvelle fenêtre`,
           type: "externalLink",
         }
-  const directLink = `${publicConfig.baseUrl}${buildJobUrl(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, row._id, row.rome_appellation_label || undefined)}`
+  const directLink = `${publicConfig.baseUrl}${buildJobUrlPath(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, row._id, row.rome_appellation_label || undefined)}`
   const isDisabled = row.job_status === "Annulée" || row.job_status === "Pourvue"
 
   const actions: PopoverMenuAction[] = [


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/LBA/boards/14?jql=assignee%20%3D%20712020%3A805c2bc3-b985-42ea-9088-d8d83d9b3925&selectedIssue=LBA-3468

Summary:
- Unified LBA job URL construction by introducing `buildLbaUrl`/`buildApplyUrlFromJob` in job opportunity service and reusing it across jobs, exports, applications, forms, and sitemap.
- Replaced `buildJobUrl`/`getDirectJobPath` with `buildJobUrlPath` in shared utilities and updated tests and UI usage accordingly.
- Added `workplace_naf_label` to URL-building inputs to improve recruiter URL titles and adjusted related mappings.
- Cleaned up imports and minor typings (e.g., `changefreq` literal) to align with new URL helpers.