### PR TITLE
fix: retire la whitelist ip temporaire du stress test

### DIFF
--- a/.infra/docker-compose.production.yml
+++ b/.infra/docker-compose.production.yml
@@ -32,7 +32,6 @@ services:
     stop_grace_period: 2m
     command: ["yarn", "cli", "start"]
     environment:
-      LBA_RATE_LIMIT_ALLOW_LIST: "88.164.218.226/32"
       NODE_OPTIONS: "--max_old_space_size=1280"
     volumes:
       - /opt/app/data/server:/data

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -23,9 +23,6 @@ const config = {
   mongodb: {
     uri: env.get("LBA_MONGODB_URI").required().asString(),
   },
-  rateLimit: {
-    allowList: env.get("LBA_RATE_LIMIT_ALLOW_LIST").default("").asArray(),
-  },
   catalogueUrl: env.get("LBA_CATALOGUE_URL").required().asString(),
   serverSentryDsn: env.get("LBA_SERVER_SENTRY_DSN").required().asString(),
   lbaSecret: env.get("LBA_SECRET").required().asString(),

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -71,7 +71,7 @@ export async function bind(app: Server) {
   app.setValidatorCompiler(validatorCompiler)
   app.setSerializerCompiler(serializerCompiler)
 
-  const allowedIps = ["127.0.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", ...config.rateLimit.allowList].map((ip) => new Netmask(ip))
+  const allowedIps = [new Netmask("127.0.0.0/16"), new Netmask("10.0.0.0/8"), new Netmask("172.16.0.0/12"), new Netmask("192.168.0.0/16")]
   await app.register(fastifyRateLimt, {
     global: false,
     allowList: (req) => {


### PR DESCRIPTION
## Changements

- Suppression de la variable d'env `LBA_RATE_LIMIT_ALLOW_LIST` dans `docker-compose.production.yml`
- Suppression du bloc `rateLimit.allowList` dans `config.ts`
- Retour à la liste statique d'IPs autorisées dans `server.ts`

## Plan de test

- [ ] Vérifier que le rate limiting fonctionne normalement en prod (plus d'IP whitelistée)