### PR TITLE
fix(lba-3790): mise à jour des versions des GitHub Actions et correction sécurité deploy preview

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: true
 
       - name: Clone mna-npm-check repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: mission-apprentissage/mna-npm-check
           path: mna-npm-check
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
           token: ${{ secrets.TOKEN_MNA_SHARED }}
@@ -74,7 +74,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           platforms: linux/amd64
           install: true
@@ -84,14 +84,14 @@ jobs:
               gckeepstorage = 10240
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
+        uses: crazy-max/ghaction-github-runtime@v4
 
       - name: Retrieve previous version
         id: get-prev-version

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: Checkout project
         if: ${{ inputs.app_version == 'latest' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -74,13 +74,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: true
 
       - name: Clone mna-npm-check repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: mission-apprentissage/mna-npm-check
           path: mna-npm-check
@@ -107,7 +107,7 @@ jobs:
         run: curl -4 ifconfig.me
 
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
           token: ${{ secrets.TOKEN_MNA_SHARED }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload logs artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs-${{ inputs.environment }}
           path: /tmp/deploy.log.gpg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: true
 
       - name: Clone mna-npm-check repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: mission-apprentissage/mna-npm-check
           path: mna-npm-check
@@ -34,9 +34,9 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "yarn"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,17 +41,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -5,7 +5,14 @@ on:
 
 jobs:
   deploy_preview:
-    if: (contains(github.event.comment.body, '🚀') || contains(github.event.comment.body, ':rocket:')) && github.event.issue.pull_request
+    if: |
+      (contains(github.event.comment.body, '🚀') || contains(github.event.comment.body, ':rocket:'))
+      && github.event.issue.pull_request
+      && (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.issue.id }}
       cancel-in-progress: true
@@ -42,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.get-branch.outputs.branch }}
           token: ${{ secrets.TOKEN_MNA_SHARED }}
@@ -52,7 +59,7 @@ jobs:
         run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
 
       - name: LFS Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .git/lfs/objects
           key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
@@ -87,8 +94,10 @@ jobs:
 
       - name: Detect force reseed
         id: force_seed
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          if echo "${{ github.event.comment.body }}" | grep -qF '🌱'; then
+          if echo "$COMMENT_BODY" | grep -qF '🌱'; then
             echo "value=true" >> "$GITHUB_OUTPUT"
           else
             echo "value=false" >> "$GITHUB_OUTPUT"
@@ -107,7 +116,7 @@ jobs:
 
       - name: Upload logs artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs-${{ github.event.issue.number }}
           path: /tmp/deploy.log.gpg

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -97,7 +97,7 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          if echo "$COMMENT_BODY" | grep -qF '🌱'; then
+          if printf '%s' "$COMMENT_BODY" | grep -qF '🌱'; then
             echo "value=true" >> "$GITHUB_OUTPUT"
           else
             echo "value=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Control pull request title
     steps:
-      - uses: thehanimo/pr-title-checker@v1.4.1
+      - uses: thehanimo/pr-title-checker@v1.4.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: false

--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           lfs: true
           token: ${{ secrets.TOKEN_MNA_SHARED }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: true
 
       - name: Clone mna-npm-check repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: mission-apprentissage/mna-npm-check
           path: mna-npm-check
@@ -55,20 +55,20 @@ jobs:
         run: yarn install --immutable
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           platforms: linux/amd64
           install: true
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
+        uses: crazy-max/ghaction-github-runtime@v4
 
       - name: Retrieve previous version
         id: get-prev-version
@@ -115,20 +115,20 @@ jobs:
         run: yarn install --immutable
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           platforms: linux/amd64
           install: true
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
+        uses: crazy-max/ghaction-github-runtime@v4
 
       - name: Build UI recette
         run: .bin/mna-lba app:build ${{ needs.release.outputs.VERSION }} push $(git rev-parse HEAD) recette
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Authenticate to Docker
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PAT }}
@@ -157,7 +157,7 @@ jobs:
           only-severities: "critical,high,medium"
 
       - name: Server Docker Upload SARIF result
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: sarif-server.output.json
           category: Docker Server
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Authenticate to Docker
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PAT }}
@@ -184,7 +184,7 @@ jobs:
           only-severities: "critical,high,medium"
 
       - name: UI Docker Upload SARIF result
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: sarif-ui.output.json
           category: Docker UI
@@ -235,7 +235,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
+++ b/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { redirect } from "next/navigation"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
+import { HomeCircleImageDecoration } from "@/app/(home)/_components/HomeCircleImageDecoration"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { apiGet } from "@/utils/api.utils"
 


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3790

---

## Changements

- Bump de toutes les GitHub Actions vers leurs dernières versions majeures :
  - `actions/checkout` v4/v5 → v6
  - `actions/setup-node` v4 → v6
  - `actions/upload-artifact` v4 → v7
  - `actions/cache` v4 → v5
  - `github/codeql-action` v3 → v4
  - `docker/setup-buildx-action` v3 → v4
  - `docker/login-action` v3 → v4
  - `crazy-max/ghaction-github-runtime` v2 → v4
  - `thehanimo/pr-title-checker` v1.4.1 → v1.4.3
- Correction sécurité dans `deploy_preview.yml` : ajout d'un gate `author_association` (OWNER/MEMBER/COLLABORATOR) sur le trigger `issue_comment` pour éviter qu'un utilisateur externe déclenche un deploy avec accès aux secrets
- Correction injection shell : `github.event.comment.body` passé via variable d'environnement `COMMENT_BODY` au lieu d'être interpolé directement dans le `run:`

## Plan de test

- [x] Vérifier que le workflow CI passe sur cette PR
- [x] Vérifier qu'un commentaire 🚀 d'un collaborateur déclenche bien le deploy preview
- [x] Vérifier qu'un commentaire 🚀 d'un utilisateur externe (non membre) ne déclenche pas le deploy preview
- [x] Vérifier que le build Docker fonctionne sur un merge sur main (actions/checkout v6 + docker actions v4)