### PR TITLE
fix: remove old secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,6 @@ jobs:
       DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
       DEPLOY_PASS: ${{ secrets.DEPLOY_PASS }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-      VAULT_PWD: ${{ secrets.VAULT_PWD }}
       OPENPGP_PRIVATE_SUBKEY: ${{ secrets.OPENPGP_PRIVATE_SUBKEY }}
       TOKEN_MNA_SHARED: ${{ secrets.TOKEN_MNA_SHARED }}
 
@@ -256,7 +255,6 @@ jobs:
       DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
       DEPLOY_PASS: ${{ secrets.DEPLOY_PASS }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-      VAULT_PWD: ${{ secrets.VAULT_PWD }}
       OPENPGP_PRIVATE_SUBKEY: ${{ secrets.OPENPGP_PRIVATE_SUBKEY }}
       TOKEN_MNA_SHARED: ${{ secrets.TOKEN_MNA_SHARED }}
 


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration by removing the use of the `VAULT_PWD` secret from the environment variables in the `release.yml` workflow. This streamlines the workflow by eliminating an unused or unnecessary secret. 

- Removed the `VAULT_PWD` secret from the environment variables in the `.github/workflows/release.yml` workflow file. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L242) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L259)