### PR TITLE
fix: ajouter les 15 sous-pages guides au sitemap

### DIFF
--- a/ui/services/generateMainSitemap.ts
+++ b/ui/services/generateMainSitemap.ts
@@ -8,7 +8,7 @@ import { getStaticMetiers } from "@/utils/getStaticData"
 import { getHostFromHeader } from "@/utils/requestUtils"
 
 // Attention ! Il faut mettre à jour cette date lorsque le sitemap généré par ce fichier change
-export const mainSitemapLastModificationDate = new Date("2026-03-26T16:30:17.696Z")
+export const mainSitemapLastModificationDate = new Date("2026-03-30T15:00:00.000Z")
 
 export function generateMainSitemap(request: Request) {
   const txtDirectory = path.join(process.cwd(), "config")
@@ -22,8 +22,23 @@ export function generateMainSitemap(request: Request) {
     `/developpeurs`,
     `/faq`,
     `/guide-alternant`,
+    `/guide-alternant/preparer-son-projet-en-alternance`,
+    `/guide-alternant/se-faire-accompagner`,
+    `/guide-alternant/la-rupture-de-contrat`,
+    `/guide-alternant/comprendre-la-remuneration`,
+    `/guide-alternant/comment-signer-un-contrat-en-alternance`,
+    `/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur`,
+    `/guide-alternant/a-propos-des-formations`,
+    `/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur`,
+    `/guide-alternant/les-aides-financieres-et-materielles`,
     `/guide-recruteur`,
+    `/guide-recruteur/je-suis-employeur-public`,
+    `/guide-recruteur/cerfa-apprentissage-et-professionnalisation`,
     `/guide-cfa`,
+    `/guide-cfa/la-carte-etudiant-des-metiers`,
+    `/guide/decouvrir-l-alternance`,
+    `/guide/apprentissage-et-handicap`,
+    `/guide/prevention-des-risques-professionnels-pour-les-apprentis`,
     `/metiers`,
     `/mentions-legales`,
     `/cgu`,


### PR DESCRIPTION
## Contexte

Les nouvelles pages guides (`/guide-alternant/*`, `/guide-recruteur/*`, `/guide-cfa/*`, `/guide/*`) ont été déployées mais seuls les 3 hubs étaient déclarés dans le sitemap. Les 15 sous-pages n'y figuraient pas.

## Problème

Le fichier `ui/services/generateMainSitemap.ts` contient un tableau `paths` hardcodé. Lors de la création des pages guides, seuls les hubs ont été ajoutés :
- `/guide-alternant`
- `/guide-recruteur`
- `/guide-cfa`

Les sous-pages (articles individuels) ont été oubliées. Google peut les découvrir via le maillage interne (liens depuis les hubs), mais l'absence du sitemap **ralentit significativement l'indexation** de pages nouvelles — le sitemap est le signal le plus direct pour demander à Google de crawler et indexer du contenu.

## Correction

Ajout des 15 URLs manquantes au tableau `paths` :

**Guide Alternant (9 sous-pages) :**
- `/guide-alternant/preparer-son-projet-en-alternance`
- `/guide-alternant/se-faire-accompagner`
- `/guide-alternant/la-rupture-de-contrat`
- `/guide-alternant/comprendre-la-remuneration`
- `/guide-alternant/comment-signer-un-contrat-en-alternance`
- `/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur`
- `/guide-alternant/a-propos-des-formations`
- `/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur`
- `/guide-alternant/les-aides-financieres-et-materielles`

**Guide Recruteur (2 sous-pages) :**
- `/guide-recruteur/je-suis-employeur-public`
- `/guide-recruteur/cerfa-apprentissage-et-professionnalisation`

**Guide CFA (1 sous-page) :**
- `/guide-cfa/la-carte-etudiant-des-metiers`

**Pages partagées (3 pages) :**
- `/guide/decouvrir-l-alternance`
- `/guide/apprentissage-et-handicap`
- `/guide/prevention-des-risques-professionnels-pour-les-apprentis`

Mise à jour de `mainSitemapLastModificationDate` pour signaler le changement à Google.

## Test plan

- [ ] Vérifier que `/sitemap-main.xml` contient les 18 URLs guides (3 hubs + 15 sous-pages)
- [ ] Vérifier que les autres URLs du sitemap (villes, métiers, pages statiques) sont toujours présentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)