### PR TITLE
fix(lba-3981): suppression du composant EnqueteTally de la page recherche

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_components/RecherchePageComponent.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RecherchePageComponent.tsx
@@ -7,7 +7,6 @@ import type { Virtualizer } from "@tanstack/react-virtual"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { LBA_ITEM_TYPE_OLD } from "shared/constants/lbaitem"
 import { Footer } from "@/app/_components/Footer"
-import { EnqueteTally } from "@/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/EnqueteTally"
 import { useNavigateToRecherchePage } from "@/app/(candidat)/(recherche)/recherche/_hooks/useNavigateToRecherchePage"
 import { useRechercheResults } from "@/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults"
 import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
@@ -174,7 +173,6 @@ export function RecherchePageComponent(props: { rechercheParams: IRecherchePageP
   if (rechercheResult.status === "disabled") {
     return (
       <>
-        <EnqueteTally />
         <RecherchePageEmpty {...props} />
         <BackToTopButton />
         <Footer />
@@ -184,7 +182,6 @@ export function RecherchePageComponent(props: { rechercheParams: IRecherchePageP
 
   return (
     <>
-      <EnqueteTally />
       <RecherchePageComponentWithParams {...props} />
       <BackToTopButton />
     </>


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3981

---

## Changements

- Suppression du composant `EnqueteTally` de la page de recherche (état désactivé et état normal)
- Suppression de l'import correspondant dans `RecherchePageComponent.tsx`

## Plan de test

- [ ] Vérifier que la page de recherche s'affiche correctement sans le composant EnqueteTally
- [ ] Vérifier que l'état "disabled" de la recherche (page vide) fonctionne toujours correctement
- [ ] S'assurer qu'aucun élément résiduel de l'enquête Tally n'apparaît sur la page