### PR TITLE
feat(lba-3930): ajout du tracking matomo P0 (search, discovery, candidature)

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
@@ -46,7 +46,19 @@ export function CandidatRechercheForm({ rechercheParams }: { rechercheParams: IR
 
   useEffect(() => {
     if (rechercheResults.status !== "success") return
-    const paramsKey = JSON.stringify(rechercheParams)
+    const paramsKey = JSON.stringify({
+      romes: rechercheParams.romes,
+      geo: rechercheParams.geo,
+      radius: rechercheParams.radius,
+      diploma: rechercheParams.diploma,
+      typesEmploi: rechercheParams.typesEmploi,
+      opco: rechercheParams.opco,
+      rncp: rechercheParams.rncp,
+      elligibleHandicapFilter: rechercheParams.elligibleHandicapFilter,
+      displayEntreprises: rechercheParams.displayEntreprises,
+      displayFormations: rechercheParams.displayFormations,
+      job_name: rechercheParams.job_name,
+    })
     if (lastTrackedParamsRef.current === paramsKey) return
     lastTrackedParamsRef.current = paramsKey
     pushMatomoEvent({

--- a/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
@@ -38,6 +38,7 @@ export function CandidatRechercheForm({ rechercheParams }: { rechercheParams: IR
         search_address: rechercheForm.lieu?.label || "non_renseigné",
         search_radius: rechercheForm.radius ? parseInt(rechercheForm.radius, 10) : 30,
         search_diploma: rechercheForm.diploma ?? "indifferent",
+        search_origin: "page_resultat",
       })
       navigateToRecherchePage({ ...rechercheFormToRechercheParams(rechercheForm), scrollToRecruteursLba: false })
     },

--- a/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import { captureException } from "@sentry/nextjs"
-import { useCallback, useEffect } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import type { IRechercheForm } from "@/app/_components/RechercheForm/RechercheForm"
 import { RechercheForm, rechercheFormToRechercheParams, UserItemTypes } from "@/app/_components/RechercheForm/RechercheForm"
 import { useNavigateToRecherchePage } from "@/app/(candidat)/(recherche)/recherche/_hooks/useNavigateToRecherchePage"
 import { useRechercheResults } from "@/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults"
 import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { apiGet } from "@/utils/api.utils"
+import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
 import { RechercheInputsLayout } from "./RechercheInputs/RechercheInputsLayout"
 import { RechercheLieuAutocomplete } from "./RechercheInputs/RechercheLieuAutocomplete"
 import { RechercheMetierAutocomplete } from "./RechercheInputs/RechercheMetierAutocomplete"
@@ -27,13 +28,37 @@ export function CandidatRechercheForm({ rechercheParams }: { rechercheParams: IR
   }
 
   const navigateToRecherchePage = useNavigateToRecherchePage(rechercheParams)
+  const lastTrackedParamsRef = useRef<string>("")
 
   const onSubmit = useCallback(
     (rechercheForm: IRechercheForm) => {
+      pushMatomoEvent({
+        event: MATOMO_EVENTS.SEARCH_LAUNCHED,
+        search_job_name: rechercheForm.metier?.label || "non_renseigné",
+        search_address: rechercheForm.lieu?.label || "non_renseigné",
+        search_radius: rechercheForm.radius ? parseInt(rechercheForm.radius, 10) : 30,
+        search_diploma: rechercheForm.diploma ?? "indifferent",
+      })
       navigateToRecherchePage({ ...rechercheFormToRechercheParams(rechercheForm), scrollToRecruteursLba: false })
     },
     [navigateToRecherchePage]
   )
+
+  useEffect(() => {
+    if (rechercheResults.status !== "success") return
+    const paramsKey = JSON.stringify(rechercheParams)
+    if (lastTrackedParamsRef.current === paramsKey) return
+    lastTrackedParamsRef.current = paramsKey
+    pushMatomoEvent({
+      event: MATOMO_EVENTS.SEARCH_RESULTS_DISPLAYED,
+      total_results: rechercheResults.displayedItems.length,
+      count_alternance: rechercheResults.displayedJobs.length,
+      count_formation: rechercheResults.displayedFormations.length,
+      search_job_name: rechercheParams.job_name || "non_renseigné",
+      search_address: rechercheParams.geo?.address || "non_renseigné",
+      search_diploma: rechercheParams.diploma ?? "indifferent",
+    })
+  }, [rechercheResults.status, rechercheResults.displayedItems.length, rechercheResults.displayedJobs.length, rechercheResults.displayedFormations.length, rechercheParams])
 
   useEffect(() => {
     const controller = new AbortController()

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/LbaItemCard.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/LbaItemCard.tsx
@@ -121,19 +121,22 @@ export function LbaItemCard({ item, active, rechercheParams, position }: ResultC
           linkProps={{
             href: itemUrl,
             prefetch: false,
-            onClick: () => {
-              pushMatomoEvent({
-                event: MATOMO_EVENTS.JOB_OFFER_CLICKED,
-                job_offer_id: item.id,
-                job_offer_type: getMatomoJobOfferType(item.ideaType),
-                job_offer_company: item.company?.name || "non_renseigné",
-                job_offer_name: getTitle(item),
-                position_in_list: position,
-                has_contact: Boolean((item as any).contact?.hasEmail || (item as any).contact?.url || (item as any).contact?.phone),
-                search_job_name: rechercheParams.job_name || "non_renseigné",
-                search_address: rechercheParams.geo?.address || "non_renseigné",
-              })
-            },
+            onClick:
+              item.ideaType === LBA_ITEM_TYPE_OLD.FORMATION
+                ? undefined
+                : () => {
+                    pushMatomoEvent({
+                      event: MATOMO_EVENTS.JOB_OFFER_CLICKED,
+                      job_offer_id: item.id,
+                      job_offer_type: getMatomoJobOfferType(item.ideaType),
+                      job_offer_company: item.company?.name || "non_renseigné",
+                      job_offer_name: getTitle(item),
+                      position_in_list: position,
+                      has_contact: Boolean((item as any).contact?.hasEmail || (item as any).contact?.url || (item as any).contact?.phone),
+                      search_job_name: rechercheParams.job_name || "non_renseigné",
+                      search_address: rechercheParams.geo?.address || "non_renseigné",
+                    })
+                  },
           }}
           start={<LbaItemTags item={item} displayTooltips={true} />}
           title={

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/LbaItemCard.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/LbaItemCard.tsx
@@ -8,11 +8,13 @@ import type { WithRecherchePageParams } from "@/app/(candidat)/(recherche)/reche
 import ItemDetailApplicationsStatus from "@/components/ItemDetail/ItemDetailServices/ItemDetailApplicationStatus"
 import { LbaItemTags } from "@/components/ItemDetail/ItemDetailServices/LbaItemTags"
 import { getDaysSinceDate } from "@/utils/dateUtils"
+import { getMatomoJobOfferType, MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
 import { CardStyling } from "./CardStyling"
 
 type ResultCardProps = WithRecherchePageParams<{
   active: boolean
   item: ILbaItem
+  position: number
 }>
 
 function getTitle(item: ILbaItem) {
@@ -99,7 +101,7 @@ const activeStyle = {
   },
 }
 
-export function LbaItemCard({ item, active, rechercheParams }: ResultCardProps) {
+export function LbaItemCard({ item, active, rechercheParams, position }: ResultCardProps) {
   const itemUrl = useResultItemUrl(item, rechercheParams)
 
   return (
@@ -119,6 +121,19 @@ export function LbaItemCard({ item, active, rechercheParams }: ResultCardProps) 
           linkProps={{
             href: itemUrl,
             prefetch: false,
+            onClick: () => {
+              pushMatomoEvent({
+                event: MATOMO_EVENTS.JOB_OFFER_CLICKED,
+                job_offer_id: item.id,
+                job_offer_type: getMatomoJobOfferType(item.ideaType),
+                job_offer_company: item.company?.name || "non_renseigné",
+                job_offer_name: getTitle(item),
+                position_in_list: position,
+                has_contact: Boolean((item as any).contact?.hasEmail || (item as any).contact?.url || (item as any).contact?.phone),
+                search_job_name: rechercheParams.job_name || "non_renseigné",
+                search_address: rechercheParams.geo?.address || "non_renseigné",
+              })
+            },
           }}
           start={<LbaItemTags item={item} displayTooltips={true} />}
           title={

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheMobileForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheMobileForm.tsx
@@ -28,6 +28,7 @@ export function RechercheMobileForm({ rechercheParams }: { rechercheParams: IRec
           search_address: formValues.lieu?.label || "non_renseigné",
           search_radius: formValues.radius ? parseInt(formValues.radius, 10) : 30,
           search_diploma: formValues.diploma ?? "indifferent",
+          search_origin: "page_resultat",
         })
         navigateToRecherchePage({ ...rechercheFormToRechercheParams(formValues), displayMobileForm: false, scrollToRecruteursLba: false })
       }}

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheMobileForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheMobileForm.tsx
@@ -13,6 +13,7 @@ import { RechercheTypesEmploiSelectFormik } from "@/app/(candidat)/(recherche)/r
 import { useNavigateToRecherchePage } from "@/app/(candidat)/(recherche)/recherche/_hooks/useNavigateToRecherchePage"
 import { useRechercheResults } from "@/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults"
 import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
+import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
 
 export function RechercheMobileForm({ rechercheParams }: { rechercheParams: IRecherchePageParams }) {
   const navigateToRecherchePage = useNavigateToRecherchePage(rechercheParams)
@@ -21,6 +22,13 @@ export function RechercheMobileForm({ rechercheParams }: { rechercheParams: IRec
   return (
     <RechercheForm
       onSubmit={(formValues) => {
+        pushMatomoEvent({
+          event: MATOMO_EVENTS.SEARCH_LAUNCHED,
+          search_job_name: formValues.metier?.label || "non_renseigné",
+          search_address: formValues.lieu?.label || "non_renseigné",
+          search_radius: formValues.radius ? parseInt(formValues.radius, 10) : 30,
+          search_diploma: formValues.diploma ?? "indifferent",
+        })
         navigateToRecherchePage({ ...rechercheFormToRechercheParams(formValues), displayMobileForm: false, scrollToRecruteursLba: false })
       }}
       rechercheParams={rechercheParams}

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheResultatsList.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheResultatsList.tsx
@@ -133,23 +133,26 @@ export function RechercheResultatsList(props: { rechercheParams: IRecherchePageP
         </Box>
       )}
     </Box>,
-    ...items.map((data, index) => {
-      const jobPosition = data.type === "lba_item" ? items.slice(0, index).filter((d) => d.type === "lba_item").length + 1 : undefined
-      return {
-        height: heightEstimation(data.type),
-        render: () => (
-          <ResultCardWithContainer
-            key={index}
-            rechercheParams={props.rechercheParams}
-            data={data}
-            jobPosition={jobPosition}
-            onValorisationCandidatureSpontaneeClick={onValorisationCandidatureSpontaneeClick}
-          />
-        ),
-        onRender: data.type === "lba_item" ? () => onRenderLbaItem(data.value) : undefined,
-        item: data,
-      }
-    }),
+    ...(() => {
+      let jobPosition = 0
+      return items.map((data, index) => {
+        const currentJobPosition = data.type === "lba_item" ? ++jobPosition : undefined
+        return {
+          height: heightEstimation(data.type),
+          render: () => (
+            <ResultCardWithContainer
+              key={index}
+              rechercheParams={props.rechercheParams}
+              data={data}
+              jobPosition={currentJobPosition}
+              onValorisationCandidatureSpontaneeClick={onValorisationCandidatureSpontaneeClick}
+            />
+          ),
+          onRender: data.type === "lba_item" ? () => onRenderLbaItem(data.value) : undefined,
+          item: data,
+        }
+      })
+    })(),
     <Box
       key="footer"
       sx={{

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheResultatsList.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheResultatsList.tsx
@@ -133,19 +133,23 @@ export function RechercheResultatsList(props: { rechercheParams: IRecherchePageP
         </Box>
       )}
     </Box>,
-    ...items.map((data, index) => ({
-      height: heightEstimation(data.type),
-      render: () => (
-        <ResultCardWithContainer
-          key={index}
-          rechercheParams={props.rechercheParams}
-          data={data}
-          onValorisationCandidatureSpontaneeClick={onValorisationCandidatureSpontaneeClick}
-        />
-      ),
-      onRender: data.type === "lba_item" ? () => onRenderLbaItem(data.value) : undefined,
-      item: data,
-    })),
+    ...items.map((data, index) => {
+      const jobPosition = data.type === "lba_item" ? items.slice(0, index).filter((d) => d.type === "lba_item").length + 1 : undefined
+      return {
+        height: heightEstimation(data.type),
+        render: () => (
+          <ResultCardWithContainer
+            key={index}
+            rechercheParams={props.rechercheParams}
+            data={data}
+            jobPosition={jobPosition}
+            onValorisationCandidatureSpontaneeClick={onValorisationCandidatureSpontaneeClick}
+          />
+        ),
+        onRender: data.type === "lba_item" ? () => onRenderLbaItem(data.value) : undefined,
+        item: data,
+      }
+    }),
     <Box
       key="footer"
       sx={{
@@ -166,10 +170,12 @@ export function RechercheResultatsList(props: { rechercheParams: IRecherchePageP
 function ResultCardWithContainer({
   data,
   rechercheParams,
+  jobPosition,
   onValorisationCandidatureSpontaneeClick,
 }: {
   data: ResultCardData
   rechercheParams: IRecherchePageParams
+  jobPosition?: number
   onValorisationCandidatureSpontaneeClick: () => void
 }) {
   return (
@@ -181,7 +187,7 @@ function ResultCardWithContainer({
         px: { md: 0, lg: fr.spacing("4v") },
       }}
     >
-      <ResultCard data={data} rechercheParams={rechercheParams} onValorisationCandidatureSpontaneeClick={onValorisationCandidatureSpontaneeClick} />
+      <ResultCard data={data} rechercheParams={rechercheParams} jobPosition={jobPosition} onValorisationCandidatureSpontaneeClick={onValorisationCandidatureSpontaneeClick} />
     </Box>
   )
 }
@@ -189,10 +195,12 @@ function ResultCardWithContainer({
 function ResultCard({
   data,
   rechercheParams,
+  jobPosition,
   onValorisationCandidatureSpontaneeClick,
 }: {
   data: ResultCardData
   rechercheParams: IRecherchePageParams
+  jobPosition?: number
   onValorisationCandidatureSpontaneeClick: () => void
 }) {
   const { type } = data
@@ -202,7 +210,7 @@ function ResultCard({
     }
     case "lba_item": {
       const item = data.value
-      return <LbaItemCard active={isItemReferenceInList(item, rechercheParams.activeItems ?? [])} item={item} rechercheParams={rechercheParams} />
+      return <LbaItemCard active={isItemReferenceInList(item, rechercheParams.activeItems ?? [])} item={item} rechercheParams={rechercheParams} position={jobPosition ?? 0} />
     }
     case "ValorisationCandidatureSpontanee": {
       return (

--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/CandidaterButton.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/CandidaterButton.tsx
@@ -10,6 +10,7 @@ import { useDisclosure } from "@/common/hooks/useDisclosure"
 import { useSubmitCandidature } from "@/components/ItemDetail/CandidatureLba/services/submitCandidature"
 import ItemDetailApplicationsStatus, { tagCandidatureSimplifiee } from "@/components/ItemDetail/ItemDetailServices/ItemDetailApplicationStatus"
 import { notifyJobPostulerV3 } from "@/utils/api"
+import { getMatomoJobOfferType, MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
 import { SendPlausibleEvent } from "@/utils/plausible"
 
 export function CandidaterButton({
@@ -41,6 +42,14 @@ export function CandidaterButton({
     const emailAvailable = item.contact?.hasEmail
     SendPlausibleEvent("Clic Postuler - Fiche emploi", { partner_label: kind, info_fiche: item.id, "avec contact": emailAvailable ? "oui" : "non" })
     notifyJobPostulerV3(item)
+    pushMatomoEvent({
+      event: MATOMO_EVENTS.SMART_APPLY_OPENED,
+      job_offer_id: item.id,
+      job_offer_type: getMatomoJobOfferType(item.ideaType),
+      job_offer_company: item.company?.name || "non_renseigné",
+      job_offer_name: item.title || "non_renseigné",
+      apply_entry_point: "offer_details",
+    })
   }
 
   const hasAppliedValue = Boolean(applicationDate)

--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
@@ -26,6 +26,7 @@ import { RecruteurLbaCandidater } from "@/components/ItemDetail/RecruteurLbaComp
 import RecruteurLbaDetail from "@/components/ItemDetail/RecruteurLbaComponents/RecruteurLbaDetail"
 import ShareLink from "@/components/ItemDetail/ShareLink"
 import { ValorisationCandidatureSpontanee } from "@/components/ItemDetail/ValorisationCandidatureSpontanee"
+import { getMatomoJobOfferType, MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
 import { PAGES } from "@/utils/routes.utils"
 
 export default function JobDetailRendererClient({ job, rechercheParams }: { job: ILbaItemJobsGlobal; rechercheParams: IRecherchePageParams }) {
@@ -91,6 +92,21 @@ function JobDetail({
     window.addEventListener("resize", updateHeaderHeight)
     return () => window.removeEventListener("resize", updateHeaderHeight)
   }, [])
+
+  useEffect(() => {
+    const position = resultList.findIndex((item) => item.id === selectedItem.id) + 1
+    pushMatomoEvent({
+      event: MATOMO_EVENTS.JOB_OFFER_VIEWED,
+      job_offer_id: selectedItem.id,
+      job_offer_type: getMatomoJobOfferType(selectedItem.ideaType),
+      job_offer_company: selectedItem.company?.name || "non_renseigné",
+      job_offer_name: selectedItem.title || "non_renseigné",
+      position_in_list: position > 0 ? position : undefined,
+      has_contact: Boolean((selectedItem as any).contact?.hasEmail || (selectedItem as any).contact?.url || (selectedItem as any).contact?.phone),
+      search_job_name: rechercheParams.job_name || "non_renseigné",
+      search_address: rechercheParams.geo?.address || "non_renseigné",
+    })
+  }, [selectedItem.id]) // eslint-disable-line react-hooks/exhaustive-deps
   const { swipeHandlers, goNext, goPrev } = useBuildNavigation({
     items: resultList,
     currentItemId: selectedItem.id,

--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
@@ -81,6 +81,7 @@ function JobDetail({
   const headerRef = useRef<HTMLDivElement>(null)
   const headerHeightRef = useRef(0)
   const isCollapsed = isMobile && isCollapsedHeader
+  const lastTrackedItemIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
     const updateHeaderHeight = () => {
@@ -94,6 +95,8 @@ function JobDetail({
   }, [])
 
   useEffect(() => {
+    if (lastTrackedItemIdRef.current === selectedItem.id) return
+    lastTrackedItemIdRef.current = selectedItem.id
     const position = resultList.findIndex((item) => item.id === selectedItem.id) + 1
     pushMatomoEvent({
       event: MATOMO_EVENTS.JOB_OFFER_VIEWED,
@@ -106,7 +109,7 @@ function JobDetail({
       search_job_name: rechercheParams.job_name || "non_renseigné",
       search_address: rechercheParams.geo?.address || "non_renseigné",
     })
-  }, [selectedItem.id]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedItem.id, resultList, rechercheParams.job_name, rechercheParams.geo?.address])
   const { swipeHandlers, goNext, goPrev } = useBuildNavigation({
     items: resultList,
     currentItemId: selectedItem.id,

--- a/ui/app/(editorial)/alternance/_components/JobsCtaTracked.tsx
+++ b/ui/app/(editorial)/alternance/_components/JobsCtaTracked.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import Button from "@codegouvfr/react-dsfr/Button"
+import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
+
+type SearchOrigin = "page_ville" | "page_metier"
+
+type Props = {
+  href: string
+  searchOrigin: SearchOrigin
+  searchJobName?: string
+  searchAddress?: string
+  children?: React.ReactNode
+  size?: "small" | "medium" | "large"
+  priority?: "primary" | "secondary" | "tertiary" | "tertiary no outline"
+  style?: React.CSSProperties
+}
+
+export function JobsCtaTracked({ href, searchOrigin, searchJobName, searchAddress, children, size = "large", priority = "primary", style }: Props) {
+  const handleClick = () => {
+    pushMatomoEvent({
+      event: MATOMO_EVENTS.SEARCH_LAUNCHED,
+      search_job_name: searchJobName || "non_renseigné",
+      search_address: searchAddress || "non_renseigné",
+      search_radius: 30,
+      search_diploma: "indifferent",
+      search_origin: searchOrigin,
+    })
+  }
+
+  return (
+    <Button linkProps={{ href, onClick: handleClick }} size={size} priority={priority} style={style}>
+      {children ?? "Démarrer mes recherches"}
+    </Button>
+  )
+}

--- a/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
+++ b/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { redirect } from "next/navigation"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import CarteOffre from "@/app/(editorial)/alternance/_components/CarteOffre"
+import { JobsCtaTracked } from "@/app/(editorial)/alternance/_components/JobsCtaTracked"
 import { HomeCircleImageDecoration } from "@/app/(home)/_components/HomeCircleImageDecoration"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { apiGet } from "@/utils/api.utils"
@@ -54,13 +55,13 @@ async function fetchMetierData(metier: string) {
   return apiGet("/_private/seo/metier/:metier", { params: { metier } })
 }
 
-function JobsCta({ href }: { href: string }) {
+function JobsCta({ href, metier }: { href: string; metier: string }) {
   return (
     <Box sx={{ textAlign: "center", mx: fr.spacing("4v") }}>
-      <Button linkProps={{ href }} size="large" priority="primary" style={{ marginTop: fr.spacing("2v") }}>
+      <JobsCtaTracked href={href} searchOrigin="page_metier" searchJobName={metier} style={{ marginTop: fr.spacing("2v") }}>
         Voir toutes les offres en alternance
         <ArrowRightLine sx={{ color: "#fff", mt: fr.spacing("1v"), ml: fr.spacing("3v"), width: 16, height: 16 }} />
-      </Button>
+      </JobsCtaTracked>
     </Box>
   )
 }
@@ -157,7 +158,7 @@ export default async function Metier({ params }: { params: Promise<{ metier: str
           </Box>
         </Box>
 
-        <JobsCta href={jobsSearchUrl} />
+        <JobsCta href={jobsSearchUrl} metier={data.metier} />
 
         {/**
          * BLOC DESCRIPTION METIER
@@ -381,7 +382,7 @@ export default async function Metier({ params }: { params: Promise<{ metier: str
           </Box>
         </Box>
 
-        <JobsCta href={jobsSearchUrl} />
+        <JobsCta href={jobsSearchUrl} metier={data.metier} />
 
         <Box
           sx={{
@@ -508,7 +509,7 @@ export default async function Metier({ params }: { params: Promise<{ metier: str
               ))}
             </Box>
 
-            <JobsCta href={jobsSearchUrl} />
+            <JobsCta href={jobsSearchUrl} metier={data.metier} />
           </Box>
         )}
       </DefaultContainer>

--- a/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
+++ b/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
@@ -1,24 +1,16 @@
 import { fr } from "@codegouvfr/react-dsfr"
-import Button from "@codegouvfr/react-dsfr/Button"
 import { Box, Link, Typography } from "@mui/material"
 import Image from "next/image"
 import { redirect } from "next/navigation"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import CarteOffre from "@/app/(editorial)/alternance/_components/CarteOffre"
+import { JobsCtaTracked } from "@/app/(editorial)/alternance/_components/JobsCtaTracked"
 import { appartements, loisirs, transports } from "@/app/(editorial)/alternance/_components/ville_data"
 import { HomeCircleImageDecoration } from "@/app/(home)/_components/HomeCircleImageDecoration"
 import { TagCandidatureSpontanee } from "@/components/ItemDetail/TagCandidatureSpontanee"
 import { TagOffreEmploi } from "@/components/ItemDetail/TagOffreEmploi"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { apiGet } from "@/utils/api.utils"
-
-function JobsCta({ href }: { href: string }) {
-  return (
-    <Button linkProps={{ href }} size="large" priority="primary" style={{ marginTop: fr.spacing("2v") }}>
-      Démarrer mes recherches
-    </Button>
-  )
-}
 
 export async function generateMetadata({ params }: { params: Promise<{ ville: string }> }) {
   const { ville } = await params
@@ -92,8 +84,10 @@ export default async function Ville({ params }: { params: Promise<{ ville: strin
               <Typography>
                 <span style={{ color: fr.colors.decisions.text.default.info.default }}>{data.job_count + data.recruteur_count}</span> offres en alternance sont disponibles:
                 <br />
-                <JobsCta
+                <JobsCtaTracked
                   href={`/recherche-emploi?radius=30&lat=${data.geopoint.lat}&lon=${data.geopoint.long}&address=${encodeURIComponent(`${data.ville} (${data.cp})`)}&${utmParams}`}
+                  searchOrigin="page_ville"
+                  searchAddress={`${data.ville} (${data.cp})`}
                 />
               </Typography>
             </Box>
@@ -289,7 +283,11 @@ export default async function Ville({ params }: { params: Promise<{ ville: strin
             </Box>
 
             <Box sx={{ textAlign: "center" }}>
-              <JobsCta href={`/recherche-emploi?radius=30&lat=${data.geopoint.lat}&lon=${data.geopoint.long}&address=${data.ville} (${data.cp})&${utmParams}`} />
+              <JobsCtaTracked
+                href={`/recherche-emploi?radius=30&lat=${data.geopoint.lat}&lon=${data.geopoint.long}&address=${data.ville} (${data.cp})&${utmParams}`}
+                searchOrigin="page_ville"
+                searchAddress={`${data.ville} (${data.cp})`}
+              />
             </Box>
           </Box>
         )}

--- a/ui/app/(home)/_components/HomeRechercheForm.tsx
+++ b/ui/app/(home)/_components/HomeRechercheForm.tsx
@@ -63,6 +63,7 @@ function HomeRechercheFormComponent(props: WithRecherchePageParams) {
           search_address: rechercheForm.lieu?.label || "non_renseigné",
           search_radius: rechercheForm.radius ? parseInt(rechercheForm.radius, 10) : 30,
           search_diploma: rechercheForm.diploma ?? "indifferent",
+          search_origin: "page_accueil",
         })
         onSubmit(rechercheFormToRechercheParams(rechercheForm))
       }}

--- a/ui/app/(home)/_components/HomeRechercheForm.tsx
+++ b/ui/app/(home)/_components/HomeRechercheForm.tsx
@@ -13,6 +13,7 @@ import { RechercheResultTypeCheckboxFormik } from "@/app/(candidat)/(recherche)/
 import { RechercheSubmitButton } from "@/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheSubmitButton"
 import { useNavigateToRecherchePage } from "@/app/(candidat)/(recherche)/recherche/_hooks/useNavigateToRecherchePage"
 import type { WithRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
+import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
 
 function HomeRechercheFormUI(props: { onSubmit: (values: IRechercheForm) => void }) {
   return (
@@ -56,6 +57,13 @@ function HomeRechercheFormComponent(props: WithRecherchePageParams) {
   return (
     <HomeRechercheFormUI
       onSubmit={(rechercheForm) => {
+        pushMatomoEvent({
+          event: MATOMO_EVENTS.SEARCH_LAUNCHED,
+          search_job_name: rechercheForm.metier?.label || "non_renseigné",
+          search_address: rechercheForm.lieu?.label || "non_renseigné",
+          search_radius: rechercheForm.radius ? parseInt(rechercheForm.radius, 10) : 30,
+          search_diploma: rechercheForm.diploma ?? "indifferent",
+        })
         onSubmit(rechercheFormToRechercheParams(rechercheForm))
       }}
     />

--- a/ui/components/ItemDetail/CandidatureLba/CandidatureLbaModal.tsx
+++ b/ui/components/ItemDetail/CandidatureLba/CandidatureLbaModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import type { ILbaItemLbaCompanyJson, ILbaItemLbaJobJson, ILbaItemPartnerJobJson } from "shared"
 import type { useDisclosure } from "@/common/hooks/useDisclosure"
 import { ModalReadOnly } from "@/components/ModalReadOnly"
+import { getMatomoJobOfferType, MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
 import CandidatureLbaFailed from "./CandidatureLbaFailed"
 import { CandidatureLbaModalBody } from "./CandidatureLbaModalBody"
 import CandidatureLbaWorked from "./CandidatureLbaWorked"
@@ -26,6 +27,15 @@ export const CandidatureLbaModal = ({
 
   const onSubmit = (formValues: IApplicationSchemaInitValues) => {
     setApplicantEmail(formValues.applicant_email)
+    pushMatomoEvent({
+      event: MATOMO_EVENTS.SMART_APPLY_SUBMITTED,
+      job_offer_id: item.id,
+      job_offer_type: getMatomoJobOfferType(item.ideaType),
+      job_offer_company: item.company?.name || "non_renseigné",
+      job_offer_name: item.title || "non_renseigné",
+      has_cv: Boolean(formValues.applicant_attachment_name),
+      has_motivation: Boolean(formValues.applicant_message?.trim()),
+    })
     handleSubmitCandidature({ formValues })
   }
 

--- a/ui/components/ItemDetail/CandidatureLba/services/submitCandidature.ts
+++ b/ui/components/ItemDetail/CandidatureLba/services/submitCandidature.ts
@@ -7,6 +7,7 @@ import { useLocalStorage } from "@/app/hooks/useLocalStorage"
 import { DisplayContext } from "@/context/DisplayContextProvider"
 import { apiPost } from "@/utils/api.utils"
 import { sessionStorageSet } from "@/utils/localStorage"
+import { getMatomoJobOfferType, MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
 import type { IApplicationSchemaInitValues } from "./getSchema"
 
 export const useStoredApplicationDate = (item: ILbaItem) => {
@@ -57,8 +58,17 @@ export const useSubmitCandidature = (
   const { isPending, error, isSuccess, isError, mutate } = useMutation({
     mutationKey: ["submitCandidature", LbaJob.id],
     mutationFn: submitCandidature,
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       setApplicationDate(Date.now())
+      pushMatomoEvent({
+        event: MATOMO_EVENTS.SMART_APPLY_CONFIRMED,
+        job_offer_id: variables.LbaJob.id,
+        job_offer_type: getMatomoJobOfferType(variables.LbaJob.ideaType),
+        job_offer_company: variables.LbaJob.company?.name || "non_renseigné",
+        job_offer_name: variables.LbaJob.title || "non_renseigné",
+        has_cv: Boolean(variables.formValues.applicant_attachment_name),
+        has_motivation: Boolean(variables.formValues.applicant_message?.trim()),
+      })
     },
   })
 

--- a/ui/components/ItemDetail/PartnerJobComponents/PartnerJobExternalApply.tsx
+++ b/ui/components/ItemDetail/PartnerJobComponents/PartnerJobExternalApply.tsx
@@ -46,6 +46,19 @@ export default function PartnerJobExternalApply({ job }: { job: ILbaItemPartnerJ
           linkProps={{
             href: job.contact.url,
             onClick: () => {
+              let partnerDomain = "non_renseigné"
+              try {
+                partnerDomain = new URL(job.contact.url).hostname
+              } catch (_e) {
+                // URL malformée, on garde la valeur par défaut
+              }
+              pushMatomoEvent({
+                event: MATOMO_EVENTS.APPLY_REDIRECT_CLICKED,
+                partner_domain: partnerDomain,
+                job_offer_id: job.id,
+                job_offer_company: job.company?.name || "non_renseigné",
+                job_offer_name: job.title || "non_renseigné",
+              })
               SendPlausibleEvent("Clic Postuler - Fiche emploi", { partner_label: job.job.partner_label, info_fiche: job.id })
               notifyJobPostulerV3(job)
               setTimeout(() => {

--- a/ui/components/ItemDetail/PartnerJobComponents/PartnerJobExternalApply.tsx
+++ b/ui/components/ItemDetail/PartnerJobComponents/PartnerJobExternalApply.tsx
@@ -53,11 +53,9 @@ export default function PartnerJobExternalApply({ job }: { job: ILbaItemPartnerJ
                 // URL malformée, on garde la valeur par défaut
               }
               pushMatomoEvent({
+                ...matomoPayload,
                 event: MATOMO_EVENTS.APPLY_REDIRECT_CLICKED,
                 partner_domain: partnerDomain,
-                job_offer_id: job.id,
-                job_offer_company: job.company?.name || "non_renseigné",
-                job_offer_name: job.title || "non_renseigné",
               })
               SendPlausibleEvent("Clic Postuler - Fiche emploi", { partner_label: job.job.partner_label, info_fiche: job.id })
               notifyJobPostulerV3(job)

--- a/ui/utils/matomoUtils.ts
+++ b/ui/utils/matomoUtils.ts
@@ -1,3 +1,5 @@
+import { LBA_ITEM_TYPE, LBA_ITEM_TYPE_OLD } from "shared/constants/lbaitem"
+
 export const MATOMO_EVENTS = {
   FILTER_HANDI_CHANGED: "filter_handi_changed",
   FILTER_DROPDOWN_OPENED: "filter_dropdown_opened",
@@ -7,6 +9,29 @@ export const MATOMO_EVENTS = {
   PARTNER_APPLY_POPIN_CONFIRMED: "partner_apply_popin_confirmed",
   PARTNER_APPLY_POPIN_LATER: "partner_apply_popin_later",
   PARTNER_APPLY_POPIN_DISMISSED: "partner_apply_popin_dismissed",
+  SEARCH_LAUNCHED: "search_launched",
+  SEARCH_RESULTS_DISPLAYED: "search_results_displayed",
+  JOB_OFFER_CLICKED: "job_offer_clicked",
+  JOB_OFFER_VIEWED: "job_offer_viewed",
+  SMART_APPLY_OPENED: "smart_apply_opened",
+  APPLY_REDIRECT_CLICKED: "apply_redirect_clicked",
+  SMART_APPLY_SUBMITTED: "smart_apply_submitted",
+  SMART_APPLY_CONFIRMED: "smart_apply_confirmed",
+}
+
+export function getMatomoJobOfferType(ideaType: LBA_ITEM_TYPE | LBA_ITEM_TYPE_OLD): string {
+  switch (ideaType) {
+    case LBA_ITEM_TYPE.RECRUTEURS_LBA:
+    case LBA_ITEM_TYPE_OLD.LBA:
+      return "lba"
+    case LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA:
+    case LBA_ITEM_TYPE_OLD.MATCHA:
+      return "algo"
+    case LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES:
+      return "partner"
+    default:
+      return ideaType
+  }
 }
 
 type MatomoEvent = {

--- a/ui/utils/matomoUtils.ts
+++ b/ui/utils/matomoUtils.ts
@@ -19,18 +19,22 @@ export const MATOMO_EVENTS = {
   SMART_APPLY_CONFIRMED: "smart_apply_confirmed",
 }
 
-export function getMatomoJobOfferType(ideaType: LBA_ITEM_TYPE | LBA_ITEM_TYPE_OLD): string {
+export function getMatomoJobOfferType(ideaType: LBA_ITEM_TYPE | LBA_ITEM_TYPE_OLD): LBA_ITEM_TYPE | "non_renseigné" {
   switch (ideaType) {
     case LBA_ITEM_TYPE.RECRUTEURS_LBA:
     case LBA_ITEM_TYPE_OLD.LBA:
-      return "lba"
+    case LBA_ITEM_TYPE_OLD.LBB:
+      return LBA_ITEM_TYPE.RECRUTEURS_LBA
     case LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA:
     case LBA_ITEM_TYPE_OLD.MATCHA:
-      return "algo"
+      return LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA
     case LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES:
-      return "partner"
+    case LBA_ITEM_TYPE_OLD.PARTNER_JOB:
+    case LBA_ITEM_TYPE_OLD.PE:
+    case LBA_ITEM_TYPE_OLD.PEJOB:
+      return LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES
     default:
-      return ideaType
+      return "non_renseigné"
   }
 }
 


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3930

---

## Changements

- Ajout des 8 constantes P0 dans `MATOMO_EVENTS` (`search_launched`, `search_results_displayed`, `job_offer_clicked`, `job_offer_viewed`, `smart_apply_opened`, `apply_redirect_clicked`, `smart_apply_submitted`, `smart_apply_confirmed`)
- Ajout du helper `getMatomoJobOfferType()` pour mapper `ideaType` → `"lba" | "algo" | "partner"`
- `search_launched` : déclenché au submit du formulaire de recherche, avec métier, lieu, rayon et diplôme
- `search_results_displayed` : déclenché après chargement complet des résultats (dédupliqué via `useRef` pour éviter les doublons au cache React Query)
- `job_offer_clicked` : déclenché au clic sur une card depuis la liste de résultats, avec position 1-based dans la liste
- `job_offer_viewed` : déclenché à l'affichage de la fiche offre (navigation initiale ET navigation via flèches)
- `smart_apply_opened` : déclenché au clic sur "Postuler" pour les offres avec smart apply
- `apply_redirect_clicked` : déclenché avant la redirection vers un partenaire externe
- `smart_apply_submitted` : déclenché au submit du formulaire de candidature (avant appel API)
- `smart_apply_confirmed` : déclenché après HTTP 200 de l'API candidature
- Valeurs absentes → `"non_renseigné"` sur tous les champs

## Plan de test

- [ ] Ouvrir DevTools > Console, taper `window._mtm` pour observer les events
- [ ] Lancer une recherche → vérifier `search_launched` avec les bons champs
- [ ] Attendre les résultats → vérifier `search_results_displayed` avec `total_results`, `count_alternance`, `count_formation`
- [ ] Relancer la même recherche → `search_results_displayed` ne doit pas se redéclencher
- [ ] Cliquer sur une offre → vérifier `job_offer_clicked` avec `position_in_list` correct (1-based)
- [ ] Arriver sur la fiche → vérifier `job_offer_viewed`
- [ ] Naviguer via flèches → vérifier un nouveau `job_offer_viewed` avec la nouvelle position
- [ ] Cliquer "Postuler" (smart apply) → vérifier `smart_apply_opened`
- [ ] Soumettre le formulaire → vérifier `smart_apply_submitted` puis `smart_apply_confirmed` après succès
- [ ] Sur une offre partenaire externe, cliquer le bouton → vérifier `apply_redirect_clicked` avec `partner_domain`
- [ ] Tester une recherche sans lieu → `search_address: "non_renseigné"`