### PR TITLE
feat(lba-3872): ajout des offres publiées avec score=1 dans l'endpoint de classification

### DIFF
--- a/server/src/common/apis/classification/classification.client.test.ts
+++ b/server/src/common/apis/classification/classification.client.test.ts
@@ -3,6 +3,7 @@ import nock from "nock"
 import { generateJobsPartnersFull } from "shared/fixtures/jobPartners.fixture"
 import type { IClassificationLabBatchResponse } from "shared/models/cacheClassification.model"
 import { describe, expect, it, vi } from "vitest"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
 import type { TJobClassification } from "@/services/cacheClassification.service"
 import { getClassificationFromLab } from "@/services/cacheClassification.service"
 import { nockLabClassification } from "./classification.client.fixture"
@@ -47,5 +48,18 @@ describe("getLabClassification - get batch classification", () => {
 
     expect(await getClassificationFromLab([payload])).toEqual([apiResponse[0].label])
     expect(nock.isDone()).toBe(true)
+  })
+
+  it("should store model and created_at in cache when saving classification", async () => {
+    const before = new Date()
+    nockLabClassification([apiPayload], apiResponse)
+
+    await getClassificationFromLab([payload])
+
+    const cached = await getDbCollection("cache_classification").findOne({ partner_job_id: jobFixture.partner_job_id })
+    expect(cached).not.toBeNull()
+    expect(cached!.model).toBe("model")
+    expect(cached!.created_at).toBeInstanceOf(Date)
+    expect(cached!.created_at!.getTime()).toBeGreaterThanOrEqual(before.getTime())
   })
 })

--- a/server/src/http/controllers/classification.controller.ts
+++ b/server/src/http/controllers/classification.controller.ts
@@ -13,6 +13,7 @@ type IModelTraining = {
   workplace_description: string
   offer_title: string
   offer_description: string
+  human_verified: boolean
 }
 
 export const classificationRoutes = (server: Server) => {
@@ -44,6 +45,35 @@ export const classificationRoutes = (server: Server) => {
             workplace_description: "$job.workplace_description",
             offer_title: "$job.offer_title",
             offer_description: "$job.offer_description",
+            human_verified: { $literal: true },
+          },
+        },
+      ])
+      .toArray()) as IModelTraining[]
+
+    const resultCacheClassificationPublished = (await getDbCollection("cache_classification")
+      .aggregate([
+        { $match: { "scores.publish": 1, classification: "publish", human_verification: { $in: [null, ""] } } },
+        { $limit: 25_000 },
+        {
+          $lookup: {
+            from: "jobs_partners",
+            localField: "partner_job_id",
+            foreignField: "partner_job_id",
+            as: "job",
+          },
+        },
+        { $unwind: "$job" },
+        {
+          $project: {
+            _id: 0,
+            partner_job_id: 1,
+            label: { $literal: "publish" },
+            workplace_name: "$job.workplace_name",
+            workplace_description: "$job.workplace_description",
+            offer_title: "$job.offer_title",
+            offer_description: "$job.offer_description",
+            human_verified: { $literal: false },
           },
         },
       ])
@@ -67,6 +97,19 @@ export const classificationRoutes = (server: Server) => {
           workplace_description: workplace_description || "",
           offer_title: offer_title || "",
           offer_description: offer_description || "",
+          human_verified: false,
+        })
+      }
+    }
+
+    for (const result of resultCacheClassificationPublished) {
+      if (!deduplicatedResults.has(result.partner_job_id)) {
+        deduplicatedResults.set(result.partner_job_id, {
+          ...result,
+          workplace_name: result.workplace_name || "",
+          workplace_description: result.workplace_description || "",
+          offer_title: result.offer_title || "",
+          offer_description: result.offer_description || "",
         })
       }
     }

--- a/server/src/services/cacheClassification.service.ts
+++ b/server/src/services/cacheClassification.service.ts
@@ -1,6 +1,5 @@
 import { ObjectId } from "bson"
 import type { IClassificationJobsPartners } from "shared/models/cacheClassification.model"
-
 import { getLabClassificationBatch } from "@/common/apis/classification/classification.client"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 
@@ -22,6 +21,7 @@ const getClassificationFromDB = async (jobs: TJobClassification[]): Promise<(ICl
 }
 
 export const getClassificationFromLab = async (jobs: TJobClassification[]): Promise<(string | null)[]> => {
+  const now = new Date()
   const cachedClassifications = await getClassificationFromDB(jobs)
   const notFoundJobs = jobs.flatMap((job, index) => {
     if (cachedClassifications[index] !== null) {
@@ -45,11 +45,11 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
   const classificationsFromLab = await getLabClassificationBatch(classificationPayload)
 
   // Create a map from job ID to classification result for safe lookup
-  const classificationMap = new Map<string, { label: string; scores: any }>()
+  const classificationMap = new Map<string, { label: string; scores: any; model: string }>()
   if (classificationsFromLab && classificationsFromLab.length) {
     classificationsFromLab.forEach((result) => {
       if (result?.label && result?.id) {
-        classificationMap.set(result.id, { label: result.label, scores: result.scores })
+        classificationMap.set(result.id, { label: result.label, scores: result.scores, model: result.model })
       }
     })
 
@@ -65,6 +65,8 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
           partner_job_id: job.partner_job_id,
           classification: result.label,
           scores: result.scores,
+          model: result.model,
+          created_at: now,
         }
       })
       .filter((payload): payload is NonNullable<typeof payload> => payload !== null)

--- a/shared/src/models/cacheClassification.model.ts
+++ b/shared/src/models/cacheClassification.model.ts
@@ -1,5 +1,4 @@
 import { z } from "zod"
-
 import type { IModelDescriptor } from "./common.js"
 import { zObjectId } from "./common.js"
 
@@ -15,6 +14,8 @@ const ZClassitifationJobsPartners = z.object({
     unpublish: z.number(),
   }),
   human_verification: z.enum(["publish", "unpublish"]).nullish(),
+  model: z.string().nullish(),
+  created_at: z.date().nullish(),
 })
 export type IClassificationJobsPartners = z.output<typeof ZClassitifationJobsPartners>
 

--- a/shared/src/routes/classification.routes.ts
+++ b/shared/src/routes/classification.routes.ts
@@ -15,6 +15,7 @@ export const zClassificationRoute = {
             workplace_description: z.string().nullable(),
             offer_title: z.string(),
             offer_description: z.string(),
+            human_verified: z.boolean(),
           })
         ),
       },


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3872

---

## Changements

- Ajout des 25 000 premiers documents avec `scores.publish=1` et `classification=publish` dans la réponse du `GET /classification`
- Ajout du champ `human_verified` (boolean) dans la réponse pour distinguer les vérifications manuelles des classifications automatiques
- Utilisation de `{ $literal: true/false }` dans les `$project` MongoDB pour éviter l'erreur de projection mixte
- Stockage de `model` et `created_at` dans `cache_classification` lors de l'appel au lab de classification
- Ajout des champs `model` et `created_at` au modèle Zod `IClassificationJobsPartners`
- Mise à jour des tests : vérification que `model` et `created_at` sont bien persistés en base

## Plan de test

- [x] Appeler `GET /classification` avec une clé API scope `classification` et vérifier que les offres avec `scores.publish=1` et `classification=publish` apparaissent avec `human_verified: false`
- [x] Vérifier que les offres vérifiées manuellement ont `human_verified: true` et ne sont pas dédupliquées par la source score=1
- [x] Vérifier que le résultat ne contient pas le champ `partner_job_id`
- [x] Lancer `yarn test server/src/common/apis/classification/classification.client.test.ts`