### PR TITLE
fix: remove pentest for release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,48 +135,6 @@ jobs:
         env:
           CI: true
 
-  build-ui-pentest:
-    if: false # disabled for now
-    needs: ["release"]
-    # if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.TOKEN_MNA_SHARED }}
-          submodules: true
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          platforms: linux/amd64
-          install: true
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-
-      - name: Build UI pentest
-        run: .bin/mna-lba app:build ${{ needs.release.outputs.VERSION }} push $(git rev-parse HEAD) pentest
-        env:
-          CI: true
-
   docker-scout-server:
     if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
     needs: ["release"]
@@ -239,23 +197,6 @@ jobs:
     uses: "./.github/workflows/_deploy.yml"
     with:
       environment: recette
-      app_version: ${{ needs.release.outputs.VERSION }}
-    secrets:
-      DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-      DEPLOY_PASS: ${{ secrets.DEPLOY_PASS }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-      OPENPGP_PRIVATE_SUBKEY: ${{ secrets.OPENPGP_PRIVATE_SUBKEY }}
-      TOKEN_MNA_SHARED: ${{ secrets.TOKEN_MNA_SHARED }}
-
-  deploy-pentest:
-    if: false # disabled for now
-    concurrency:
-      group: "deploy-pentest-${{ github.workflow }}-${{ github.ref }}"
-    needs: ["release", "build-ui-pentest"]
-    name: Deploy ${{ needs.release.outputs.VERSION }} on pentest
-    uses: "./.github/workflows/_deploy.yml"
-    with:
-      environment: pentest
       app_version: ${{ needs.release.outputs.VERSION }}
     secrets:
       DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
This pull request removes the disabled pentest build and deploy jobs from the `.github/workflows/release.yml` workflow file. These jobs were previously present but commented out with `if: false`, and are now fully deleted to clean up the workflow configuration.

Workflow cleanup:

* Removed the entire `build-ui-pentest` job, including all steps related to building and pushing the pentest UI image. (`.github/workflows/release.yml`, [.github/workflows/release.ymlL138-L179](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L138-L179))
* Removed the entire `deploy-pentest` job, including concurrency settings, environment variables, and secret references for pentest deployment. (`.github/workflows/release.yml`, [.github/workflows/release.ymlL250-L266](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L250-L266))