### PR TITLE
fix: preview buildx & docker optimization

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -78,6 +78,10 @@ jobs:
         with:
           platforms: linux/amd64
           install: true
+          buildkitd-config-inline: |
+            [worker.oci]
+              gc = true
+              gckeepstorage = 10240
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -99,6 +103,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
+
+      - name: Prune BuildKit cache
+        run: docker buildx prune --filter until=24h --force
+        if: always()
 
   deploy:
     concurrency:

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,6 @@ WORKDIR /app
 FROM root AS builder_server
 WORKDIR /app
 
-COPY ./server ./server
-COPY ./shared ./shared
-
 RUN yarn --cwd server build
 
 RUN mkdir -p /app/shared/node_modules && mkdir -p /app/server/node_modules
@@ -51,10 +48,8 @@ ARG COMMIT_HASH
 ENV COMMIT_HASH=$COMMIT_HASH
 
 COPY --from=builder_server /app/server ./server
-COPY --from=builder_server /app/shared ./shared
 COPY --from=builder_server /app/node_modules ./node_modules
 COPY --from=builder_server /app/server/node_modules ./server/node_modules
-COPY --from=builder_server /app/shared/node_modules ./shared/node_modules
 COPY ./server/static /app/server/static
 
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN yarn install --immutable
 
 COPY . .
 
-RUN yarn typecheck
+RUN yarn --cwd shared build
 
 FROM builder_root AS root
 WORKDIR /app
@@ -86,6 +86,7 @@ ENV __RRWEB_EXCLUDE_IFRAME__=true
 ENV __RRWEB_EXCLUDE_SHADOW_DOM__=true
 ENV __SENTRY_EXCLUDE_REPLAY_WORKER__=true
 
+ENV NODE_OPTIONS="--max-old-space-size=3072"
 RUN --mount=type=cache,target=/app/ui/.next/cache yarn --cwd ui build
 
 # Production image, copy all the files and run next


### PR DESCRIPTION
This pull request introduces optimizations to the Docker build process and improvements to the GitHub Actions workflow for building and caching Docker images. The main focus is on improving build efficiency, cache management, and resource usage.

**Docker build optimizations:**
- Replaces the `yarn typecheck` step with a `yarn --cwd shared build` step to ensure the `shared` package is built before proceeding.
- Removes redundant `COPY` commands for the `shared` directory and its `node_modules` in the final image, streamlining the build context and reducing image size.
- Adds `NODE_OPTIONS="--max-old-space-size=3072"` to increase Node.js memory limit during the UI build, which helps prevent out-of-memory errors.

**GitHub Actions workflow improvements:**
- Adds an inline BuildKit configuration to enable garbage collection and set a storage limit for build cache, helping manage disk usage during builds.
- Adds a step to prune the BuildKit cache older than 24 hours after each build, further controlling cache growth and disk consumption.