### PR TITLE
fix: prevent autoheal from killing MongoDB during preview seed

### DIFF
--- a/.infra/docker-compose.preview-system.yml
+++ b/.infra/docker-compose.preview-system.yml
@@ -58,9 +58,9 @@ services:
     healthcheck:
       test: ["CMD", "mongosh", "--eval", '''db.runCommand("ping").ok''', "--quiet"]
       interval: 10s
-      timeout: 5s
-      retries: 12
-      start_period: 10s
+      timeout: 20s
+      retries: 30
+      start_period: 30s
     labels:
       - autoheal=true
 


### PR DESCRIPTION
## Constat

Pendant `mongorestore` (étape de seed des previews), MongoDB est sous forte charge. Le healthcheck `mongosh ping` avec un timeout de **5s** échoue répétitivement. Après **12 échecs consécutifs**, Docker marque le container comme unhealthy → autoheal le redémarre avec SIGKILL → `mongorestore` est tué → rc=137.

Logs autoheal confirmant le problème :
```
05-03-2026 08:49:56 Container /lba_mongodb found to be unhealthy - Restarting container now with 10s timeout
```

La mémoire n'était pas en cause (< 2 GB pendant le restore, serveur 32 GB à 24% d'utilisation). Buildx était arrêté proprement (SIGTERM, pas OOM). La cause réelle : le timeout trop court du healthcheck sous charge.

## Correction

Paramètres du healthcheck MongoDB dans [`docker-compose.preview-system.yml`](.infra/docker-compose.preview-system.yml) :

| | Avant | Après |
|---|---|---|
| `timeout` | 5s | 20s |
| `retries` | 12 | 30 |
| `start_period` | 10s | 30s |

Avec `timeout: 20s` et `retries: 30`, MongoDB peut être sous charge jusqu'à **10 minutes** (30 × 20s dans le pire cas où chaque check timeout) avant d'être marqué unhealthy — largement au-delà de la durée d'un `mongorestore`.