### PR TITLE
fix(lba-3680): only display active recruteurs_lba

### DIFF
--- a/server/src/services/recruteurLba.service.test.ts
+++ b/server/src/services/recruteurLba.service.test.ts
@@ -1,12 +1,13 @@
 import { badRequest, notFound } from "@hapi/boom"
 import { generateApplicationFixture } from "shared/fixtures/application.fixture"
 import { generateJobsPartnersOfferPrivate } from "shared/fixtures/jobPartners.fixture"
+import { JOB_STATUS_ENGLISH } from "shared/models/job.model"
 import { ERecruteurLbaUpdateEventType } from "shared/models/index"
 import type { IJobsPartnersRecruteurAlgoPrivate } from "shared/models/jobsPartners.model"
 import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
 import { beforeEach, describe, expect, it } from "vitest"
 
-import { getCompanyContactInfo, updateContactInfo } from "./recruteurLba.service"
+import { getCompanyContactInfo, getRecruteursLbaFromDB, updateContactInfo } from "./recruteurLba.service"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { useMongo } from "@tests/utils/mongo.test.utils"
 
@@ -160,5 +161,39 @@ describe("/lbacompany/:siret/contactInfo", () => {
 
     const eventCount = await getDbCollection("recruteurlbaupdateevents").countDocuments({})
     expect.soft(eventCount).toEqual(0)
+  })
+})
+
+describe("getRecruteursLbaFromDB", () => {
+  const activeRecruteur = generateJobsPartnersOfferPrivate({
+    partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+    workplace_siret: "58006820882692",
+    offer_status: JOB_STATUS_ENGLISH.ACTIVE,
+  }) as IJobsPartnersRecruteurAlgoPrivate
+
+  const inactiveRecruteur = generateJobsPartnersOfferPrivate({
+    partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+    workplace_siret: "13002526500013",
+    offer_status: JOB_STATUS_ENGLISH.ANNULEE,
+  }) as IJobsPartnersRecruteurAlgoPrivate
+
+  beforeEach(async () => {
+    await getDbCollection("jobs_partners").insertMany([activeRecruteur, inactiveRecruteur])
+    return async () => {
+      await getDbCollection("jobs_partners").deleteMany({})
+    }
+  })
+
+  it("retourne uniquement les recruteurs actifs", async () => {
+    const result = await getRecruteursLbaFromDB({ geo: null, romes: null, opco: null, departements: null, partners_to_exclude: null })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].workplace_siret).toBe(activeRecruteur.workplace_siret)
+  })
+
+  it("retourne un tableau vide si RECRUTEURS_LBA est exclu des partenaires", async () => {
+    const result = await getRecruteursLbaFromDB({ geo: null, romes: null, opco: null, departements: null, partners_to_exclude: [JOBPARTNERS_LABEL.RECRUTEURS_LBA] })
+
+    expect(result).toHaveLength(0)
   })
 })

--- a/server/src/services/recruteurLba.service.ts
+++ b/server/src/services/recruteurLba.service.ts
@@ -2,7 +2,7 @@ import { badRequest, internal, notFound } from "@hapi/boom"
 import type { Document, Filter } from "mongodb"
 import { ObjectId } from "mongodb"
 import type { IApplication, IRecruteurLbaUpdateEvent } from "shared"
-import { ERecruteurLbaUpdateEventType, JobCollectionName } from "shared"
+import { ERecruteurLbaUpdateEventType, JOB_STATUS_ENGLISH, JobCollectionName } from "shared"
 import { LBA_ITEM_TYPE, LBA_ITEM_TYPE_OLD } from "shared/constants/lbaitem"
 import { OPCOS_LABEL } from "shared/constants/recruteur"
 import type { IJobsPartnersOfferPrivate, IJobsPartnersOfferPrivateWithDistance, IJobsPartnersRecruteurAlgoPrivate } from "shared/models/jobsPartners.model"
@@ -246,7 +246,7 @@ export const getRecruteursLbaFromDB = async ({ geo, romes, opco, departements, p
     return []
   }
 
-  const query: Filter<IJobsPartnersOfferPrivate> = { partner_label: LBA_ITEM_TYPE.RECRUTEURS_LBA }
+  const query: Filter<IJobsPartnersOfferPrivate> = { partner_label: LBA_ITEM_TYPE.RECRUTEURS_LBA, offer_status: JOB_STATUS_ENGLISH.ACTIVE }
 
   if (romes) {
     query.offer_rome_codes = { $in: romes }
@@ -316,7 +316,7 @@ const getCompanies = async ({
   try {
     const distance = radius || 10
 
-    const query: Filter<IJobsPartnersRecruteurAlgoPrivate> = { partner_label: LBA_ITEM_TYPE.RECRUTEURS_LBA }
+    const query: Filter<IJobsPartnersRecruteurAlgoPrivate> = { partner_label: LBA_ITEM_TYPE.RECRUTEURS_LBA, offer_status: JOB_STATUS_ENGLISH.ACTIVE }
 
     if (romes) {
       query.offer_rome_codes = { $in: romes?.split(",") }


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3680

-----

This pull request updates the recruiter-related service queries to ensure only active job offers are returned. The main change is the addition of an `offer_status` filter using the new `JOB_STATUS_ENGLISH.ACTIVE` constant, which improves data accuracy by excluding inactive offers.

**Query filtering improvements:**

* Added `offer_status: JOB_STATUS_ENGLISH.ACTIVE` to the job offers query in `getRecruteursLbaFromDB`, ensuring only active offers are retrieved.
* Added `offer_status: JOB_STATUS_ENGLISH.ACTIVE` to the companies query in `getCompanies`, so only active recruiter offers are included.

**Constants and imports:**

* Imported `JOB_STATUS_ENGLISH` from `shared` to support the new filtering logic.