### PR TITLE
fix(lba-3659): mobile search filter display error 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ Scanner les secrets dans le repo
   yarn gitleaks:check
 ```
 
-
 #### SOPS
 
 Édition des variables d'environnement.

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RecherchePageComponent.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RecherchePageComponent.tsx
@@ -27,10 +27,6 @@ function RecherchePageComponentWithParams(props: { rechercheParams: IRecherchePa
   const rechercheResult = useRechercheResults(props.rechercheParams)
   const virtualizerRef = useRef<Virtualizer<any, Element>>(null)
 
-  if (displayMobileForm) {
-    return <RechercheMobileFormUpdate rechercheParams={props.rechercheParams} />
-  }
-
   const elements: ReturnType<typeof RechercheResultatsList> = []
 
   const scrollToItem = (item: ResultCardData) => {
@@ -49,6 +45,10 @@ function RecherchePageComponentWithParams(props: { rechercheParams: IRecherchePa
     },
     ...RechercheResultatsList({ ...props, scrollToItem })
   )
+
+  if (displayMobileForm) {
+    return <RechercheMobileFormUpdate rechercheParams={props.rechercheParams} />
+  }
 
   const getScolledElementIndex = () => {
     return elements.findIndex((element) => {

--- a/ui/app/(candidat)/(recherche)/recherche/page.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/page.tsx
@@ -1,5 +1,3 @@
-"use server"
-
 import type { Metadata } from "next"
 import { permanentRedirect } from "next/navigation"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"


### PR DESCRIPTION
## Analyse du problème

### Ce qui se passait

1. `RechercheResultatsList` était appelé comme une fonction (ligne 50), et non rendu comme un composant JSX
2. Il utilisait des hooks en interne : `useRechercheResults`, `useWhispers`, `useMemo`, `useSearchViewNotifier`
3. Le return anticipé à la ligne 30 (`if (displayMobileForm)`) sautait complètement cet appel
4. React détectait moins de hooks que lors du rendu précédent, causant l'erreur "Rendered fewer hooks than expected", qui était capturée par l'error boundary et affichée comme une page d'erreur

### La solution

Le return anticipé a été déplacé après l'appel à `RechercheResultatsList` afin que tous les hooks soient toujours exécutés, quel que soit le flag `displayMobileForm`. Le résultat de `RechercheResultatsList` est simplement inutilisé lorsque `displayMobileForm` est true, mais les hooks sont correctement appelés.