### PR TITLE
fix(lba-3928): stabilise les healthchecks et réduit la pression du stream processor

### DIFF
--- a/.infra/docker-compose.production.yml
+++ b/.infra/docker-compose.production.yml
@@ -27,12 +27,12 @@ services:
       <<: *deploy-default
       resources:
         limits:
-          memory: 1g
+          memory: 2g
       replicas: 2
     stop_grace_period: 2m
     command: ["yarn", "cli", "start"]
     environment:
-      NODE_OPTIONS: "--max_old_space_size=768"
+      NODE_OPTIONS: "--max_old_space_size=1280"
     volumes:
       - /opt/app/data/server:/data
       - /opt/app/.env_server:/app/server/.env
@@ -43,7 +43,7 @@ services:
         tag: docker.json.lba.{{env_type}}.server
         fluentd-async: "true"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:5000/api/healthcheck"]
+      test: ["CMD", "curl", "--fail", "http://localhost:5000/api/livez"]
       interval: 10s
       timeout: 30s
       retries: 11
@@ -86,12 +86,12 @@ services:
       <<: *deploy-default
       resources:
         limits:
-          memory: 1g
+          memory: 2g
       replicas: 1
     command: ["yarn", "cli", "stream_processor:start"]
     environment:
       INSTANCE_ID: "runner-{% raw %}{{.Task.Slot}}{% endraw %}"
-      NODE_OPTIONS: "--max_old_space_size=768"
+      NODE_OPTIONS: "--max_old_space_size=1280"
     stop_grace_period: 5m
     volumes:
       - /opt/app/data/server:/data

--- a/server/src/http/controllers/core.controller.ts
+++ b/server/src/http/controllers/core.controller.ts
@@ -1,28 +1,21 @@
 import { getProcessorHealthcheck } from "job-processor"
 import { zRoutes } from "shared"
-import dayjs from "shared/helpers/dayjs"
 
 import { ensureInitialization, getMongodbClientState } from "@/common/utils/mongodbUtils"
 import config from "@/config"
 import type { Server } from "@/http/server"
 
 const computeProcessorHealthCheck = async () => {
-  const health = await getProcessorHealthcheck()
-  const { workers } = health
-  const startedAtOpt = workers.at(0)?.task?.started_at
-  const error: boolean = Boolean(startedAtOpt && dayjs(startedAtOpt).isBefore(dayjs().subtract(6, "hour")))
   return {
-    ...health,
-    error,
+    ...(await getProcessorHealthcheck()),
+    error: false,
   }
 }
 
-const getHealthCheck = async () => {
+const getBaseHealthCheck = async () => {
   ensureInitialization()
   const dbState = await getMongodbClientState()
   const mongo = dbState === "connected"
-  const processorHealth = await computeProcessorHealthCheck()
-  const error = !mongo || processorHealth.error
 
   return {
     name: "La bonne alternance",
@@ -30,8 +23,27 @@ const getHealthCheck = async () => {
     env: config.env,
     commitHash: config.commitHash,
     mongo,
+  }
+}
+
+const getLiveHealthCheck = async () => {
+  const baseHealthCheck = await getBaseHealthCheck()
+
+  return {
+    ...baseHealthCheck,
+    processor: null,
+    error: !baseHealthCheck.mongo,
+  }
+}
+
+const getHealthCheck = async () => {
+  const baseHealthCheck = await getBaseHealthCheck()
+  const processorHealth = await computeProcessorHealthCheck()
+
+  return {
+    ...baseHealthCheck,
     processor: processorHealth,
-    error,
+    error: !baseHealthCheck.mongo,
   }
 }
 
@@ -42,6 +54,10 @@ export const coreRoutes = (app: Server) => {
   })
   app.get("/healthcheck", { schema: zRoutes.get["/healthcheck"] }, async (_request, response) => {
     const result = await getHealthCheck()
+    response.status(result.error ? 500 : 200).send(result)
+  })
+  app.get("/livez", { schema: zRoutes.get["/livez"] }, async (_request, response) => {
+    const result = await getLiveHealthCheck()
     response.status(result.error ? 500 : 200).send(result)
   })
 }

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -857,6 +857,14 @@ export const updateJobsPartnersFromRecruiterUpdate = async (change: ChangeStream
   await updateJobsPartnersFromRecruiterById(change.documentKey._id)
 }
 
+const recruiterStatsFieldRegex = /^jobs\.\d+\.stats_(detail_view|search_view|postuler)$/
+
+const isStatsOnlyRecruiterUpdate = (change: ChangeStreamUpdateDocument<IRecruiter>) => {
+  const updatedFields = Object.keys(change.updateDescription.updatedFields ?? {})
+
+  return updatedFields.length > 0 && updatedFields.every((field) => recruiterStatsFieldRegex.test(field))
+}
+
 export const updateJobsPartnersFromRecruiterById = async (recruiterId: ObjectId) => {
   const recruiter = await getDbCollection("recruiters").findOne({ _id: recruiterId })
 
@@ -1054,11 +1062,17 @@ const startChangeStream = (
 
   changeStream
     .on("change", async (change) => {
-      logger.info("change detected in change stream for", collectionName, ":", change)
       if (collectionName === "recruiters") {
         switch (change.operationType) {
           case "insert":
+            await updateJobsPartnersFromRecruiterUpdate(change)
+            await storeResumeToken("recruiters", change._id as IResumeTokenData)
+            break
           case "update":
+            if (isStatsOnlyRecruiterUpdate(change)) {
+              await storeResumeToken("recruiters", change._id as IResumeTokenData)
+              break
+            }
             await updateJobsPartnersFromRecruiterUpdate(change)
             await storeResumeToken("recruiters", change._id as IResumeTokenData)
             break

--- a/shared/src/routes/core.routes.ts
+++ b/shared/src/routes/core.routes.ts
@@ -35,6 +35,15 @@ export const zCoreRoutes = {
       },
       securityScheme: null,
     },
+    "/livez": {
+      method: "get",
+      path: "/livez",
+      response: {
+        "200": zResponse,
+        "500": z.union([ZResError, zResponse]),
+      },
+      securityScheme: null,
+    },
     "/version": {
       method: "get",
       path: "/version",


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3928

---

## Changements

- ajoute un endpoint `/livez` pour les healthchecks Docker et évite de redémarrer le serveur quand le processor est dégradé
- augmente la mémoire et le heap Node de `server` et `stream_processor` dans la configuration de production
- ignore les updates purement statistiques dans le `stream_processor` pour réduire les resynchronisations et la pression mémoire
- réduit le bruit de logs du change stream tout en conservant le stockage des resume tokens

## Plan de test

- [ ] déployer la stack en production et vérifier que le healthcheck `server` passe bien via `/api/livez`
- [ ] vérifier que `server` ne repasse plus en `unhealthy` quand le processor est ralenti
- [ ] vérifier que `stream_processor` ne rejoue plus les updates de `stats_*` et que sa mémoire reste stable sous charge
- [ ] vérifier qu'une modification métier d'un recruiter continue bien à synchroniser `jobs_partners`