### PR TITLE
fix(lba-3929): ajoute un job de resynchronisation des stats lba

### DIFF
--- a/server/src/jobs/oneTimeJob/resyncLbaJobsPartnersStats.ts
+++ b/server/src/jobs/oneTimeJob/resyncLbaJobsPartnersStats.ts
@@ -1,0 +1,73 @@
+import { type AnyBulkWriteOperation, ObjectId } from "mongodb"
+import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import type { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
+
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+
+const BULK_SIZE = 500
+
+export const resyncLbaJobsPartnersStats = async (): Promise<void> => {
+  const recruitersCursor = getDbCollection("recruiters")
+    .find(
+      { "jobs.0": { $exists: true } },
+      {
+        projection: {
+          _id: 1,
+          jobs: {
+            _id: 1,
+            stats_detail_view: 1,
+            stats_search_view: 1,
+          },
+        },
+      }
+    )
+    .batchSize(BULK_SIZE)
+
+  let recruitersCount = 0
+  let jobsCount = 0
+  let syncedJobsCount = 0
+  let bulkOperations: AnyBulkWriteOperation<IJobsPartnersOfferPrivate>[] = []
+
+  const flushBulkOperations = async () => {
+    if (bulkOperations.length === 0) {
+      return
+    }
+
+    const result = await getDbCollection("jobs_partners").bulkWrite(bulkOperations, { ordered: false })
+    syncedJobsCount += result.matchedCount
+    bulkOperations = []
+  }
+
+  logger.info("resyncLbaJobsPartnersStats: start")
+
+  for await (const recruiter of recruitersCursor) {
+    recruitersCount += 1
+
+    for (const job of recruiter.jobs ?? []) {
+      jobsCount += 1
+      bulkOperations.push({
+        updateOne: {
+          filter: {
+            _id: job._id,
+            partner_label: LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA,
+          },
+          update: {
+            $set: {
+              stats_detail_view: job.stats_detail_view ?? 0,
+              stats_search_view: job.stats_search_view ?? 0,
+            },
+          },
+        },
+      })
+
+      if (bulkOperations.length >= BULK_SIZE) {
+        await flushBulkOperations()
+      }
+    }
+  }
+
+  await flushBulkOperations()
+
+  logger.info(`resyncLbaJobsPartnersStats: terminé (recruiters=${recruitersCount}, jobs=${jobsCount}, jobs_partners_synced=${syncedJobsCount})`)
+}

--- a/server/src/jobs/oneTimeJob/resyncLbaJobsPartnersStats.ts
+++ b/server/src/jobs/oneTimeJob/resyncLbaJobsPartnersStats.ts
@@ -1,4 +1,4 @@
-import { type AnyBulkWriteOperation, ObjectId } from "mongodb"
+import type { AnyBulkWriteOperation } from "mongodb"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import type { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
 
@@ -14,11 +14,9 @@ export const resyncLbaJobsPartnersStats = async (): Promise<void> => {
       {
         projection: {
           _id: 1,
-          jobs: {
-            _id: 1,
-            stats_detail_view: 1,
-            stats_search_view: 1,
-          },
+          "jobs._id": 1,
+          "jobs.stats_detail_view": 1,
+          "jobs.stats_search_view": 1,
         },
       }
     )

--- a/server/src/jobs/simpleJobDefinitions.ts
+++ b/server/src/jobs/simpleJobDefinitions.ts
@@ -59,6 +59,7 @@ import { processRhAlternance } from "./offrePartenaire/rh-alternance/processRhAl
 import { analyzeClosedCompanies } from "./oneTimeJob/analyzeClosedCompanies"
 import { cleanClosedCompanies } from "./oneTimeJob/cleanClosedCompanies"
 import { renvoiMailCreationCompte } from "./oneTimeJob/renvoiMailCreationCompte"
+import { resyncLbaJobsPartnersStats } from "./oneTimeJob/resyncLbaJobsPartnersStats"
 import { exportFileForAlgo } from "./partenaireExport/exportBlacklistAlgo"
 import { sendContactsToBrevo } from "./partenaireExport/exportContactsToBrevo"
 import { exportLbaJobsToS3 } from "./partenaireExport/exportJobsToS3"
@@ -380,6 +381,10 @@ export const simpleJobDefinitions: SimpleJobDefinition[] = [
   {
     fct: renvoiMailCreationCompte,
     description: "Envoi les mails de validation de compte",
+  },
+  {
+    fct: resyncLbaJobsPartnersStats,
+    description: "Resynchronise les stats de consultation des offres LBA depuis recruiters vers jobs_partners",
   },
   {
     fct: syncLbaJobsIntoJobsPartners,


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3929

---

## Changements

- ajoute un job one-shot `resyncLbaJobsPartnersStats` dans `server/src/jobs/oneTimeJob/` pour recopier les compteurs de vues depuis `recruiters` vers `jobs_partners`
- traite les offres LBA par batches de `bulkWrite` pour pouvoir rejouer la resynchronisation directement en production
- déclare le job dans `simpleJobDefinitions` pour permettre son exécution manuelle via le runner CLI du serveur

## Plan de test

- [ ] lancer `yarn workspace server typecheck`
- [ ] exécuter le job manuellement sur un environnement de test ou de recette
- [ ] vérifier qu'un échantillon d'offres LBA a les mêmes valeurs de `stats_detail_view` et `stats_search_view` dans `recruiters` et `jobs_partners`
- [ ] vérifier que les offres non LBA ne sont pas modifiées par le job