### PR TITLE
fix(lbac-3946): fix recherche formations

### DIFF
--- a/server/src/http/controllers/formations.controller.ts
+++ b/server/src/http/controllers/formations.controller.ts
@@ -69,11 +69,20 @@ export default (server: Server) => {
     async (req, res) => {
       const { referer } = req.headers
       const { romes, latitude, longitude, radius, diploma } = req.query
-      const result = await getFormationsQuery({ romes, longitude, latitude, radius, diploma: INiveauDiplomeEuropeen.fromParam(diploma), referer, isMinimalData: true })
+      const result = await getFormationsQuery({
+        romes,
+        longitude,
+        latitude,
+        radius,
+        diploma: INiveauDiplomeEuropeen.fromParam(diploma),
+        referer,
+        isMinimalData: true,
+        isPrivate: true,
+      })
 
       if ("error" in result) {
         if (result.error === "wrong_parameters") {
-          throw badRequest()
+          throw badRequest(JSON.stringify({ errors: result.error_messages ?? [] }, null, 2))
         }
 
         throw internal("Failed to fetch formations min", { error: result.error })

--- a/server/src/http/controllers/formations.controller.ts
+++ b/server/src/http/controllers/formations.controller.ts
@@ -82,7 +82,7 @@ export default (server: Server) => {
 
       if ("error" in result) {
         if (result.error === "wrong_parameters") {
-          throw badRequest(JSON.stringify({ errors: result.error_messages ?? [] }, null, 2))
+          throw badRequest("wrong_parameters", { error_messages: result.error_messages ?? [] })
         }
 
         throw internal("Failed to fetch formations min", { error: result.error })

--- a/server/src/services/formation.service.ts
+++ b/server/src/services/formation.service.ts
@@ -639,6 +639,7 @@ export const getFormationsQuery = async ({
   referer,
   api = "formationV1",
   isMinimalData,
+  isPrivate = false,
 }: {
   romes?: string
   longitude?: number
@@ -651,8 +652,9 @@ export const getFormationsQuery = async ({
   referer?: string
   api?: string
   isMinimalData: boolean
+  isPrivate?: boolean
 }): Promise<IApiError | { results: ILbaItemFormation[] }> => {
-  const parameterControl = await formationsQueryValidator({ romes, longitude, latitude, radius, diploma, romeDomain, caller, referer })
+  const parameterControl = await formationsQueryValidator({ romes, longitude, latitude, radius, diploma, romeDomain, caller, referer }, isPrivate)
 
   if ("error" in parameterControl) {
     return parameterControl

--- a/server/src/services/queryValidator.service.test.ts
+++ b/server/src/services/queryValidator.service.test.ts
@@ -40,4 +40,15 @@ describe("formationsQueryValidator — limite romes", () => {
     expect(result).toMatchObject({ error: "wrong_parameters" })
     expect((result as { error_messages: string[] }).error_messages).toEqual(expect.arrayContaining([expect.stringContaining(`Maximum is ${MAX_SEARCH_ROMES}`)]))
   })
+
+  it(`accepte ${MAX_SEARCH_ROMES_PRIVATE} romes en mode privé`, async () => {
+    const result = await formationsQueryValidator({ ...baseQuery, romes: generateRomes(MAX_SEARCH_ROMES_PRIVATE) }, true)
+    expect(result).toMatchObject({ result: "passed" })
+  })
+
+  it(`rejette ${MAX_SEARCH_ROMES_PRIVATE + 1} romes en mode privé`, async () => {
+    const result = await formationsQueryValidator({ ...baseQuery, romes: generateRomes(MAX_SEARCH_ROMES_PRIVATE + 1) }, true)
+    expect(result).toMatchObject({ error: "wrong_parameters" })
+    expect((result as { error_messages: string[] }).error_messages).toEqual(expect.arrayContaining([expect.stringContaining(`Maximum is ${MAX_SEARCH_ROMES_PRIVATE}`)]))
+  })
 })

--- a/server/src/services/queryValidator.service.ts
+++ b/server/src/services/queryValidator.service.ts
@@ -261,14 +261,15 @@ export const jobsQueryValidator = async (query: TJobSearchQuery): Promise<{ resu
  * @param {TFormationSearchQuery} query paramètres de la requête
  */
 export const formationsQueryValidator = async (
-  query: Omit<TFormationSearchQuery, "isMinimalData">
+  query: Omit<TFormationSearchQuery, "isMinimalData">,
+  isPrivate?: boolean
 ): Promise<{ result: "passed"; romes: string | undefined } | { error: "wrong_parameters"; error_messages: string[] }> => {
   const error_messages = []
 
   // présence d'identifiant de la source : caller
   validateCaller({ caller: query.caller, referer: query.referer }, error_messages)
 
-  validateRomeOrDomain({ romes: query.romes, romeDomain: query.romeDomain, romeLimit: MAX_SEARCH_ROMES }, error_messages)
+  validateRomeOrDomain({ romes: query.romes, romeDomain: query.romeDomain, romeLimit: isPrivate ? MAX_SEARCH_ROMES_PRIVATE : MAX_SEARCH_ROMES }, error_messages)
 
   // coordonnées gps optionnelles : latitude et longitude
   if (query.latitude || query.longitude) {


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3946

Overview
This fix improves the formations search feature by supporting a "private" query mode with relaxed validation rules, and improving error reporting on bad requests.

Changes
formations.controller.ts

Reformatted the getFormationsQuery call for readability.
Added isPrivate: true to the internal (private) endpoint call.
Improved the wrong_parameters error response to include the actual validation error messages in the response body instead of a generic 400 Bad Request.
formation.service.ts

Added isPrivate parameter (default: false) to getFormationsQuery.
Passes isPrivate down to formationsQueryValidator.
queryValidator.service.ts

Added isPrivate parameter to formationsQueryValidator.
When isPrivate is true, uses MAX_SEARCH_ROMES_PRIVATE limit instead of MAX_SEARCH_ROMES for the ROME codes validation, allowing private callers to search with more ROME codes.