### PR TITLE
fix(lba-3671): import plausible en double

### DIFF
--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,7 +1,6 @@
 //import { Alert, AlertTitle } from "@mui/material"
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter"
 import type { Metadata } from "next"
-import PlausibleProvider from "next-plausible"
 import type { PropsWithChildren } from "react"
 import { setupZodErrorMap } from "shared/helpers/zodHelpers/setupZodErrorMap"
 
@@ -47,7 +46,6 @@ export default function RootLayout({ children }: PropsWithChildren) {
           ]}
           doDisableFavicon={true}
         />
-        <PlausibleProvider domain={publicConfig.host} />
         <Matomo />
       </head>
       <body>


### PR DESCRIPTION
This pull request removes the usage of the `PlausibleProvider` analytics component from the application layout. This means Plausible analytics tracking is no longer initialized on every page load.

Analytics:

* Removed the import and usage of `PlausibleProvider` from `ui/app/layout.tsx`, disabling Plausible analytics tracking across the app. [[1]](diffhunk://#diff-4a94f97c3780c3f5947219ccdf5f45f018f0429e70ec97516768012c0a79a64bL4) [[2]](diffhunk://#diff-4a94f97c3780c3f5947219ccdf5f45f018f0429e70ec97516768012c0a79a64bL50)