### PR TITLE
fix(lba-3400): ajustement des paramètres Sentry cron (checkinMargin & maxRuntimeInMinutes)

### DIFF
--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -178,6 +178,8 @@ export async function setupJobProcessor() {
             cron_string: "15 2 * * *",
             handler: importCatalogueFormationJob,
             tag: "main",
+            checkinMargin: 30,
+            maxRuntimeInMinutes: 90,
           },
           "Mise à jour des champs spécifiques de la collection formations catalogue": {
             cron_string: "30 2 * * *",

--- a/server/src/jobs/offrePartenaire/jobsPartners.importer.ts
+++ b/server/src/jobs/offrePartenaire/jobsPartners.importer.ts
@@ -152,7 +152,7 @@ export const importers: Record<string, CronDef> = {
     cron_string: timings.process_computed,
     handler: processComputedAndImportToJobPartners,
     checkinMargin: 350,
-    maxRuntimeInMinutes: 120,
+    maxRuntimeInMinutes: 300,
     tag: "slave",
     resumable: true,
   },


### PR DESCRIPTION
## Contexte

Analyse des monitors Sentry sur les jobs cron — deux problèmes détectés en production :

- **`process-computed-and-import-to-jobs-partners`** : timeout 3 jours consécutifs (1-3 mars 2026) — le job dépasse les 120 min configurées
- **`Import des formations depuis le Catalogue RCO`** : missed check-in 5 jours consécutifs (20-24 fév 2026) — le `checkinMargin` par défaut (5 min) était trop court

## Changements

### `jobsPartners.importer.ts`
- `Process computed and import to Jobs Partners` : `maxRuntimeInMinutes` 120 → **300** (job resumable et lourd, timeouts répétés confirmés par Sentry)

### `jobs.ts`
- `Import des formations depuis le Catalogue RCO` : ajout `checkinMargin: 30` et `maxRuntimeInMinutes: 90` (aucune valeur définie → defaults trop stricts causaient des faux positifs)

## Test plan
- [ ] Vérifier dans Sentry que les monitors `process-computed-and-import-to-jobs-partners` et `import-des-formations-depuis-le-catalogue-rco` ne déclenchent plus d'alertes après le prochain passage des crons en production