### PR TITLE
fix: missing geosphere keys following second 2sphere index

### DIFF
--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -1146,6 +1146,7 @@ export async function getPartnerJobsCount({
         $geoNear: {
           near: { type: "Point", coordinates: [longitude, latitude] },
           distanceField: "distance",
+          key: "workplace_geopoint",
           maxDistance: radius * 1000,
           spherical: true,
           query: {

--- a/server/src/services/seo.service.ts
+++ b/server/src/services/seo.service.ts
@@ -56,6 +56,7 @@ export const updateSeoVilleActivities = async () => {
           $geoNear: {
             near: { type: "Point", coordinates: [ville.geopoint.long, ville.geopoint.lat] },
             distanceField: "distance",
+            key: "workplace_geopoint",
             maxDistance: DEFAULT_RADIUS_KM * 1000,
             spherical: true,
             query: {


### PR DESCRIPTION
This pull request introduces a minor but important update to how geospatial queries are performed in two service methods. The main change is the explicit specification of the geospatial index key in `$geoNear` queries, which improves the accuracy and performance of location-based searches.

**Geospatial query improvements:**

* Added the `key: "workplace_geopoint"` property to the `$geoNear` stage in the `getPartnerJobsCount` method in `jobOpportunity.service.ts` to ensure the correct geospatial index is used.
* Added the `key: "workplace_geopoint"` property to the `$geoNear` stage in the `updateSeoVilleActivities` function in `seo.service.ts` for more precise geospatial filtering.