### PR TITLE
fix(lba-3807): utiliser un type de contrat par défaut si absent lors de l'upsert d'offre privée

### DIFF
--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -754,7 +754,7 @@ async function upsertJobOfferPrivate({
   const writableData: Omit<IComputedJobsPartners, InvariantFields> = {
     contract_start: data.contract.start,
     contract_duration: data.contract.duration,
-    contract_type: data.contract.type || [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
+    contract_type: data.contract.type ?? [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
     contract_remote: data.contract.remote,
     contract_is_disabled_elligible,
 

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -754,7 +754,7 @@ async function upsertJobOfferPrivate({
   const writableData: Omit<IComputedJobsPartners, InvariantFields> = {
     contract_start: data.contract.start,
     contract_duration: data.contract.duration,
-    contract_type: data.contract.type,
+    contract_type: data.contract.type || [TRAINING_CONTRACT_TYPE.APPRENTISSAGE, TRAINING_CONTRACT_TYPE.PROFESSIONNALISATION],
     contract_remote: data.contract.remote,
     contract_is_disabled_elligible,
 


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3907

---

## Changements

- Ajout d'un fallback sur `contract_type` dans `upsertJobOfferPrivate` : si la valeur est absente ou nulle, on utilise par défaut `[APPRENTISSAGE, PROFESSIONNALISATION]`

## Plan de test

- [x] Créer/mettre à jour une offre privée sans spécifier `contract_type` et vérifier que la valeur par défaut est bien enregistrée
- [x] Créer/mettre à jour une offre privée avec un `contract_type` explicite et vérifier qu'il est bien conservé