### PR TITLE
fix(lba-3689): permet le passage des candidatures en preview

### DIFF
--- a/server/src/services/clamav.service.ts
+++ b/server/src/services/clamav.service.ts
@@ -8,6 +8,8 @@ import { notifyToSlack } from "@/common/utils/slackUtils"
 import config from "@/config"
 import { sentryCaptureException, startSentryPerfRecording } from "@/common/utils/sentryUtils"
 
+const isClamavDisabled = config.env === "preview"
+
 let clamavCache: Promise<NodeClam> | null = null
 let watcher: NodeJS.Timeout | null = null
 
@@ -71,6 +73,10 @@ export async function getVersion(): Promise<string> {
 }
 
 export async function isClamavAvailable(): Promise<boolean> {
+  if (isClamavDisabled) {
+    logger.info("ClamAV is disabled in preview environment, skipping availability check")
+    return true
+  }
   try {
     await getVersion()
     return true
@@ -80,6 +86,10 @@ export async function isClamavAvailable(): Promise<boolean> {
 }
 
 export async function isInfected(file: string): Promise<boolean> {
+  if (isClamavDisabled) {
+    logger.info("ClamAV is disabled in preview environment, skipping virus scan")
+    return false
+  }
   let _isInfected: boolean = false
   await startSentryPerfRecording({ name: "clamav", operation: "scan" }, async () => {
     const clamav = await getClamav()


### PR DESCRIPTION
⏺ Résumé des modifications

  Fichier modifié : server/src/services/clamav.service.ts

  Problème : Quand ClamAV est désactivé en preview, isClamavAvailable() retourne false, ce qui bloque tout le pipeline processApplications (scan antivirus + envoi d'emails). Les candidatures restent en statut
  WAITING_FOR_SCAN indéfiniment.

  Solution : Ajout d'un guard isClamavDisabled basé sur config.env === "preview" à deux endroits :

  1. isClamavAvailable() (ligne 76) — retourne true directement, permettant à processApplications d'entrer dans le bloc de traitement
  2. isInfected() (ligne 89) — retourne false directement, considérant tous les fichiers comme sains (pas de connexion TCP tentée)

  Les deux cas loggent un message info pour traçabilité. En production/recette, le comportement reste inchangé.