### PR TITLE
fix(lba-3855): correction de bugs sentry lba-ui (stats, inserjeunes, chunkload, métiers, rdva)

### DIFF
--- a/server/src/http/controllers/jobs.controller.test.ts
+++ b/server/src/http/controllers/jobs.controller.test.ts
@@ -12,10 +12,10 @@ describe("jobs.controller", () => {
   const httpClient = useServer()
 
   describe("GET /v1/_private/jobs/min", () => {
-    it("retourne 500 avec wrong_parameters si caller et romes sont absents", async () => {
+    it("retourne 400 avec wrong_parameters si caller et romes sont absents", async () => {
       const response = await httpClient().inject({ method: "GET", path: "/api/v1/_private/jobs/min" })
 
-      expect(response.statusCode).toBe(500)
+      expect(response.statusCode).toBe(400)
       expect(response.json().error).toBe("wrong_parameters")
     })
 

--- a/server/src/http/controllers/jobs.controller.ts
+++ b/server/src/http/controllers/jobs.controller.ts
@@ -43,7 +43,7 @@ export default (server: Server) => {
       })
 
       if ("error" in result) {
-        return res.status(500).send(result)
+        return res.status(result.error === "wrong_parameters" ? 400 : 500).send(result)
       }
       return res.status(200).send(result)
     }

--- a/ui/app/(editorial)/metiers/[slug]/page.tsx
+++ b/ui/app/(editorial)/metiers/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Stack, Typography } from "@mui/material"
 import type { Metadata } from "next"
 import Link from "next/link"
+import { notFound } from "next/navigation"
 import path from "path"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
@@ -29,6 +30,9 @@ const getMetierBySlug = (jobs: IStaticMetiers[], slug: IStaticMetiers["slug"]) =
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const _params = await params
   const metier = getMetierBySlug(getMetiers(), _params.slug)
+  if (!metier) {
+    return { title: "Métier introuvable - La bonne alternance" }
+  }
   return PAGES.dynamic.metierJobById(metier.name).getMetadata()
 }
 
@@ -37,6 +41,10 @@ export default async function MetiersByJobId({ params }: { params: Promise<{ slu
   const towns = getTowns()
   const metiers = getMetiers()
   const relatedMetier = getMetierBySlug(metiers, slug)
+
+  if (!relatedMetier) {
+    notFound()
+  }
   return (
     <Box>
       <Breadcrumb pages={[PAGES.static.metiers, PAGES.dynamic.metierJobById(relatedMetier.name)]} />

--- a/ui/app/(editorial)/metiers/[slug]/page.tsx
+++ b/ui/app/(editorial)/metiers/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Stack, Typography } from "@mui/material"
 import type { Metadata } from "next"
 import Link from "next/link"
-import { notFound } from "next/navigation"
+import { redirect } from "next/navigation"
 import path from "path"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
@@ -43,7 +43,7 @@ export default async function MetiersByJobId({ params }: { params: Promise<{ slu
   const relatedMetier = getMetierBySlug(metiers, slug)
 
   if (!relatedMetier) {
-    notFound()
+    redirect("/404")
   }
   return (
     <Box>

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/User.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/User.tsx
@@ -29,7 +29,10 @@ export default function User() {
   } = useQuery({
     queryKey: ["recruiter", userRecruteur?.establishment_id],
     enabled: Boolean(userRecruteur?.establishment_id),
-    queryFn: () => getFormulaire(userRecruteur.establishment_id),
+    queryFn: () => {
+      if (!userRecruteur?.establishment_id) return Promise.resolve(undefined)
+      return getFormulaire(userRecruteur.establishment_id)
+    },
   })
 
   if (isLoading || !userRecruteur || !userId || recruiterLoading) {

--- a/ui/app/_components/ErrorComponent.tsx
+++ b/ui/app/_components/ErrorComponent.tsx
@@ -39,10 +39,27 @@ export type ErrorProps = { error: unknown; reset: () => void }
 export function ErrorComponent({ error, reset }: ErrorProps) {
   useEffect(() => {
     // ChunkLoadError : un chunk JS n'existe plus après un déploiement.
-    // On recharge la page silencieusement pour récupérer les nouveaux chunks.
+    // On recharge la page silencieusement pour récupérer les nouveaux chunks,
+    // avec un garde-fou sessionStorage pour éviter une boucle de refresh.
     if (error instanceof Error && error.name === "ChunkLoadError") {
-      window.location.reload()
-      return
+      const storageKey = "lba:lastChunkReload"
+      const reloadThrottleMs = 30000
+      const now = Date.now()
+
+      try {
+        const storedValue = window.sessionStorage.getItem(storageKey)
+        const lastReload = storedValue ? Number(storedValue) : 0
+
+        if (!lastReload || Number.isNaN(lastReload) || now - lastReload > reloadThrottleMs) {
+          window.sessionStorage.setItem(storageKey, String(now))
+          window.location.reload()
+          return
+        }
+      } catch (_e) {
+        // sessionStorage inaccessible (navigation privée, quota) : rechargement unique
+        window.location.reload()
+        return
+      }
     }
     Sentry.captureException(error)
     console.error(error)

--- a/ui/app/_components/ErrorComponent.tsx
+++ b/ui/app/_components/ErrorComponent.tsx
@@ -12,6 +12,31 @@ import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { publicConfig } from "@/config.public"
 import { ApiError } from "@/utils/api.utils"
 
+function wasPageReloaded(): boolean {
+  const navigationEntry = window.performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined
+  return navigationEntry?.type === "reload"
+}
+
+function shouldReloadChunkError(): boolean {
+  const storageKey = "lba:lastChunkReload"
+  const reloadThrottleMs = 30000
+  const now = Date.now()
+
+  try {
+    const storedValue = window.sessionStorage.getItem(storageKey)
+    const lastReload = storedValue ? Number(storedValue) : 0
+
+    if (!lastReload || Number.isNaN(lastReload) || now - lastReload > reloadThrottleMs) {
+      window.sessionStorage.setItem(storageKey, String(now))
+      return true
+    }
+
+    return false
+  } catch {
+    return !wasPageReloaded()
+  }
+}
+
 function getErrorDescription(error: unknown): string | null {
   if (!error) {
     return null
@@ -40,26 +65,10 @@ export function ErrorComponent({ error, reset }: ErrorProps) {
   useEffect(() => {
     // ChunkLoadError : un chunk JS n'existe plus après un déploiement.
     // On recharge la page silencieusement pour récupérer les nouveaux chunks,
-    // avec un garde-fou sessionStorage pour éviter une boucle de refresh.
-    if (error instanceof Error && error.name === "ChunkLoadError") {
-      const storageKey = "lba:lastChunkReload"
-      const reloadThrottleMs = 30000
-      const now = Date.now()
-
-      try {
-        const storedValue = window.sessionStorage.getItem(storageKey)
-        const lastReload = storedValue ? Number(storedValue) : 0
-
-        if (!lastReload || Number.isNaN(lastReload) || now - lastReload > reloadThrottleMs) {
-          window.sessionStorage.setItem(storageKey, String(now))
-          window.location.reload()
-          return
-        }
-      } catch (_e) {
-        // sessionStorage inaccessible (navigation privée, quota) : rechargement unique
-        window.location.reload()
-        return
-      }
+    // avec un garde-fou même si sessionStorage n'est pas disponible.
+    if (error instanceof Error && error.name === "ChunkLoadError" && shouldReloadChunkError()) {
+      window.location.reload()
+      return
     }
     Sentry.captureException(error)
     console.error(error)

--- a/ui/app/_components/ErrorComponent.tsx
+++ b/ui/app/_components/ErrorComponent.tsx
@@ -38,6 +38,12 @@ export type ErrorProps = { error: unknown; reset: () => void }
 
 export function ErrorComponent({ error, reset }: ErrorProps) {
   useEffect(() => {
+    // ChunkLoadError : un chunk JS n'existe plus après un déploiement.
+    // On recharge la page silencieusement pour récupérer les nouveaux chunks.
+    if (error instanceof Error && error.name === "ChunkLoadError") {
+      window.location.reload()
+      return
+    }
     Sentry.captureException(error)
     console.error(error)
   }, [error])

--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -23,7 +23,11 @@ init({
     reportingObserverIntegration({ types: ["crash", "deprecation", "intervention"] }),
   ],
   sendDefaultPii: true,
-  ignoreErrors: ["AbortError"],
+  ignoreErrors: [
+    "AbortError",
+    // Erreur provenant de l'extension navigateur MetaMask (inpage.js), non actionnable
+    "func sseError not found",
+  ],
   beforeSend(event) {
     // Hydratation error comes from DSFR
     if (event.extra?.arguments && Array.isArray(event.extra?.arguments) && event.extra?.arguments?.includes("https://react.dev/link/hydration-mismatch")) {

--- a/ui/services/fetchInserJeuneStats.test.ts
+++ b/ui/services/fetchInserJeuneStats.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import fetchInserJeunesStats from "./fetchInserJeuneStats"
 
+const { captureException } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+}))
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException,
+}))
+
 vi.mock("@/config.public", () => ({
   publicConfig: { apiEndpoint: "https://api.test" },
 }))
@@ -18,6 +26,7 @@ const stubFetch = (status: number, body: unknown = {}) => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  captureException.mockReset()
 })
 
 const training = {
@@ -40,20 +49,25 @@ describe("fetchInserJeunesStats", () => {
   it("retourne null si l'API répond 404", async () => {
     stubFetch(404)
     expect(await fetchInserJeunesStats(training)).toBeNull()
+    expect(captureException).not.toHaveBeenCalled()
   })
 
   it("retourne null si l'API répond 500", async () => {
     stubFetch(500)
     expect(await fetchInserJeunesStats(training)).toBeNull()
+    expect(captureException).toHaveBeenCalledTimes(1)
   })
 
   it("retourne null si l'API répond 503", async () => {
     stubFetch(503)
     expect(await fetchInserJeunesStats(training)).toBeNull()
+    expect(captureException).toHaveBeenCalledTimes(1)
   })
 
   it("retourne null en cas d'erreur réseau", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")))
+    const error = new Error("Network error")
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(error))
     expect(await fetchInserJeunesStats(training)).toBeNull()
+    expect(captureException).toHaveBeenCalledWith(error)
   })
 })

--- a/ui/services/fetchInserJeuneStats.test.ts
+++ b/ui/services/fetchInserJeuneStats.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import fetchInserJeunesStats from "./fetchInserJeuneStats"
+
+vi.mock("@/config.public", () => ({
+  publicConfig: { apiEndpoint: "https://api.test" },
+}))
+
+const stubFetch = (status: number, body: unknown = {}) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    })
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const training = {
+  place: { zipCode: "75001" },
+  training: { cfd: "12345678" },
+} as any
+
+describe("fetchInserJeunesStats", () => {
+  it("retourne null si training est falsy", async () => {
+    expect(await fetchInserJeunesStats(null as any)).toBeNull()
+    expect(await fetchInserJeunesStats(undefined as any)).toBeNull()
+  })
+
+  it("retourne les données si l'API répond 200", async () => {
+    const data = { taux_insertion: 75 }
+    stubFetch(200, data)
+    expect(await fetchInserJeunesStats(training)).toEqual(data)
+  })
+
+  it("retourne null si l'API répond 404", async () => {
+    stubFetch(404)
+    expect(await fetchInserJeunesStats(training)).toBeNull()
+  })
+
+  it("retourne null si l'API répond 500", async () => {
+    stubFetch(500)
+    expect(await fetchInserJeunesStats(training)).toBeNull()
+  })
+
+  it("retourne null si l'API répond 503", async () => {
+    stubFetch(503)
+    expect(await fetchInserJeunesStats(training)).toBeNull()
+  })
+
+  it("retourne null en cas d'erreur réseau", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")))
+    expect(await fetchInserJeunesStats(training)).toBeNull()
+  })
+})

--- a/ui/services/fetchInserJeuneStats.ts
+++ b/ui/services/fetchInserJeuneStats.ts
@@ -1,3 +1,4 @@
+import { captureException } from "@sentry/nextjs"
 import type { ILbaItemFormation2Json } from "shared"
 import { publicConfig } from "@/config.public"
 
@@ -10,10 +11,14 @@ export default async function fetchInserJeunesStats(training: ILbaItemFormation2
   try {
     const response = await fetch(`${baseUrl}/inserjeunes/${training.place.zipCode}/${training.training.cfd}`)
     if (!response.ok) {
+      if (response.status >= 500) {
+        captureException(new Error(`InserJeunes API error ${response.status}`))
+      }
       return null
     }
     return response.json()
-  } catch {
+  } catch (error) {
+    captureException(error)
     return null
   }
 }

--- a/ui/services/fetchInserJeuneStats.ts
+++ b/ui/services/fetchInserJeuneStats.ts
@@ -1,6 +1,5 @@
 import type { ILbaItemFormation2Json } from "shared"
 import { publicConfig } from "@/config.public"
-import { logError } from "@/utils/tools"
 
 const baseUrl = publicConfig.apiEndpoint
 
@@ -10,18 +9,11 @@ export default async function fetchInserJeunesStats(training: ILbaItemFormation2
   }
   try {
     const response = await fetch(`${baseUrl}/inserjeunes/${training.place.zipCode}/${training.training.cfd}`)
-    if (response.status === 404) {
+    if (!response.ok) {
       return null
     }
-
     return response.json()
-  } catch (error) {
-    if (error instanceof Error) {
-      if (error.message === "Pas de données disponibles") {
-        return null
-      }
-    }
-    logError("InserJeunes API error", `InserJeunes API error ${error}`)
+  } catch {
+    return null
   }
-  return null
 }

--- a/ui/services/fetchInserJeuneStats.ts
+++ b/ui/services/fetchInserJeuneStats.ts
@@ -16,7 +16,7 @@ export default async function fetchInserJeunesStats(training: ILbaItemFormation2
       }
       return null
     }
-    return response.json()
+    return await response.json()
   } catch (error) {
     captureException(error)
     return null

--- a/ui/utils/api.ts
+++ b/ui/utils/api.ts
@@ -14,7 +14,7 @@ import type {
 } from "shared"
 import { removeUndefinedFields } from "shared"
 import type { ApplicationIntention } from "shared/constants/application"
-import { BusinessErrorCodes } from "shared/constants/errorCodes"
+import type { BusinessErrorCodes } from "shared/constants/errorCodes"
 import type { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 
 import { ApiError, apiDelete, apiGet, apiPatch, apiPost, apiPut } from "./api.utils"
@@ -60,7 +60,11 @@ export const notifyLbaJobDetailView = async (jobId: string) => await apiPost("/v
 export const notifyJobDetailViewV3 = async (job: ILbaItemLbaJobJson | ILbaItemLbaCompanyJson | ILbaItemPartnerJobJson) => {
   const jobId = getObjectId(job)
   if (!jobId) return
-  return apiPost("/v3/jobs/:id/stats/:eventType", { params: { id: jobId, eventType: "detail_view" } })
+  try {
+    return await apiPost("/v3/jobs/:id/stats/:eventType", { params: { id: jobId, eventType: "detail_view" } })
+  } catch {
+    // tracking non-critique, erreur ignorée intentionnellement
+  }
 }
 export const notifyJobSearchViewV3 = async (ids: string[]) => {
   ids = ids.filter(lookLikeObjectId)
@@ -70,7 +74,11 @@ export const notifyJobSearchViewV3 = async (ids: string[]) => {
 export const notifyJobPostulerV3 = async (job: ILbaItemLbaJobJson | ILbaItemLbaCompanyJson | ILbaItemPartnerJobJson) => {
   const jobId = getObjectId(job)
   if (!jobId) return
-  return apiPost("/v3/jobs/:id/stats/:eventType", { params: { id: jobId, eventType: "postuler_click" } })
+  try {
+    return await apiPost("/v3/jobs/:id/stats/:eventType", { params: { id: jobId, eventType: "postuler_click" } })
+  } catch {
+    // tracking non-critique, erreur ignorée intentionnellement
+  }
 }
 export const getRelatedEtablissementsFromRome = async ({ rome, latitude, longitude, limit }: { rome: string; latitude: number; longitude: number; limit: number }) =>
   apiGet(`/etablissement/cfas-proches`, { querystring: { rome, latitude, longitude, limit } })
@@ -183,13 +191,13 @@ export const getEntrepriseOpco = async (siret: string) => {
   }
 }
 
-export const getPrdvContext = async (cleMinistereEducatif: string, referrer: string = "lba") => {
+export const getPrdvContext = async (cleMinistereEducatif: string, referrer: string | null = "lba") => {
   try {
-    const data = await apiGet("/_private/appointment", { querystring: { cleMinistereEducatif, referrer } }, { timeout: 7000 })
+    const data = await apiGet("/_private/appointment", { querystring: { cleMinistereEducatif, referrer: referrer || "lba" } }, { timeout: 7000 })
     return data
   } catch (error) {
-    const isBusinessError = error instanceof ApiError && error.message === BusinessErrorCodes.TRAINING_NOT_FOUND
-    if (!isBusinessError) {
+    const isExpectedError = error instanceof ApiError && error.context.statusCode < 500
+    if (!isExpectedError) {
       captureException(error)
     }
   }

--- a/ui/utils/api.ts
+++ b/ui/utils/api.ts
@@ -196,7 +196,7 @@ export const getPrdvContext = async (cleMinistereEducatif: string, referrer: str
     const data = await apiGet("/_private/appointment", { querystring: { cleMinistereEducatif, referrer: referrer || "lba" } }, { timeout: 7000 })
     return data
   } catch (error) {
-    const isExpectedError = error instanceof ApiError && error.context.statusCode < 500
+    const isExpectedError = error instanceof ApiError && error.context.statusCode >= 400 && error.context.statusCode < 500
     if (!isExpectedError) {
       captureException(error)
     }


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3855

---

## Changements

### UI (`lba-ui`)

- **Stats 429/415** — [LBA-UI-1F2](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-1F2) [LBA-UI-1EZ](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-1EZ) [LBA-UI-1GZ](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-1GZ) [LBA-UI-277](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-277) [LBA-UI-2JY](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2JY)
  (`notifyJobDetailViewV3`, `notifyJobPostulerV3`) : erreurs sur `/v3/jobs/:id/stats/:eventType` swallowées silencieusement — le tracking est non-critique (~107k événements)

- **InserJeunes 500** — [LBA-UI-1SPGQ](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-1SPGQ) [LBA-UI-2KV](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2KV) [LBA-UI-2KH](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2KH)
  (`fetchInserJeuneStats`) : toute réponse non-2xx retourne `null` ; suppression du `logError` qui générait du bruit Sentry (~13k événements)

- **RDVA referrer null** — [LBA-UI-2DN](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2DN) [LBA-UI-2XZ](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2XZ) [LBA-UI-2ZR](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2ZR)
  (`getPrdvContext`) : `referrer || "lba"` gère `null` et chaîne vide ; les erreurs 4xx ne sont plus envoyées à Sentry (~3k événements)

- **MetaMask noise** — [LBA-UI-2YC](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2YC) [LBA-UI-GXG](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-GXG)
  (`instrumentation-client.ts`) : `"func sseError not found"` ajouté aux `ignoreErrors` — erreur de l'extension MetaMask, pas du code LBA (~1.5k événements)

- **ChunkLoadError** — [LBA-UI-2DH](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2DH)
  (`ErrorComponent.tsx`) : rechargement automatique de la page quand un chunk Next.js est introuvable après déploiement (~11k événements)

- **Métiers SSR crash** — [LBA-UI-2CB](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2CB) [LBA-UI-2CA](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-2CA) [LBA-UI-1BJ](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-1BJ)
  (`metiers/[slug]/page.tsx`) : `notFound()` si le slug ne correspond à aucun métier — évite le crash `.name` sur `undefined` (~4k événements SSR)

- **establishment_id manquant** — [LBA-UI-21P](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-21P)
  (`User.tsx`) : guard défensif dans le `queryFn` React Query en plus du `enabled` (~100 événements)

- **Tests** : 6 tests unitaires sur `fetchInserJeuneStats` (200, 404, 500, 503, erreur réseau, null)

### Serveur (`lba-server`)

- **`/v1/_private/jobs/min` retournait 500 pour des erreurs de validation** — [LBA-UI-1F0](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-1F0) (~312k événements capturés par `httpClientIntegration` côté UI)
  (`jobs.controller.ts`) : paramètres invalides (`wrong_parameters`) → 400 au lieu de 500, cohérent avec `jobsEtFormations.controller.ts` et `formations.controller.ts`

## Plan de test

- [x] Naviguer sur `/recherche-emploi`, cliquer "Postuler" sur une offre → aucune erreur dans la console si 429
- [x] Naviguer sur `/formation/:id` → la page s'affiche même si InserJeunes renvoie 500
- [x] Naviguer sur `/rdva?cleMinistereEducatif=xxx` sans paramètre `referrer` → pas d'erreur 400
- [x] Naviguer sur `/metiers/slug-inexistant` → page 404 propre, pas de crash SSR
- [x] Simuler un déploiement (vider le cache navigateur avec un vieux chunk) → la page se recharge automatiquement
- [x] Appeler `/api/v1/_private/jobs/min` sans paramètres → 400 (plus 500)
