### PR TITLE
fix(lba-3758): amélioration des core web vitals et gestion du # dans l'url rdva

### DIFF
--- a/ui/app/(candidat)/detail-rendez-vous/[id]/DetailRendezVousRendererClient.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/DetailRendezVousRendererClient.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { fr } from "@codegouvfr/react-dsfr"
+import Button from "@codegouvfr/react-dsfr/Button"
 import { Box, List, ListItem, Typography } from "@mui/material"
 import { useFormik } from "formik"
 import { useState } from "react"
@@ -14,61 +15,74 @@ import { CfaCandidatInformationUnreachable } from "@/components/espace_pro/CfaCa
 import { RdvReasons } from "@/components/RDV/RdvReasons"
 import { apiPost } from "@/utils/api.utils"
 
+type State = "initial" | "sending" | "answered" | "other" | "unreachable" | "error"
+
 export default function DetailRendezVousRendererClient({ appointmentId, appointment, token }: { appointmentId: string; appointment: IAppointmentRecapJson; token: string }) {
-  const [currentState, setCurrentState] = useState("initial")
+  const [currentState, setCurrentState] = useState<State>("initial")
 
   const formik = useFormik({
     initialValues: {
       message: "",
     },
+    validateOnChange: false,
+    validateOnBlur: true,
     validationSchema: Yup.object({ message: Yup.string().required("Veuillez remplir le message") }),
     onSubmit: async (values) => {
       setCurrentState("sending")
-
-      await apiPost("/appointment-request/reply", {
-        body: {
-          appointment_id: appointmentId,
-          cfa_intention_to_applicant: "personalised_answer",
-          cfa_message_to_applicant: values.message,
-        },
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      })
-
-      setCurrentState("answered")
+      try {
+        await apiPost("/appointment-request/reply", {
+          body: {
+            appointment_id: appointmentId,
+            cfa_intention_to_applicant: "personalised_answer",
+            cfa_message_to_applicant: values.message,
+          },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        })
+        setCurrentState("answered")
+      } catch {
+        setCurrentState("error")
+      }
     },
   })
 
   const otherClicked = async () => {
     setCurrentState("sending")
-
-    await apiPost("/appointment-request/reply", {
-      body: {
-        appointment_id: appointmentId,
-        cfa_intention_to_applicant: "other_channel",
-        cfa_message_to_applicant: "",
-      },
-      headers: {
-        authorization: `Bearer ${token}`,
-      },
-    })
-    setCurrentState("other")
+    try {
+      await apiPost("/appointment-request/reply", {
+        body: {
+          appointment_id: appointmentId,
+          cfa_intention_to_applicant: "other_channel",
+          cfa_message_to_applicant: "",
+        },
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      })
+      setCurrentState("other")
+    } catch {
+      setCurrentState("error")
+    }
   }
+
   const unreachableClicked = async () => {
     setCurrentState("sending")
-
-    await apiPost("/appointment-request/reply", {
-      body: {
-        appointment_id: appointmentId,
-        cfa_intention_to_applicant: "no_answer",
-        cfa_message_to_applicant: "",
-      },
-      headers: {
-        authorization: `Bearer ${token}`,
-      },
-    })
-    setCurrentState("unreachable")
+    try {
+      await apiPost("/appointment-request/reply", {
+        body: {
+          appointment_id: appointmentId,
+          cfa_intention_to_applicant: "no_answer",
+          cfa_message_to_applicant: "",
+        },
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      })
+      setCurrentState("unreachable")
+    } catch {
+      setCurrentState("error")
+    }
   }
 
   return (
@@ -130,7 +144,7 @@ export default function DetailRendezVousRendererClient({ appointmentId, appointm
             <Typography component="p" sx={{ mt: fr.spacing("2v") }}>
               Il ou elle souhaite aborder avec vous le(s) sujet(s) suivant(s) :
             </Typography>
-            <Typography component="p">
+            <Typography component="div">
               <List sx={{ listStyleType: "disc", pl: fr.spacing("4v") }}>
                 {(appointment.appointment?.applicant_reasons || []).map((reason, i) => {
                   return (
@@ -164,15 +178,25 @@ export default function DetailRendezVousRendererClient({ appointmentId, appointm
             )}
           </Box>
           <hr />
-          {currentState === "initial" ? (
+          {currentState === "initial" && (
             <CfaCandidatInformationForm formik={formik} setCurrentState={setCurrentState} otherClicked={otherClicked} unreachableClicked={unreachableClicked} />
-          ) : (
-            <></>
           )}
-          {currentState === "sending" ? <div>Envoi en cours...</div> : <></>}
-          {currentState === "answered" ? <CfaCandidatInformationAnswered msg={formik.values.message} /> : <></>}
-          {currentState === "other" ? <CfaCandidatInformationOther /> : <></>}
-          {currentState === "unreachable" ? <CfaCandidatInformationUnreachable /> : <></>}
+          {currentState === "sending" && (
+            <Box sx={{ mt: fr.spacing("8v"), p: fr.spacing("8v"), backgroundColor: "#F5F5FE" }}>
+              <Typography>Envoi en cours...</Typography>
+            </Box>
+          )}
+          {currentState === "answered" && <CfaCandidatInformationAnswered msg={formik.values.message} />}
+          {currentState === "other" && <CfaCandidatInformationOther />}
+          {currentState === "unreachable" && <CfaCandidatInformationUnreachable />}
+          {currentState === "error" && (
+            <Box sx={{ mt: fr.spacing("8v"), p: fr.spacing("8v"), backgroundColor: "#F5F5FE" }}>
+              <Typography sx={{ fontWeight: 700, color: "#CE0500", mb: fr.spacing("4v") }}>Une erreur est survenue. Veuillez réessayer.</Typography>
+              <Button priority="secondary" onClick={() => setCurrentState("initial")}>
+                Réessayer
+              </Button>
+            </Box>
+          )}
         </Box>
       )}
     </FormLayoutComponent>

--- a/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
@@ -11,14 +11,17 @@ export const metadata: Metadata = {
 export default async function DetailRendezVousPage({ params, searchParams }: { params: Promise<{ id: string }>; searchParams: Promise<{ token: string }> }) {
   const { id } = await params
   const { token } = await searchParams
-  const appointmentRecap = await apiGet("/appointment-request/context/recap", {
-    querystring: { appointmentId: id },
-    headers: {
-      authorization: `Bearer ${token}`,
-    },
-  })
 
-  if (!appointmentRecap) redirect("/404")
+  try {
+    const appointmentRecap = await apiGet("/appointment-request/context/recap", {
+      querystring: { appointmentId: id },
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    })
 
-  return <DetailRendezVousRendererClient appointmentId={id} appointment={appointmentRecap} token={token} />
+    return <DetailRendezVousRendererClient appointmentId={id} appointment={appointmentRecap} token={token} />
+  } catch {
+    redirect("/404")
+  }
 }

--- a/ui/app/(rdva)/rdva/RdvaPage.tsx
+++ b/ui/app/(rdva)/rdva/RdvaPage.tsx
@@ -3,45 +3,60 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Container } from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
-import { useSearchParams } from "next/navigation"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
-import LoadingEmptySpace from "@/app/(espace-pro)/_components/LoadingEmptySpace"
 import { useFormationPrdvTracker } from "@/app/hooks/useFormationPrdvTracker"
 import { ContactCfaSummary } from "@/components/espace_pro/Candidat/layout/ContactCfaSummary"
 import { DemandeDeContactConfirmation } from "@/components/RDV/DemandeDeContactConfirmation"
 import { DemandeDeContactForm } from "@/components/RDV/DemandeDeContactForm"
 import { getPrdvContext } from "@/utils/api"
 
+type PrdvData = NonNullable<Awaited<ReturnType<typeof getPrdvContext>>>
+
+type Props = {
+  data: PrdvData | null
+  cleMinistereEducatif: string | null
+  referrer: string | null
+}
+
 /**
  * Appointment form page.
  */
-export default function PriseDeRendezVous() {
-  const searchParams = useSearchParams()
-  const cleMinistereEducatif = searchParams.get("cleMinistereEducatif")
-  const referrer = searchParams.get("referrer")
-
+export default function PriseDeRendezVous({ data, cleMinistereEducatif, referrer }: Props) {
   return (
     <Container disableGutters>
-      <PageContent cleMinistereEducatif={cleMinistereEducatif} referrer={referrer} />
+      <PageContent data={data} cleMinistereEducatif={cleMinistereEducatif} referrer={referrer} />
     </Container>
   )
 }
 
-const PageContent = ({ cleMinistereEducatif, referrer }: { cleMinistereEducatif: string; referrer: string }) => {
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ["getPrdvForm", cleMinistereEducatif],
-    queryFn: () => getPrdvContext(cleMinistereEducatif, referrer),
-    enabled: !!cleMinistereEducatif,
+const PageContent = ({ data: initialData, cleMinistereEducatif, referrer }: Props) => {
+  // Rescue client-side : si le # n'était pas encodé dans l'URL, le navigateur l'a
+  // interprété comme un fragment et le serveur n'a pas reçu la partie "#L01".
+  // On détecte ce cas en comparant window.location.hash avec la clé reçue côté serveur.
+  const [rescueCleMinistereEducatif, setRescueCleMinistereEducatif] = useState<string | null>(null)
+
+  useEffect(() => {
+    const hash = window.location.hash // ex: "#L01"
+    if (hash && cleMinistereEducatif && !initialData) {
+      // Le hash ressemble à un suffixe de cleMinistereEducatif (ex: "#L01", "#L05")
+      setRescueCleMinistereEducatif(`${cleMinistereEducatif}${hash}`)
+    }
+  }, [cleMinistereEducatif, initialData])
+
+  const { data: rescuedData } = useQuery({
+    queryKey: ["getPrdvForm-rescue", rescueCleMinistereEducatif],
+    queryFn: () => getPrdvContext(rescueCleMinistereEducatif!, referrer ?? "lba"),
+    enabled: !!rescueCleMinistereEducatif,
     gcTime: 0,
   })
 
-  const { setPrdvDone } = useFormationPrdvTracker(cleMinistereEducatif)
+  const data = initialData ?? rescuedData ?? null
+
+  const { setPrdvDone } = useFormationPrdvTracker(rescueCleMinistereEducatif ?? cleMinistereEducatif)
   const [confirmation, setConfirmation] = useState<{ appointmentId: string; token: string } | null>(null)
 
-  if (isLoading) return <LoadingEmptySpace />
-
-  if (isError || !data) {
+  if (!data) {
     return <Box sx={{ my: "5rem", textAlign: "center" }}>La prise de rendez-vous n'est pas disponible pour cette formation.</Box>
   }
 
@@ -55,13 +70,13 @@ const PageContent = ({ cleMinistereEducatif, referrer }: { cleMinistereEducatif:
   return confirmation ? (
     <DemandeDeContactConfirmation {...confirmation} />
   ) : (
-    <Box sx={{ my: fr.spacing("6v") }}>
+    <Box sx={{ my: fr.spacing("6v"), mx: fr.spacing("2v") }}>
       <ContactCfaSummary
-        entrepriseRaisonSociale={data?.etablissement_formateur_entreprise_raison_sociale}
-        intitule={data?.intitule_long}
-        adresse={data?.lieu_formation_adresse}
-        codePostal={data?.code_postal}
-        ville={data?.localite}
+        entrepriseRaisonSociale={data.etablissement_formateur_entreprise_raison_sociale}
+        intitule={data.intitule_long}
+        adresse={data.lieu_formation_adresse}
+        codePostal={data.code_postal}
+        ville={data.localite}
       />
       <DemandeDeContactForm context={context} referrer={referrer} onRdvSuccess={localOnSuccess} />
     </Box>

--- a/ui/app/(rdva)/rdva/RdvaPage.tsx
+++ b/ui/app/(rdva)/rdva/RdvaPage.tsx
@@ -44,7 +44,7 @@ const PageContent = ({ data: initialData, cleMinistereEducatif, referrer }: Prop
     }
   }, [cleMinistereEducatif, initialData])
 
-  const { data: rescuedData } = useQuery({
+  const { data: rescuedData, isFetching: isRescueFetching } = useQuery({
     queryKey: ["getPrdvForm-rescue", rescueCleMinistereEducatif],
     queryFn: () => getPrdvContext(rescueCleMinistereEducatif!, referrer ?? "lba"),
     enabled: !!rescueCleMinistereEducatif,
@@ -53,8 +53,15 @@ const PageContent = ({ data: initialData, cleMinistereEducatif, referrer }: Prop
 
   const data = initialData ?? rescuedData ?? null
 
-  const { setPrdvDone } = useFormationPrdvTracker(rescueCleMinistereEducatif ?? cleMinistereEducatif)
+  // Utilise la clé depuis la réponse API (la plus fiable) ou la clé de rescue/url
+  const trackingId = data?.cle_ministere_educatif ?? rescueCleMinistereEducatif ?? cleMinistereEducatif ?? ""
+  const { setPrdvDone } = useFormationPrdvTracker(trackingId)
   const [confirmation, setConfirmation] = useState<{ appointmentId: string; token: string } | null>(null)
+
+  // Rescue en cours : ne pas afficher le message d'erreur tant que la requête n'est pas terminée
+  if (!data && (rescueCleMinistereEducatif === null || isRescueFetching)) {
+    return null
+  }
 
   if (!data) {
     return <Box sx={{ my: "5rem", textAlign: "center" }}>La prise de rendez-vous n'est pas disponible pour cette formation.</Box>
@@ -78,7 +85,7 @@ const PageContent = ({ data: initialData, cleMinistereEducatif, referrer }: Prop
         codePostal={data.code_postal}
         ville={data.localite}
       />
-      <DemandeDeContactForm context={context} referrer={referrer} onRdvSuccess={localOnSuccess} />
+      <DemandeDeContactForm context={context} referrer={referrer ?? "lba"} onRdvSuccess={localOnSuccess} />
     </Box>
   )
 }

--- a/ui/app/(rdva)/rdva/page.tsx
+++ b/ui/app/(rdva)/rdva/page.tsx
@@ -1,12 +1,19 @@
 import type { Metadata } from "next"
+
+import { getPrdvContext } from "@/utils/api"
+
 import RdvaPage from "./RdvaPage"
 
 export const metadata: Metadata = {
   title: "Contacter un centre de formation - La bonne alternance",
 }
 
-const Page = async () => {
-  return <RdvaPage />
+type SearchParams = Promise<{ cleMinistereEducatif?: string; referrer?: string }>
+
+const Page = async ({ searchParams }: { searchParams: SearchParams }) => {
+  const { cleMinistereEducatif, referrer } = await searchParams
+  const data = cleMinistereEducatif ? ((await getPrdvContext(cleMinistereEducatif, referrer ?? "lba")) ?? null) : null
+  return <RdvaPage data={data} cleMinistereEducatif={cleMinistereEducatif ?? null} referrer={referrer ?? null} />
 }
 
 export default Page

--- a/ui/components/RDV/DemandeDeContactForm.tsx
+++ b/ui/components/RDV/DemandeDeContactForm.tsx
@@ -3,7 +3,7 @@ import Button from "@codegouvfr/react-dsfr/Button"
 import { Box, Checkbox, FormControl, FormControlLabel, FormHelperText, FormLabel, Input, Radio, RadioGroup, Typography } from "@mui/material"
 import emailMisspelled, { top100 } from "email-misspelled"
 import { Formik, useField } from "formik"
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { EReasonsKey } from "shared"
 import { EApplicantType } from "shared/constants/rdva"
 import * as Yup from "yup"
@@ -199,6 +199,12 @@ const EmailField = () => {
   const [suggestedEmails, setSuggestedEmails] = useState([])
   const [field, meta, helper] = useField("email")
   const emailDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (emailDebounceRef.current) clearTimeout(emailDebounceRef.current)
+    }
+  }, [])
 
   /**
    * On email change, check if email is correct and set suggestion if not.

--- a/ui/components/RDV/DemandeDeContactForm.tsx
+++ b/ui/components/RDV/DemandeDeContactForm.tsx
@@ -3,7 +3,7 @@ import Button from "@codegouvfr/react-dsfr/Button"
 import { Box, Checkbox, FormControl, FormControlLabel, FormHelperText, FormLabel, Input, Radio, RadioGroup, Typography } from "@mui/material"
 import emailMisspelled, { top100 } from "email-misspelled"
 import { Formik, useField } from "formik"
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { EReasonsKey } from "shared"
 import { EApplicantType } from "shared/constants/rdva"
 import * as Yup from "yup"
@@ -37,6 +37,8 @@ export const DemandeDeContactForm = ({
         applicantType: EApplicantType.ETUDIANT,
         applicantReasons: [],
       }}
+      validateOnChange={false}
+      validateOnBlur={true}
       validationSchema={Yup.object({
         firstname: Yup.string().required("⚠ Le prénom est obligatoire"),
         lastname: Yup.string().required("⚠ Le nom est obligatoire"),
@@ -85,7 +87,7 @@ export const DemandeDeContactForm = ({
           <form onSubmit={formik.handleSubmit}>
             <FormControl>
               <Box sx={{ display: "flex", flexDirection: { xs: "column", md: "row" }, alignItems: { xs: "flex-start", md: "center" }, mb: fr.spacing("4v") }}>
-                <Typography sx={{ mr: { xs: 0, md: 3 }, mb: { xs: 1, sm: 1, md: 0 } }}>Vous êtes * :</Typography>
+                <Typography sx={{ mr: { xs: 0, md: fr.spacing("2v") }, mb: { xs: fr.spacing("2v"), sm: fr.spacing("2v"), md: 0 } }}>Vous êtes * :</Typography>
                 <RadioGroup row data-testid="fieldset-who-type" value={formik.values.applicantType} onChange={async (_, value) => formik.setFieldValue("applicantType", value)}>
                   <FormControlLabel value={EApplicantType.ETUDIANT} label="L'étudiant" control={<Radio />} />
                   <FormControlLabel value={EApplicantType.PARENT} label="Le parent" control={<Radio />} />
@@ -198,14 +200,18 @@ export const DemandeDeContactForm = ({
 const EmailField = () => {
   const [suggestedEmails, setSuggestedEmails] = useState([])
   const [field, meta, helper] = useField("email")
+  const emailDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   /**
    * On email change, check if email is correct and set suggestion if not.
    */
   const onEmailChange = (e) => {
-    const suggestedEmails = emailChecker(e.target.value)
-    setSuggestedEmails(suggestedEmails)
     field.onChange(e)
+    const value = e.target.value
+    if (emailDebounceRef.current) clearTimeout(emailDebounceRef.current)
+    emailDebounceRef.current = setTimeout(() => {
+      setSuggestedEmails(emailChecker(value))
+    }, 300)
   }
 
   /**

--- a/ui/components/RDV/DemandeDeContactForm.tsx
+++ b/ui/components/RDV/DemandeDeContactForm.tsx
@@ -141,21 +141,19 @@ export const DemandeDeContactForm = ({
             <Box sx={{ display: "flex", flexDirection: { xs: "column", md: "row" }, mb: fr.spacing("4v") }}>
               <ReasonsField formik={formik} />
             </Box>
-            <Box
-              sx={{
-                width: "95%",
-                fontSize: "12px",
-              }}
-            >
+            <Box sx={{ width: "95%" }}>
               <Typography
+                variant="caption"
+                component="p"
                 sx={{
                   color: fr.colors.decisions.text.mention.grey.default,
                   mb: fr.spacing("4v"),
+                  display: "block",
                 }}
               >
                 * Champs obligatoires
               </Typography>
-              <Typography sx={{ mb: fr.spacing("4v") }}>
+              <Typography variant="body2" sx={{ mb: fr.spacing("4v") }}>
                 En remplissant ce formulaire, vous acceptez les{" "}
                 <DsfrLink href="/conditions-generales-utilisation" external aria-description="Conditions générales d'utilisation - nouvelle fenêtre">
                   Conditions générales d&apos;utilisation

--- a/ui/components/espace_pro/Candidat/layout/ContactCfaSummary.tsx
+++ b/ui/components/espace_pro/Candidat/layout/ContactCfaSummary.tsx
@@ -25,9 +25,11 @@ export const ContactCfaSummary = (props: Props) => {
         <Box
           sx={{
             mt: fr.spacing("2v"),
+            display: "flex",
+            alignItems: "center",
           }}
         >
-          <MapPin2Fill sx={{ color: "#3a55d1", mb: fr.spacing("1v") }} />
+          <MapPin2Fill sx={{ color: "#3a55d1", flexShrink: 0 }} />
           <Typography
             component="span"
             sx={{
@@ -43,7 +45,7 @@ export const ContactCfaSummary = (props: Props) => {
       )}
       <Box
         sx={{
-          mt: fr.spacing("16v"),
+          mt: fr.spacing("10v"),
           borderBottom: "1px solid #D0C9C4",
         }}
       />

--- a/ui/components/espace_pro/Candidat/layout/ContactCfaSummary.tsx
+++ b/ui/components/espace_pro/Candidat/layout/ContactCfaSummary.tsx
@@ -18,9 +18,13 @@ export const ContactCfaSummary = (props: Props) => {
   const { adresse, codePostal, entrepriseRaisonSociale, ville, intitule } = props
 
   return (
-    <Box sx={{ py: { xs: 0, sm: fr.spacing("7v"), mt: fr.spacing("2v") } }}>
-      <Typography sx={{ fontWeight: "700", color: "#2a2a2a" }}>{entrepriseRaisonSociale}</Typography>
-      <Typography sx={{ fontWeight: "400", color: "#2a2a2a" }}>{intitule}</Typography>
+    <Box sx={{ py: { xs: fr.spacing("4v"), md: fr.spacing("6v") } }}>
+      <Typography variant="h6" sx={{ fontWeight: "700", color: "#2a2a2a" }}>
+        {entrepriseRaisonSociale}
+      </Typography>
+      <Typography variant="body1" sx={{ fontWeight: "400", color: "#2a2a2a" }}>
+        {intitule}
+      </Typography>
       {adresse && codePostal && (
         <Box
           sx={{

--- a/ui/components/espace_pro/CfaCandidatInformationPage/CfaCandidatInformationForm.tsx
+++ b/ui/components/espace_pro/CfaCandidatInformationPage/CfaCandidatInformationForm.tsx
@@ -8,18 +8,17 @@ export const CfaCandidatInformationForm = (props) => {
   return (
     <form onSubmit={formik.handleSubmit}>
       <Box sx={{ mt: fr.spacing("2v"), p: fr.spacing("8v"), backgroundColor: "#F5F5FE" }}>
-        <Typography variant="h2" sx={{ fontWeight: 700, color: "#000091", fontSize: "22px", lineHeight: "36px" }}>
+        <Typography variant="h2" sx={{ fontWeight: 700, color: "#000091", fontSize: "2rem" }}>
           Votre réponse au candidat
         </Typography>
-        <Typography sx={{ fontWeight: 400, color: "#161616", fontSize: "16px", lineHeight: "24px", mt: 4 }}>Quelle est votre réponse ?</Typography>
-        <Typography sx={{ fontWeight: 400, color: "#666666", fontSize: "12px", lineHeight: "20px", mt: 1 }}>
-          Le candidat recevra votre réponse directement dans sa boîte mail.
-        </Typography>
+        <Typography sx={{ fontWeight: 400, color: "#161616", mt: fr.spacing("3v") }}>Quelle est votre réponse ?</Typography>
+        <Typography sx={{ fontWeight: 400, color: "#666666", mb: fr.spacing("3v") }}>Le candidat recevra votre réponse directement dans sa boîte mail.</Typography>
         <FormControl error={formik.touched.message && Boolean(formik.errors.message)} fullWidth sx={{ pb: fr.spacing("4v") }}>
           <TextareaAutosize
             className={fr.cx("fr-input")}
             id="message"
             name="message"
+            // minRows={4}
             onChange={formik.handleChange}
             value={formik.values.message}
             placeholder={`Bonjour,


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3758

---

## Changements

### Page `/rdva`

- **LCP** : le fetch de `getPrdvContext` est déplacé côté serveur (Server Component async) — plus d'écran blanc ni de spinner au chargement
- **Gestion du `#` non encodé** : rescue client-side via `window.location.hash` pour les cas où le référenceur (ex: Onisep) envoie un `#` non encodé dans la `cleMinistereEducatif` (le navigateur le traitait comme un fragment, le serveur ne recevait pas la partie `#L01`)
- **INP** : debounce 300ms sur `emailChecker` dans `DemandeDeContactForm` (était synchrone à chaque keystroke)
- **INP** : `validateOnChange={false}` sur Formik — la validation Yup ne se déclenche plus à chaque frappe

### Page `/detail-rendez-vous/[id]`

- **Bug 404** : `apiGet` throw une exception sur réponse non-ok (jamais `null`) — le `if (!appointmentRecap) redirect("/404")` était du dead code. Remplacé par un `try/catch` → redirect `/404` sur toute erreur API
- **Gestion d'erreur** : les 3 appels `apiPost` (`personalised_answer`, `other_channel`, `no_answer`) n'avaient aucun try/catch — en cas d'échec, la page restait bloquée à "Envoi en cours..." indéfiniment. Ajout d'un état `"error"` avec message et bouton "Réessayer"
- **CLS** : `<div>Envoi en cours...</div>` remplacé par un `<Box>` avec le même style que les composants de résultat (évite le saut de layout)
- **INP** : `validateOnChange: false` sur Formik
- **Hydration error** : `<Typography component="p">` wrappant un `<List>` (`<ul>`) — HTML invalide, changé en `component="div"`

## Plan de test

### `/rdva`
- [x] Ouvrir `/rdva?referrer=onisep&cleMinistereEducatif=...%23L01` → formulaire s'affiche directement sans spinner
- [x] Ouvrir `/rdva?referrer=onisep&cleMinistereEducatif=...#L01` (# non encodé) → formulaire s'affiche grâce au rescue client-side
- [x] Saisir un email avec faute de frappe → suggestion apparaît après ~300ms
- [x] La validation des champs se déclenche au blur, pas à chaque frappe

### `/detail-rendez-vous/[id]`
- [x] Accéder avec un `id` invalide → redirige vers `/404` (pas d'erreur 500)
- [x] Envoyer une réponse → transition fluide sans saut de layout
- [x] Simuler une erreur réseau → affiche "Une erreur est survenue" avec bouton "Réessayer"
- [x] Taper dans le textarea → validation ne se déclenche pas à chaque frappe