### PR TITLE
fix(revert): annule la migration vers Blacksmith runners

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   npm-packages-check:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     concurrency:
       group: "build-${{ github.workflow }}-${{ github.ref }}"
     permissions: write-all
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v5
@@ -73,8 +73,15 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64
+          install: true
+          buildkitd-config-inline: |
+            [worker.oci]
+              gc = true
+              gckeepstorage = 10240
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   version:
     name: Get Version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       VERSION: ${{ steps.get-version.outputs.VERSION }}
     steps:
@@ -71,7 +71,7 @@ jobs:
           APP_VERSION: ${{ inputs.app_version }}
 
   npm-packages-check:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -92,7 +92,7 @@ jobs:
     if: ${{ success() }}
     needs: ["version", "npm-packages-check"]
     name: Deploy ${{ needs.version.outputs.VERSION }} on ${{ inputs.environment }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Notify new deployment on Slack
         uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
         required: true
 jobs:
   npm-packages-check:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     needs: ["npm-packages-check"]
     timeout-minutes: 10
     name: "Tests"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout project

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -10,7 +10,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.issue.id }}
       cancel-in-progress: true
     name: Deploy Preview ${{ github.event.issue.number }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Get Run URL
         id: run_url

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   npm-packages-check:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
     outputs:
       VERSION: ${{ steps.get-version.outputs.VERSION }}
       PREV_VERSION: ${{ steps.get-prev-version.outputs.VERSION }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v6
@@ -54,8 +54,11 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64
+          install: true
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -85,7 +88,7 @@ jobs:
   build-ui-recette:
     needs: ["release"]
     if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v6
@@ -111,8 +114,11 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64
+          install: true
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -132,7 +138,7 @@ jobs:
   docker-scout-server:
     if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
     needs: ["release"]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Authenticate to Docker
         uses: docker/login-action@v3
@@ -159,7 +165,7 @@ jobs:
   docker-scout-ui:
     if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
     needs: ["release"]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Authenticate to Docker
         uses: docker/login-action@v3
@@ -201,7 +207,7 @@ jobs:
 
   sentry:
     needs: ["release"]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Annule le commit de migration vers les runners Blacksmith (#2748)
- Restaure `ubuntu-latest` dans tous les workflows CI/CD
- Restaure `docker/setup-buildx-action@v3` à la place de `useblacksmith/setup-docker-builder@v1`

## Fichiers modifiés

- `.github/workflows/_build.yml`
- `.github/workflows/_deploy.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/deploy_preview.yml`
- `.github/workflows/release.yml`