### PR TITLE
fix(lba-3937): borne les romes des liens de recherche

### DIFF
--- a/server/src/services/queryValidator.service.ts
+++ b/server/src/services/queryValidator.service.ts
@@ -1,3 +1,4 @@
+import { MAX_SEARCH_ROMES } from "shared"
 import { allLbaItemTypeOLD } from "shared/constants/lbaitem"
 import { isOriginLocal } from "@/common/utils/isOriginLocal"
 import { regionCodeToDepartmentList } from "@/common/utils/regionInseeCodes"
@@ -27,7 +28,7 @@ const validateRncp = (rncp: string, error_messages: string[]) => {
  * @param {number} romeLimit le nombre maximum de codes ROME pouvant être acceptés
  * @returns {undefined}
  */
-const validateRomesOrRncp = async (query: Omit<TJobSearchQuery, "isMinimalData">, error_messages: string[], romeLimit = 20) => {
+const validateRomesOrRncp = async (query: Omit<TJobSearchQuery, "isMinimalData">, error_messages: string[], romeLimit = MAX_SEARCH_ROMES) => {
   const { romes, rncp } = query
 
   // codes ROME : romes
@@ -62,7 +63,7 @@ const validateRomesOrRncp = async (query: Omit<TJobSearchQuery, "isMinimalData">
  * @returns {undefined}
  */
 const validateRomeOrDomain = (
-  { romes, romeDomain, romeLimit = 20, optional }: { romes: string | undefined; romeDomain: string | undefined; romeLimit?: number; optional?: boolean },
+  { romes, romeDomain, romeLimit = MAX_SEARCH_ROMES, optional }: { romes: string | undefined; romeDomain: string | undefined; romeLimit?: number; optional?: boolean },
   error_messages: string[]
 ) => {
   if (!optional && !romes && !romeDomain) {
@@ -88,7 +89,7 @@ const validateRomeOrDomain = (
  * @returns {undefined}
  */
 const validateOptionalRomeOrDomain = (
-  { romes, romeDomain, romeLimit = 20 }: { romes: string | undefined; romeDomain: string | undefined; romeLimit?: number },
+  { romes, romeDomain, romeLimit = MAX_SEARCH_ROMES }: { romes: string | undefined; romeDomain: string | undefined; romeLimit?: number },
   error_messages: string[]
 ) => {
   validateRomeOrDomain({ romes, romeDomain, romeLimit, optional: true }, error_messages)
@@ -297,7 +298,7 @@ export const formationsRegionQueryValidator = (
   validateCaller({ caller: query.caller, referer: query.referer }, error_messages)
 
   // codes ROME : romes ou romeDomain optionnels dans ce contexte
-  validateOptionalRomeOrDomain({ romes: query.romes, romeDomain: query.romeDomain, romeLimit: 20 }, error_messages)
+  validateOptionalRomeOrDomain({ romes: query.romes, romeDomain: query.romeDomain, romeLimit: MAX_SEARCH_ROMES }, error_messages)
 
   // region. Soit département soit région soit aucune des deux = France entière
   validateOptionalRegion({ region: query.region, departement: query.departement }, error_messages)

--- a/server/src/services/trainingLinks.service.ts
+++ b/server/src/services/trainingLinks.service.ts
@@ -1,4 +1,5 @@
 import { getDistance } from "geolib"
+import { MAX_SEARCH_ROMES } from "shared"
 import type { IFormationCatalogue, IReferentielCommune } from "shared/models/index"
 import { URL } from "url"
 import { asyncForEach } from "@/common/utils/asyncUtils"
@@ -54,6 +55,8 @@ const getFormations = (
     _id: 0,
   }
 ) => getSecondaryDbCollection("formationcatalogues").find(query, { projection }).toArray()
+
+const limitSearchRomes = (romes: string[]) => romes.slice(0, MAX_SEARCH_ROMES)
 
 const getTrainingsFromParameters = async (wish: IWish, formationsByCle?: Map<string, IFormationCatalogue[]>): Promise<IFormationCatalogue[]> => {
   let formations
@@ -208,7 +211,7 @@ export const getLBALink = async (wish: IWish, formationsByCle?: Map<string, IFor
   if (formations?.length === 1) {
     const { rome_codes, lieu_formation_geo_coordonnees } = formations[0]
     const [latitude, longitude] = lieu_formation_geo_coordonnees!.split(",")
-    const romes = await expandRomesV3toV4(rome_codes ?? [])
+    const romes = limitSearchRomes(await expandRomesV3toV4(rome_codes ?? []))
     return buildEmploiUrl({ params: { romes, lat: latitude, lon: longitude, radius: "60", ...utmParams } })
   }
 
@@ -224,7 +227,7 @@ export const getLBALink = async (wish: IWish, formationsByCle?: Map<string, IFor
     : await getRomesGlobaux({ rncp: wish.rncp, cfd: wish.cfd, mef: wish.mef }, romesIndex)
 
   romes = romes.filter((rome_code) => rome_code.length === 5 && !rome_code.endsWith("00"))
-  romes = await expandRomesV3toV4(romes)
+  romes = limitSearchRomes(await expandRomesV3toV4(romes))
 
   // Build url based on formations and coordinates
   if (formations?.length) {

--- a/shared/src/constants/index.ts
+++ b/shared/src/constants/index.ts
@@ -2,3 +2,4 @@ const megaByte = 1024 ** 2
 export const FILE_SIZE_LIMIT = 100 * megaByte
 
 export * from "./recruteur.js"
+export * from "./search.js"

--- a/shared/src/constants/search.ts
+++ b/shared/src/constants/search.ts
@@ -1,0 +1,1 @@
+export const MAX_SEARCH_ROMES = 20

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./constants/index.js"
 export * from "./models/index.js"
 export * from "./routes/index.js"
 export * from "./utils/index.js"

--- a/shared/src/models/lbacError.model.ts
+++ b/shared/src/models/lbacError.model.ts
@@ -1,3 +1,4 @@
+import { MAX_SEARCH_ROMES } from "../constants/search.js"
 import { z } from "../helpers/zodWithOpenApi.js"
 
 export const ZLbacError = z
@@ -10,7 +11,10 @@ export const ZLbacError = z
       .array(z.string())
       .openapi({
         description: "Une liste d'erreurs détaillées. Ex : les erreurs de paramétrage de la requête.",
-        example: ["romes : Badly formatted rome codes. Rome code must be one letter followed by 4 digit number. ex : A1234", "romes : Too many rome codes. Maximum is 20."],
+        example: [
+          "romes : Badly formatted rome codes. Rome code must be one letter followed by 4 digit number. ex : A1234",
+          `romes : Too many rome codes. Maximum is ${MAX_SEARCH_ROMES}.`,
+        ],
       })
       .nullish(),
   })
@@ -28,7 +32,10 @@ export const ZApiError = z
       .array(z.string())
       .openapi({
         description: "Une liste d'erreurs détaillées. Ex : les erreurs de paramétrage de la requête.",
-        example: ["romes : Badly formatted rome codes. Rome code must be one letter followed by 4 digit number. ex : A1234", "romes : Too many rome codes. Maximum is 20."],
+        example: [
+          "romes : Badly formatted rome codes. Rome code must be one letter followed by 4 digit number. ex : A1234",
+          `romes : Too many rome codes. Maximum is ${MAX_SEARCH_ROMES}.`,
+        ],
       })
       .nullish(),
   })

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
@@ -1,5 +1,5 @@
 import type { ReadonlyURLSearchParams } from "next/navigation"
-import { parseEnum, typedKeys } from "shared"
+import { MAX_SEARCH_ROMES, parseEnum, typedKeys } from "shared"
 import { LBA_ITEM_TYPE, LBA_ITEM_TYPE_OLD, newItemTypeToOldItemType, oldItemTypeToNewItemType } from "shared/constants/lbaitem"
 import type { ITypeEmploi } from "shared/constants/recruteur"
 import { NIVEAUX_POUR_LBA, TYPE_EMPLOI_OPTIONS } from "shared/constants/recruteur"
@@ -107,6 +107,8 @@ export type IRecherchePageParams = Required<z.output<typeof zRecherchePageParams
 
 export type WithRecherchePageParams<T = object> = T & { rechercheParams: IRecherchePageParams }
 
+const normalizeRomes = (romes: string[]) => romes.slice(0, MAX_SEARCH_ROMES)
+
 export enum IRechercheMode {
   DEFAULT = "default",
   FORMATIONS_ONLY = "formations-only",
@@ -118,7 +120,7 @@ export function buildRecherchePageParams(rechercheParams: Partial<IRecherchePage
   const query = new URLSearchParams()
 
   if (rechercheParams?.romes?.length > 0) {
-    query.set("romes", rechercheParams.romes.join(","))
+    query.set("romes", normalizeRomes(rechercheParams.romes).join(","))
   }
 
   if (rechercheParams.radius !== undefined) {
@@ -200,7 +202,7 @@ export function parseRecherchePageParams(search: ReadonlyURLSearchParams | URLSe
     return null
   }
 
-  const romes = search.get("romes")?.split(",") ?? []
+  const romes = normalizeRomes(search.get("romes")?.split(",") ?? [])
   const activeItems = deserializeItemReferences(search.get("activeItems") ?? "")
 
   const rawLat = search.get("lat")


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3937

---

## Changements

- borne a 20 les romes generes par `trainingLinks` pour eviter la generation de liens incompatibles avec la recherche
- centralise la limite de romes de recherche dans une constante partagee
- rend la page de recherche tolerante aux anciens liens de campagne contenant trop de romes

## Plan de test

- [ ] verifier qu'un appel a `/traininglinks` ne genere plus de `lien_lba` avec plus de 20 romes
- [ ] verifier qu'un ancien lien `/recherche-emploi` avec plus de 20 romes charge la page sans erreur 400 sur les appels de recherche
- [ ] verifier qu'une recherche standard continue de fonctionner avec des romes valides
- [ ] verifier que les messages d'erreur de validation mentionnent toujours correctement la limite de romes