### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,7 @@ jobs:
       DEPLOY_PASS: ${{ secrets.DEPLOY_PASS }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       VAULT_PWD: ${{ secrets.VAULT_PWD }}
+      OPENPGP_PRIVATE_SUBKEY: ${{ secrets.OPENPGP_PRIVATE_SUBKEY }}
 
   deploy-pentest:
     concurrency:
@@ -255,6 +256,7 @@ jobs:
       DEPLOY_PASS: ${{ secrets.DEPLOY_PASS }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       VAULT_PWD: ${{ secrets.VAULT_PWD }}
+      OPENPGP_PRIVATE_SUBKEY: ${{ secrets.OPENPGP_PRIVATE_SUBKEY }}
 
   sentry:
     needs: ["release"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,7 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       VAULT_PWD: ${{ secrets.VAULT_PWD }}
       OPENPGP_PRIVATE_SUBKEY: ${{ secrets.OPENPGP_PRIVATE_SUBKEY }}
+      TOKEN_MNA_SHARED: ${{ secrets.TOKEN_MNA_SHARED }}
 
   deploy-pentest:
     concurrency:
@@ -257,6 +258,7 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       VAULT_PWD: ${{ secrets.VAULT_PWD }}
       OPENPGP_PRIVATE_SUBKEY: ${{ secrets.OPENPGP_PRIVATE_SUBKEY }}
+      TOKEN_MNA_SHARED: ${{ secrets.TOKEN_MNA_SHARED }}
 
   sentry:
     needs: ["release"]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/release.yml` to include two new secret environment variables for the `deploy` and `deploy-pentest` jobs. These changes improve the deployment process by ensuring that the necessary secrets are available for secure operations.

**Deployment secrets added:**

* Added `OPENPGP_PRIVATE_SUBKEY` and `TOKEN_MNA_SHARED` as environment variables to the `deploy` job.
* Added `OPENPGP_PRIVATE_SUBKEY` and `TOKEN_MNA_SHARED` as environment variables to the `deploy-pentest` job.