### PR TITLE
fix(lba-3917): corriger la priorité de human_verification dans getClassificationFromLab

### DIFF
--- a/server/src/common/apis/classification/classification.client.test.ts
+++ b/server/src/common/apis/classification/classification.client.test.ts
@@ -50,6 +50,50 @@ describe("getLabClassification - get batch classification", () => {
     expect(nock.isDone()).toBe(true)
   })
 
+  it("should prioritize human_verification over classification when job is cached and batch contains uncached jobs", async () => {
+    const cachedJob = generateJobsPartnersFull({
+      workplace_name: "CFA",
+      workplace_description: "CFA",
+      offer_title: "Cached Job",
+      offer_description: "Cached Job",
+    })
+    const cachedPayload: TJobClassification = {
+      partner_job_id: cachedJob.partner_job_id,
+      partner_label: cachedJob.partner_label,
+      workplace_name: cachedJob.workplace_name!,
+      workplace_description: cachedJob.workplace_description!,
+      offer_title: cachedJob.offer_title,
+      offer_description: cachedJob.offer_description,
+    }
+    // Insert cached job with human_verification = "unpublish" but classification = "publish"
+    await getDbCollection("cache_classification").insertOne({
+      _id: new (await import("bson")).ObjectId(),
+      partner_label: cachedJob.partner_label,
+      partner_job_id: cachedJob.partner_job_id,
+      classification: "publish",
+      human_verification: "unpublish",
+      scores: { publish: 0.9, unpublish: 0.1 },
+      model: "model",
+      created_at: new Date(),
+    })
+
+    // The uncached job triggers the API call — only it is sent to the API
+    const uncachedApiPayload = {
+      id: jobFixture.partner_job_id,
+      workplace_name: jobFixture.workplace_name ?? undefined,
+      workplace_description: jobFixture.workplace_description ?? undefined,
+      offer_title: jobFixture.offer_title ?? undefined,
+      offer_description: jobFixture.offer_description ?? undefined,
+    }
+    nockLabClassification([uncachedApiPayload], apiResponse)
+
+    const result = await getClassificationFromLab([cachedPayload, payload])
+    // cachedJob should return human_verification ("unpublish"), not classification ("publish")
+    expect(result[0]).toBe("unpublish")
+    // uncached job should return the API result
+    expect(result[1]).toBe(apiResponse[0].label)
+  })
+
   it("should store model and created_at in cache when saving classification", async () => {
     const before = new Date()
     nockLabClassification([apiPayload], apiResponse)

--- a/server/src/services/cacheClassification.service.ts
+++ b/server/src/services/cacheClassification.service.ts
@@ -79,7 +79,7 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
   // Return results in the same order as input jobs
   return jobs.map((job, index) => {
     const cached = cachedClassifications[index]
-    if (cached) return cached.classification
+    if (cached) return cached.human_verification ? cached.human_verification : cached.classification
 
     // Use the map for safe lookup
     const result = classificationMap.get(job.partner_job_id)


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3917

---

## Changements

- Dans `getClassificationFromLab`, la branche de retour finale (exécutée quand au moins un job du batch n'est pas en cache) retournait `cached.classification` (classification IA) sans vérifier `human_verification`
- Résultat : une offre annulée manuellement (human_verification = "unpublish") pouvait être réactivée si elle se retrouvait dans un batch contenant un nouveau job inconnu
- Fix : aligner cette branche sur la logique de l'early return (ligne 34) qui préfère déjà `human_verification` quand il est défini

## Plan de test

- [ ] Marquer une offre en "unpublish" via le back-office de classification
- [ ] Vérifier que `cache_classification.human_verification = "unpublish"` est bien set
- [ ] Déclencher `fillComputedJobsPartners` + `importFromComputedToJobsPartners` sur cette offre
- [ ] Vérifier que l'offre reste en statut `ANNULEE` dans `jobs_partners` après le pipeline