### PR TITLE
fix(lba-3761): missing statut for recruteurs_lba

### DIFF
--- a/server/src/services/recruteurLba.service.ts
+++ b/server/src/services/recruteurLba.service.ts
@@ -58,6 +58,7 @@ const transformCompany = ({
 
   const resultCompany: ILbaItemLbaCompany = {
     ideaType: LBA_ITEM_TYPE_OLD.LBA,
+    status: company.offer_status,
     // ideaType: LBA_ITEM_TYPE.RECRUTEURS_LBA,
     id: company.workplace_siret!,
     title: company.workplace_brand || company.workplace_legal_name,
@@ -113,6 +114,7 @@ const transformCompanyWithMinimalData = ({
 
   const resultCompany: ILbaItemLbaCompany = {
     ideaType: LBA_ITEM_TYPE_OLD.LBA,
+    status: company.offer_status,
     id: company.workplace_siret!,
     title: company.workplace_brand || company.workplace_legal_name,
     place: {
@@ -155,6 +157,7 @@ const transformCompanyV2 = ({
 
   const resultCompany: ILbaItemLbaCompany = {
     ideaType: LBA_ITEM_TYPE.RECRUTEURS_LBA,
+    status: company.offer_status,
     id: company.workplace_siret!,
     title: company.workplace_brand || company.workplace_legal_name,
     contact: {

--- a/shared/src/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
+++ b/shared/src/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
@@ -947,6 +947,15 @@ exports[`generateOpenApiSchema > should generate proper schema 1`] = `
             "description": "Identifiant personnalisé (ID mongoDB préfixé du nom de la collection) envoyé au server pour la candidature",
             "type": "string",
           },
+          "status": {
+            "description": "Status de l'offre (surtout utilisé pour les offres ajouté par API)",
+            "enum": [
+              "Active",
+              "Filled",
+              "Cancelled",
+            ],
+            "type": "string",
+          },
           "title": {
             "type": [
               "string",
@@ -968,6 +977,7 @@ exports[`generateOpenApiSchema > should generate proper schema 1`] = `
         },
         "required": [
           "ideaType",
+          "status",
           "id",
           "place",
           "company",

--- a/shared/src/models/lbaItem.model.ts
+++ b/shared/src/models/lbaItem.model.ts
@@ -6,6 +6,7 @@ import { z } from "../helpers/zodWithOpenApi.js"
 
 import { ZJobType } from "./job.model.js"
 import { ZReferentielRomeForJob } from "./rome.model.js"
+import { ZJobsPartnersOfferPrivate } from "./jobsPartners.model.js"
 
 const ZLbaItemPlace = z
   .object({
@@ -533,6 +534,7 @@ export type ILbaItemPartnerJobReturnedByAPI = Jsonify<z.output<typeof ZLbaItemPa
 export const ZLbaItemLbaCompany = z
   .object({
     ideaType: z.enum([LBA_ITEM_TYPE_OLD.LBA, LBA_ITEM_TYPE.RECRUTEURS_LBA]),
+    status: ZJobsPartnersOfferPrivate.shape.offer_status,
     // ideaType: z.literal(LBA_ITEM_TYPE.RECRUTEURS_LBA),
     id: z.string().nullable().openapi({}),
     title: z.string().nullish(), // lbb/lba -> enseigne

--- a/ui/app/(candidat)/(recherche)/recherche/_components/isOfferActive.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/isOfferActive.ts
@@ -1,7 +1,11 @@
 import type { ILbaItemLbaCompanyJson, ILbaItemLbaJobJson, ILbaItemPartnerJobJson } from "shared"
-import { JOB_STATUS } from "shared"
+import { JOB_STATUS, JOB_STATUS_ENGLISH } from "shared"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 
 export function isOfferActive(item: ILbaItemLbaJobJson | ILbaItemLbaCompanyJson | ILbaItemPartnerJobJson): boolean {
-  return item.ideaType === LBA_ITEM_TYPE.RECRUTEURS_LBA || ("job" in item && item.job?.status === JOB_STATUS.ACTIVE)
+  if (item.ideaType === LBA_ITEM_TYPE.RECRUTEURS_LBA) {
+    return item.status === JOB_STATUS_ENGLISH.ACTIVE
+  } else {
+    return "job" in item && item.job?.status === JOB_STATUS.ACTIVE
+  }
 }


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3761

-----

This pull request introduces the `status` field to the `ILbaItemLbaCompany` model, updates its schema validation and OpenAPI documentation, and ensures that offer activity checks use the new status field for recruiter-type items. These changes improve data consistency and allow for more accurate filtering of active offers.

**Model and Schema Updates:**

* Added the `status` field to the `ILbaItemLbaCompany` model and linked its validation to `ZJobsPartnersOfferPrivate.shape.offer_status` in `shared/src/models/lbaItem.model.ts`.
* Updated the OpenAPI schema snapshot to document the new `status` field, including its description, allowed values, and required status. [[1]](diffhunk://#diff-dd14371fec43a3bf2370a6f5856afc97cb2997adab9eafc4c3a4f609da07afcfR950-R958) [[2]](diffhunk://#diff-dd14371fec43a3bf2370a6f5856afc97cb2997adab9eafc4c3a4f609da07afcfR980)

**Backend Data Transformation:**

* Added the `status` property to the returned object in all relevant company transformation functions in `server/src/services/recruteurLba.service.ts` (`transformCompany`, `transformCompanyWithMinimalData`, and `transformCompanyV2`). [[1]](diffhunk://#diff-156ee690b1cb02be25b6c4217c83c2a759c993502ca7668987c4a71c9c84f132R61) [[2]](diffhunk://#diff-156ee690b1cb02be25b6c4217c83c2a759c993502ca7668987c4a71c9c84f132R117) [[3]](diffhunk://#diff-156ee690b1cb02be25b6c4217c83c2a759c993502ca7668987c4a71c9c84f132R160)

**Frontend Logic Adjustment:**

* Modified the `isOfferActive` function to use the new `status` field for recruiter-type items, ensuring correct active offer filtering in the UI.

**Dependency Update:**

* Imported `ZJobsPartnersOfferPrivate` to support schema validation for the new `status` field.