### PR TITLE
fix: no index restore seed mongodb

### DIFF
--- a/.infra/files/scripts/seed.sh
+++ b/.infra/files/scripts/seed.sh
@@ -34,4 +34,5 @@ echo "Restoring database $TARGET_DB..."
   --nsTo="$TARGET_DB.*" \
   --drop \
   --gzip \
+  --noIndexRestore \
   "mongodb://__system:{{ MONGODB_KEYFILE }}@localhost:27017/?authSource=local&directConnection=true"


### PR DESCRIPTION
This pull request makes a small but important change to the database seeding script. The change disables index restoration during the database restore process, which can help speed up the restore and avoid potential issues with index compatibility.

* Added the `--noIndexRestore` option to the `mongorestore` command in `seed.sh` to prevent indexes from being restored.