### PR TITLE
fix(lba-3783): ajout d'une valeur par défaut vide pour offer_status_history dans le modèle

### DIFF
--- a/shared/src/models/jobsPartners.model.ts
+++ b/shared/src/models/jobsPartners.model.ts
@@ -154,7 +154,7 @@ export const ZJobsPartnersOfferApi = ZJobsPartnersRecruiterApi.omit({
   offer_expiration: z.date().nullable().describe("Date d'expiration de l'offre. Si pas présente, mettre à creation_date + 60j").openapi({ format: "date-time" }),
   offer_opening_count: z.number().describe("Nombre de poste disponible"),
   offer_status: extensions.buildEnum(JOB_STATUS_ENGLISH).describe("Status de l'offre (surtout utilisé pour les offres ajouté par API)"),
-  offer_status_history: z.array(ZJobsPartnersOfferHistoryEvent).describe("Historique de l'offre"),
+  offer_status_history: z.array(ZJobsPartnersOfferHistoryEvent).default([]).describe("Historique de l'offre"),
 
   stats_detail_view: z.number().default(0).describe("Nombre de vues de la page de détail"),
   stats_search_view: z.number().default(0).describe("Nombre de vues sur une page de recherche"),


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3783

---

## Changements

- Ajout de `.default([])` sur le champ `offer_status_history` dans `jobsPartners.model.ts`
- Corrige l'erreur de validation Zod `invalid_type: expected array, received undefined` remontée lors de l'import `importEmploiInclusionToComputed`, dont le mapper ne renseigne pas ce champ

## Plan de test

- [ ] Lancer `importEmploiInclusionToComputed` et vérifier que les documents ne remontent plus l'erreur `offer_status_history` dans le champ `errors` après la validation