### PR TITLE
fix(lba-3633): fix company name display

### DIFF
--- a/ui/components/ItemDetail/ItemDetailServices/JobItemCardHeader.tsx
+++ b/ui/components/ItemDetail/ItemDetailServices/JobItemCardHeader.tsx
@@ -29,7 +29,7 @@ export default function JobItemCardHeader({ selectedItem, kind, isMandataire, is
           <Typography component="span" sx={{ fontWeight: 400 }}>
             Le centre de formation&nbsp;
           </Typography>
-          <Typography component="span">{companyName}</Typography>
+          <Typography component="span" dangerouslySetInnerHTML={{ __html: companyName }} />
           <Typography component="span" sx={{ fontWeight: 400 }}>
             &nbsp;propose actuellement cette offre dans le domaine suivant
           </Typography>
@@ -42,7 +42,7 @@ export default function JobItemCardHeader({ selectedItem, kind, isMandataire, is
         <Typography component="p" sx={{ ...detailActivityProperties, my: 1 }}>
           {companyName ? (
             <>
-              <Typography component="span">{companyName}</Typography>
+              <Typography component="span" dangerouslySetInnerHTML={{ __html: companyName }} />
               <Typography component="span" sx={{ fontWeight: 400 }}>
                 &nbsp;recherche un.e alternant.e pour le poste suivant :
               </Typography>
@@ -68,7 +68,7 @@ export default function JobItemCardHeader({ selectedItem, kind, isMandataire, is
     if (kind === LBA_ITEM_TYPE.RECRUTEURS_LBA) {
       res = (
         <Typography component="p" sx={{ ...detailActivityProperties, my: 1 }}>
-          <Typography component="span">{companyName}</Typography>
+          <Typography component="span" dangerouslySetInnerHTML={{ __html: companyName }} />
           <Typography component="span" sx={{ fontWeight: 400 }}>
             &nbsp;a des salariés qui exercent le métier auquel vous vous destinez. Envoyez votre candidature spontanée !
           </Typography>


### PR DESCRIPTION
This pull request updates the way company names are rendered in the `JobItemCardHeader` component to allow HTML content within the company name. The main change is the use of `dangerouslySetInnerHTML` instead of rendering the company name as plain text, which enables support for HTML formatting in company names.

### Rendering improvements

* Updated all instances of `<Typography>{companyName}</Typography>` to use `<Typography dangerouslySetInnerHTML={{ __html: companyName }} />` in `JobItemCardHeader.tsx` to allow HTML content in company names. [[1]](diffhunk://#diff-99b6c340287aab07d354d5fd8b0383b55d9266d2edb8d948a3254d386ac57534L32-R32) [[2]](diffhunk://#diff-99b6c340287aab07d354d5fd8b0383b55d9266d2edb8d948a3254d386ac57534L45-R45) [[3]](diffhunk://#diff-99b6c340287aab07d354d5fd8b0383b55d9266d2edb8d948a3254d386ac57534L71-R71)