### PR TITLE
fix(lba-3799): passage du flag isWidget au composant DepotSimplifieCreationOffre

### DIFF
--- a/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/offre/page.tsx
+++ b/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/offre/page.tsx
@@ -6,5 +6,5 @@ export const metadata: Metadata = {
 }
 
 export default function Page() {
-  return <DepotSimplifieCreationOffre />
+  return <DepotSimplifieCreationOffre isWidget />
 }

--- a/ui/app/(espace-pro-creation-compte)/_components/DepotSimplifieCreationOffre.tsx
+++ b/ui/app/(espace-pro-creation-compte)/_components/DepotSimplifieCreationOffre.tsx
@@ -9,7 +9,7 @@ import { createOffreByToken } from "@/utils/api"
 import { PAGES } from "@/utils/routes.utils"
 import { useSearchParamsRecord } from "@/utils/useSearchParamsRecord"
 
-export function DepotSimplifieCreationOffre() {
+export function DepotSimplifieCreationOffre({ isWidget = false }: { isWidget?: boolean }) {
   const router = useRouter()
   const { displayBanner, userId, establishment_id } = useSearchParamsRecord()
   const { email, token } = useSearchParamsRecord() as { token: string; email: string }
@@ -26,7 +26,7 @@ export function DepotSimplifieCreationOffre() {
           fromDashboard: false,
           userId: userId,
           token: jobToken ?? undefined,
-          isWidget: false,
+          isWidget: isWidget,
         })
         .getPath()
     )


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3799

---

## Changements

- Ajout d'une prop `isWidget` (optionnelle, `false` par défaut) sur le composant `DepotSimplifieCreationOffre`
- La page widget (`/espace-pro/widget/entreprise/offre`) passe désormais `isWidget={true}` au composant au lieu de la valeur en dur `false`

## Plan de test

- [x] Vérifier que le dépôt d'offre via le widget redirige correctement avec `isWidget=true`
- [x] Vérifier que le dépôt d'offre hors widget fonctionne toujours normalement (`isWidget=false` par défaut)