### PR TITLE
fix: private search rome limit

### DIFF
--- a/server/src/services/queryValidator.service.test.ts
+++ b/server/src/services/queryValidator.service.test.ts
@@ -1,0 +1,43 @@
+import { MAX_SEARCH_ROMES, MAX_SEARCH_ROMES_PRIVATE } from "shared"
+import { describe, expect, it, vi } from "vitest"
+import { formationsQueryValidator, jobsQueryValidatorPrivate } from "./queryValidator.service"
+
+vi.mock("./external/api-alternance/certification.service", () => ({
+  getRomesFromRncp: vi.fn(),
+}))
+
+vi.mock("@/common/utils/isOriginLocal", () => ({
+  isOriginLocal: vi.fn(() => true),
+}))
+
+const generateRomes = (count: number) => Array.from({ length: count }, (_, i) => `A${String(i + 1).padStart(4, "0")}`).join(",")
+
+describe("jobsQueryValidatorPrivate — limite romes", () => {
+  const baseQuery = { caller: "test", isMinimalData: true }
+
+  it(`accepte ${MAX_SEARCH_ROMES_PRIVATE} romes`, async () => {
+    const result = await jobsQueryValidatorPrivate({ ...baseQuery, romes: generateRomes(MAX_SEARCH_ROMES_PRIVATE) })
+    expect(result).toMatchObject({ result: "passed" })
+  })
+
+  it(`rejette ${MAX_SEARCH_ROMES_PRIVATE + 1} romes`, async () => {
+    const result = await jobsQueryValidatorPrivate({ ...baseQuery, romes: generateRomes(MAX_SEARCH_ROMES_PRIVATE + 1) })
+    expect(result).toMatchObject({ error: "wrong_parameters" })
+    expect((result as { error_messages: string[] }).error_messages).toEqual(expect.arrayContaining([expect.stringContaining(`Maximum is ${MAX_SEARCH_ROMES_PRIVATE}`)]))
+  })
+})
+
+describe("formationsQueryValidator — limite romes", () => {
+  const baseQuery = { caller: "test", isMinimalData: true }
+
+  it(`accepte ${MAX_SEARCH_ROMES} romes`, async () => {
+    const result = await formationsQueryValidator({ ...baseQuery, romes: generateRomes(MAX_SEARCH_ROMES) })
+    expect(result).toMatchObject({ result: "passed" })
+  })
+
+  it(`rejette ${MAX_SEARCH_ROMES + 1} romes`, async () => {
+    const result = await formationsQueryValidator({ ...baseQuery, romes: generateRomes(MAX_SEARCH_ROMES + 1) })
+    expect(result).toMatchObject({ error: "wrong_parameters" })
+    expect((result as { error_messages: string[] }).error_messages).toEqual(expect.arrayContaining([expect.stringContaining(`Maximum is ${MAX_SEARCH_ROMES}`)]))
+  })
+})

--- a/server/src/services/queryValidator.service.ts
+++ b/server/src/services/queryValidator.service.ts
@@ -268,7 +268,7 @@ export const formationsQueryValidator = async (
   // présence d'identifiant de la source : caller
   validateCaller({ caller: query.caller, referer: query.referer }, error_messages)
 
-  validateRomeOrDomain({ romes: query.romes, romeDomain: query.romeDomain, romeLimit: MAX_SEARCH_ROMES_PRIVATE }, error_messages)
+  validateRomeOrDomain({ romes: query.romes, romeDomain: query.romeDomain, romeLimit: MAX_SEARCH_ROMES }, error_messages)
 
   // coordonnées gps optionnelles : latitude et longitude
   if (query.latitude || query.longitude) {

--- a/server/src/services/queryValidator.service.ts
+++ b/server/src/services/queryValidator.service.ts
@@ -1,4 +1,4 @@
-import { MAX_SEARCH_ROMES } from "shared"
+import { MAX_SEARCH_ROMES, MAX_SEARCH_ROMES_PRIVATE } from "shared"
 import { allLbaItemTypeOLD } from "shared/constants/lbaitem"
 import { isOriginLocal } from "@/common/utils/isOriginLocal"
 import { regionCodeToDepartmentList } from "@/common/utils/regionInseeCodes"
@@ -200,7 +200,7 @@ export const jobsQueryValidatorPrivate = async (query: TJobSearchQuery): Promise
   validateCaller({ caller, referer }, error_messages)
 
   // codes ROME  et code RNCP : romes, rncp. Modifie la valeur de query.romes si code rncp correct
-  await validateRomesOrRncp(query, error_messages, 110)
+  await validateRomesOrRncp(query, error_messages, MAX_SEARCH_ROMES_PRIVATE)
 
   // coordonnées gps optionnelles : latitude et longitude
   if (latitude || longitude) {
@@ -268,7 +268,7 @@ export const formationsQueryValidator = async (
   // présence d'identifiant de la source : caller
   validateCaller({ caller: query.caller, referer: query.referer }, error_messages)
 
-  validateRomeOrDomain({ romes: query.romes, romeDomain: query.romeDomain, romeLimit: 110 }, error_messages)
+  validateRomeOrDomain({ romes: query.romes, romeDomain: query.romeDomain, romeLimit: MAX_SEARCH_ROMES_PRIVATE }, error_messages)
 
   // coordonnées gps optionnelles : latitude et longitude
   if (query.latitude || query.longitude) {

--- a/shared/src/constants/search.ts
+++ b/shared/src/constants/search.ts
@@ -1,1 +1,2 @@
 export const MAX_SEARCH_ROMES = 20
+export const MAX_SEARCH_ROMES_PRIVATE = 110

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
@@ -1,5 +1,5 @@
 import type { ReadonlyURLSearchParams } from "next/navigation"
-import { MAX_SEARCH_ROMES, parseEnum, typedKeys } from "shared"
+import { MAX_SEARCH_ROMES, MAX_SEARCH_ROMES_PRIVATE, parseEnum, typedKeys } from "shared"
 import { LBA_ITEM_TYPE, LBA_ITEM_TYPE_OLD, newItemTypeToOldItemType, oldItemTypeToNewItemType } from "shared/constants/lbaitem"
 import type { ITypeEmploi } from "shared/constants/recruteur"
 import { NIVEAUX_POUR_LBA, TYPE_EMPLOI_OPTIONS } from "shared/constants/recruteur"
@@ -107,7 +107,7 @@ export type IRecherchePageParams = Required<z.output<typeof zRecherchePageParams
 
 export type WithRecherchePageParams<T = object> = T & { rechercheParams: IRecherchePageParams }
 
-const normalizeRomes = (romes: string[]) => romes.slice(0, MAX_SEARCH_ROMES)
+const normalizeRomes = (romes: string[]) => romes.slice(0, MAX_SEARCH_ROMES_PRIVATE)
 
 export enum IRechercheMode {
   DEFAULT = "default",

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
@@ -1,5 +1,5 @@
 import type { ReadonlyURLSearchParams } from "next/navigation"
-import { MAX_SEARCH_ROMES, MAX_SEARCH_ROMES_PRIVATE, parseEnum, typedKeys } from "shared"
+import { MAX_SEARCH_ROMES_PRIVATE, parseEnum, typedKeys } from "shared"
 import { LBA_ITEM_TYPE, LBA_ITEM_TYPE_OLD, newItemTypeToOldItemType, oldItemTypeToNewItemType } from "shared/constants/lbaitem"
 import type { ITypeEmploi } from "shared/constants/recruteur"
 import { NIVEAUX_POUR_LBA, TYPE_EMPLOI_OPTIONS } from "shared/constants/recruteur"


### PR DESCRIPTION
This pull request increases the maximum number of ROME codes that can be handled in both backend and frontend logic by introducing a new constant, `MAX_SEARCH_ROMES_PRIVATE`, set to 110. The changes ensure consistency across the application by using this new constant in relevant validators and utilities.

**Constants and Limits Update:**

* Added `MAX_SEARCH_ROMES_PRIVATE` (set to 110) to `shared/src/constants/search.ts` to allow for higher ROME code limits in private/internal queries.
* Updated imports to include `MAX_SEARCH_ROMES_PRIVATE` in both backend (`server/src/services/queryValidator.service.ts`) and frontend (`ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts`). [[1]](diffhunk://#diff-fb56ab3d668bd9b14e52b2d61f6343cab411016be1c73da458b0cb6b59d9bd3eL1-R1) [[2]](diffhunk://#diff-5a35468a953cccff8810ff26c547436dc717e644c2c3de20b7dc064f948b98ccL2-R2)

**Backend Validation Changes:**

* Changed the ROME code limit in `jobsQueryValidatorPrivate` and `formationsQueryValidator` to use `MAX_SEARCH_ROMES_PRIVATE`, allowing up to 110 codes for private/internal searches. [[1]](diffhunk://#diff-fb56ab3d668bd9b14e52b2d61f6343cab411016be1c73da458b0cb6b59d9bd3eL203-R203) [[2]](diffhunk://#diff-fb56ab3d668bd9b14e52b2d61f6343cab411016be1c73da458b0cb6b59d9bd3eL271-R271)

**Frontend Utility Update:**

* Updated the `normalizeRomes` function to use `MAX_SEARCH_ROMES_PRIVATE`, ensuring the frontend respects the new, higher limit for ROME codes.