### PR TITLE
fix: correction des tests impactés par la geoloc

### DIFF
--- a/server/src/http/controllers/etablissementRecruteur.controller.test.ts
+++ b/server/src/http/controllers/etablissementRecruteur.controller.test.ts
@@ -45,6 +45,7 @@ describe("POST /etablissement/creation", () => {
       .reply(200, {
         features: [
           {
+            type: "Feature",
             geometry: parisFixture.centre,
             properties: generateFeaturePropertyFixture({ city: parisFixture.nom, postcode: parisFixture.codesPostaux[0], name: "20 AVENUE DE SEGUR" }),
           },

--- a/server/src/jobs/offrePartenaire/fillLocationInfosForPartners.test.ts
+++ b/server/src/jobs/offrePartenaire/fillLocationInfosForPartners.test.ts
@@ -83,6 +83,7 @@ describe("fillLocationInfosForPartners", () => {
       .reply(200, {
         features: [
           {
+            type: "Feature",
             geometry: clichyFixture.centre,
             properties: generateFeaturePropertyFixture({
               city: clichyFixture.nom,

--- a/shared/src/models/address.model.ts
+++ b/shared/src/models/address.model.ts
@@ -134,7 +134,7 @@ const ZPointProperties = z
 
 // only type="Point" feature
 export const ZPointFeature = z.object({
-  type: z.literal("Feature"),
+  type: z.literal("Feature").nullish(),
   geometry: ZPointGeometry,
   properties: ZPointProperties,
 })

--- a/shared/src/models/address.model.ts
+++ b/shared/src/models/address.model.ts
@@ -134,7 +134,7 @@ const ZPointProperties = z
 
 // only type="Point" feature
 export const ZPointFeature = z.object({
-  type: z.literal("Feature").nullish(),
+  type: z.literal("Feature"),
   geometry: ZPointGeometry,
   properties: ZPointProperties,
 })


### PR DESCRIPTION
Des tests sur etablissementRecruteur.controller et sur fillLocationInfoForPartners étaient cassés suite à de mauvais mocks