### PR TITLE
fix(lba-3526): supprimer les mentions à cfa dock

### DIFF
--- a/docs/DATASOURCES.md
+++ b/docs/DATASOURCES.md
@@ -41,12 +41,6 @@ https://adresse.data.gouv.fr/
 
 Récupération des coordonnées géographiques entreprises
 
-## API CFADock
-
-https://www.cfadock.fr
-
-Récupération des OPCO & IDCC des entreprises
-
 ## France Competence
 
 https://www.francecompetences.fr

--- a/server/src/http/controllers/etablissementRecruteur.controller.ts
+++ b/server/src/http/controllers/etablissementRecruteur.controller.ts
@@ -103,7 +103,7 @@ export default (server: Server) => {
   )
 
   /**
-   * Récupérer l'OPCO d'une entreprise à l'aide des données en base ou de l'API CFA DOCK
+   * Récupérer l'OPCO d'une entreprise à l'aide des données en base
    */
   server.get(
     "/etablissement/entreprise/:siret/opco",


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3526

Car CFA Dock n'est plus utilisé par LBA