### PR TITLE
fix(preview): optimize preview memory usage

### DIFF
--- a/.infra/docker-compose.preview-system.yml
+++ b/.infra/docker-compose.preview-system.yml
@@ -48,7 +48,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 7g
+          memory: 5g
     ports:
       - "127.0.0.1:27017:27017"
     command: ["-f", "/etc/mongod/mongod.conf"]
@@ -64,24 +64,26 @@ services:
     labels:
       - autoheal=true
 
-  clamav:
-    <<: *default
-    image: clamav/clamav:latest
-    container_name: lba_clamav
-    deploy:
-      resources:
-        limits:
-          memory: 1.5g
-    volumes:
-      - /opt/app/data/clamav:/var/lib/clamav
-      - /opt/app/configs/clamav/clamd.conf:/etc/clamav/clamd.conf
-    healthcheck:
-      test: ["CMD", "/usr/local/bin/clamdcheck.sh"]
-      interval: 60s
-      retries: 3
-      start_period: 6m
-    labels:
-      - autoheal=true
+  # ClamAV désactivé en preview pour économiser 1.5Go de RAM
+  # Le scan antivirus n'est pas nécessaire en preview (données de seed uniquement)
+  # clamav:
+  #   <<: *default
+  #   image: clamav/clamav:latest
+  #   container_name: lba_clamav
+  #   deploy:
+  #     resources:
+  #       limits:
+  #         memory: 1.5g
+  #   volumes:
+  #     - /opt/app/data/clamav:/var/lib/clamav
+  #     - /opt/app/configs/clamav/clamd.conf:/etc/clamav/clamd.conf
+  #   healthcheck:
+  #     test: ["CMD", "/usr/local/bin/clamdcheck.sh"]
+  #     interval: 60s
+  #     retries: 3
+  #     start_period: 6m
+  #   labels:
+  #     - autoheal=true
 
   smtp:
     <<: *default

--- a/.infra/docker-compose.preview.yml
+++ b/.infra/docker-compose.preview.yml
@@ -58,6 +58,10 @@ services:
 
   jobs_processor:
     <<: *default
+    deploy:
+      resources:
+        limits:
+          memory: 300m
     image: "ghcr.io/mission-apprentissage/mna_lba_server:0.0.0-{{pr_number}}"
     container_name: lba_{{pr_number}}_jobs_processor
     command: ["yarn", "cli", "job_processor:start"]
@@ -67,6 +71,10 @@ services:
 
   stream_processor:
     <<: *default
+    deploy:
+      resources:
+        limits:
+          memory: 300m
     image: "ghcr.io/mission-apprentissage/mna_lba_server:0.0.0-{{pr_number}}"
     container_name: lba_{{pr_number}}_stream_processor
     command: ["yarn", "cli", "stream_processor:start"]

--- a/.infra/files/configs/mongodb/mongod.conf
+++ b/.infra/files/configs/mongodb/mongod.conf
@@ -1,6 +1,11 @@
 net:
   bindIpAll: true
-  
+
+storage:
+  wiredTiger:
+    engineConfig:
+      cacheSizeGB: 2
+
 replication:
   replSetName: replica
 


### PR DESCRIPTION
This pull request introduces optimizations to the preview environment's resource usage, mainly targeting memory allocation for services. The changes reduce memory consumption for MongoDB and disable the ClamAV antivirus service in preview mode, while also adding explicit memory limits for background processors.

Resource optimization for MongoDB:

* Reduced MongoDB container memory limit from 7GB to 5GB in `.infra/docker-compose.preview-system.yml` for more efficient resource usage.
* Added `storage.wiredTiger.engineConfig.cacheSizeGB: 2` to `.infra/files/configs/mongodb/mongod.conf` to explicitly limit MongoDB's internal cache size to 2GB.

Preview environment simplification:

* Disabled the ClamAV antivirus service in `.infra/docker-compose.preview-system.yml` to save 1.5GB RAM, since antivirus scanning is unnecessary for seed data in preview mode.

Explicit memory limits for background processors:

* Added a 300MB memory limit for the `jobs_processor` service in `.infra/docker-compose.preview.yml`.
* Added a 300MB memory limit for the `stream_processor` service in `.infra/docker-compose.preview.yml`.