### PR TITLE
fix: remove overflow:visible causing 122k Sentry warnings

### DIFF
--- a/ui/app/(home)/_components/HomeCircleImageDecoration.tsx
+++ b/ui/app/(home)/_components/HomeCircleImageDecoration.tsx
@@ -12,7 +12,6 @@ export const HomeCircleImageDecoration = ({ size }: { size: "small" | "high" }) 
     height={size === "high" ? motifHigh.height : motifSmall.height}
     width={size === "high" ? motifHigh.width : motifSmall.width}
     style={{
-      overflow: "visible",
       height: "calc(100% - 10px)",
       width: "100%",
       top: "20px",


### PR DESCRIPTION
## Summary
- Supprime la propriété CSS `overflow: "visible"` sur le composant `<NextImage>` dans `HomeCircleImageDecoration`
- Cette propriété déclenchait un avertissement de dépréciation Chrome (ReportingObserver) capté par Sentry, générant **122 257 occurrences** (issue LBA-UI-1B7)
- La propriété n'avait aucun effet utile (l'image est en `position: absolute` avec `objectFit: cover`)

## Test plan
- [ ] Vérifier visuellement que les décorations circulaires de la page d'accueil s'affichent correctement
- [ ] Confirmer l'absence du warning dans la console Chrome DevTools

Fixes LBA-UI-1B7