### PR TITLE
fix: clean preview metabase

### DIFF
--- a/.infra/ansible/tasks/preview_pr.yml
+++ b/.infra/ansible/tasks/preview_pr.yml
@@ -169,7 +169,6 @@
     - name: "[{{ pr_number }}] Remove database from Metabase"
       shell:
         cmd: "bash /opt/app/configs/metabase/remove-preview-database.sh {{ pr_number }}"
-      when: check_stat.stat.exists
       ignore_errors: true
 
     - name: "[{{ pr_number }}] Remove database"

--- a/.infra/files/configs/metabase/cleanup-preview-databases.sh
+++ b/.infra/files/configs/metabase/cleanup-preview-databases.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+METABASE_URL="https://metabase.{{dns_name}}"
+GITHUB_REPO="mission-apprentissage/{{repo_name}}"
+
+SESSION_PAYLOAD=$(jq -n \
+  --arg username "{{ LBA_METABASE_ADMIN_EMAIL }}" \
+  --arg password "{{ LBA_METABASE_ADMIN_PASS }}" \
+  '{"username": $username, "password": $password}')
+SESSION=$(curl -sSf -X POST "${METABASE_URL}/api/session" \
+  --header 'Content-Type: application/json' \
+  --data-raw "$SESSION_PAYLOAD")
+TOKEN=$(echo "$SESSION" | jq -r '.id')
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+  echo "Error: Failed to authenticate with Metabase" >&2
+  exit 1
+fi
+
+echo "Fetching preview databases from Metabase..."
+DATABASES=$(curl -sSf "${METABASE_URL}/api/database" \
+  --header "X-Metabase-Session: $TOKEN" | \
+  jq -r '.data[] | select(.name | test("^MongoDB PR-[0-9]+$")) | "\(.id) \(.name)"')
+
+if [[ -z "$DATABASES" ]]; then
+  echo "No preview databases found in Metabase."
+  exit 0
+fi
+
+while IFS= read -r line; do
+  DB_ID=$(echo "$line" | awk '{print $1}')
+  DB_NAME=$(echo "$line" | awk '{print $2}')
+  PR_NUMBER=$(echo "$DB_NAME" | grep -oE '[0-9]+$')
+
+  PR_STATE=$(curl -sSf "https://api.github.com/repos/${GITHUB_REPO}/pulls/${PR_NUMBER}" \
+    --header "Accept: application/vnd.github+json" | \
+    jq -r '.state // "not_found"')
+
+  if [[ "$PR_STATE" == "open" ]]; then
+    echo "PR-${PR_NUMBER}: open — skipping"
+  else
+    echo "PR-${PR_NUMBER}: ${PR_STATE} — removing database (id=${DB_ID})"
+    curl -sSf -X DELETE "${METABASE_URL}/api/database/${DB_ID}" \
+      --header "X-Metabase-Session: $TOKEN"
+    echo "  -> removed"
+  fi
+done <<< "$DATABASES"
+
+echo "Cleanup done."

--- a/.infra/files/configs/metabase/cleanup-preview-databases.sh
+++ b/.infra/files/configs/metabase/cleanup-preview-databases.sh
@@ -32,9 +32,9 @@ while IFS= read -r line; do
   DB_NAME=$(echo "$line" | awk '{print $2}')
   PR_NUMBER=$(echo "$DB_NAME" | grep -oE '[0-9]+$')
 
-  PR_STATE=$(curl -sSf "https://api.github.com/repos/${GITHUB_REPO}/pulls/${PR_NUMBER}" \
-    --header "Accept: application/vnd.github+json" | \
-    jq -r '.state // "not_found"')
+  PR_RESPONSE=$(curl -sS "https://api.github.com/repos/${GITHUB_REPO}/pulls/${PR_NUMBER}" \
+    --header "Accept: application/vnd.github+json")
+  PR_STATE=$(echo "$PR_RESPONSE" | jq -r '.state // "not_found"')
 
   if [[ "$PR_STATE" == "open" ]]; then
     echo "PR-${PR_NUMBER}: open — skipping"


### PR DESCRIPTION
This pull request introduces an automated cleanup script for preview databases in Metabase and makes a minor adjustment to the Ansible playbook for removing preview databases. The main improvement is the addition of a script that identifies and deletes databases associated with closed or merged pull requests, helping to keep the Metabase environment clean.

**Metabase preview database cleanup automation:**

* Added a new script `cleanup-preview-databases.sh` that authenticates with Metabase, lists all preview databases matching the naming pattern, checks the state of the associated GitHub pull request, and deletes the database if the PR is not open. This helps automate the cleanup of unused preview databases.

**Ansible playbook adjustment:**

* Removed the `when: check_stat.stat.exists` condition from the task that removes preview databases from Metabase in `.infra/ansible/tasks/preview_pr.yml`, ensuring the removal command runs regardless of file existence.