### PR TITLE
fix: release checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
+          token: ${{ secrets.TOKEN_MNA_SHARED }}
+          persist-credentials: false
+          submodules: recursive
           fetch-depth: 0
-          persist-credentials: true
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.TOKEN_MNA_SHARED }}
           persist-credentials: false


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases to improve security and repository checkout behavior. The most important changes are:

**Workflow dependency updates and security improvements:**

* Upgraded the `actions/checkout` action from version 5 to version 6 for improved features and security.
* Changed the `token` used for checkout to `${{ secrets.TOKEN_MNA_SHARED }}` to use a shared secret for authentication.
* Explicitly set `persist-credentials` to `false` instead of `true` to prevent credentials from being persisted, enhancing security.

**Repository checkout behavior:**

* Enabled recursive checkout of submodules by setting `submodules: recursive`.
* Maintained `fetch-depth: 0` to ensure the full history is fetched.