### PR TITLE
fix(lba-3994): vérifier que le cache de géolocalisation contient des résultats avant de l'utiliser

### DIFF
--- a/server/src/services/geolocation.service.ts
+++ b/server/src/services/geolocation.service.ts
@@ -93,7 +93,7 @@ export const getGeolocation = async (rawAddress: string): Promise<IPointFeature 
     const address = rawAddress.toUpperCase()
 
     const cachedGeolocation = await getGeolocationFromCache(address)
-    if (cachedGeolocation) {
+    if (cachedGeolocation?.features?.length) {
       return cachedGeolocation.features.at(0) ?? null
     }
 


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3994

---

## Changements

- Correction de la condition de lecture du cache de géolocalisation : on vérifie désormais que `features` existe et contient au moins un élément avant de retourner le résultat mis en cache, évitant ainsi de retourner un cache vide comme résultat valide

## Plan de test

- [x] Tester une recherche géolocalisée dont le résultat est mis en cache
- [x] Vérifier que le cas d'un cache existant mais avec `features` vide ou absent ne bloque plus la recherche