### PR TITLE
fix: corrections SEO — canonical guides, robots espace-pro, meta simulateur

### DIFF
--- a/ui/app/(editorial)/guide/apprentissage-et-handicap/page.tsx
+++ b/ui/app/(editorial)/guide/apprentissage-et-handicap/page.tsx
@@ -17,7 +17,10 @@ import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteu
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
-export const metadata: Metadata = PAGES.static.guideApprentissageEtHandicap.getMetadata()
+export const metadata: Metadata = {
+  ...PAGES.static.guideApprentissageEtHandicap.getMetadata(),
+  alternates: { canonical: PAGES.static.guideApprentissageEtHandicap.getPath() },
+}
 
 const ALLER_PLUS_LOIN_ITEMS_ALTERNANT = [
   ARTICLES_ALTERNANT["role-et-missions-du-maitre-d-apprentissage-ou-tuteur"],

--- a/ui/app/(editorial)/guide/decouvrir-l-alternance/page.tsx
+++ b/ui/app/(editorial)/guide/decouvrir-l-alternance/page.tsx
@@ -15,7 +15,10 @@ import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteu
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
-export const metadata: Metadata = PAGES.static.guideDecouvrirLAlternance.getMetadata()
+export const metadata: Metadata = {
+  ...PAGES.static.guideDecouvrirLAlternance.getMetadata(),
+  alternates: { canonical: PAGES.static.guideDecouvrirLAlternance.getPath() },
+}
 
 const ALLER_PLUS_LOIN_ITEMS_ALTERNANT = [
   ARTICLES_ALTERNANT["preparer-son-projet-en-alternance"],

--- a/ui/app/(editorial)/guide/prevention-des-risques-professionnels-pour-les-apprentis/page.tsx
+++ b/ui/app/(editorial)/guide/prevention-des-risques-professionnels-pour-les-apprentis/page.tsx
@@ -12,7 +12,10 @@ import { ARTICLES as ARTICLES_CFA } from "@/app/(editorial)/guide-cfa/const"
 import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteur/const"
 import { PAGES } from "@/utils/routes.utils"
 
-export const metadata: Metadata = PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getMetadata()
+export const metadata: Metadata = {
+  ...PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getMetadata(),
+  alternates: { canonical: PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getPath() },
+}
 
 const ALLER_PLUS_LOIN_ITEMS_ALTERNANT = [ARTICLES_ALTERNANT["comprendre-la-remuneration"], ARTICLES_ALTERNANT["la-rupture-de-contrat"], ARTICLES_ALTERNANT["se-faire-accompagner"]]
 const ALLER_PLUS_LOIN_ITEMS_RECRUTEUR = [

--- a/ui/app/robots.ts
+++ b/ui/app/robots.ts
@@ -9,7 +9,7 @@ const getRobotRules = () => {
       return {
         rules: {
           userAgent: "*",
-          disallow: ["/test-widget", "/recherche-formation", "/recherche-emploi"],
+          disallow: ["/test-widget", "/recherche-formation", "/recherche-emploi", "/espace-pro"],
         },
         sitemap: "https://labonnealternance.apprentissage.beta.gouv.fr/sitemap-index.xml",
       }

--- a/ui/utils/routes.utils.ts
+++ b/ui/utils/routes.utils.ts
@@ -322,8 +322,9 @@ export const PAGES = {
       title: "Salaire alternant",
       index: true,
       getMetadata: () => ({
-        title: "Simulateur salaire alternant 2026 | Calculez votre rémunération",
-        description: "Simulez gratuitement votre salaire en alternance selon votre âge, contrat (apprentissage ou professionnalisation) et année de formation. Barèmes 2026.",
+        title: "Simulateur salaire alternance 2026 | Calcul gratuit brut et net",
+        description:
+          "Calculez votre salaire net en alternance en 2 clics. Indiquez votre âge, type de contrat et durée : le simulateur affiche votre rémunération mensuelle brut et net.",
       }),
     },
     EspaceDeveloppeurs: {


### PR DESCRIPTION
## Summary

3 corrections SEO identifiées via l'analyse Google Search Console :

- **Canonical sur les pages guides partagées** : les 3 pages sous `/guide/` (découvrir l'alternance, apprentissage et handicap, prévention des risques) sont atteintes via `?source=guide-alternant`, `?source=guide-recruteur` et `?source=guide-cfa`. Le `canonical: "./"` du root layout générait un canonical différent par variante → Google indexait jusqu'à 12 URLs pour du contenu identique. Ajout d'un canonical explicite pointant vers l'URL sans paramètre.

- **Blocage de `/espace-pro` dans robots.txt** : ~40+ pages privées derrière authentification consommaient du crawl budget inutilement (59K impressions sur `/espace-pro/authentification`). Les landing pages publiques (`/je-suis-recruteur`, `/acces-recruteur`) ne sont pas sous `/espace-pro/` et ne sont pas impactées.

- **Différenciation du simulateur salaire** : le simulateur `/salaire-alternant` (position 19.3) et le guide `/guide-alternant/comprendre-la-remuneration` (position 5.9) se cannibalisaient sur les mêmes mots-clés "salaire alternance 2026". Réécriture des meta du simulateur pour cibler les requêtes "simulateur", "calcul", "brut et net" au lieu de "barèmes" (territoire du guide).

## Fichiers modifiés

- `ui/app/(editorial)/guide/apprentissage-et-handicap/page.tsx` — canonical ajouté
- `ui/app/(editorial)/guide/decouvrir-l-alternance/page.tsx` — canonical ajouté
- `ui/app/(editorial)/guide/prevention-des-risques-professionnels-pour-les-apprentis/page.tsx` — canonical ajouté
- `ui/app/robots.ts` — `/espace-pro` ajouté au disallow
- `ui/utils/routes.utils.ts` — meta title/description du simulateur salaire différenciées

## Test plan

- [ ] Vérifier le code source de `/guide/apprentissage-et-handicap` : `<link rel="canonical">` pointe vers `/guide/apprentissage-et-handicap` (sans `?source=`)
- [ ] Vérifier `/guide/apprentissage-et-handicap?source=guide-recruteur` : même canonical
- [ ] Accéder à `/robots.txt` en production : `/espace-pro` apparaît dans Disallow
- [ ] Vérifier la meta description de `/salaire-alternant` : contient "brut et net", ne contient plus "Barèmes"
- [ ] Les pages `/je-suis-recruteur` et `/acces-recruteur` ne sont pas bloquées par robots.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)