### PR TITLE
fix(lba-3786): restauration de l'endpoint GET /partners/parcoursup/formations

### DIFF
--- a/server/src/http/controllers/partners.controller.test.ts
+++ b/server/src/http/controllers/partners.controller.test.ts
@@ -1,0 +1,15 @@
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { useServer } from "@tests/utils/server.test.utils"
+import assert from "assert"
+import { describe, expect, it } from "vitest"
+
+describe("partnersRoutes", () => {
+  useMongo()
+  const httpClient = useServer()
+  it("Vérifie que l'on expose bien les id_parcoursup disponibles sur le catalogue", async () => {
+    const response = await httpClient().inject({ method: "GET", path: "/api/partners/parcoursup/formations" })
+
+    expect(response.statusCode).toBe(200)
+    assert.ok(JSON.parse(response.body).ids)
+  })
+})

--- a/server/src/http/controllers/partners.controller.ts
+++ b/server/src/http/controllers/partners.controller.ts
@@ -1,0 +1,34 @@
+import { zRoutes } from "shared"
+import { referrers } from "shared/constants/referers"
+
+import * as eligibleTrainingsForAppointmentService from "../../services/eligibleTrainingsForAppointment.service"
+import type { Server } from "../server"
+
+/**
+ * @description Partners server.
+ */
+export default (server: Server) => {
+  /**
+   * @description Returns all available parcoursup ids.
+   * This endpoint is used by Parcoursup.
+   */
+  server.get(
+    "/partners/parcoursup/formations",
+    {
+      schema: zRoutes.get["/partners/parcoursup/formations"],
+    },
+    async (req, res) => {
+      const ids = await eligibleTrainingsForAppointmentService.find(
+        {
+          parcoursup_id: {
+            $ne: null,
+          },
+          referrers: { $in: [referrers.PARCOURSUP.name] },
+        },
+        { projection: { parcoursup_id: 1 } }
+      )
+
+      return res.send({ ids: ids.map((eligibleTrainingsForAppointment) => eligibleTrainingsForAppointment.parcoursup_id) })
+    }
+  )
+}

--- a/server/src/http/controllers/partners.controller.ts
+++ b/server/src/http/controllers/partners.controller.ts
@@ -1,7 +1,7 @@
 import { zRoutes } from "shared"
 import { referrers } from "shared/constants/referers"
 
-import * as eligibleTrainingsForAppointmentService from "../../services/eligibleTrainingsForAppointment.service"
+import * as eligibleTrainingsForAppointmentService from "@/services/eligibleTrainingsForAppointment.service"
 import type { Server } from "../server"
 
 /**
@@ -21,6 +21,7 @@ export default (server: Server) => {
       const ids = await eligibleTrainingsForAppointmentService.find(
         {
           parcoursup_id: {
+            $exists: true,
             $ne: null,
           },
           referrers: { $in: [referrers.PARCOURSUP.name] },
@@ -28,7 +29,7 @@ export default (server: Server) => {
         { projection: { parcoursup_id: 1 } }
       )
 
-      return res.send({ ids: ids.map((eligibleTrainingsForAppointment) => eligibleTrainingsForAppointment.parcoursup_id) })
+      return res.send({ ids: ids.map((eligibleTrainingsForAppointment) => eligibleTrainingsForAppointment.parcoursup_id).filter((id) => id !== null) })
     }
   )
 }

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -40,6 +40,7 @@ import jobsV1Route from "./controllers/jobs.controller"
 import jobsEtFormationsV1Route from "./controllers/jobsEtFormations.controller"
 import login from "./controllers/login.controller"
 import metiers from "./controllers/metiers.controller"
+import partnersRoute from "./controllers/partners.controller"
 import reportedCompanyController from "./controllers/reportedCompany.controller"
 import rome from "./controllers/rome.controller"
 import sitemapController from "./controllers/sitemap.controller"
@@ -133,6 +134,7 @@ export async function bind(app: Server) {
        */
       version(typedSubApp)
       metiers(typedSubApp)
+      partnersRoute(typedSubApp)
       rome(typedSubApp)
       updateLbaCompany(typedSubApp)
       application(typedSubApp)

--- a/shared/src/routes/index.ts
+++ b/shared/src/routes/index.ts
@@ -21,6 +21,7 @@ import { zV1JobsRoutes } from "./jobs.routes.js"
 import { zV1JobsEtFormationsRoutes } from "./jobsEtFormations.routes.js"
 import { zLoginRoutes } from "./login.routes.js"
 import { zMetiersRoutes } from "./metiers.routes.js"
+import { zPartnersRoutes } from "./partners.routes.js"
 import { zRecruiterRoutes } from "./recruiters.routes.js"
 import { zReportedCompanyRoutes } from "./reportedCompany.routes.js"
 import { zRomeRoutes } from "./rome.routes.js"
@@ -60,6 +61,7 @@ const zRoutesGetP4 = {
   ...zUpdateLbaCompanyRoutes.get,
   ...zUserRecruteurRoutes.get,
   ...zV1FormationsParRegion.get,
+  ...zPartnersRoutes.get,
   ...zLoginRoutes.get,
   ...zInserJeunesRoutes.get,
 } as const

--- a/shared/src/routes/partners.routes.ts
+++ b/shared/src/routes/partners.routes.ts
@@ -1,0 +1,17 @@
+import { z } from "../helpers/zodWithOpenApi.js"
+import { ZEligibleTrainingsForAppointmentSchema } from "../models/elligibleTraining.model.js"
+
+import type { IRoutesDef } from "./common.routes.js"
+
+export const zPartnersRoutes = {
+  get: {
+    "/partners/parcoursup/formations": {
+      method: "get",
+      path: "/partners/parcoursup/formations",
+      response: {
+        "200": z.object({ ids: z.array(ZEligibleTrainingsForAppointmentSchema.shape.parcoursup_id) }).strict(),
+      },
+      securityScheme: null,
+    },
+  },
+} as const satisfies IRoutesDef

--- a/shared/src/routes/partners.routes.ts
+++ b/shared/src/routes/partners.routes.ts
@@ -1,5 +1,4 @@
 import { z } from "../helpers/zodWithOpenApi.js"
-import { ZEligibleTrainingsForAppointmentSchema } from "../models/elligibleTraining.model.js"
 
 import type { IRoutesDef } from "./common.routes.js"
 
@@ -9,7 +8,7 @@ export const zPartnersRoutes = {
       method: "get",
       path: "/partners/parcoursup/formations",
       response: {
-        "200": z.object({ ids: z.array(ZEligibleTrainingsForAppointmentSchema.shape.parcoursup_id) }).strict(),
+        "200": z.object({ ids: z.array(z.string()) }).strict(),
       },
       securityScheme: null,
     },


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3786

---

## Changements

- Restauration du fichier `shared/src/routes/partners.routes.ts` (supprimé dans la PR #2403)
- Restauration du fichier `server/src/http/controllers/partners.controller.ts`
- Restauration du fichier `server/src/http/controllers/partners.controller.test.ts`
- Réenregistrement de la route dans `shared/src/routes/index.ts`
- Réenregistrement du controller dans `server/src/http/server.ts` (supprimé dans un commit séparé)

## Plan de test

- [x] Appeler `GET /api/partners/parcoursup/formations` et vérifier que la réponse est `200` avec un champ `ids`