### PR TITLE
feat(lba-3660): review preview memory

### DIFF
--- a/.infra/docker-compose.preview-system.yml
+++ b/.infra/docker-compose.preview-system.yml
@@ -2,7 +2,7 @@ x-default: &default
   deploy:
     resources:
       limits:
-        memory: 1g
+        memory: 128M
   restart: always
   networks:
     - mna_network

--- a/.infra/docker-compose.preview-system.yml
+++ b/.infra/docker-compose.preview-system.yml
@@ -2,7 +2,7 @@ x-default: &default
   deploy:
     resources:
       limits:
-        memory: 128M
+        memory: 128m
   restart: always
   networks:
     - mna_network

--- a/.infra/docker-compose.preview.yml
+++ b/.infra/docker-compose.preview.yml
@@ -2,7 +2,7 @@ x-default: &default
   deploy:
     resources:
       limits:
-        memory: 512M
+        memory: 512m
   restart: always
   networks:
     - mna_network
@@ -38,7 +38,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          memory: 256m
     image: "ghcr.io/mission-apprentissage/mna_lba_ui:0.0.0-{{pr_number}}-preview"
     container_name: lba_{{pr_number}}_ui
     env_file: .env_ui

--- a/.infra/docker-compose.preview.yml
+++ b/.infra/docker-compose.preview.yml
@@ -2,7 +2,7 @@ x-default: &default
   deploy:
     resources:
       limits:
-        memory: 1g
+        memory: 512M
   restart: always
   networks:
     - mna_network
@@ -35,6 +35,10 @@ services:
 
   ui:
     <<: *default
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     image: "ghcr.io/mission-apprentissage/mna_lba_ui:0.0.0-{{pr_number}}-preview"
     container_name: lba_{{pr_number}}_ui
     env_file: .env_ui


### PR DESCRIPTION
This pull request adjusts the memory limits for several services in the Docker Compose preview configurations. The main focus is on optimizing resource usage by lowering memory allocations for different services.

**Resource limit adjustments:**

* Reduced the default memory limit for services in `.infra/docker-compose.preview-system.yml` from `1g` to `128M`.
* Reduced the default memory limit for services in `.infra/docker-compose.preview.yml` from `1g` to `512M`.
* Added a specific memory limit of `256M` for the `ui` service in `.infra/docker-compose.preview.yml`.