### PR TITLE
fix(lba-3670): slow query - add dedicated 2dsphere index for partner jobs geo search

### DIFF
--- a/server/src/migrations/20260218174124-update-indexes.ts
+++ b/server/src/migrations/20260218174124-update-indexes.ts
@@ -1,0 +1,8 @@
+import { recreateIndexes } from "@/jobs/database/recreateIndexes"
+
+export const up = async () => {
+  await recreateIndexes()
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/shared/src/models/jobsPartners.model.ts
+++ b/shared/src/models/jobsPartners.model.ts
@@ -292,6 +292,7 @@ export default {
   zod: ZJobsPartnersOfferPrivate,
   indexes: [
     [{ workplace_geopoint: "2dsphere", offer_multicast: 1, offer_rome_codes: 1, offer_status: 1, offer_expiration: 1, partner_label: 1, "offer_target_diploma.european": 1 }, {}],
+    [{ workplace_geopoint: "2dsphere", offer_status: 1, offer_expiration: 1, partner_label: 1, offer_rome_codes: 1, "offer_target_diploma.european": 1 }, {}],
     [{ offer_multicast: 1, offer_rome_codes: 1, offer_creation: -1 }, {}],
     [{ offer_multicast: 1, "offer_target_diploma.european": 1, offer_creation: -1 }, {}],
     [{ partner_label: 1, partner_job_id: 1 }, { unique: true }],


### PR DESCRIPTION
## Summary

  - Ajout d'un index compound `2dsphere` dédié à `getJobsPartnersFromDBForUI` sur la collection `jobs_partners`
  - L'index existant `{ workplace_geopoint: "2dsphere", offer_multicast, ... }` n'est pas exploité efficacement par cette requête car elle ne filtre pas sur `offer_multicast`, cassant le préfixe du compound index
  - Le nouvel index `{ workplace_geopoint: "2dsphere", offer_status, offer_expiration, partner_label, offer_rome_codes, offer_target_diploma.european }` couvre directement les filtres de la requête

  ## Context

  Requête identifiée comme la plus lente de la base via Percona :
  - **9 sec de temps moyen** par exécution
  - **37% du query time total** du serveur
  - ~14k exécutions sur la période observée

  Le problème vient du fait que `getJobsPartnersFromDBForUI` n'inclut pas `offer_multicast` dans son filtre `$geoNear`, contrairement à `getJobsPartnersFromDB`. Le champ `offer_multicast` étant le 2e champ de
  l'index compound, les champs suivants (`offer_status`, `offer_rome_codes`, etc.) ne peuvent pas être utilisés pour le filtrage au niveau de l'index.