### PR TITLE
fix(lbac-3944): rdva: fix creation user

### DIFF
--- a/server/src/services/cfa.service.ts
+++ b/server/src/services/cfa.service.ts
@@ -1,3 +1,4 @@
+import { internal } from "@hapi/boom"
 import { ObjectId } from "mongodb"
 import type { ICFA } from "shared/models/cfa.model"
 
@@ -13,6 +14,6 @@ export const upsertCfa = async (siret: string, cfaFields: Omit<ICFA, "_id" | "cr
     },
     { upsert: true, returnDocument: "after" }
   )
-  if (!cfa) throw new Error("inattendu: pas de cfa")
+  if (!cfa) throw internal("inattendu: pas de cfa")
   return cfa
 }

--- a/server/src/services/cfa.service.ts
+++ b/server/src/services/cfa.service.ts
@@ -5,21 +5,14 @@ import { getDbCollection } from "@/common/utils/mongodbUtils"
 
 export const upsertCfa = async (siret: string, cfaFields: Omit<ICFA, "_id" | "createdAt" | "updatedAt" | "origin" | "siret">, origin: string): Promise<ICFA> => {
   const now = new Date()
-  let cfa = await getDbCollection("cfas").findOne({ siret })
-  if (cfa) {
-    cfa = await getDbCollection("cfas").findOneAndUpdate({ siret }, { $set: { ...cfaFields, siret } }, { returnDocument: "after" })
-    if (!cfa) throw new Error("inattendu: pas de cfa")
-    return cfa
-  } else {
-    const createCfaFields: ICFA = {
-      ...cfaFields,
-      origin,
-      siret,
-      _id: new ObjectId(),
-      createdAt: now,
-      updatedAt: now,
-    }
-    await getDbCollection("cfas").insertOne(createCfaFields)
-    return createCfaFields
-  }
+  const cfa = await getDbCollection("cfas").findOneAndUpdate(
+    { siret },
+    {
+      $set: { ...cfaFields, siret, updatedAt: now },
+      $setOnInsert: { _id: new ObjectId(), createdAt: now, origin },
+    },
+    { upsert: true, returnDocument: "after" }
+  )
+  if (!cfa) throw new Error("inattendu: pas de cfa")
+  return cfa
 }

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -11,7 +11,7 @@ import { getUserRecruteursForManagement } from "./userRecruteur.service"
 
 export const createOrUpdateUserByEmail = async (email: string, update: Partial<IUser>, create: Partial<IUser>): Promise<{ user: IUser; isNew: boolean }> => {
   const newUserId = new ObjectId()
-  await getDbCollection("users").findOneAndUpdate(
+  const savedUser = await getDbCollection("users").findOneAndUpdate(
     { email },
     {
       $set: update,
@@ -19,9 +19,9 @@ export const createOrUpdateUserByEmail = async (email: string, update: Partial<I
     },
     {
       upsert: true,
+      returnDocument: "after",
     }
   )
-  const savedUser = await getDbCollection("users").findOne({ email })
   if (!savedUser) {
     throw internal("inattendu : user non sauvegardé")
   }


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3944

Description  
L’issue Sentry LBA-SERVER-5J7KF4ZZZT678 remonte une erreur non gérée sur l’endpoint POST /api/appointment-request/validate avec le message :  
Error: inattendu : user non sauvegardé  
Fonction concernée : createOrUpdateUserByEmail.
Contexte / Cause probable  
Le flux faisait 2 opérations Mongo successives :  

findOneAndUpdate(..., { upsert: true }) pour créer/mettre à jour l’utilisateur  

findOne({ email }) pour relire l’utilisateur
Avec une config Mongo en readPreference: secondaryPreferred (hors local), le write est fait sur primary, puis la relecture peut partir sur un secondary en retard de réplication.  
Dans ce cas, findOne peut retourner null de manière intermittente, ce qui déclenche l’erreur.
Impact  

Erreurs 500 sur la validation de demande de RDV.  

Fréquence significative (110 occurrences observées dans Sentry).  

Dégradation de l’expérience candidat et bruit Sentry.
Correctif proposé  
Rendre l’opération atomique côté service user :  

Utiliser directement le document retourné par findOneAndUpdate avec returnDocument: "after"  

Supprimer la relecture séparée findOne({ email })  
=> Supprime le risque de lecture sur un secondary non à jour.
Critères d’acceptation  

Plus aucune erreur Sentry inattendu : user non sauvegardé sur l’endpoint concerné après déploiement.  

Le comportement métier reste inchangé (création/mise à jour utilisateur + détection isNew).  

Vérification en staging puis en production sur un volume représentatif de requêtes RDV.  
Référence Sentry  

Issue ID: 12601  

URL: https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/12601/