### PR TITLE
fix(lba-3827): sécurisation et enrichissement de la route GET /classification

### DIFF
--- a/server/src/http/controllers/classification.controller.ts
+++ b/server/src/http/controllers/classification.controller.ts
@@ -2,10 +2,12 @@ import { unauthorized } from "@hapi/boom"
 import { addJob } from "job-processor"
 import type { ICredential } from "shared"
 import { JOB_STATUS_ENGLISH, zRoutes } from "shared"
+import { JOB_PARTNER_BUSINESS_ERROR } from "shared/models/jobsPartnersComputed.model"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 import type { Server } from "@/http/server"
 
 type IModelTraining = {
+  partner_job_id: string
   label: string
   workplace_name: string
   workplace_description: string
@@ -14,8 +16,10 @@ type IModelTraining = {
 }
 
 export const classificationRoutes = (server: Server) => {
-  server.get("/classification", { schema: zRoutes.get["/classification"] }, async (_, res) => {
-    const result = (await getDbCollection("cache_classification")
+  server.get("/classification", { schema: zRoutes.get["/classification"], onRequest: server.auth(zRoutes.get["/classification"]) }, async (req, res) => {
+    const user = req.user?.value as ICredential
+    if (user.scope !== "classification") throw unauthorized("scope classification required")
+    const resultCacheClassification = (await getDbCollection("cache_classification")
       .aggregate([
         {
           $match: {
@@ -34,6 +38,7 @@ export const classificationRoutes = (server: Server) => {
         {
           $project: {
             _id: 0,
+            partner_job_id: 1,
             label: "$human_verification",
             workplace_name: "$job.workplace_name",
             workplace_description: "$job.workplace_description",
@@ -44,7 +49,29 @@ export const classificationRoutes = (server: Server) => {
       ])
       .toArray()) as IModelTraining[]
 
-    return res.status(200).send(result)
+    const resultComputedBlacklisted = await getDbCollection("computed_jobs_partners")
+      .find(
+        { business_error: JOB_PARTNER_BUSINESS_ERROR.CFA_BLACKLISTED },
+        { projection: { workplace_name: 1, workplace_description: 1, offer_title: 1, offer_description: 1, partner_job_id: 1, _id: 0 } }
+      )
+      .toArray()
+
+    const deduplicatedResults = new Map<string, IModelTraining>(resultCacheClassification.map((result) => [result.partner_job_id, result]))
+
+    for (const { partner_job_id, workplace_name, workplace_description, offer_title, offer_description } of resultComputedBlacklisted) {
+      if (!deduplicatedResults.has(partner_job_id)) {
+        deduplicatedResults.set(partner_job_id, {
+          partner_job_id,
+          label: "unpublish",
+          workplace_name: workplace_name || "",
+          workplace_description: workplace_description || "",
+          offer_title: offer_title || "",
+          offer_description: offer_description || "",
+        })
+      }
+    }
+
+    return res.status(200).send(Array.from(deduplicatedResults.values()).map(({ partner_job_id: _partner_job_id, ...result }) => result))
   })
 
   server.post("/classification", { schema: zRoutes.post["/classification"], onRequest: server.auth(zRoutes.post["/classification"]) }, async (req, res) => {

--- a/shared/src/routes/classification.routes.ts
+++ b/shared/src/routes/classification.routes.ts
@@ -18,7 +18,11 @@ export const zClassificationRoute = {
           })
         ),
       },
-      securityScheme: null,
+      securityScheme: {
+        auth: "api-key",
+        access: null,
+        resources: {},
+      },
     },
   },
   post: {


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3827

---

## Changements

- Ajout de l'authentification API key sur la route `GET /classification`
- Vérification du scope `classification` requis
- Enrichissement des résultats avec les offres blacklistées (`CFA_BLACKLISTED`) issues de `computed_jobs_partners`
- Déduplication des résultats par `partner_job_id`

## Plan de test

- [ ] Appeler `GET /api/classification` sans token → doit retourner 401
- [ ] Appeler `GET /api/classification` avec un token sans scope `classification` → doit retourner 401
- [ ] Appeler `GET /api/classification` avec un token valide et scope `classification` → doit retourner 200 avec les résultats fusionnés
- [ ] Vérifier que les offres `CFA_BLACKLISTED` apparaissent bien dans la réponse
- [ ] Vérifier l'absence de doublons par `partner_job_id`