### PR TITLE
fix(lba-3940): augmente le revalidate ISR des pages notion de 1h à 24h

### DIFF
--- a/ui/app/(editorial-with-notion)/accessibilite/page.tsx
+++ b/ui/app/(editorial-with-notion)/accessibilite/page.tsx
@@ -16,4 +16,4 @@ const Page = async () => {
 
 export default Page
 
-export const revalidate = 3600 // revalider toutes les heures
+export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)

--- a/ui/app/(editorial-with-notion)/conditions-generales-utilisation/page.tsx
+++ b/ui/app/(editorial-with-notion)/conditions-generales-utilisation/page.tsx
@@ -13,4 +13,4 @@ export default async function CGU() {
   return <CGURendererClient recordMap={notionPage} />
 }
 
-export const revalidate = 3600 // revalider toutes les heures
+export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)

--- a/ui/app/(editorial-with-notion)/faq/page.tsx
+++ b/ui/app/(editorial-with-notion)/faq/page.tsx
@@ -33,4 +33,4 @@ export default async function FAQ({ searchParams }: { searchParams: Promise<Reco
   )
 }
 
-export const revalidate = 3600 // revalider toutes les heures
+export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)

--- a/ui/app/(editorial-with-notion)/mentions-legales/page.tsx
+++ b/ui/app/(editorial-with-notion)/mentions-legales/page.tsx
@@ -14,4 +14,4 @@ export default async function MentionsLegales() {
   return <MentionLegalesRendererClient mentionsLegales={mentionsLegales} />
 }
 
-export const revalidate = 3600 // revalider toutes les heures
+export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)

--- a/ui/app/(editorial-with-notion)/politique-de-confidentialite/page.tsx
+++ b/ui/app/(editorial-with-notion)/politique-de-confidentialite/page.tsx
@@ -13,4 +13,4 @@ export default async function PolitiqueDeConfidentialite() {
   return <PolitiqueDeConfidentialiteRendererClient politiqueDeConfidentialite={politiqueDeConfidentialite} />
 }
 
-export const revalidate = 3600 // revalider toutes les heures
+export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3940

Sentry : https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-5CVZZZZZZG2K1

---

## Contexte

Les pages éditorielles alimentées par Notion (`/mentions-legales`, `/faq`, `/conditions-generales-utilisation`, `/politique-de-confidentialite`, `/accessibilite`) utilisent l'API non-officielle Notion via `notion-client`. Cette API est rate-limitée par IP et retourne des `429 Too Many Requests` lors des revalidations ISR en arrière-plan.

Next.js gère l'erreur gracieusement (il sert le contenu périmé), mais logue un `console.error` que Sentry capte.

## Changements

- `revalidate` passe de `3600` (1h) à `86400` (24h) sur les 5 pages Notion
- Ces pages (légales, politique, FAQ, accessibilité) changent très rarement — 24h est un bon compromis
- Réduit les appels à l'API Notion de 24×, donc les risques de 429

## Plan de test

- [ ] Vérifier que les 5 pages s'affichent correctement en production après déploiement
- [ ] Vérifier l'absence de nouvelles erreurs Sentry `429 Notion` dans les 24h suivant le déploiement