### PR TITLE
fix(lba-3910): gérer le rate limit 429 sur l'API job-étudiant avec retry et throttling proactif

### DIFF
--- a/server/src/common/apis/etudiant/etudiant.client.fixture.ts
+++ b/server/src/common/apis/etudiant/etudiant.client.fixture.ts
@@ -48,8 +48,20 @@ function buildBaseNock() {
   return nock(origin, { reqheaders: { authorization: `Bearer ${config.job_etudiant.apiKey}` } }).get(path)
 }
 
-export function nockJobEtudiantPage({ total, totalPages, ...rest }: IJobEtudiantPageResponse) {
-  return buildBaseNock().reply(200, { total: total ?? rest.jobs.length, totalPages: totalPages ?? 1, ...rest })
+type IRateLimitHeaders = { rateLimitRemaining?: number; rateLimitReset?: number }
+
+export function nockJobEtudiantPage({ total, totalPages, ...rest }: IJobEtudiantPageResponse, { rateLimitRemaining, rateLimitReset }: IRateLimitHeaders = {}) {
+  const headers: Record<string, string> = {}
+  if (rateLimitRemaining !== undefined) headers["x-ratelimit-remaining"] = String(rateLimitRemaining)
+  if (rateLimitReset !== undefined) headers["x-ratelimit-reset"] = String(rateLimitReset)
+  return buildBaseNock().reply(200, { total: total ?? rest.jobs.length, totalPages: totalPages ?? 1, ...rest }, headers)
+}
+
+export function nockJobEtudiantRateLimit({ retryAfter }: { retryAfter: number }) {
+  const { origin, pathname, search } = new URL(config.job_etudiant.url)
+  return nock(origin, { reqheaders: { authorization: `Bearer ${config.job_etudiant.apiKey}` } })
+    .get(`${pathname}${search}`)
+    .reply(429, "Too Many Requests", { "retry-after": String(retryAfter) })
 }
 
 export function nockJobEtudiantNextPage(nextPageToken: string, { total, totalPages, ...rest }: IJobEtudiantPageResponse) {

--- a/server/src/common/apis/etudiant/etudiant.client.test.ts
+++ b/server/src/common/apis/etudiant/etudiant.client.test.ts
@@ -1,10 +1,15 @@
 import nock from "nock"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import config from "@/config"
 import { getJobEtudiantJobs } from "./etudiant.client"
-import { generateJobEtudiantJobFixture, nockJobEtudiantNextPage, nockJobEtudiantPage } from "./etudiant.client.fixture"
+import { generateJobEtudiantJobFixture, nockJobEtudiantNextPage, nockJobEtudiantPage, nockJobEtudiantRateLimit } from "./etudiant.client.fixture"
 
 describe("getJobEtudiantJobs", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    nock.cleanAll()
+  })
+
   it("should return jobs from a single page", async () => {
     const job = generateJobEtudiantJobFixture()
     nockJobEtudiantPage({ jobs: [job] })
@@ -64,5 +69,54 @@ describe("getJobEtudiantJobs", () => {
     nock(origin).get(`${pathname}${search}`).reply(401, "Unauthorized")
 
     await expect(getJobEtudiantJobs()).rejects.toThrow()
+  })
+
+  it("should retry on 429 and succeed after waiting Retry-After seconds", async () => {
+    vi.spyOn(global, "setTimeout").mockImplementation((fn) => {
+      if (typeof fn === "function") fn()
+      return 0 as unknown as ReturnType<typeof setTimeout>
+    })
+
+    const job = generateJobEtudiantJobFixture()
+    nockJobEtudiantRateLimit({ retryAfter: 2 })
+    nockJobEtudiantPage({ jobs: [job] })
+
+    const result = await getJobEtudiantJobs()
+
+    expect(result).toEqual([job])
+    expect(nock.isDone()).toBe(true)
+  })
+
+  it("should throw after MAX_RETRIES consecutive 429 responses", async () => {
+    vi.spyOn(global, "setTimeout").mockImplementation((fn) => {
+      if (typeof fn === "function") fn()
+      return 0 as unknown as ReturnType<typeof setTimeout>
+    })
+
+    nockJobEtudiantRateLimit({ retryAfter: 1 })
+    nockJobEtudiantRateLimit({ retryAfter: 1 })
+    nockJobEtudiantRateLimit({ retryAfter: 1 })
+    nockJobEtudiantRateLimit({ retryAfter: 1 })
+
+    await expect(getJobEtudiantJobs()).rejects.toThrow("429")
+  })
+
+  it("should pause proactively when X-RateLimit-Remaining is low", async () => {
+    vi.spyOn(global, "setTimeout").mockImplementation((fn) => {
+      if (typeof fn === "function") fn()
+      return 0 as unknown as ReturnType<typeof setTimeout>
+    })
+
+    const job1 = generateJobEtudiantJobFixture({ public_id: "job-1" })
+    const job2 = generateJobEtudiantJobFixture({ public_id: "job-2" })
+    const nextPageToken = "token-abc"
+
+    nockJobEtudiantPage({ "next-page": nextPageToken, jobs: [job1] }, { rateLimitRemaining: 1, rateLimitReset: 2 })
+    nockJobEtudiantNextPage(nextPageToken, { jobs: [job2] })
+
+    const result = await getJobEtudiantJobs()
+
+    expect(result).toEqual([job1, job2])
+    expect(nock.isDone()).toBe(true)
   })
 })

--- a/server/src/common/apis/etudiant/etudiant.client.test.ts
+++ b/server/src/common/apis/etudiant/etudiant.client.test.ts
@@ -6,7 +6,7 @@ import { generateJobEtudiantJobFixture, nockJobEtudiantNextPage, nockJobEtudiant
 
 describe("getJobEtudiantJobs", () => {
   afterEach(() => {
-    vi.useRealTimers()
+    vi.restoreAllMocks()
     nock.cleanAll()
   })
 

--- a/server/src/common/apis/etudiant/etudiant.client.ts
+++ b/server/src/common/apis/etudiant/etudiant.client.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosResponse } from "axios"
 import z from "zod"
 
 import { logger } from "@/common/logger"
+import { delay } from "@/common/utils/asyncUtils"
 import config from "@/config"
 
 const ZTranslation = z.object({
@@ -62,10 +63,13 @@ const ZJobEtudiantResponse = z.object({
   jobs: z.array(ZJobEtudiantJob),
 })
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
-
 const RATE_LIMIT_REMAINING_THRESHOLD = 2
 const MAX_RETRIES = 3
+
+function parseRetryAfterMs(value: string | undefined): number {
+  const seconds = parseInt(value ?? "", 10)
+  return isNaN(seconds) || seconds <= 0 ? 1000 : seconds * 1000
+}
 
 /**
  * API Doc : https://developers.piloty.fr/feeds/feed-jobs
@@ -81,7 +85,7 @@ export const getJobEtudiantJobs = async (): Promise<IJobEtudiantJob[]> => {
     }
 
     let response!: AxiosResponse
-    let attempt = 0
+    let retries = 0
 
     while (true) {
       try {
@@ -93,12 +97,11 @@ export const getJobEtudiantJobs = async (): Promise<IJobEtudiantJob[]> => {
         const status = err?.response?.status
         const headers = err?.response?.headers ?? {}
 
-        if (status === 429 && attempt < MAX_RETRIES) {
-          const retryAfter = parseFloat(headers["retry-after"] ?? headers["retry-after-short"] ?? "1")
-          const waitMs = Math.ceil(retryAfter) * 1000
-          logger.warn({ attempt, waitMs, url: url.toString() }, "job-etudiant: rate limit 429, attente avant retry")
-          await sleep(waitMs)
-          attempt++
+        if (status === 429 && retries < MAX_RETRIES) {
+          const waitMs = parseRetryAfterMs(headers["retry-after"] ?? headers["retry-after-short"])
+          logger.warn({ retries, waitMs, url: url.toString() }, "job-etudiant: rate limit 429, attente avant retry")
+          await delay(waitMs)
+          retries++
           continue
         }
 
@@ -108,22 +111,24 @@ export const getJobEtudiantJobs = async (): Promise<IJobEtudiantJob[]> => {
       }
     }
 
-    // Throttling proactif : si le quota restant est bas, on attend le reset
-    const remaining = parseInt(response.headers["x-ratelimit-remaining"] ?? response.headers["x-ratelimit-remaining-short"] ?? "99", 10)
-    const resetIn = parseFloat(response.headers["x-ratelimit-reset"] ?? response.headers["x-ratelimit-reset-short"] ?? "0")
-    if (!isNaN(remaining) && remaining <= RATE_LIMIT_REMAINING_THRESHOLD && resetIn > 0) {
-      const waitMs = Math.ceil(resetIn) * 1000
-      logger.info({ remaining, waitMs, url: url.toString() }, "job-etudiant: quota bas, pause avant prochaine requête")
-      await sleep(waitMs)
-    }
-
-    const parsed = ZJobEtudiantResponse.safeParse(response!.data)
+    const parsed = ZJobEtudiantResponse.safeParse(response.data)
     if (!parsed.success) {
       logger.error({ err: parsed.error.issues, url: url.toString() }, "job-etudiant: erreur de parsing de la réponse")
       throw parsed.error
     }
     allJobs.push(...parsed.data.jobs)
     nextPageToken = parsed.data["next-page"]
+
+    // Throttling proactif : si le quota restant est bas et qu'une prochaine page existe, on attend le reset
+    if (nextPageToken) {
+      const remaining = parseInt(response.headers["x-ratelimit-remaining"] ?? response.headers["x-ratelimit-remaining-short"] ?? "99", 10)
+      const resetIn = parseInt(response.headers["x-ratelimit-reset"] ?? response.headers["x-ratelimit-reset-short"] ?? "0", 10)
+      if (!isNaN(remaining) && remaining <= RATE_LIMIT_REMAINING_THRESHOLD && resetIn > 0) {
+        const waitMs = resetIn * 1000
+        logger.info({ remaining, waitMs, url: url.toString() }, "job-etudiant: quota bas, pause avant prochaine requête")
+        await delay(waitMs)
+      }
+    }
   } while (nextPageToken)
 
   return allJobs

--- a/server/src/common/apis/etudiant/etudiant.client.ts
+++ b/server/src/common/apis/etudiant/etudiant.client.ts
@@ -1,4 +1,4 @@
-import axios from "axios"
+import axios, { type AxiosResponse } from "axios"
 import z from "zod"
 
 import { logger } from "@/common/logger"
@@ -62,6 +62,11 @@ const ZJobEtudiantResponse = z.object({
   jobs: z.array(ZJobEtudiantJob),
 })
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const RATE_LIMIT_REMAINING_THRESHOLD = 2
+const MAX_RETRIES = 3
+
 /**
  * API Doc : https://developers.piloty.fr/feeds/feed-jobs
  */
@@ -75,18 +80,44 @@ export const getJobEtudiantJobs = async (): Promise<IJobEtudiantJob[]> => {
       url.searchParams.set("next-page", decodeURIComponent(nextPageToken))
     }
 
-    const response = await axios
-      .get(url.toString(), {
-        headers: { Authorization: `Bearer ${config.job_etudiant.apiKey}` },
-      })
-      .catch((err: any) => {
+    let response!: AxiosResponse
+    let attempt = 0
+
+    while (true) {
+      try {
+        response = await axios.get(url.toString(), {
+          headers: { Authorization: `Bearer ${config.job_etudiant.apiKey}` },
+        })
+        break
+      } catch (err: any) {
         const status = err?.response?.status
+        const headers = err?.response?.headers ?? {}
+
+        if (status === 429 && attempt < MAX_RETRIES) {
+          const retryAfter = parseFloat(headers["retry-after"] ?? headers["retry-after-short"] ?? "1")
+          const waitMs = Math.ceil(retryAfter) * 1000
+          logger.warn({ attempt, waitMs, url: url.toString() }, "job-etudiant: rate limit 429, attente avant retry")
+          await sleep(waitMs)
+          attempt++
+          continue
+        }
+
         const data = err?.response?.data
         logger.error({ status, data, url: url.toString() }, "job-etudiant: erreur API")
         throw new Error(`job-etudiant: API error ${status} - ${JSON.stringify(data)}`)
-      })
+      }
+    }
 
-    const parsed = ZJobEtudiantResponse.safeParse(response.data)
+    // Throttling proactif : si le quota restant est bas, on attend le reset
+    const remaining = parseInt(response.headers["x-ratelimit-remaining"] ?? response.headers["x-ratelimit-remaining-short"] ?? "99", 10)
+    const resetIn = parseFloat(response.headers["x-ratelimit-reset"] ?? response.headers["x-ratelimit-reset-short"] ?? "0")
+    if (!isNaN(remaining) && remaining <= RATE_LIMIT_REMAINING_THRESHOLD && resetIn > 0) {
+      const waitMs = Math.ceil(resetIn) * 1000
+      logger.info({ remaining, waitMs, url: url.toString() }, "job-etudiant: quota bas, pause avant prochaine requête")
+      await sleep(waitMs)
+    }
+
+    const parsed = ZJobEtudiantResponse.safeParse(response!.data)
     if (!parsed.success) {
       logger.error({ err: parsed.error.issues, url: url.toString() }, "job-etudiant: erreur de parsing de la réponse")
       throw parsed.error


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3910

---

## Changements

- Ajout d'un mécanisme de retry automatique sur les réponses 429 : jusqu'à 3 tentatives, en respectant le délai indiqué dans l'en-tête `Retry-After`
- Ajout d'un throttling proactif : si `X-RateLimit-Remaining` tombe à 2 ou moins, la fonction attend la réinitialisation de la fenêtre (`X-RateLimit-Reset`) avant la requête suivante
- Support des variantes d'en-têtes `-short` (`Retry-After-short`, `X-RateLimit-Remaining-short`, etc.)
- Nouveaux tests couvrant : retry sur 429, échec après MAX_RETRIES, et pause proactive sur quota bas

## Plan de test

- [x] Vérifier que les 9 tests unitaires passent (`yarn test server/src/common/apis/etudiant/etudiant.client.test.ts`)
- [x] Vérifier que le typecheck ne remonte aucune erreur (`yarn workspace server tsc --noEmit`)