### PR TITLE
feat(lba-3841): update blacklist fields

### DIFF
--- a/docs/optimization/blocked-cfa-aho-corasick.md
+++ b/docs/optimization/blocked-cfa-aho-corasick.md
@@ -1,0 +1,74 @@
+# Blocked CFA Detection Optimization
+
+## Context
+
+The job [server/src/jobs/offrePartenaire/blockJobsPartnersFromCfaList.ts](server/src/jobs/offrePartenaire/blockJobsPartnersFromCfaList.ts) blocks partner offers when a blacklisted CFA is detected in one of these fields:
+
+- `workplace_name`
+- `offer_description`
+- `workplace_description`
+
+The matching logic currently lives in [server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.ts](server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.ts).
+
+## Current Implementation
+
+The current implementation keeps the blacklist as a simple `cfaCompanyList` string array. Adding a new blocked CFA only requires adding a new string entry to that array.
+
+Matching behavior is:
+
+- case-insensitive
+- accent-insensitive
+- punctuation normalized to spaces
+- able to detect a blocked CFA mention inside a longer text
+
+This simplicity is intentional and is kept for now.
+
+## Observed Scale
+
+Current order of magnitude:
+
+- blacklist size: about 1810 entries
+- `offer_description` count: 383170
+- `offer_description` average length: about 445 chars
+- `offer_description` p90/p95/p99: about 1984 / 2851 / 4892 chars
+- `offer_description` max length: 14428 chars
+- `workplace_description` average length: about 55 chars
+- `workplace_description` p90/p95/p99: about 261 / 405 / 1050 chars
+- `workplace_description` max length: 4019 chars
+
+With those inputs, the current linear scan remains acceptable short term, but it may become a bottleneck on full collection runs if text lengths or blacklist size keep growing.
+
+## Why Aho-Corasick
+
+If this detection needs to be optimized, Aho-Corasick is the preferred direction over a giant compiled regex.
+
+Reasons:
+
+- it is designed for multi-pattern search
+- it scales better with a large blacklist
+- it is more predictable on long text fields
+- it keeps the source of truth unchanged: `cfaCompanyList`
+
+A compiled regex would be simpler to introduce, but with a blacklist of this size it is more of an intermediate solution than a durable one.
+
+## Deferred Refactor Plan
+
+If optimization becomes necessary:
+
+1. Add a small server-side Aho-Corasick matcher utility.
+2. Keep `cfaCompanyList` unchanged in [server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.ts](server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.ts).
+3. Keep the current normalization pipeline unchanged.
+4. Build the automaton once at module load.
+5. Replace the current linear substring scan with the matcher.
+6. Keep existing tests unchanged as the behavioral contract.
+
+## Decision
+
+The current implementation is kept for now.
+
+Reason:
+
+- the feature is correct
+- the blacklist remains easy to maintain
+- the current runtime cost is acceptable short term
+- the Aho-Corasick path is documented and ready if optimization becomes necessary

--- a/server/src/jobs/offrePartenaire/blockJobsPartnersFromCfaList.test.ts
+++ b/server/src/jobs/offrePartenaire/blockJobsPartnersFromCfaList.test.ts
@@ -32,10 +32,47 @@ describe("blockJobsPartnersFromCfaListTask", () => {
     const { business_error } = job
     expect.soft(business_error).toEqual(JOB_PARTNER_BUSINESS_ERROR.CFA_BLACKLISTED)
   })
+
+  it("should block the offer when the CFA is mentioned in offer_description", async () => {
+    await givenSomeComputedJobPartners([
+      {
+        workplace_name: "totally valid company name",
+        offer_description: "Formation en alternance avec Iscod pour une prise de poste immediate",
+        business_error: null,
+      },
+    ])
+
+    await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+
+    const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect.soft(jobs.length).toBe(1)
+    const [job] = jobs
+    expect.soft(job.business_error).toEqual(JOB_PARTNER_BUSINESS_ERROR.CFA_BLACKLISTED)
+  })
+
+  it("should block the offer when the CFA is mentioned in workplace_description", async () => {
+    await givenSomeComputedJobPartners([
+      {
+        workplace_name: "totally valid company name",
+        workplace_description: "Entreprise partenaire du CFA Iscod pour le recrutement en alternance",
+        business_error: null,
+      },
+    ])
+
+    await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+
+    const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect.soft(jobs.length).toBe(1)
+    const [job] = jobs
+    expect.soft(job.business_error).toEqual(JOB_PARTNER_BUSINESS_ERROR.CFA_BLACKLISTED)
+  })
+
   it("should NOT block the offer", async () => {
     await givenSomeComputedJobPartners([
       {
         workplace_name: "totally valid company name",
+        offer_description: "Description d'offre legitime",
+        workplace_description: "Description d'entreprise legitime",
         business_error: null,
       },
     ])

--- a/server/src/jobs/offrePartenaire/blockJobsPartnersFromCfaList.ts
+++ b/server/src/jobs/offrePartenaire/blockJobsPartnersFromCfaList.ts
@@ -4,7 +4,19 @@ import type { FillComputedJobsPartnersContext } from "./fillComputedJobsPartners
 import { fillFieldsForComputedPartnersFactory } from "./fillFieldsForPartnersFactory"
 import { isCompanyInBlockedCfaList } from "./isCompanyInBlockedCfaList"
 
-const sourceFields = ["workplace_name"] as const satisfies (keyof IComputedJobsPartners)[]
+const sourceFields = ["workplace_name", "offer_description", "workplace_description"] as const satisfies (keyof IComputedJobsPartners)[]
+
+// La detection actuelle reste volontairement simple. Si le cout devient trop
+// eleve sur des champs texte longs avec la taille actuelle de la blacklist,
+// privilegier un matcher Aho-Corasick en conservant `cfaCompanyList` comme
+// source de verite. Voir /docs/optimization/blocked-cfa-aho-corasick.md.
+const hasBlockedCfaMention = ({
+  workplace_name,
+  offer_description,
+  workplace_description,
+}: Pick<IComputedJobsPartners, "workplace_name" | "offer_description" | "workplace_description">) => {
+  return [workplace_name, offer_description, workplace_description].some(isCompanyInBlockedCfaList)
+}
 
 export const blockJobsPartnersFromCfaList = async ({ addedMatchFilter }: FillComputedJobsPartnersContext) => {
   const filledFields = ["business_error"] as const satisfies (keyof IComputedJobsPartners)[]
@@ -17,10 +29,10 @@ export const blockJobsPartnersFromCfaList = async ({ addedMatchFilter }: FillCom
     addedMatchFilter,
     getData: async (documents) => {
       return documents.map((document) => {
-        const { _id, workplace_name, business_error } = document
+        const { _id, workplace_name, offer_description, workplace_description, business_error } = document
         const result: Pick<IComputedJobsPartners, (typeof filledFields)[number] | "_id"> = {
           _id,
-          business_error: isCompanyInBlockedCfaList(workplace_name) ? JOB_PARTNER_BUSINESS_ERROR.CFA_BLACKLISTED : business_error,
+          business_error: hasBlockedCfaMention({ workplace_name, offer_description, workplace_description }) ? JOB_PARTNER_BUSINESS_ERROR.CFA_BLACKLISTED : business_error,
         }
         return result
       })

--- a/server/src/jobs/offrePartenaire/blockJobsPartnersFromCfaList.ts
+++ b/server/src/jobs/offrePartenaire/blockJobsPartnersFromCfaList.ts
@@ -6,10 +6,10 @@ import { isCompanyInBlockedCfaList } from "./isCompanyInBlockedCfaList"
 
 const sourceFields = ["workplace_name", "offer_description", "workplace_description"] as const satisfies (keyof IComputedJobsPartners)[]
 
-// La detection actuelle reste volontairement simple. Si le cout devient trop
-// eleve sur des champs texte longs avec la taille actuelle de la blacklist,
-// privilegier un matcher Aho-Corasick en conservant `cfaCompanyList` comme
-// source de verite. Voir /docs/optimization/blocked-cfa-aho-corasick.md.
+// La détection actuelle reste volontairement simple. Si le coût devient trop
+// élevé sur des champs texte longs avec la taille actuelle de la blacklist,
+// privilégier un matcher Aho-Corasick en conservant `cfaCompanyList` comme
+// source de vérité. Voir /docs/optimization/blocked-cfa-aho-corasick.md.
 const hasBlockedCfaMention = ({
   workplace_name,
   offer_description,

--- a/server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.test.ts
+++ b/server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.test.ts
@@ -29,6 +29,11 @@ describe("isCompanyInBlockedCfaList (insensible à la casse et aux accents)", ()
     expect(isCompanyInBlockedCfaList("CIO'sup drome-ardeche")).toBe(true)
   })
 
+  it("devrait trouver les CFA lorsqu'ils sont mentionnés dans un texte", () => {
+    expect(isCompanyInBlockedCfaList("Formation en alternance avec Iscod pour une prise de poste immediate")).toBe(true)
+    expect(isCompanyInBlockedCfaList("Entreprise partenaire du CFA Iscod pour le recrutement en alternance")).toBe(true)
+  })
+
   it("ne doit pas trouver un CFA qui n'existe pas", () => {
     expect(isCompanyInBlockedCfaList("CFA Bidon")).toBe(false)
     expect(isCompanyInBlockedCfaList("AFTEC Toulouse")).toBe(false)

--- a/server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.test.ts
+++ b/server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.test.ts
@@ -35,8 +35,8 @@ describe("isCompanyInBlockedCfaList (insensible à la casse et aux accents)", ()
   })
 
   it("ne doit pas trouver un CFA qui n'existe pas", () => {
-    expect(isCompanyInBlockedCfaList("CFA Bidon")).toBe(false)
-    expect(isCompanyInBlockedCfaList("AFTEC Toulouse")).toBe(false)
+    expect(isCompanyInBlockedCfaList("Boulangerie Dupont")).toBe(false)
+    expect(isCompanyInBlockedCfaList("Plomberie Martin")).toBe(false)
     expect(isCompanyInBlockedCfaList("Université Inconnue")).toBe(false)
   })
 })

--- a/server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.ts
+++ b/server/src/jobs/offrePartenaire/isCompanyInBlockedCfaList.ts
@@ -1815,12 +1815,19 @@ const cfaCompanyList = [
 
 const stringNormaliser = (str: string): string => {
   return removeAccents(str.toLowerCase())
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ")
 }
 
-const normalizedCfaSet = new Set(cfaCompanyList.map(stringNormaliser))
+const normalizedCfaList = cfaCompanyList.map(stringNormaliser)
+const normalizedCfaSet = new Set(normalizedCfaList)
 
 export const isCompanyInBlockedCfaList = (nom: string | null | undefined): boolean => {
   if (!nom) return false
   const nomNormalise = stringNormaliser(nom)
-  return normalizedCfaSet.has(nomNormalise)
+  if (normalizedCfaSet.has(nomNormalise)) return true
+
+  const normalizedSentence = ` ${nomNormalise} `
+  return normalizedCfaList.some((cfaName) => normalizedSentence.includes(` ${cfaName} `))
 }


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3841

----

## Changements effectués

- Extension du blocage des CFA blacklistés aux champs texte `offer_description` et `workplace_description`, en plus de `workplace_name`, dans `blockJobsPartnersFromCfaList.ts`
- Adaptation de la détection dans `isCompanyInBlockedCfaList.ts` pour reconnaître une occurrence de CFA blacklisté à l'intérieur d'un texte normalisé, et non plus uniquement un match exact sur tout le champ
- Ajout de tests couvrant les nouveaux cas de détection dans les descriptions dans `blockJobsPartnersFromCfaList.test.ts`
- Renforcement des tests unitaires de la détection pour valider la présence d'un CFA blacklisté dans une phrase dans `isCompanyInBlockedCfaList.test.ts`
- Documentation de la piste d'optimisation Aho-Corasick, sans changement fonctionnel immédiat, dans `blocked-cfa-aho-corasick.md`
- Ajout d'un commentaire dans `blockJobsPartnersFromCfaList.ts` pour référencer cette optimisation potentielle si la volumétrie devient limitante