### PR TITLE
feat(lba-3645): cancel job when application > 80

### DIFF
--- a/server/src/http/controllers/v2/applications.controller.v2.test.ts
+++ b/server/src/http/controllers/v2/applications.controller.v2.test.ts
@@ -395,8 +395,8 @@ describe("POST /v2/application", () => {
   })
 
   it("Should mark offer as ANNULEE in jobs_partners when application count exceeds limit", async () => {
-    // 81 pre-existing applications for the recruteur's siret exceeds the limit of 80
-    const preExistingApplications = Array.from({ length: 81 }, () => generateApplicationFixture({ company_siret: recruteur.workplace_siret }))
+    // 80 existing + current submission = 81 total, condition (80+1) > 80 is true
+    const preExistingApplications = Array.from({ length: 80 }, () => generateApplicationFixture({ company_siret: recruteur.workplace_siret }))
     await getDbCollection("applications").insertMany(preExistingApplications)
 
     const body: IApplicationApiPublic = {

--- a/server/src/http/controllers/v2/applications.controller.v2.test.ts
+++ b/server/src/http/controllers/v2/applications.controller.v2.test.ts
@@ -1,7 +1,7 @@
 import { omit } from "lodash-es"
 import { ObjectId } from "mongodb"
 import type { IApplicationApiPublic } from "shared"
-import { CompanyFeebackSendStatus, EMAIL_LOG_TYPE, JOB_STATUS, JobCollectionName } from "shared"
+import { CompanyFeebackSendStatus, EMAIL_LOG_TYPE, JOB_STATUS, JOB_STATUS_ENGLISH, JobCollectionName } from "shared"
 import { ApplicationIntention } from "shared/constants/application"
 import { NIVEAUX_POUR_LBA, OPCOS_LABEL, RECRUITER_STATUS } from "shared/constants/index"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
@@ -392,6 +392,34 @@ describe("POST /v2/application", () => {
       company_feedback_send_status: CompanyFeebackSendStatus.CANCELED,
       company_recruitment_intention: ApplicationIntention.ENTRETIEN,
     })
+  })
+
+  it("Should mark offer as ANNULEE in jobs_partners when application count exceeds limit", async () => {
+    // 81 pre-existing applications for the recruteur's siret exceeds the limit of 80
+    const preExistingApplications = Array.from({ length: 81 }, () => generateApplicationFixture({ company_siret: recruteur.workplace_siret }))
+    await getDbCollection("applications").insertMany(preExistingApplications)
+
+    const body: IApplicationApiPublic = {
+      applicant_attachment_name: "cv.pdf",
+      applicant_attachment_content: applicationTestFile,
+      applicant_email: "jean.dupont@mail.com",
+      applicant_first_name: "Jean",
+      applicant_last_name: "Dupont",
+      applicant_phone: "0101010101",
+      recipient_id: getRecipientID(JobCollectionName.partners, recruteur._id.toString()),
+    }
+
+    const response = await httpClient().inject({
+      method: "POST",
+      path: "/api/v2/application",
+      body,
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    expect.soft(response.statusCode).toEqual(202)
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: recruteur._id })
+    expect(updatedJob?.offer_status).toBe(JOB_STATUS_ENGLISH.ANNULEE)
   })
 
   it.skip("Remove scheduled intention when Envoyer le message button", async () => {

--- a/server/src/services/application.service.test.ts
+++ b/server/src/services/application.service.test.ts
@@ -508,8 +508,8 @@ describe("checkMaxApplicationCount", () => {
     })
     await getDbCollection("jobs_partners").insertOne(partnerJob)
 
-    // 80 applications = exactly at the limit (> 80 is false)
-    const applications = Array.from({ length: 80 }, () => generateApplicationFixture({ company_siret: "12345678901234" }))
+    // 79 existing + current submission = 80 total, condition (79+1) > 80 is false
+    const applications = Array.from({ length: 79 }, () => generateApplicationFixture({ company_siret: "12345678901234" }))
     await getDbCollection("applications").insertMany(applications)
 
     await sendApplicationV2({
@@ -533,8 +533,8 @@ describe("checkMaxApplicationCount", () => {
     })
     await getDbCollection("jobs_partners").insertOne(partnerJob)
 
-    // 81 applications exceeds the limit of 80
-    const applications = Array.from({ length: 81 }, () => generateApplicationFixture({ company_siret: "98765432109876" }))
+    // 80 existing + current submission = 81 total, condition (80+1) > 80 is true
+    const applications = Array.from({ length: 80 }, () => generateApplicationFixture({ company_siret: "98765432109876" }))
     await getDbCollection("applications").insertMany(applications)
 
     await sendApplicationV2({
@@ -558,7 +558,8 @@ describe("checkMaxApplicationCount", () => {
     })
     await getDbCollection("jobs_partners").insertOne(partnerJob)
 
-    const applications = Array.from({ length: 81 }, () => generateApplicationFixture({ company_siret: "11111111111111" }))
+    // count is by job_id for OFFRES_EMPLOI_PARTENAIRES (not company_siret)
+    const applications = Array.from({ length: 80 }, () => generateApplicationFixture({ job_id: new ObjectId("6081289803569600282e0032") }))
     await getDbCollection("applications").insertMany(applications)
 
     await sendApplicationV2({
@@ -598,7 +599,8 @@ describe("checkMaxApplicationCount", () => {
       })
     )
 
-    const applications = Array.from({ length: 81 }, () => generateApplicationFixture({ job_id: jobId }))
+    // 80 existing + current submission = 81 total, condition (80+1) > 80 is true
+    const applications = Array.from({ length: 80 }, () => generateApplicationFixture({ job_id: jobId }))
     await getDbCollection("applications").insertMany(applications)
 
     await sendApplicationV2({

--- a/server/src/services/application.service.test.ts
+++ b/server/src/services/application.service.test.ts
@@ -9,6 +9,7 @@ import { generateReferentielRome } from "shared/fixtures/rome.fixture"
 import dayjs from "shared/helpers/dayjs"
 import type { IReferentielRome } from "shared/models/index"
 import { JOB_STATUS, JOB_STATUS_ENGLISH } from "shared/models/index"
+import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { omit } from "lodash-es"
@@ -445,7 +446,7 @@ describe("buildApplicationFromHelloworkAndSaveToDb", () => {
     await expect(buildApplicationFromHelloworkAndSaveToDb(helloworkPayload)).rejects.toThrow(BusinessErrorCodes.TOO_MANY_APPLICATIONS_PER_DAY)
   })
 
-  it("Should throw error when too many applications per SIRET from caller", async () => {
+  it("Should throw error when too many applications per SIRET from caller (Hellowork)", async () => {
     const partnerJob = generateJobsPartnersOfferPrivate({
       _id: new ObjectId("6081289803569600282e0019"),
       partner_job_id: "job_dev_010",
@@ -485,5 +486,129 @@ describe("buildApplicationFromHelloworkAndSaveToDb", () => {
     await getDbCollection("applications").insertMany(applications)
 
     await expect(buildApplicationFromHelloworkAndSaveToDb(helloworkPayload)).rejects.toThrow(BusinessErrorCodes.TOO_MANY_APPLICATIONS_PER_SIRET)
+  })
+})
+
+describe("checkMaxApplicationCount", () => {
+  afterEach(async () => {
+    await getDbCollection("jobs_partners").deleteMany({})
+    await getDbCollection("applications").deleteMany({})
+    await getDbCollection("applicants").deleteMany({})
+    await getDbCollection("recruiters").deleteMany({})
+    await getDbCollection("referentielromes").deleteMany({})
+  })
+
+  it("Should not update offer status when application count is at the limit (RECRUTEURS_LBA)", async () => {
+    const partnerJob = generateJobsPartnersOfferPrivate({
+      _id: new ObjectId("6081289803569600282e0030"),
+      partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+      offer_status: JOB_STATUS_ENGLISH.ACTIVE,
+      apply_email: "employer@test.fr",
+      workplace_siret: "12345678901234",
+    })
+    await getDbCollection("jobs_partners").insertOne(partnerJob)
+
+    // 80 applications = exactly at the limit (> 80 is false)
+    const applications = Array.from({ length: 80 }, () => generateApplicationFixture({ company_siret: "12345678901234" }))
+    await getDbCollection("applications").insertMany(applications)
+
+    await sendApplicationV2({
+      newApplication: {
+        ...fakeApplication,
+        recipient_id: { collectionName: "partners", jobId: "6081289803569600282e0030" },
+      },
+    })
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: new ObjectId("6081289803569600282e0030") })
+    expect(updatedJob?.offer_status).toBe(JOB_STATUS_ENGLISH.ACTIVE)
+  })
+
+  it("Should update offer status to ANNULEE when application count exceeds limit (RECRUTEURS_LBA)", async () => {
+    const partnerJob = generateJobsPartnersOfferPrivate({
+      _id: new ObjectId("6081289803569600282e0031"),
+      partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+      offer_status: JOB_STATUS_ENGLISH.ACTIVE,
+      apply_email: "employer@test.fr",
+      workplace_siret: "98765432109876",
+    })
+    await getDbCollection("jobs_partners").insertOne(partnerJob)
+
+    // 81 applications exceeds the limit of 80
+    const applications = Array.from({ length: 81 }, () => generateApplicationFixture({ company_siret: "98765432109876" }))
+    await getDbCollection("applications").insertMany(applications)
+
+    await sendApplicationV2({
+      newApplication: {
+        ...fakeApplication,
+        recipient_id: { collectionName: "partners", jobId: "6081289803569600282e0031" },
+      },
+    })
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: new ObjectId("6081289803569600282e0031") })
+    expect(updatedJob?.offer_status).toBe(JOB_STATUS_ENGLISH.ANNULEE)
+  })
+
+  it("Should update offer status to ANNULEE when application count exceeds limit (OFFRES_EMPLOI_PARTENAIRES)", async () => {
+    const partnerJob = generateJobsPartnersOfferPrivate({
+      _id: new ObjectId("6081289803569600282e0032"),
+      partner_label: JOBPARTNERS_LABEL.HELLOWORK,
+      offer_status: JOB_STATUS_ENGLISH.ACTIVE,
+      apply_email: "employer@test.fr",
+      workplace_siret: "11111111111111",
+    })
+    await getDbCollection("jobs_partners").insertOne(partnerJob)
+
+    const applications = Array.from({ length: 81 }, () => generateApplicationFixture({ company_siret: "11111111111111" }))
+    await getDbCollection("applications").insertMany(applications)
+
+    await sendApplicationV2({
+      newApplication: {
+        ...fakeApplication,
+        recipient_id: { collectionName: "partners", jobId: "6081289803569600282e0032" },
+      },
+    })
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: new ObjectId("6081289803569600282e0032") })
+    expect(updatedJob?.offer_status).toBe(JOB_STATUS_ENGLISH.ANNULEE)
+  })
+
+  it("Should update offer status to ANNULEE when application count exceeds limit (OFFRES_EMPLOI_LBA)", async () => {
+    const jobId = new ObjectId("6081289803569600282e0033")
+
+    await getDbCollection("referentielromes").insertOne(generateReferentielRome({ rome: { code_rome: "A1101", intitule: "Opérations administratives", code_ogr: "475" } }))
+    await saveRecruiter(
+      generateRecruiterFixture({
+        status: RECRUITER_STATUS.ACTIF,
+        jobs: [
+          {
+            _id: jobId,
+            rome_code: ["A1101"],
+            job_status: JOB_STATUS.ACTIVE,
+            job_expiration_date: new Date("2050-01-01"),
+          },
+        ],
+      })
+    )
+    // Mirror entry in jobs_partners so the status update can be verified
+    await getDbCollection("jobs_partners").insertOne(
+      generateJobsPartnersOfferPrivate({
+        _id: jobId,
+        offer_status: JOB_STATUS_ENGLISH.ACTIVE,
+        apply_email: "employer@test.fr",
+      })
+    )
+
+    const applications = Array.from({ length: 81 }, () => generateApplicationFixture({ job_id: jobId }))
+    await getDbCollection("applications").insertMany(applications)
+
+    await sendApplicationV2({
+      newApplication: {
+        ...fakeApplication,
+        recipient_id: { collectionName: "recruiters", jobId: jobId.toString() },
+      },
+    })
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: jobId })
+    expect(updatedJob?.offer_status).toBe(JOB_STATUS_ENGLISH.ANNULEE)
   })
 })

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -818,18 +818,18 @@ const checkUserApplicationCountV2 = async (applicantId: ObjectId, LbaJob: IJobOr
 const checkMaxApplicationCount = async (lbaJob: IJobOrCompanyV2) => {
   const { type, job } = lbaJob
   let applicationCount: number
-  if (type === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA) {
+  if (type === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA || type === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES) {
     applicationCount = await getDbCollection("applications").countDocuments({
       job_id: job._id,
     })
-  } else if (type === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES || type === LBA_ITEM_TYPE.RECRUTEURS_LBA) {
+  } else if (type === LBA_ITEM_TYPE.RECRUTEURS_LBA) {
     applicationCount = await getDbCollection("applications").countDocuments({
       company_siret: job.workplace_siret,
     })
   } else {
     assertUnreachable(type)
   }
-  if (applicationCount > MAX_APPLICATIONS_PER_OFFER) {
+  if (applicationCount + 1 > MAX_APPLICATIONS_PER_OFFER) {
     await getDbCollection("jobs_partners").updateOne({ _id: job._id }, { $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE } })
   }
 }

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -49,6 +49,7 @@ import { userWithAccountToUserForToken } from "@/security/accessTokenService"
 const MAX_MESSAGES_PAR_OFFRE_PAR_CANDIDAT = 3
 const MAX_MESSAGES_PAR_SIRET_PAR_CALLER = 20
 const MAX_CANDIDATURES_PAR_CANDIDAT_PAR_JOUR = 100
+const MAX_APPLICATIONS_PER_OFFER = 80
 
 const publicUrl = config.publicUrl
 
@@ -362,6 +363,7 @@ export const sendApplicationV2 = async ({
   }
 
   await checkUserApplicationCountV2(applicant._id, lbaJob, caller)
+  await checkMaxApplicationCount(lbaJob)
 
   const { type, job, recruiter } = lbaJob
   const recruteurEmail = (type === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA ? recruiter.email : job.apply_email)?.toLowerCase()
@@ -810,6 +812,25 @@ const checkUserApplicationCountV2 = async (applicantId: ObjectId, LbaJob: IJobOr
 
   if (callerApplicationCount >= MAX_MESSAGES_PAR_SIRET_PAR_CALLER) {
     throw tooManyRequests(BusinessErrorCodes.TOO_MANY_APPLICATIONS_PER_SIRET)
+  }
+}
+
+const checkMaxApplicationCount = async (lbaJob: IJobOrCompanyV2) => {
+  const { type, job } = lbaJob
+  let applicationCount: number
+  if (type === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA) {
+    applicationCount = await getDbCollection("applications").countDocuments({
+      job_id: job._id,
+    })
+  } else if (type === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES || type === LBA_ITEM_TYPE.RECRUTEURS_LBA) {
+    applicationCount = await getDbCollection("applications").countDocuments({
+      company_siret: job.workplace_siret,
+    })
+  } else {
+    assertUnreachable(type)
+  }
+  if (applicationCount > MAX_APPLICATIONS_PER_OFFER) {
+    await getDbCollection("jobs_partners").updateOne({ _id: job._id }, { $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE } })
   }
 }
 

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -830,7 +830,7 @@ const checkMaxApplicationCount = async (lbaJob: IJobOrCompanyV2) => {
     assertUnreachable(type)
   }
   if (applicationCount + 1 > MAX_APPLICATIONS_PER_OFFER) {
-    await getDbCollection("jobs_partners").updateOne({ _id: job._id }, { $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE } })
+    await getDbCollection("jobs_partners").updateOne({ _id: job._id }, { $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: new Date() } })
   }
 }
 


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3645

----

This pull request introduces and tests a new business rule that automatically marks job offers as canceled ("ANNULEE") in the `jobs_partners` collection when the number of applications for an offer exceeds a set limit (80). The changes ensure this logic is applied consistently across different job types and validated by comprehensive tests.

### Business logic enforcement

* Added a new constant `MAX_APPLICATIONS_PER_OFFER` (80) and the function `checkMaxApplicationCount` to enforce the application limit per offer. When the count exceeds the limit, the job's `offer_status` is updated to `JOB_STATUS_ENGLISH.ANNULEE` in `jobs_partners`. This logic is triggered in `sendApplicationV2`. [[1]](diffhunk://#diff-aec31ac301362ac8da91d00c90c9fa24c09a34d6263dde85f7a1ef8b33ab0404R52) [[2]](diffhunk://#diff-aec31ac301362ac8da91d00c90c9fa24c09a34d6263dde85f7a1ef8b33ab0404R366) [[3]](diffhunk://#diff-aec31ac301362ac8da91d00c90c9fa24c09a34d6263dde85f7a1ef8b33ab0404R818-R836)

### Test coverage

* Added multiple tests in `application.service.test.ts` to verify that offers are only marked as canceled when the application count exceeds 80, and remain active when at the limit, covering all relevant job types (`RECRUTEURS_LBA`, `OFFRES_EMPLOI_PARTENAIRES`, and `OFFRES_EMPLOI_LBA`). [[1]](diffhunk://#diff-f3ed7ca5e2bce4d40e2fed2d23675665b99b3889b6c1c5234358dcd45118d6bdL448-R449) [[2]](diffhunk://#diff-f3ed7ca5e2bce4d40e2fed2d23675665b99b3889b6c1c5234358dcd45118d6bdR491-R614)
* Added a test in `applications.controller.v2.test.ts` to confirm that the offer is marked as canceled when the application count for a recruiter’s SIRET exceeds the limit.

### Minor changes

* Updated imports to include new constants and labels required for the new logic and tests. [[1]](diffhunk://#diff-f27c7b8ef3e2d7a02f087d4ca0f21e915339b5490c0f814fb6e9def9f0e9de40L4-R4) [[2]](diffhunk://#diff-f3ed7ca5e2bce4d40e2fed2d23675665b99b3889b6c1c5234358dcd45118d6bdR12)