### PR TITLE
feat(lba-3933): ajoute les lectures mongo sur secondaires pour la recherche

### DIFF
--- a/server/src/common/utils/mongodbUtils.ts
+++ b/server/src/common/utils/mongodbUtils.ts
@@ -81,6 +81,10 @@ export const getDbCollection = <K extends CollectionName>(name: K): Collection<I
   return ensureInitialization().db().collection(name)
 }
 
+export const getSecondaryDbCollection = <K extends CollectionName>(name: K): Collection<IDocument<K>> => {
+  return ensureInitialization().db().collection(name, { readPreference: "secondaryPreferred" })
+}
+
 export const getCollectionList = async (): Promise<(CollectionInfo | Pick<CollectionInfo, "name" | "type">)[]> => {
   return ensureInitialization().db().listCollections().toArray()
 }

--- a/server/src/services/formation.service.ts
+++ b/server/src/services/formation.service.ts
@@ -9,7 +9,7 @@ import type { INiveauDiplomeEuropeen } from "shared/models/jobsPartners.model"
 import type { IApiError } from "@/common/utils/errorManager"
 import { roundDistance } from "@/common/utils/geolib"
 import { isValidEmail } from "@/common/utils/isValidEmail"
-import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { getDbCollection, getSecondaryDbCollection } from "@/common/utils/mongodbUtils"
 import { regionCodeToDepartmentList } from "@/common/utils/regionInseeCodes"
 import { trackApiCall } from "@/common/utils/sendTrackingEvent"
 import { sentryCaptureException } from "@/common/utils/sentryUtils"
@@ -129,7 +129,7 @@ const getFormations = async ({
         query,
       },
     })
-    formations = await getDbCollection("formationcatalogues").aggregate(stages).toArray()
+    formations = await getSecondaryDbCollection("formationcatalogues").aggregate(stages).toArray()
   } else {
     stages.unshift({
       $match: query,
@@ -140,7 +140,7 @@ const getFormations = async ({
       },
     })
 
-    formations = await getDbCollection("formationcatalogues").aggregate(stages).toArray()
+    formations = await getSecondaryDbCollection("formationcatalogues").aggregate(stages).toArray()
   }
 
   return formations
@@ -220,7 +220,7 @@ const getRegionFormations = async ({
     },
   })
 
-  const formations: any[] = await getDbCollection("formationcatalogues").aggregate(stages).toArray()
+  const formations: any[] = await getSecondaryDbCollection("formationcatalogues").aggregate(stages).toArray()
   if (formations.length === 0 && !caller) {
     await notifyToSlack({ subject: "FORMATION", message: `Aucune formation par région trouvée pour les romes ${romes} ou le domaine ${romeDomain}.` })
   }

--- a/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
+++ b/server/src/services/jobs/jobOpportunity/jobOpportunity.service.ts
@@ -26,7 +26,7 @@ import { JOB_PUBLISHING_STATUS, jobsRouteApiv3Converters, zJobOfferApiReadV3, zJ
 import { logger } from "@/common/logger"
 import type { IApiError } from "@/common/utils/errorManager"
 import { normalizeDepartementToRegex } from "@/common/utils/geolib"
-import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { getDbCollection, getSecondaryDbCollection } from "@/common/utils/mongodbUtils"
 import { trackApiCall } from "@/common/utils/sendTrackingEvent"
 import { sentryCaptureException } from "@/common/utils/sentryUtils"
 import config from "@/config"
@@ -367,7 +367,7 @@ export const getJobsPartnersFromDB = async ({
           { $sort: { distance: 1, offer_creation: -1 } },
         ]
 
-  return await getDbCollection("jobs_partners")
+  return await getSecondaryDbCollection("jobs_partners")
     .aggregate<IJobsPartnersOfferPrivate>([
       ...filterStages,
       {
@@ -424,7 +424,7 @@ export const getJobsPartnersFromDBForUI = async ({
           { $sort: { distance: 1, offer_creation: -1 } },
         ]
 
-  return await getDbCollection("jobs_partners")
+  return await getSecondaryDbCollection("jobs_partners")
     .aggregate<IJobsPartnersOfferPrivateWithDistance>([
       ...filterStages,
       {
@@ -1143,7 +1143,7 @@ export async function getPartnerJobsCount({
   partnerLabel: string
   includePartnerLabel: boolean
 }): Promise<number> {
-  const result = await getDbCollection("jobs_partners")
+  const result = await getSecondaryDbCollection("jobs_partners")
     .aggregate([
       {
         $geoNear: {

--- a/server/src/services/recruteurLba.service.ts
+++ b/server/src/services/recruteurLba.service.ts
@@ -13,7 +13,7 @@ import type { IApiError } from "@/common/utils/errorManager"
 import { manageApiError } from "@/common/utils/errorManager"
 import { normalizeDepartementToRegex, roundDistance } from "@/common/utils/geolib"
 import { isAllowedSource } from "@/common/utils/isAllowedSource"
-import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { getDbCollection, getSecondaryDbCollection } from "@/common/utils/mongodbUtils"
 import { sentryCaptureException } from "@/common/utils/sentryUtils"
 import { generateApplicationToken } from "./appLinks.service"
 import type { IApplicationCount } from "./application.service"
@@ -284,7 +284,7 @@ export const getRecruteursLbaFromDB = async ({ geo, romes, opco, departements, p
           { $sort: { distance: 1 } },
         ]
 
-  return await getDbCollection("jobs_partners")
+  return await getSecondaryDbCollection("jobs_partners")
     .aggregate<IJobsPartnersOfferPrivate>([
       ...filterStages,
       {
@@ -344,7 +344,7 @@ const getCompanies = async ({
     let companies: IJobsPartnersRecruteurAlgoPrivate[] = []
 
     if (latitude && longitude) {
-      companies = (await getDbCollection("jobs_partners")
+      companies = (await getSecondaryDbCollection("jobs_partners")
         .aggregate([
           {
             $geoNear: {
@@ -361,7 +361,7 @@ const getCompanies = async ({
         ])
         .toArray()) as IJobsPartnersRecruteurAlgoPrivate[]
     } else {
-      companies = (await getDbCollection("jobs_partners")
+      companies = (await getSecondaryDbCollection("jobs_partners")
         .aggregate([
           {
             $match: query,

--- a/server/src/services/seo.service.ts
+++ b/server/src/services/seo.service.ts
@@ -5,7 +5,7 @@ import seoMetierModel, { SEO_METIER_FORMATION_DESCRIPTIONS, SEO_METIER_FORMATION
 import seoVilleModel from "shared/models/seoVille.model"
 import { logger } from "@/common/logger"
 import { asyncForEach } from "@/common/utils/asyncUtils"
-import { getDbCollection } from "@/common/utils/mongodbUtils.js"
+import { getDbCollection, getSecondaryDbCollection } from "@/common/utils/mongodbUtils.js"
 import { metierData } from "@/jobs/seo/dataMetierSEO"
 import { getApplicationByCompanyCount, getApplicationByJobCount } from "@/services/application.service"
 import { getJobsPartnersFromDBForUI, getPartnerJobsCount } from "./jobs/jobOpportunity/jobOpportunity.service"
@@ -62,7 +62,7 @@ export const updateSeoVilleActivities = async () => {
     .toArray()
 
   for (const ville of villes) {
-    const activities = await getDbCollection(jobsPartnersModel.collectionName)
+    const activities = await getSecondaryDbCollection(jobsPartnersModel.collectionName)
       .aggregate([
         {
           $geoNear: {
@@ -127,11 +127,11 @@ export const getSeoMetier = async ({ metier }: { metier: string }) => {
 }
 
 const getJobCountForMetier = async (romes: string[]) => {
-  return await getDbCollection("jobs_partners").countDocuments({ offer_rome_codes: { $in: romes }, offer_status: JOB_STATUS_ENGLISH.ACTIVE })
+  return await getSecondaryDbCollection("jobs_partners").countDocuments({ offer_rome_codes: { $in: romes }, offer_status: JOB_STATUS_ENGLISH.ACTIVE })
 }
 
 const getCompanyCountForMetier = async (romes: string[]) => {
-  const companyCountResult = await getDbCollection("jobs_partners")
+  const companyCountResult = await getSecondaryDbCollection("jobs_partners")
     .aggregate([
       {
         $match: {
@@ -206,7 +206,7 @@ const getApplicantCountForMetier = async (romes: string[]) => {
 const getTopCompaniesForMetier = async (romes: string[]) => {
   const topLimit = 6
 
-  const topCompanies = await getDbCollection("jobs_partners")
+  const topCompanies = await getSecondaryDbCollection("jobs_partners")
     .aggregate([
       // 1. Filtrer par statut Active et codes ROME
       {
@@ -284,7 +284,7 @@ const getTopCitiesForMetier = async (romes: string[]) => {
   const cityCounts: { nom: string; job_count: number; geopoint: { lat: number; long: number } }[] = []
 
   await asyncForEach(cities, async (city) => {
-    const count = await getDbCollection("jobs_partners")
+    const count = await getSecondaryDbCollection("jobs_partners")
       .aggregate([
         {
           $geoNear: {
@@ -321,7 +321,7 @@ const getTopCitiesForMetier = async (romes: string[]) => {
 }
 
 const getFormationsForMetier = async (romes: string[]) => {
-  const niveaux = await getDbCollection("formationcatalogues")
+  const niveaux = await getSecondaryDbCollection("formationcatalogues")
     .aggregate([
       {
         $match: { rome_codes: { $in: romes } },

--- a/server/src/services/trainingLinks.service.ts
+++ b/server/src/services/trainingLinks.service.ts
@@ -2,7 +2,7 @@ import { getDistance } from "geolib"
 import type { IFormationCatalogue, IReferentielCommune } from "shared/models/index"
 import { URL } from "url"
 import { asyncForEach } from "@/common/utils/asyncUtils"
-import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { getDbCollection, getSecondaryDbCollection } from "@/common/utils/mongodbUtils"
 import config from "@/config.js"
 import { getRomesFromRncp } from "./external/api-alternance/certification.service"
 import { filterWrongRomes } from "./formation.service"
@@ -53,7 +53,7 @@ const getFormations = (
     rome_codes: 1,
     _id: 0,
   }
-) => getDbCollection("formationcatalogues").find(query, filter).toArray()
+) => getSecondaryDbCollection("formationcatalogues").find(query, filter).toArray()
 
 const getTrainingsFromParameters = async (wish: IWish, formationsByCle?: Map<string, IFormationCatalogue[]>): Promise<IFormationCatalogue[]> => {
   let formations
@@ -130,7 +130,7 @@ const getRomesGlobaux = async ({ rncp, cfd, mef }: { rncp?: string | null; cfd?:
     return romes
   }
 
-  const tmpFormations = await getDbCollection("formationcatalogues")
+  const tmpFormations = await getSecondaryDbCollection("formationcatalogues")
     .find(
       {
         $or: [{ rncp_code: rncp }, { cfd: cfd ? cfd : undefined }, { "bcn_mefs_10.mef10": mef }],
@@ -275,12 +275,12 @@ export const getTrainingLinks = async (params: IWish[]): Promise<ILinks[]> => {
           .toArray()
       : Promise.resolve([]),
     cles.length
-      ? getDbCollection("formationcatalogues")
+      ? getSecondaryDbCollection("formationcatalogues")
           .find({ cle_ministere_educatif: { $in: cles } }, { projection: { lieu_formation_geo_coordonnees: 1, rome_codes: 1, cle_ministere_educatif: 1, _id: 0 } })
           .toArray()
       : Promise.resolve([]),
     hasRomesQuery
-      ? (getDbCollection("formationcatalogues")
+      ? (getSecondaryDbCollection("formationcatalogues")
           .find(
             {
               $or: [

--- a/server/src/services/trainingLinks.service.ts
+++ b/server/src/services/trainingLinks.service.ts
@@ -48,12 +48,12 @@ const buildEmploiUrl = ({ baseUrl = `${config.publicUrl}/recherche-emploi`, para
 
 const getFormations = (
   query: object,
-  filter: object = {
+  projection: object = {
     lieu_formation_geo_coordonnees: 1,
     rome_codes: 1,
     _id: 0,
   }
-) => getSecondaryDbCollection("formationcatalogues").find(query, filter).toArray()
+) => getSecondaryDbCollection("formationcatalogues").find(query, { projection }).toArray()
 
 const getTrainingsFromParameters = async (wish: IWish, formationsByCle?: Map<string, IFormationCatalogue[]>): Promise<IFormationCatalogue[]> => {
   let formations


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3933

---

## Changements

- ajoute le helper `getSecondaryDbCollection` avec `readPreference: secondaryPreferred`
- bascule les lectures Mongo de la recherche jobs et recruteurs sur les secondaires
- bascule les lectures Mongo de la recherche formations et des usages non critiques associés sur les secondaires

## Plan de test

- [ ] vérifier qu'une recherche jobs renvoie les résultats attendus
- [ ] vérifier qu'une recherche formations renvoie les résultats attendus
- [ ] vérifier qu'un détail d'offre et un détail de formation restent cohérents après écriture
- [ ] vérifier que les pages SEO et les liens formations continuent de se générer correctement