### PR TITLE
fix(lba-3774): metabase preview scripts

### DIFF
--- a/.infra/files/configs/metabase/add-preview-database.sh
+++ b/.infra/files/configs/metabase/add-preview-database.sh
@@ -25,7 +25,7 @@ fi
 
 EXISTING_ID=$(curl -sSf "${METABASE_URL}/api/database" \
   --header "X-Metabase-Session: $TOKEN" | \
-  jq -r --arg name "MongoDB PR-${PR_NUMBER}" '.data[] | select(.name == $name) | .id' | head -n1)
+  jq -r --arg name "MongoDB PR-${PR_NUMBER}" '[.data[] | select(.name == $name) | .id] | first // empty')
 
 if [[ -n "$EXISTING_ID" ]]; then
   echo "Database MongoDB PR-${PR_NUMBER} already exists in Metabase (id=${EXISTING_ID}), skipping"

--- a/.infra/files/configs/metabase/add-preview-database.sh
+++ b/.infra/files/configs/metabase/add-preview-database.sh
@@ -23,6 +23,15 @@ if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
   exit 1
 fi
 
+EXISTING_ID=$(curl -sSf "${METABASE_URL}/api/database" \
+  --header "X-Metabase-Session: $TOKEN" | \
+  jq -r --arg name "MongoDB PR-${PR_NUMBER}" '.data[] | select(.name == $name) | .id' | head -n1)
+
+if [[ -n "$EXISTING_ID" ]]; then
+  echo "Database MongoDB PR-${PR_NUMBER} already exists in Metabase (id=${EXISTING_ID}), skipping"
+  exit 0
+fi
+
 DB_PAYLOAD=$(jq -n \
   --arg name "MongoDB PR-${PR_NUMBER}" \
   --arg uri "$MONGO_URI" \

--- a/.infra/files/configs/metabase/cleanup-preview-databases.sh
+++ b/.infra/files/configs/metabase/cleanup-preview-databases.sh
@@ -29,8 +29,7 @@ fi
 
 while IFS= read -r line; do
   DB_ID=$(echo "$line" | awk '{print $1}')
-  DB_NAME=$(echo "$line" | awk '{print $2}')
-  PR_NUMBER=$(echo "$DB_NAME" | grep -oE '[0-9]+$')
+  PR_NUMBER=$(echo "$line" | grep -oE '[0-9]+$')
 
   PR_RESPONSE=$(curl -sS "https://api.github.com/repos/${GITHUB_REPO}/pulls/${PR_NUMBER}" \
     --header "Accept: application/vnd.github+json")


### PR DESCRIPTION
This pull request introduces improvements to the Metabase preview database scripts, focusing on preventing duplicate database creation and simplifying the cleanup process. The main changes include adding a check for existing databases before creation and streamlining the extraction of pull request numbers during cleanup.

Metabase preview database management improvements:

* Added a check in `add-preview-database.sh` to detect if a database named `MongoDB PR-${PR_NUMBER}` already exists in Metabase, skipping creation if found to prevent duplicates.

Cleanup script simplification:

* Simplified the extraction of the pull request number in `cleanup-preview-databases.sh` by removing the intermediate variable and directly parsing the PR number from the input line.