### PR TITLE
fix: clean closed companies script

### DIFF
--- a/server/src/jobs/oneTimeJob/cleanClosedCompanies.ts
+++ b/server/src/jobs/oneTimeJob/cleanClosedCompanies.ts
@@ -21,7 +21,7 @@ interface CsvRow {
 }
 
 export const cleanClosedCompanies = async (csvPath?: string) => {
-  const filePath = csvPath ?? join(__dirname, "companies-to-close.csv")
+  const filePath = typeof csvPath === "string" ? csvPath : join(__dirname, "companies-to-close.csv")
   const content = readFileSync(filePath, "utf-8")
   const rows: CsvRow[] = parse(content, { columns: true, skip_empty_lines: true })
 


### PR DESCRIPTION
This pull request makes a small improvement to how the `cleanClosedCompanies` function determines the file path for the CSV file. The change ensures that the `csvPath` parameter is only used if it is a string, providing better type safety and preventing potential errors.

- Improved file path resolution in `cleanClosedCompanies` by using `csvPath` only if it is a string, otherwise defaulting to `companies-to-close.csv`.