### PR TITLE
fix: mongo maxPoolSize & secondary helper

### DIFF
--- a/server/src/common/utils/mongodbUtils.ts
+++ b/server/src/common/utils/mongodbUtils.ts
@@ -32,7 +32,7 @@ export const connectToMongodb = async (uri: string) => {
     retryWrites: true,
     retryReads: true,
     minPoolSize: config.env === "local" ? 0 : 5,
-    maxPoolSize: 1_000,
+    maxPoolSize: 50,
     serverSelectionTimeoutMS: config.env === "local" ? 1_000 : 10_000,
   })
 
@@ -82,7 +82,7 @@ export const getDbCollection = <K extends CollectionName>(name: K): Collection<I
 }
 
 export const getSecondaryDbCollection = <K extends CollectionName>(name: K): Collection<IDocument<K>> => {
-  return ensureInitialization().db().collection(name, { readPreference: "secondaryPreferred" })
+  return ensureInitialization().db().collection(name, { readPreference: "secondary" })
 }
 
 export const getCollectionList = async (): Promise<(CollectionInfo | Pick<CollectionInfo, "name" | "type">)[]> => {

--- a/server/src/common/utils/mongodbUtils.ts
+++ b/server/src/common/utils/mongodbUtils.ts
@@ -82,7 +82,9 @@ export const getDbCollection = <K extends CollectionName>(name: K): Collection<I
 }
 
 export const getSecondaryDbCollection = <K extends CollectionName>(name: K): Collection<IDocument<K>> => {
-  return ensureInitialization().db().collection(name, { readPreference: "secondary" })
+  return ensureInitialization()
+    .db()
+    .collection(name, { readPreference: config.env === "production" ? "secondary" : "secondaryPreferred" })
 }
 
 export const getCollectionList = async (): Promise<(CollectionInfo | Pick<CollectionInfo, "name" | "type">)[]> => {


### PR DESCRIPTION
- Mise à jour du MaxPoolSize, surdimensionné et ne favorise pas une bonne répartition des connexions, même si ce n'est pas son rôle
- Mise à jour du helper getSecondaryDbCollection --> readPreference secondary strict en production
<img width="1508" height="863" alt="screenshot-pmm" src="https://github.com/user-attachments/assets/82299f02-ef67-4b90-a881-bcbc4b646b4b" />

