### PR TITLE
feat: update preview setup flow

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -90,11 +90,21 @@ jobs:
         run: |
           sudo pipx inject ansible-core jmespath
 
+      - name: Detect force reseed
+        id: force_seed
+        run: |
+          if echo "${{ github.event.comment.body }}" | grep -qF '🌱'; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run playbook
         run: .bin/mna-lba app:deploy preview "${{ github.event.issue.number }}"
         env:
           ANSIBLE_REMOTE_USER: deploy
           ANSIBLE_BECOME_PASS: ${{ secrets.DEPLOY_PASS_PREVIEW }}
+          FORCE_SEED: ${{ steps.force_seed.outputs.value }}
 
       - name: Encrypt logs
         run: .bin/mna-lba app:deploy:log:encrypt
@@ -128,7 +138,8 @@ jobs:
 
             You can access runner logs in ${{ steps.run_url.outputs.url }}
 
-            To re-deploy just add a comment with :rocket:
+            To re-deploy just add a comment with :rocket: (data is preserved)
+            To re-deploy and reset data add a comment with :seedling: :rocket:
           comment-tag: deployment
           mode: recreate
           pr-number: ${{ github.event.issue.number }}

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: hmarr/debug-action@v2
 
   deploy_preview:
-    if: (startsWith(github.event.comment.body, '🚀') || startsWith(github.event.comment.body, ':rocket:')) && github.event.issue.pull_request
+    if: (contains(github.event.comment.body, '🚀') || contains(github.event.comment.body, ':rocket:')) && github.event.issue.pull_request
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.issue.id }}
       cancel-in-progress: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,6 +19,7 @@ jobs:
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
-            To deploy this PR just add a comment with a simple :rocket:
+            To deploy this PR, add a comment with :rocket:
+            To deploy and reset the database, add a comment with :seedling: :rocket:
           comment-tag: deployment_instructions
           mode: upsert

--- a/.infra/ansible/preview_cleanup.yml
+++ b/.infra/ansible/preview_cleanup.yml
@@ -30,6 +30,29 @@
           - mna_lba_ui
           - mna_lba_server
 
+    - name: List all preview databases in MongoDB
+      shell:
+        cmd: >
+          docker compose -f /opt/app/docker-compose.preview-system.yml exec -T mongodb
+          mongosh
+          "mongodb://__system:{{ MONGODB_KEYFILE }}@localhost:27017/admin?authSource=local&directConnection=true"
+          --eval "db.adminCommand({ listDatabases: 1, nameOnly: true, filter: { name: /^preview_/ } }).databases.map(d => d.name).join('\n')"
+          --quiet
+      register: all_preview_dbs
+      changed_when: false
+
+    - name: Drop orphaned preview databases (no matching project directory)
+      shell:
+        cmd: |
+          if [ ! -d "/opt/app/projects/{{ item | replace('preview_', '') }}" ]; then
+            docker compose -f /opt/app/docker-compose.preview-system.yml exec -T mongodb \
+              mongosh \
+              "mongodb://__system:{{ MONGODB_KEYFILE }}@localhost:27017/{{ item }}?authSource=local&directConnection=true" \
+              --eval "db.dropDatabase()" --quiet
+          fi
+      loop: "{{ all_preview_dbs.stdout_lines | select('match', '^preview_\\d+$') | list }}"
+      ignore_errors: true
+
     - name: Prune Docker Containers
       shell:
         cmd: docker container prune --force

--- a/.infra/ansible/tasks/preview_pr.yml
+++ b/.infra/ansible/tasks/preview_pr.yml
@@ -85,19 +85,34 @@
         path: "/opt/app/projects/{{ pr_number }}"
       register: preview_exists
 
-    - name: "[{{ pr_number }}] Stop existing application before seed"
+    - name: "[{{ pr_number }}] Stop existing application before deploy"
       shell:
         chdir: "/opt/app/projects/{{ pr_number }}"
         cmd: docker compose down --remove-orphans
       when: preview_exists.stat.exists
       ignore_errors: true
 
+    - name: "[{{ pr_number }}] Check if database is already seeded"
+      shell:
+        cmd: >
+          docker compose -f /opt/app/docker-compose.preview-system.yml exec -T mongodb
+          mongosh
+          "mongodb://__system:{{ MONGODB_KEYFILE }}@localhost:27017/preview_{{ pr_number }}?authSource=local&directConnection=true"
+          --eval "db.getCollectionNames().length"
+          --quiet
+      register: db_collections_count
+      ignore_errors: true
+
     - name: "[{{ pr_number }}] Seed database"
       shell:
         chdir: "/opt/app"
-        cmd: "flock --verbose --close /tmp/deployment_seed.lock /opt/app/scripts/seed.sh preview_{{ pr_number | default('00') }}"
+        cmd: "flock --verbose --timeout 600 --close /tmp/deployment_seed.lock /opt/app/scripts/seed.sh preview_{{ pr_number | default('00') }}"
       async: 1500 # max 20 minutes
       poll: 15 # check every 15s
+      when: >
+        lookup('env', 'FORCE_SEED') == 'true' or
+        db_collections_count.rc != 0 or
+        (db_collections_count.stdout | trim | int) == 0
 
     - name: "[{{ pr_number }}] Execute MongoDB migrations"
       shell:
@@ -159,7 +174,12 @@
 
     - name: "[{{ pr_number }}] Remove database"
       shell:
-        cmd: docker run --rm -i --network mna_network mongo:6.0.2-focal mongosh "{{ LBA_MONGODB_URI }}" --eval "db.dropDatabase()"
+        cmd: >
+          docker compose -f /opt/app/docker-compose.preview-system.yml exec -T mongodb
+          mongosh
+          "mongodb://__system:{{ MONGODB_KEYFILE }}@localhost:27017/preview_{{ pr_number }}?authSource=local&directConnection=true"
+          --eval "db.dropDatabase()"
+      ignore_errors: true
 
     - name: "[{{ pr_number }}] Removing preview directory"
       shell:

--- a/.infra/ansible/tasks/preview_pr.yml
+++ b/.infra/ansible/tasks/preview_pr.yml
@@ -114,6 +114,13 @@
         db_collections_count.rc != 0 or
         (db_collections_count.stdout | trim | int) == 0
 
+    - name: "[{{ pr_number }}] Create MongoDB indexes (before migrations)"
+      shell:
+        chdir: "/opt/app/projects/{{ pr_number }}"
+        cmd: "docker compose run --rm server yarn cli indexes:recreate"
+      async: 900 # max 15 minutes
+      poll: 15 # check every 15s
+
     - name: "[{{ pr_number }}] Execute MongoDB migrations"
       shell:
         chdir: "/opt/app/projects/{{ pr_number }}"
@@ -128,13 +135,6 @@
       shell:
         chdir: /opt/app
         cmd: docker exec nginx-proxy-acme /app/signal_le_service
-
-    - name: "Create MongoDB Indexes"
-      shell:
-        chdir: "/opt/app/projects/{{ pr_number }}"
-        cmd: "flock --verbose --close /tmp/deployment_index.lock /opt/app/scripts/sync-index.sh"
-      async: 900 # max 15 minutes
-      poll: 15 # check every 15s
 
     - name: "[{{ pr_number }}] Register database in Metabase"
       shell:

--- a/.infra/docker-compose.preview.yml
+++ b/.infra/docker-compose.preview.yml
@@ -51,10 +51,10 @@ services:
       - HOSTNAME=0.0.0.0
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:3000/healthcheck"]
-      interval: 60s
-      timeout: 30s
-      retries: 11
-      start_period: 10s
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 30s
 
   # job_processor désactivé car inutile et permet de récupérer des ressources pour d'autres preview
   # jobs_processor:

--- a/.infra/files/configs/mongodb/seed.gpg
+++ b/.infra/files/configs/mongodb/seed.gpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8664a741ddf74900349e24b079bd398ecfc97e7c3dfdbf73f9745f7941a7dde3
-size 177487764
+oid sha256:ceca9ee5f0ef7578e1a07fce2f62ec21d0c2daf14755454e29b82883c500c7c8
+size 137954096

--- a/.infra/files/scripts/seed.sh
+++ b/.infra/files/scripts/seed.sh
@@ -34,5 +34,4 @@ echo "Restoring database $TARGET_DB..."
   --nsTo="$TARGET_DB.*" \
   --drop \
   --gzip \
-  --noIndexRestore \
   "mongodb://__system:{{ MONGODB_KEYFILE }}@localhost:27017/?authSource=local&directConnection=true"

--- a/gitleaks-fingerprints-baseline.txt
+++ b/gitleaks-fingerprints-baseline.txt
@@ -1,3 +1,6 @@
+.infra/ansible/preview_cleanup.yml:mongodb-connection-string:mongodb://__system:{{ MONGODB_KEYFILE }}@localhost:27017/{{
+.infra/ansible/preview_cleanup.yml:mongodb-connection-string:mongodb://__system:{{ MONGODB_KEYFILE }}@localhost:27017/admin?authSource=local&directConnection=true
+.infra/ansible/tasks/preview_pr.yml:mongodb-connection-string:mongodb://__system:{{ MONGODB_KEYFILE }}@localhost:27017/preview_{{
 .infra/docker-compose.preview-system.yml:generic-secret-assignment:SECRET_KEY
 LBA_CATALOGUE_URL=https://catalogue-apprentissage.intercariforef.org
 LBA_SERVER_SENTRY_DSN=https://public@sentry.example.com/1

--- a/server/src/jobs/database/obfuscateCollections.ts
+++ b/server/src/jobs/database/obfuscateCollections.ts
@@ -19,6 +19,8 @@ import config from "@/config"
 const fakeEmail = "faux_email@faux-domaine-compagnie.com"
 export const getFakeEmail = () => `${randomUUID()}@faux-domaine.fr`
 
+// leave this function to be used.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function reduceModel(model: CollectionName, limit = 20000) {
   logger.info(`reducing collection ${model} to ${limit} latest documents`)
   try {
@@ -151,6 +153,18 @@ const obfuscatePartnerJobs = async () => {
   )
 }
 
+const reduceRecruteursLba = async (limit = 75_000) => {
+  logger.info(`reducing jobs_partners recruteurs_lba to ${limit} latest documents`)
+  const result = await getDbCollection("jobs_partners")
+    .aggregate([{ $match: { partner_label: "recruteurs_lba" } }, { $sort: { _id: -1 } }, { $skip: limit }, { $project: { _id: 1 } }])
+    .toArray()
+  const idsToDelete = result.map((val) => val._id)
+  const chunks = chunk(idsToDelete, 1_000)
+  if (chunks.length) {
+    await Promise.all(chunks.map(async (chunk) => await getDbCollection("jobs_partners").deleteMany({ _id: { $in: chunk } })))
+  }
+}
+
 const keepSpecificUser = async (email: string, type: AccessEntityType) => {
   const role = await getDbCollection("rolemanagements").findOne({ authorized_type: type })
   const replacement = {
@@ -276,48 +290,54 @@ export async function obfuscateCollections(): Promise<void> {
   await dropUnknownCollections()
 
   const collectionsToEmpty: CollectionName[] = [
-    "apicalls",
-    "applicants",
-    "applications",
-    "appointments",
-    "cache_geolocation",
-    "cache_siret",
-    "unsubscribedrecruteurslba",
-    "unsubscribedofs",
-    "trafficsources",
-    "sessions",
-    "rolemanagement360",
-    "reported_companies",
-    "recruteurlbaupdateevents",
-    "jobs",
-    "eligible_trainings_for_appointments_histories",
-    "applicants_email_logs",
     "anonymized_applicants",
     "anonymized_applications",
     "anonymized_appointments",
     "anonymized_recruiters",
     "anonymized_users",
     "anonymized_userswithaccounts",
+    "apicalls",
+    "applicants",
+    "applicants_email_logs",
+    "applications",
+    "appointments",
+    "cache_classification",
+    "cache_geolocation",
+    "cache_siret",
+    "computed_jobs_partners",
+    "eligible_trainings_for_appointments_histories",
+    "emailblacklists",
+    "jobs",
+    "opcos",
+    "raw_apec",
+    "raw_atlas",
+    "raw_decathlon",
+    // "raw_emploi_inclusion",
+    "raw_engagement_jeunes",
+    "raw_france_travail_cegid",
     "raw_francetravail",
-    "raw_pass",
     "raw_hellowork",
+    "raw_jobteaser",
+    "raw_jooble",
     "raw_kelio",
     "raw_laposte",
     "raw_leboncoin",
-    "raw_jooble",
-    "raw_jobteaser",
+    "raw_meteojob",
+    "raw_monster",
+    "raw_nos_talents_nos_emplois",
+    "raw_pass",
     "raw_rhalternance",
     "raw_recruteurslba",
     "raw_toulouse_metropole",
-    "raw_engagement_jeunes",
-    "raw_france_travail_cegid",
-    "raw_monster",
-    "raw_nos_talents_nos_emplois",
     "raw_vite_un_emploi",
-    "raw_atlas",
-    "raw_meteojob",
-    "raw_decathlon",
-    "computed_jobs_partners",
+    "recruteurlbaupdateevents",
+    "reported_companies",
+    "rolemanagement360",
+    "sessions",
+    "trafficsources",
+    "unsubscribedofs",
+    "unsubscribedrecruteurslba",
+    "users",
   ]
 
   await Promise.all(
@@ -329,13 +349,10 @@ export async function obfuscateCollections(): Promise<void> {
     })
   )
 
-  await reduceModel("emailblacklists", 100)
-  await reduceModel("users", 10)
-  await reduceModel("opcos", 5000)
-
   await obfuscateApplicants()
   await obfuscateApplications()
   await obfuscatePartnerJobs()
+  await reduceRecruteursLba()
   await obfuscateEmailBlackList()
   await obfuscateAppointments()
   await obfuscateElligibleTrainingsForAppointment()
@@ -344,7 +361,6 @@ export async function obfuscateCollections(): Promise<void> {
   await obfuscateRecruiter()
   await obfuscateUser()
   await obfuscateUsersWithAccounts()
-  await obfuscatePartnerJobs()
 
   await recreateIndexes({ drop: true })
 }


### PR DESCRIPTION
## Fiabilisation du processus de déploiement des previews

### Problèmes identifiés

- **Seed systématique à chaque re-déploiement** (~15-20 min, verrou global, drop + restore complet) même quand seul le code change
- **Trois `flock` globaux** (build, seed, index) qui sérialisent tous les déploiements simultanés
- **Healthcheck UI à 60s d'intervalle** : `docker compose up --wait` pouvait attendre jusqu'à 11 min
- **`Remove database` défaillant** : utilisait `mongo:6.0.2-focal` avec `LBA_MONGODB_URI` potentiellement incorrect → sans `ignore_errors`, l'échec bloquait la suppression du répertoire, créant des DBs orphelines accumulées
- **Pas de nettoyage des DBs orphelines** : le cleanup ne parcourt que les répertoires `/opt/app/projects/`, jamais les databases sans répertoire correspondant

### Changements

#### Seed conditionnel ([`preview_pr.yml`](.infra/ansible/tasks/preview_pr.yml))
Avant de lancer le seed, on vérifie si la base de données est déjà peuplée via `mongosh`. Le seed ne tourne que si :
- La DB est vide ou n'existe pas (premier déploiement), **ou**
- `FORCE_SEED=true` (commentaire 🌱 sur la PR)

Résultat : les re-déploiements passent de ~30-40 min à ~5-10 min.

#### Re-seed à la demande ([`deploy_preview.yml`](.github/workflows/deploy_preview.yml), [`preview.yml`](.github/workflows/preview.yml))
- 🚀 = re-déploiement sans toucher aux données
- 🌱 🚀 = reset complet de la DB + re-seed

#### Correction du "Remove database" ([`preview_pr.yml`](.infra/ansible/tasks/preview_pr.yml))
Remplace `docker run --rm mongo:6.0.2-focal` par `docker compose exec mongodb` avec `__system` + keyfile (même mécanisme que le seed). Cible explicitement `preview_{{ pr_number }}`. Ajoute `ignore_errors: true` pour que la suppression du répertoire se fasse même si le drop échoue.

#### Nettoyage des DBs orphelines ([`preview_cleanup.yml`](.infra/ansible/preview_cleanup.yml))
Le cron nightly liste maintenant toutes les databases `preview_*` dans MongoDB et supprime celles qui n'ont plus de répertoire `/opt/app/projects/N/` correspondant. Nettoie aussi les DBs laissées par les anciennes défaillances.

#### Healthcheck UI ([`docker-compose.preview.yml`](.infra/docker-compose.preview.yml))
| | Avant | Après |
|---|---|---|
| interval | 60s | 10s |
| timeout | 30s | 10s |
| retries | 11 | 30 |
| Attente max (`--wait`) | ~11 min | ~5 min |