### PR TITLE
fix(release): sentry & disable pentest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.TOKEN_MNA_SHARED }}
@@ -136,14 +136,17 @@ jobs:
           CI: true
 
   build-ui-pentest:
+    if: false # disabled for now
     needs: ["release"]
-    if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
+    # if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.TOKEN_MNA_SHARED }}
+          submodules: true
 
       - uses: actions/setup-node@v6
         with:
@@ -245,6 +248,7 @@ jobs:
       TOKEN_MNA_SHARED: ${{ secrets.TOKEN_MNA_SHARED }}
 
   deploy-pentest:
+    if: false # disabled for now
     concurrency:
       group: "deploy-pentest-${{ github.workflow }}-${{ github.ref }}"
     needs: ["release", "build-ui-pentest"]
@@ -265,10 +269,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
+          token: ${{ secrets.TOKEN_MNA_SHARED }}
+          persist-credentials: false
+          submodules: recursive
           fetch-depth: 0
-          persist-credentials: true
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/release.yml`, focusing on dependency upgrades and temporarily disabling pentest-related jobs. The changes improve security and compatibility by updating action versions and adjusting job configurations.

Dependency upgrades:

* Updated `actions/checkout` from version 5 to version 6 in multiple jobs to ensure compatibility and benefit from security improvements. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L94-R94) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R139-R149) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L268-L271)
* Added and updated parameters for `actions/checkout`, including `token`, `submodules`, and `persist-credentials`, to enhance security and support submodule handling. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R139-R149) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L268-L271)

Workflow configuration changes:

* Disabled the `build-ui-pentest` and `deploy-pentest` jobs by setting `if: false`, temporarily preventing them from running in the workflow. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R139-R149) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R251)