### PR TITLE
fix(lba-3386): corriger le CLS et les erreurs d'hydratation sur la page d'accueil

### DIFF
--- a/ui/app/(editorial-with-notion)/layout.tsx
+++ b/ui/app/(editorial-with-notion)/layout.tsx
@@ -1,7 +1,6 @@
 import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
-import { ClientOnly } from "@/app/_components/ClientOnly"
 import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/getSession"
@@ -18,9 +17,7 @@ export default async function HomeLayout({ children }: PropsWithChildren) {
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <ClientOnly>
-        <PublicHeader user={user} hideConnectionButton={true} />
-      </ClientOnly>
+      <PublicHeader user={user} hideConnectionButton={true} />
       <Box>{children}</Box>
       <Footer />
     </>

--- a/ui/app/(home)/_components/AlgoHome.tsx
+++ b/ui/app/(home)/_components/AlgoHome.tsx
@@ -36,7 +36,7 @@ export const AlgoHome = () => (
           <Typography className={fr.cx("fr-text--lg")}>La bonne alternance expose différents types d&apos;opportunités d&apos;emplois :</Typography>
           <Box sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("6v") }}>
             <Box className={fr.cx("fr-text--lg")}>
-              <Typography>
+              <Typography component="div">
                 <strong>Les offres d&apos;emploi</strong> identifiables grâce au tag <TagOffreEmploi /> qui sont de 3 types :
               </Typography>
               <ul>
@@ -45,7 +45,7 @@ export const AlgoHome = () => (
                 <li>celles publiées par des écoles qui recrutent pour le compte des entreprises de leur réseau.</li>
               </ul>
             </Box>
-            <Typography className={fr.cx("fr-text--lg")}>
+            <Typography component="div" className={fr.cx("fr-text--lg")}>
               <strong>Les candidatures spontanées :</strong> correspondant au marché caché de l'emploi. Chaque mois, un algorithme prédictif de France Travail analyse les
               recrutements des 6 années passées pour prédire ceux des 6 mois à venir. Grâce à ces données, il identifie une liste restreinte d'entreprises "à fort potentiel
               d'embauche en alternance" pour faciliter vos démarches de candidatures spontanées. Elles sont identifiées grâce au tag <TagCandidatureSpontanee />

--- a/ui/app/(home)/layout.tsx
+++ b/ui/app/(home)/layout.tsx
@@ -1,7 +1,6 @@
 import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks"
 import type { PropsWithChildren } from "react"
 
-import { ClientOnly } from "@/app/_components/ClientOnly"
 import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/getSession"
@@ -19,9 +18,7 @@ export default async function HomeLayout({ children }: PropsWithChildren) {
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <ClientOnly>
-        <PublicHeader user={user} />
-      </ClientOnly>
+      <PublicHeader user={user} />
       {children}
       <Footer />
     </>


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3386

---

## Changements

- Suppression du wrapper `ClientOnly` autour de `PublicHeader` dans `(home)/layout.tsx` et `(editorial-with-notion)/layout.tsx` : le header n'était plus rendu en SSR, ce qui causait un layout shift au moment de l'hydratation (CLS terrain mobile passé de 0.07 à 0.14 depuis le 12 février 2026)
- Correction des erreurs d'hydratation React dans `AlgoHome.tsx` : ajout de `component="div"` sur les deux `Typography` qui contenaient `TagOffreEmploi` et `TagCandidatureSpontanee` — ces composants rendent un `<div>` (Box MUI) imbriqué dans un `<p>`, ce qui est du HTML invalide

## Plan de test

- [x] Vérifier que le header s'affiche bien immédiatement sur la page d'accueil (pas de "pop" après chargement)
- [x] Vérifier l'absence d'erreurs d'hydratation dans la console navigateur sur `/`
- [x] Vérifier que la section AlgoHome s'affiche correctement (texte + tags offres/candidatures)
- [x] Vérifier le même comportement sur une page éditoriale (layout `editorial-with-notion`)