### PR TITLE
feat(lba-3996): réordonnancement des offres lba selon le statut mandataire

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults.ts
@@ -235,6 +235,19 @@ function useFormationQuery(rechercheParams: IRecherchePageParams | null) {
 
 export type DisplayedJob = ILbaItemLbaCompanyJson | ILbaItemPartnerJobJson | ILbaItemLbaJobJson
 
+function splitLbaJobs(lbaJobs: ILbaItemLbaJobJson[]): { direct: ILbaItemLbaJobJson[]; delegated: ILbaItemLbaJobJson[] } {
+  const direct: ILbaItemLbaJobJson[] = []
+  const delegated: ILbaItemLbaJobJson[] = []
+  for (const job of lbaJobs) {
+    if (job.company?.mandataire === false) {
+      direct.push(job)
+    } else {
+      delegated.push(job)
+    }
+  }
+  return { direct, delegated }
+}
+
 export function matchesTypeEmploi(job: DisplayedJob, typeEmploi: ITypeEmploi): boolean {
   switch (typeEmploi) {
     case TYPE_EMPLOI_OPTIONS.alternance:
@@ -259,8 +272,11 @@ export function useRechercheResults(rechercheParams: IRecherchePageParams | null
   const result = useMemo(() => {
     const selectedJobQuery = rechercheParams.elligibleHandicapFilter ? handicapJobQueryResult : allJobQueryResult
 
-    const allJobs = [...allJobQueryResult.lbaJobs, ...allJobQueryResult.partnerJobs, ...allJobQueryResult.lbaCompanies]
-    const handicapJobs = [...handicapJobQueryResult.lbaJobs, ...handicapJobQueryResult.partnerJobs, ...handicapJobQueryResult.lbaCompanies]
+    const { direct: allDirect, delegated: allDelegated } = splitLbaJobs(allJobQueryResult.lbaJobs)
+    const allJobs = [...allDirect, ...allJobQueryResult.partnerJobs, ...allDelegated, ...allJobQueryResult.lbaCompanies]
+
+    const { direct: handicapDirect, delegated: handicapDelegated } = splitLbaJobs(handicapJobQueryResult.lbaJobs)
+    const handicapJobs = [...handicapDirect, ...handicapJobQueryResult.partnerJobs, ...handicapDelegated, ...handicapJobQueryResult.lbaCompanies]
 
     const unfilteredJobs: DisplayedJob[] = rechercheParams.elligibleHandicapFilter ? handicapJobs : allJobs
     const displayedJobs = filterJobsByTypesEmploi(unfilteredJobs, rechercheParams.typesEmploi)

--- a/ui/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults.ts
@@ -235,14 +235,14 @@ function useFormationQuery(rechercheParams: IRecherchePageParams | null) {
 
 export type DisplayedJob = ILbaItemLbaCompanyJson | ILbaItemPartnerJobJson | ILbaItemLbaJobJson
 
-function splitLbaJobs(lbaJobs: ILbaItemLbaJobJson[]): { direct: ILbaItemLbaJobJson[]; delegated: ILbaItemLbaJobJson[] } {
-  const direct: ILbaItemLbaJobJson[] = []
-  const delegated: ILbaItemLbaJobJson[] = []
+function splitLbaJobs<T extends { company?: { mandataire?: boolean | null } | null }>(lbaJobs: T[]): { direct: T[]; delegated: T[] } {
+  const direct: T[] = []
+  const delegated: T[] = []
   for (const job of lbaJobs) {
-    if (job.company?.mandataire === false) {
-      direct.push(job)
-    } else {
+    if (job.company?.mandataire === true) {
       delegated.push(job)
+    } else {
+      direct.push(job)
     }
   }
   return { direct, delegated }


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3996

---

## Changements

- Réordonnancement des offres d'emploi affichées sur la page recherche
- Nouvel ordre : offres LBA directes (`is_delegated = false`) → offres partenaires → offres LBA mandataires (`is_delegated = true`) → entreprises LBA
- Split des `lbaJobs` en deux groupes (`direct` / `delegated`) effectué côté frontend dans `useRechercheResults`
- Aucun changement du contrat API ni des types partagés
- `matchesTypeEmploi` inchangé (déjà aligné avec cette logique)

## Plan de test

- [x] Lancer une recherche avec des résultats OFFRES_EMPLOI_LBA mixtes (mandataire et non-mandataire)
- [x] Vérifier que les offres directes (`mandataire = false`) apparaissent en premier
- [x] Vérifier que les offres partenaires apparaissent en deuxième position
- [x] Vérifier que les offres déléguées (`mandataire = true`) apparaissent après les partenaires
- [x] Vérifier que les entreprises LBA (candidatures spontanées) apparaissent en dernier
- [x] Vérifier que le filtre par type d'emploi fonctionne toujours correctement