### PR TITLE
fix: mauvais affichage des captions des table

### DIFF
--- a/ui/app/(espace-pro)/_components/Table.tsx
+++ b/ui/app/(espace-pro)/_components/Table.tsx
@@ -29,7 +29,7 @@ const Table = ({ caption, data, columns }: { caption: string; data: any[]; colum
         <Box className="fr-table__container">
           <Box className="fr-table__content">
             <Box component="table" {...getTableProps()}>
-              <Box sx={{ fontSize: "20px !important", fontWeight: "700", mb: fr.spacing("1w") }} component="caption">
+              <Box sx={{ position: "relative !important", fontSize: "20px !important", fontWeight: "700", mb: fr.spacing("1w") }} component="caption">
                 {caption}
               </Box>
               <Box component="thead">

--- a/ui/app/(espace-pro)/_components/TableWithPagination.tsx
+++ b/ui/app/(espace-pro)/_components/TableWithPagination.tsx
@@ -168,7 +168,7 @@ function TableWithPagination({
           <Box className="fr-table__container">
             <Box className="fr-table__content">
               <Box as="table" {...getTableProps()}>
-                <Box sx={{ fontSize: "20px !important", fontWeight: "700", mb: fr.spacing("1w") }} component="caption">
+                <Box sx={{ position: "relative !important", fontSize: "20px !important", fontWeight: "700", mb: fr.spacing("1w") }} component="caption">
                   {caption}
                 </Box>
                 <Box component="thead">

--- a/ui/components/espace_pro/UserValidationHistory.tsx
+++ b/ui/components/espace_pro/UserValidationHistory.tsx
@@ -35,7 +35,7 @@ const UserValidationHistory = ({ histories }: { histories: IUserStatusValidation
               <Box className="fr-table__container">
                 <Box className="fr-table__content">
                   <Box component="table">
-                    <Box component="caption" sx={{ fontSize: "20px !important", fontWeight: "700", mb: fr.spacing("1w") }}>
+                    <Box component="caption" sx={{ position: "relative !important", fontWeight: "700", mb: fr.spacing("1w") }}>
                       Historique des changements d'état du compte
                     </Box>
                     <Box component="thead">


### PR DESCRIPTION
Les captions des tables sont affichées en positionnement absolute et selon les navigateurs passent en overlap au dessus ou en dessous des coins supérieurs droits du contenu des tables.