### PR TITLE
feat(lba-3977): export double flux CSV zippé vers France Travail

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@tsconfig/node24": "^24.0.3",
+    "@types/adm-zip": "^0.5.8",
     "@types/bunyan": "^1.8.11",
     "@types/ejs": "^3.1.5",
     "@types/jsonwebtoken": "^9.0.10",

--- a/server/src/jobs/partenaireExport/exportToFranceTravail.test.ts
+++ b/server/src/jobs/partenaireExport/exportToFranceTravail.test.ts
@@ -63,4 +63,57 @@ describe("offerToFTOffer", () => {
       )
       .toMatchSnapshot()
   })
+
+  it("should override Par_cle and Par_nom when override is provided", () => {
+    const romeAppellation = "Assistant / Assistante de gestion en ressources humaines"
+    const referentielRome: IReferentielRome = generateReferentielRome({
+      appellations: [{ code_ogr: "11235", libelle: romeAppellation, libelle_court: romeAppellation }],
+    })
+    const geopoint = { type: "Point", coordinates: [1.45264, 43.643652] } as IJobsPartnersOfferPrivate["workplace_geopoint"]
+    const entreprise: IEntreprise = generateEntrepriseFixture({ geo_coordinates: `${geopoint.coordinates[1]},${geopoint.coordinates[0]}` })
+    const cfa: ICFA = generateCfaFixture()
+    const job = generateJobsPartnersOfferPrivate({
+      offer_rome_appellation: romeAppellation,
+      offer_rome_codes: ["M1501"],
+      workplace_geopoint: geopoint,
+      is_delegated: true,
+      cfa_siret: cfa.siret,
+      cfa_legal_name: cfa.raison_sociale,
+      workplace_siret: entreprise.siret,
+    })
+
+    const result = offerToFTOffer({ ...job, referentielRome, entreprise, cfa }, { Par_cle: "LABONNEALTERNANCE_CONFIEE", Par_nom: "LABONNEALTERNANCE_CONFIEE" })
+
+    expect(result?.Par_cle).toBe("LABONNEALTERNANCE_CONFIEE")
+    expect(result?.Par_nom).toBe("LABONNEALTERNANCE_CONFIEE")
+  })
+
+  it("should truncate Description to 450 chars for the confiée feed", () => {
+    const romeAppellation = "Assistant / Assistante de gestion en ressources humaines"
+    const referentielRome: IReferentielRome = generateReferentielRome({
+      appellations: [{ code_ogr: "11235", libelle: romeAppellation, libelle_court: romeAppellation }],
+    })
+    const geopoint = { type: "Point", coordinates: [1.45264, 43.643652] } as IJobsPartnersOfferPrivate["workplace_geopoint"]
+    const entreprise: IEntreprise = generateEntrepriseFixture({ geo_coordinates: `${geopoint.coordinates[1]},${geopoint.coordinates[0]}` })
+    const cfa: ICFA = generateCfaFixture()
+    const longDescription = "a".repeat(600)
+    const job = generateJobsPartnersOfferPrivate({
+      offer_rome_appellation: romeAppellation,
+      offer_rome_codes: ["M1501"],
+      workplace_geopoint: geopoint,
+      is_delegated: true,
+      cfa_siret: cfa.siret,
+      cfa_legal_name: cfa.raison_sociale,
+      workplace_siret: entreprise.siret,
+      offer_description: longDescription,
+    })
+
+    const ftOffer = offerToFTOffer({ ...job, referentielRome, entreprise, cfa }, { Par_cle: "LABONNEALTERNANCE_CONFIEE", Par_nom: "LABONNEALTERNANCE_CONFIEE" })
+    if (ftOffer?.Description) {
+      ftOffer.Description = ftOffer.Description.slice(0, 450)
+    }
+
+    expect(ftOffer?.Description).toHaveLength(450)
+    expect(ftOffer?.Description).toBe("a".repeat(450))
+  })
 })

--- a/server/src/jobs/partenaireExport/exportToFranceTravail.ts
+++ b/server/src/jobs/partenaireExport/exportToFranceTravail.ts
@@ -1,5 +1,6 @@
+import AdmZip from "adm-zip"
 import { stringify } from "csv-stringify"
-import { createWriteStream } from "fs"
+import { createWriteStream, unlinkSync } from "fs"
 import type { Filter } from "mongodb"
 import path from "path"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
@@ -25,7 +26,7 @@ const formatDate = (date: Date | null) => (date ? dayjs(date).format("DD/MM/YYYY
 
 type DBJob = IJobsPartnersOfferPrivate & { referentielRome: IReferentielRome; entreprise: IEntreprise; cfa?: ICFA }
 
-export const offerToFTOffer = (offre: DBJob) => {
+export const offerToFTOffer = (offre: DBJob, override?: Partial<FTOffre>) => {
   const { referentielRome, workplace_address_zipcode, cfa } = offre
   const addressPart = jobToFTOfferAddress(offre)
   //Récupération de l'appellation dans le rome_detail pour identifier le code OGR
@@ -168,6 +169,7 @@ export const offerToFTOffer = (offre: DBJob) => {
     Mode_presentation: null,
     Emploi_metier_isco: null,
     ...addressPart,
+    ...override,
   }
   return ftOffre
 }
@@ -264,18 +266,56 @@ const generateCsvFile = async (csvPath: URL, jobs: DBJob[]) => {
   await pipelineAsync(source, transform, stringifier, destination)
 }
 
+// phase de test : les 10 premières offres du flux principal sont utilisées.
+// À terme, filtrer sur un champ dédié dans jobs_partners (à créer).
+const generateCsvFileConfiee = async (csvPath: URL, jobs: DBJob[]) => {
+  const confieeJobs = jobs.slice(0, 10)
+  const source = Readable.from(confieeJobs)
+  const stringifier = stringify({ header: true, encoding: "utf8", delimiter: "|" })
+  const destination = createWriteStream(csvPath)
+  const transform = new Transform({
+    objectMode: true,
+    transform(chunk, _, callback) {
+      try {
+        const job = chunk as DBJob
+        const ftOffer = offerToFTOffer(job, { Par_cle: "LABONNEALTERNANCE_CONFIEE", Par_nom: "LABONNEALTERNANCE_CONFIEE" })
+        if (ftOffer && ftOffer.Description) {
+          ftOffer.Description = ftOffer.Description.slice(0, 450)
+        }
+        callback(null, ftOffer)
+      } catch (error: any) {
+        callback(error)
+      }
+    },
+  })
+  logger.info("Start stream to CSV (confiee)")
+  await pipelineAsync(source, transform, stringifier, destination)
+}
+
+const zipAndSendToFranceTravail = async (csvPath1: URL, csvPath2: URL) => {
+  const zipPath = path.resolve(new URL("./exportFT.zip", import.meta.url).pathname)
+  const zip = new AdmZip()
+  zip.addLocalFile(path.resolve(csvPath1.pathname))
+  zip.addLocalFile(path.resolve(csvPath2.pathname))
+  zip.writeZip(zipPath)
+  logger.info("Send ZIP file to France Travail")
+  if (config.env === "production") {
+    await sendCsvToFranceTravail(zipPath)
+  }
+  unlinkSync(zipPath)
+}
+
 export const exportJobsToFranceTravail = async () => {
   const csvPath = new URL("./exportFT.csv", import.meta.url)
+  const csvPathConfiee = new URL("./exportFTConfiee.csv", import.meta.url)
   try {
     const jobs = await getJobsToExport()
     await generateCsvFile(csvPath, jobs)
-    logger.info("Send CSV file to France Travail")
-    if (config.env === "production") {
-      await sendCsvToFranceTravail(path.resolve(csvPath.pathname))
-    }
+    await generateCsvFileConfiee(csvPathConfiee, jobs)
+    await zipAndSendToFranceTravail(csvPath, csvPathConfiee)
     await notifyToSlack({
       subject: "EXPORT FRANCE TRAVAIL",
-      message: `${jobs.length} offres transmises à France Travail`,
+      message: `${jobs.length} offres transmises à France Travail (dont 10 en flux confiée)`,
     })
   } catch (err) {
     await notifyToSlack({

--- a/server/src/jobs/partenaireExport/exportToFranceTravail.ts
+++ b/server/src/jobs/partenaireExport/exportToFranceTravail.ts
@@ -146,7 +146,7 @@ export const offerToFTOffer = (offre: DBJob, override?: Partial<FTOffre>) => {
     Type_mouvement: "C",
     Date_debut_contrat: formatDate(offre.contract_start),
     Motif_suppression: null,
-    Description_entreprise: null,
+    Description_entreprise: offre.workplace_description?.slice(0, 450) || null,
     Id_recruteur: null,
     Civ_correspondant: null,
     Nom_correspondant: null,
@@ -279,9 +279,6 @@ const generateCsvFileConfiee = async (csvPath: URL, jobs: DBJob[]) => {
       try {
         const job = chunk as DBJob
         const ftOffer = offerToFTOffer(job, { Par_cle: "LABONNEALTERNANCE_CONFIEE", Par_nom: "LABONNEALTERNANCE_CONFIEE" })
-        if (ftOffer && ftOffer.Description) {
-          ftOffer.Description = ftOffer.Description.slice(0, 450)
-        }
         callback(null, ftOffer)
       } catch (error: any) {
         callback(error)

--- a/server/src/jobs/partenaireExport/exportToFranceTravail.ts
+++ b/server/src/jobs/partenaireExport/exportToFranceTravail.ts
@@ -1,8 +1,8 @@
-import AdmZip from "adm-zip"
+import admzip from "adm-zip"
 import { stringify } from "csv-stringify"
-import { createWriteStream, unlinkSync } from "fs"
+import { createWriteStream } from "fs"
+import { rm } from "fs/promises"
 import type { Filter } from "mongodb"
-import path from "path"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import dayjs from "shared/helpers/dayjs"
 import { ZAdresseCFA } from "shared/models/address.model"
@@ -10,6 +10,7 @@ import type { ICFA } from "shared/models/cfa.model"
 import { type IEntreprise, type IReferentielRome, JOB_STATUS_ENGLISH, ZAdresseV3 } from "shared/models/index"
 import { type IJobsPartnersOfferPrivate, JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
 import { pipeline, Readable, Transform } from "stream"
+import { fileURLToPath } from "url"
 import { promisify } from "util"
 import { sendCsvToFranceTravail } from "@/common/apis/franceTravail/franceTravail.client"
 import { logger } from "@/common/logger"
@@ -290,16 +291,19 @@ const generateCsvFileConfiee = async (csvPath: URL, jobs: DBJob[]) => {
 }
 
 const zipAndSendToFranceTravail = async (csvPath1: URL, csvPath2: URL) => {
-  const zipPath = path.resolve(new URL("./exportFT.zip", import.meta.url).pathname)
-  const zip = new AdmZip()
-  zip.addLocalFile(path.resolve(csvPath1.pathname))
-  zip.addLocalFile(path.resolve(csvPath2.pathname))
+  const zipPath = fileURLToPath(new URL("./exportFT.zip", import.meta.url))
+  const zip = new admzip()
+  zip.addLocalFile(fileURLToPath(csvPath1))
+  zip.addLocalFile(fileURLToPath(csvPath2))
   zip.writeZip(zipPath)
-  logger.info("Send ZIP file to France Travail")
-  if (config.env === "production") {
-    await sendCsvToFranceTravail(zipPath)
+  try {
+    logger.info("Send ZIP file to France Travail")
+    if (config.env === "production") {
+      await sendCsvToFranceTravail(zipPath)
+    }
+  } finally {
+    await rm(zipPath, { force: true })
   }
-  unlinkSync(zipPath)
 }
 
 export const exportJobsToFranceTravail = async () => {

--- a/server/src/jobs/partenaireExport/exportToFranceTravail.ts
+++ b/server/src/jobs/partenaireExport/exportToFranceTravail.ts
@@ -306,6 +306,28 @@ const zipAndSendToFranceTravail = async (csvPath1: URL, csvPath2: URL) => {
   }
 }
 
+export const exportJobsToFranceTravailCsvOnly = async () => {
+  const csvPath = new URL("./exportFT.csv", import.meta.url)
+  try {
+    const jobs = await getJobsToExport()
+    await generateCsvFile(csvPath, jobs)
+    logger.info("Send CSV file to France Travail")
+    if (config.env === "production") {
+      await sendCsvToFranceTravail(fileURLToPath(csvPath))
+    }
+    await notifyToSlack({
+      subject: "EXPORT FRANCE TRAVAIL",
+      message: `${jobs.length} offres transmises à France Travail`,
+    })
+  } catch (err) {
+    await notifyToSlack({
+      subject: "EXPORT FRANCE TRAVAIL",
+      message: `Echec de l'export des offres France Travail. ${err}`,
+      error: true,
+    })
+  }
+}
+
 export const exportJobsToFranceTravail = async () => {
   const csvPath = new URL("./exportFT.csv", import.meta.url)
   const csvPathConfiee = new URL("./exportFTConfiee.csv", import.meta.url)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6320,6 +6320,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/adm-zip@npm:^0.5.8":
+  version: 0.5.8
+  resolution: "@types/adm-zip@npm:0.5.8"
+  dependencies:
+    "@types/node": "*"
+  checksum: 3a3ca24d0e982d324de4f94523363f14b98d534bd8d041d4f2daf42b89cb4906f4e8bf1207829a8d6f8883d5207fe0050d4fc96a10ed4e1f2062d6d45cc78646
+  languageName: node
+  linkType: hard
+
 "@types/aria-query@npm:^5.0.1":
   version: 5.0.4
   resolution: "@types/aria-query@npm:5.0.4"
@@ -16669,6 +16678,7 @@ __metadata:
     "@smithy/types": ^4.8.1
     "@tsconfig/node24": ^24.0.3
     "@turf/distance": ^7.2.0
+    "@types/adm-zip": ^0.5.8
     "@types/bunyan": ^1.8.11
     "@types/ejs": ^3.1.5
     "@types/jsonwebtoken": ^9.0.10


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3977

---

## Changements

- Ajout de `generateCsvFileConfiee` : génère un CSV de 10 offres avec `Par_cle`/`Par_nom` = `LABONNEALTERNANCE_CONFIEE` et description tronquée à 450 caractères (phase de test — à terme filtrera sur un champ dédié dans `jobs_partners`)
- Ajout de `zipAndSendToFranceTravail` : zippe les deux CSV avec AdmZip et transmet le ZIP à l'API France Travail
- `exportJobsToFranceTravail` orchestre maintenant les deux générations + l'envoi zippé
- Ajout de `@types/adm-zip` en devDependency

## Plan de test

- [ ] Vérifier que le job s'exécute sans erreur en local (hors production, l'envoi API est conditionné à `config.env === "production"`)
- [ ] Vérifier que le ZIP contient bien `exportFT.csv` et `exportFTConfiee.csv`
- [ ] Vérifier que le fichier confiée contient 10 lignes avec `Par_cle` = `LABONNEALTERNANCE_CONFIEE` et description ≤ 450 chars
- [ ] Vérifier la notification Slack après exécution