### PR TITLE
fix: recruteurs_lba - move blacklisting outside imports

### DIFF
--- a/server/src/jobs/offrePartenaire/fillComputedRecruteursLba.ts
+++ b/server/src/jobs/offrePartenaire/fillComputedRecruteursLba.ts
@@ -7,7 +7,11 @@ import type { FillComputedJobsPartnersContext } from "./fillComputedJobsPartners
 import { fillEntrepriseEngagementComputedJobsPartners } from "./fillEntrepriseEngagementComputedJobsPartners"
 import { fillLocationInfosForPartners } from "./fillLocationInfosForPartners"
 import { fillOpcoInfosForPartners } from "./fillOpcoInfosForPartners"
-import { removeMissingRecruteursLbaFromComputedJobPartners, removeUnsubscribedRecruteursLbaFromComputedJobPartners } from "./recruteur-lba/importRecruteursLbaRaw"
+import {
+  clearBlacklistedEmailsRecruteursLba,
+  removeMissingRecruteursLbaFromComputedJobPartners,
+  removeUnsubscribedRecruteursLbaFromComputedJobPartners,
+} from "./recruteur-lba/importRecruteursLbaRaw"
 import { validateComputedJobPartners } from "./validateComputedJobPartners"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 
@@ -20,6 +24,7 @@ export const fillComputedRecruteursLba = async () => {
 
   await removeMissingRecruteursLbaFromComputedJobPartners()
   await removeUnsubscribedRecruteursLbaFromComputedJobPartners()
+  await clearBlacklistedEmailsRecruteursLba()
   // reset checks
   await getDbCollection("computed_jobs_partners").updateMany(computedJobFilter, { $set: { business_error: null, jobs_in_success: [], errors: [] } })
   await fillEntrepriseEngagementComputedJobsPartners(context)

--- a/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
@@ -19,7 +19,6 @@ import { sentryCaptureException } from "@/common/utils/sentryUtils"
 import { notifyToSlack } from "@/common/utils/slackUtils"
 import { groupStreamData } from "@/common/utils/streamUtils"
 import config from "@/config"
-import { isEmailBlacklisted } from "@/services/application.service"
 
 const require = createRequire(import.meta.url)
 
@@ -136,14 +135,12 @@ export const importRecruteurLbaToComputed = async () => {
             }
           }
 
-          const isEmailBl = apply_email ? await isEmailBlacklisted(apply_email) : false
-
           operations.push({
             updateOne: {
               filter: { workplace_siret: rest.workplace_siret },
               update: {
                 $set: {
-                  apply_email: isEmailBl ? null : apply_email,
+                  apply_email,
                   apply_phone,
                   offer_creation,
                   updated_at: importDate,
@@ -268,4 +265,30 @@ export const removeUnsubscribedRecruteursLbaFromComputedJobPartners = async () =
     subject: `mapping Raw => computed_jobs_partners`,
     message,
   })
+}
+
+export const clearBlacklistedEmailsRecruteursLba = async () => {
+  logger.info("clearBlacklistedEmailsRecruteursLba: chargement de la blacklist emails")
+  const blacklistedEmails = new Set(
+    (
+      await getDbCollection("emailblacklists")
+        .find({}, { projection: { email: 1 } })
+        .toArray()
+    ).map((d) => d.email as string)
+  )
+  logger.info(`clearBlacklistedEmailsRecruteursLba: ${blacklistedEmails.size} emails blacklistés chargés`)
+
+  const cursor = getDbCollection("computed_jobs_partners")
+    .find({ partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA, apply_email: { $ne: null } }, { projection: { _id: 1, apply_email: 1 } })
+    .stream()
+
+  let total = 0
+  for await (const doc of cursor as AsyncIterable<{ _id: IComputedJobsPartners["_id"]; apply_email: string }>) {
+    if (blacklistedEmails.has(doc.apply_email)) {
+      await getDbCollection("computed_jobs_partners").updateOne({ _id: doc._id }, { $set: { apply_email: null } })
+      total++
+    }
+  }
+
+  logger.info(`clearBlacklistedEmailsRecruteursLba: terminé, ${total} emails supprimés`)
 }


### PR DESCRIPTION
This pull request introduces a new step in the `fillComputedRecruteursLba` job to ensure that blacklisted emails are removed from the `computed_jobs_partners` collection. The main change is the addition of a function that clears blacklisted emails after removing missing and unsubscribed recruiters. Additionally, the logic that previously filtered blacklisted emails during import has been moved to this new dedicated cleanup step. 

**Enhancements to recruiter email handling:**

* Added a new function, `clearBlacklistedEmailsRecruteursLba`, which loads blacklisted emails from the `emailblacklists` collection and removes them from `computed_jobs_partners` by setting `apply_email` to `null` when a match is found. This function is now called as part of the `fillComputedRecruteursLba` job. [[1]](diffhunk://#diff-f8f4bfb3c145eea5f60d96b2e91b15265864045335860d28707f028aab0789c7L10-R14) [[2]](diffhunk://#diff-f8f4bfb3c145eea5f60d96b2e91b15265864045335860d28707f028aab0789c7R27) [[3]](diffhunk://#diff-324d3b84480f4f378c6d63f2777f6655462a04e63c28311c1bc9f93793302f86R269-R294)

**Refactoring and code simplification:**

* Removed the inline check for blacklisted emails in the `importRecruteurLbaToComputed` function, so all blacklisted email handling is centralized in the new cleanup step.
* Cleaned up unused imports related to email blacklist checking.