### PR TITLE
fix: classification api

### DIFF
--- a/server/src/common/apis/classification/classification.client.test.ts
+++ b/server/src/common/apis/classification/classification.client.test.ts
@@ -29,7 +29,10 @@ describe("getLabClassification - get batch classification", () => {
   }
   const apiPayload = {
     id: jobFixture.partner_job_id,
-    text: [jobFixture.workplace_name, jobFixture.workplace_description, jobFixture.offer_title, jobFixture.offer_description].filter(Boolean).join("\n"),
+    workplace_name: jobFixture.workplace_name ?? undefined,
+    workplace_description: jobFixture.workplace_description ?? undefined,
+    offer_title: jobFixture.offer_title ?? undefined,
+    offer_description: jobFixture.offer_description ?? undefined,
   }
   const apiResponse: IClassificationLabBatchResponse = [
     {
@@ -37,7 +40,6 @@ describe("getLabClassification - get batch classification", () => {
       label: "unpublish",
       model: "model",
       scores: { publish: 0.4, unpublish: 0.5 },
-      text: "Software Engineer",
     },
   ]
 

--- a/server/src/common/apis/classification/classification.client.ts
+++ b/server/src/common/apis/classification/classification.client.ts
@@ -34,7 +34,6 @@ export type IGetLabClassificationBatch = {
 export const getLabClassificationBatch = async (jobs: IGetLabClassificationBatch): Promise<IClassificationLabBatchResponse> => {
   try {
     const response = await client.post("/model/scores", { items: jobs }, { timeout: 30_000 })
-    console.log("response from classification lab", response.data)
     const validation = ZClassificationLabBatchResponse.safeParse(response.data)
     if (!validation.success) {
       throw internal("getLabClassificationBatch: format de réponse non valide", { error: validation.error })

--- a/server/src/common/apis/classification/classification.client.ts
+++ b/server/src/common/apis/classification/classification.client.ts
@@ -9,7 +9,7 @@ import config from "@/config"
 const client = getApiClient({ baseURL: config.labonnealternanceLab.baseUrl })
 // const client = getApiClient({ baseURL: "http://localhost:8000" })
 
-export const getLabClassification = async (job: string): Promise<IClassificationLabResponse> => {
+export const getLabClassification = async (job: IGetLabClassificationBatch[0]): Promise<IClassificationLabResponse> => {
   try {
     const response = await client.post("/score", { text: job })
     const validation = ZClassificationLabResponse.safeParse(response.data)
@@ -25,12 +25,16 @@ export const getLabClassification = async (job: string): Promise<IClassification
 
 export type IGetLabClassificationBatch = {
   id: string
-  text: string
+  workplace_name?: string
+  workplace_description?: string
+  offer_title?: string
+  offer_description?: string
 }[]
 
 export const getLabClassificationBatch = async (jobs: IGetLabClassificationBatch): Promise<IClassificationLabBatchResponse> => {
   try {
     const response = await client.post("/model/scores", { items: jobs }, { timeout: 30_000 })
+    console.log("response from classification lab", response.data)
     const validation = ZClassificationLabBatchResponse.safeParse(response.data)
     if (!validation.success) {
       throw internal("getLabClassificationBatch: format de réponse non valide", { error: validation.error })

--- a/server/src/jobs/offrePartenaire/detectClassificationJobsPartners.test.ts
+++ b/server/src/jobs/offrePartenaire/detectClassificationJobsPartners.test.ts
@@ -27,7 +27,6 @@ describe("detectClassificationJobsPartners", () => {
         label: "publish",
         model: "model",
         scores: { publish: 0.6, unpublish: 0.4 },
-        text: "Software Engineer",
       },
     ]
     nock(config.labonnealternanceLab.baseUrl).post("/model/scores").reply(200, apiResponse)
@@ -130,7 +129,6 @@ describe("detectClassificationJobsPartners", () => {
         label: "unpublish",
         model: "model",
         scores: { publish: 0.3, unpublish: 0.7 },
-        text: "Software Engineer",
       },
     ]
     nock(config.labonnealternanceLab.baseUrl).post("/model/scores").reply(200, unpublishResponse)

--- a/server/src/jobs/offrePartenaire/detectClassificationJobsPartners.ts
+++ b/server/src/jobs/offrePartenaire/detectClassificationJobsPartners.ts
@@ -12,7 +12,7 @@ export const detectClassificationJobsPartners = async ({ addedMatchFilter, shoul
     job: COMPUTED_ERROR_SOURCE.CLASSIFICATION,
     sourceFields: ["workplace_description", "workplace_name", "offer_description", "offer_title", "partner_job_id", "partner_label"],
     filledFields,
-    groupSize: 100,
+    groupSize: 50,
     addedMatchFilter,
     getData: async (documents) => {
       const payload = documents.map((document) => {

--- a/server/src/jobs/simpleJobDefinitions.ts
+++ b/server/src/jobs/simpleJobDefinitions.ts
@@ -78,6 +78,7 @@ import { updateSEO } from "./seo/updateSEO"
 import { fillEntrepriseEngagementJobsPartners } from "./offrePartenaire/fillEntrepriseEngagementJobsPartners"
 import { cancelRemovedJobsPartners } from "./offrePartenaire/cancelRemovedJobsPartners"
 import { processApec } from "./offrePartenaire/apec/processApec"
+import { detectClassificationJobsPartners } from "./offrePartenaire/detectClassificationJobsPartners"
 import { generateSitemap } from "@/services/sitemap.service"
 import { processScheduledRecruiterIntentions } from "@/services/application.service"
 
@@ -448,5 +449,9 @@ export const simpleJobDefinitions: SimpleJobDefinition[] = [
   {
     fct: processApec,
     description: "Import du flux APEC jusqu'à la collection computed_jobs_partners",
+  },
+  {
+    fct: detectClassificationJobsPartners,
+    description: "Analyse la classification des offres partenaires",
   },
 ]

--- a/server/src/services/cacheClassification.service.ts
+++ b/server/src/services/cacheClassification.service.ts
@@ -36,7 +36,10 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
 
   const classificationPayload = notFoundJobs.map((job) => ({
     id: job.partner_job_id,
-    text: [job.workplace_name, job.workplace_description, job.offer_title, job.offer_description].filter(Boolean).join("\n"),
+    workplace_name: job.workplace_name,
+    workplace_description: job.workplace_description,
+    offer_title: job.offer_title,
+    offer_description: job.offer_description,
   }))
 
   const classificationsFromLab = await getLabClassificationBatch(classificationPayload)

--- a/shared/src/models/cacheClassification.model.ts
+++ b/shared/src/models/cacheClassification.model.ts
@@ -31,7 +31,6 @@ export const ZClassificationLabBatchResponse = z
     id: z.string(),
     label: z.enum(["publish", "unpublish"]),
     scores: ZClassitifationJobsPartners.shape.scores,
-    text: z.string(),
     model: z.string(),
   })
   .array()


### PR DESCRIPTION
This pull request updates how job classification data is sent to and received from the classification lab API, refactoring the payload structure for both batch and single requests. It removes the concatenated `text` field in favor of sending individual job attributes, updates related type definitions, and ensures tests and schema validations are consistent with these changes. Additionally, it reduces the batch group size for classification jobs and registers the classification detection job in the job definitions.

**API payload and type refactoring:**

* The classification lab API payload now sends individual fields (`workplace_name`, `workplace_description`, `offer_title`, `offer_description`) instead of a single concatenated `text` field, updating both batch and single request logic in `classification.client.ts` and related service files. [[1]](diffhunk://#diff-909a93cb195345d11af44ca858dbafb7854383359b9c6e8ae9cfea930a1dc04bL28-R37) [[2]](diffhunk://#diff-0a7d8e3b1af6d2c9db9116d2698e77296035ede78b35bd2da527b4f50b65a4e0L39-R42) [[3]](diffhunk://#diff-87f6ed75dfe5cc293ab9fcebef5baa36a93df20338c92100888a407dd34d1c71L32-L40)
* The type definition `IGetLabClassificationBatch` is updated to use the new fields, and the validation schema in `cacheClassification.model.ts` removes the `text` field from the expected response structure. [[1]](diffhunk://#diff-909a93cb195345d11af44ca858dbafb7854383359b9c6e8ae9cfea930a1dc04bL28-R37) [[2]](diffhunk://#diff-6886df91b0f9c78a8e0cf98c6ca6a3bdb42b3167d396bdc703954327aac46879L34)

**Test updates:**

* Tests for batch classification and job partner classification detection are updated to remove the `text` field from expected API responses, aligning them with the new payload structure. [[1]](diffhunk://#diff-87f6ed75dfe5cc293ab9fcebef5baa36a93df20338c92100888a407dd34d1c71L32-L40) [[2]](diffhunk://#diff-bf146f07e99a18d4142affb86f87a62f26267e8e0b385c7c88c1cce8ae33cd59L30) [[3]](diffhunk://#diff-bf146f07e99a18d4142affb86f87a62f26267e8e0b385c7c88c1cce8ae33cd59L133)

**Job execution and configuration:**

* The batch group size for classification jobs is reduced from 100 to 50 in `detectClassificationJobsPartners.ts` to optimize processing.
* The `detectClassificationJobsPartners` job is registered in `simpleJobDefinitions.ts`, enabling scheduled execution for partner job classification analysis. [[1]](diffhunk://#diff-3d05788271adc9d8e2b5647af6fadb541fd19bfada2db3720f389495e0d63b0bR81) [[2]](diffhunk://#diff-3d05788271adc9d8e2b5647af6fadb541fd19bfada2db3720f389495e0d63b0bR453-R456)