### PR TITLE
feat: ajout de 10 nouvelles pages métier SEO (/alternance/metier/*)

### DIFF
--- a/server/src/migrations/20260507120000-add-10-seo-metiers-batch-2.ts
+++ b/server/src/migrations/20260507120000-add-10-seo-metiers-batch-2.ts
@@ -1,0 +1,769 @@
+// Migration : ajout de 10 nouvelles pages métier SEO (/alternance/metier/[metier])
+//
+// Métiers ajoutés (ordre alphabétique) :
+//   - Ambulancier (J1305)
+//   - Architecte d'intérieur (F1102)
+//   - Assistant dentaire (J1312)
+//   - Assistant social (K1201)
+//   - Auxiliaire de puériculture (J1304)
+//   - Éducateur spécialisé (K1207)
+//   - Gestionnaire de paie (M1507)
+//   - Moniteur-éducateur (K1207)
+//   - Préparateur en pharmacie (J1307)
+//   - Secrétaire médicale (M1609)
+//
+// À FAIRE POUR LE DÉPLOIEMENT :
+//   1. Déposer ce fichier dans server/src/migrations/
+//   2. Vérifier que ui/app/(editorial)/alternance/_components/metier_data.tsx contient bien les 10 nouvelles entrées (ordre alphabétique)
+//   3. Lancer : yarn migrations:up
+//
+// Le up() ci-dessous :
+//   - insère les 10 métiers dans seo_metiers (pas de deleteMany — migration additive)
+//   - appelle updateSEO() qui remplit automatiquement job_count, company_count, applicant_count, entreprises, formations, villes, cards
+
+import { ObjectId } from "mongodb"
+
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { updateSEO } from "@/jobs/seo/updateSEO"
+
+const metierData = [
+  {
+    metier: "Ambulancier",
+    slug: "ambulancier",
+    romes: ["J1305"],
+    description:
+      "L'ambulancier assure le transport sanitaire de personnes malades, blessées ou âgées vers les structures de soins. Il prend en charge le patient, surveille son état pendant le trajet et applique les premiers gestes d'urgence si nécessaire. En alternance, il développe des compétences techniques en conduite sanitaire tout en acquérant les qualités humaines indispensables au contact des patients.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1280,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Prise en charge des patients",
+        description: "Accueil, mise en confiance et installation du patient dans le véhicule sanitaire",
+      },
+      {
+        title: "Transport sanitaire",
+        description: "Conduite adaptée du véhicule en respectant le confort et la sécurité du patient",
+      },
+      {
+        title: "Surveillance médicale",
+        description: "Contrôle des paramètres vitaux et observation de l'état du patient durant le trajet",
+      },
+      {
+        title: "Gestes de premiers secours",
+        description: "Intervention rapide en cas d'urgence ou d'aggravation de l'état du patient",
+      },
+      {
+        title: "Entretien du véhicule",
+        description: "Désinfection, nettoyage et vérification du matériel médical embarqué",
+      },
+      {
+        title: "Gestion administrative",
+        description: "Recueil des documents médicaux et transmission des informations aux services concernés",
+      },
+    ],
+    competences: [
+      {
+        title: "Gestes d'urgence",
+        description: "Maîtrise des techniques de réanimation, de bandage et des protocoles de premiers secours",
+      },
+      {
+        title: "Conduite sanitaire",
+        description: "Pilotage adapté du véhicule selon l'état du patient et les conditions de circulation",
+      },
+      {
+        title: "Anatomie et pathologies",
+        description: "Connaissance des bases médicales pour comprendre les pathologies courantes",
+      },
+      {
+        title: "Relation au patient",
+        description: "Écoute, empathie et communication adaptée aux personnes fragiles ou anxieuses",
+      },
+      {
+        title: "Hygiène et sécurité",
+        description: "Application stricte des protocoles de désinfection et de prévention des infections",
+      },
+      {
+        title: "Réactivité",
+        description: "Capacité à prendre des décisions rapides face à une situation imprévue",
+      },
+    ],
+  },
+  {
+    metier: "Architecte d'intérieur",
+    slug: "architecte-d-interieur",
+    romes: ["F1102"],
+    description:
+      "L'architecte d'intérieur conçoit et aménage des espaces intérieurs en répondant aux besoins fonctionnels et esthétiques de ses clients. Il imagine des plans, choisit les matériaux et le mobilier, puis suit la réalisation du chantier jusqu'à la livraison. En alternance, il développe sa créativité tout en acquérant les compétences techniques de conduite de projet et de dessin assisté par ordinateur.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1310,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Analyse des besoins clients",
+        description: "Compréhension des attentes, contraintes et budget pour cadrer le projet d'aménagement",
+      },
+      {
+        title: "Conception des plans",
+        description: "Réalisation de croquis, plans 2D et perspectives 3D des espaces à aménager",
+      },
+      {
+        title: "Choix des matériaux et mobilier",
+        description: "Sélection de revêtements, couleurs, luminaires et meubles adaptés au projet",
+      },
+      {
+        title: "Établissement des devis",
+        description: "Chiffrage du projet et négociation avec les fournisseurs et artisans",
+      },
+      {
+        title: "Suivi de chantier",
+        description: "Coordination des corps de métier et contrôle de la conformité des travaux",
+      },
+      {
+        title: "Livraison du projet",
+        description: "Vérification finale et présentation de l'espace aménagé au client",
+      },
+    ],
+    competences: [
+      {
+        title: "Logiciels de CAO",
+        description: "Maîtrise d'AutoCAD, SketchUp, Revit ou 3ds Max pour modéliser les projets",
+      },
+      {
+        title: "Sens de l'espace",
+        description: "Capacité à visualiser et organiser des volumes en trois dimensions",
+      },
+      {
+        title: "Créativité",
+        description: "Imagination de solutions originales adaptées aux contraintes du lieu",
+      },
+      {
+        title: "Connaissance des matériaux",
+        description: "Maîtrise des propriétés et possibilités des revêtements, textiles et mobiliers",
+      },
+      {
+        title: "Gestion de projet",
+        description: "Pilotage du planning, du budget et coordination des intervenants",
+      },
+      {
+        title: "Relation client",
+        description: "Écoute des attentes et présentation claire des propositions d'aménagement",
+      },
+    ],
+  },
+  {
+    metier: "Assistant dentaire",
+    slug: "assistant-dentaire",
+    romes: ["J1312"],
+    description:
+      "L'assistant dentaire seconde le chirurgien-dentiste dans tous les actes cliniques et administratifs du cabinet. Il prépare les instruments, assiste le praticien pendant les soins, accueille les patients et gère le planning. En alternance, il développe un savoir-faire technique tout en acquérant les qualités relationnelles indispensables dans un environnement médical structuré.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1220,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Assistance au fauteuil",
+        description: "Préparation des instruments et aide au praticien pendant les soins dentaires",
+      },
+      {
+        title: "Accueil des patients",
+        description: "Réception, mise en confiance et préparation du patient pour la consultation",
+      },
+      {
+        title: "Stérilisation du matériel",
+        description: "Décontamination et stérilisation des instruments selon les protocoles en vigueur",
+      },
+      {
+        title: "Gestion du planning",
+        description: "Prise de rendez-vous, organisation de l'agenda et relances des patients",
+      },
+      {
+        title: "Suivi administratif",
+        description: "Tenue des dossiers médicaux, télétransmission et facturation des actes",
+      },
+      {
+        title: "Gestion des stocks",
+        description: "Suivi et commande des consommables médicaux et fournitures du cabinet",
+      },
+    ],
+    competences: [
+      {
+        title: "Hygiène et asepsie",
+        description: "Application rigoureuse des protocoles de stérilisation et prévention des infections",
+      },
+      {
+        title: "Anatomie dentaire",
+        description: "Connaissance des structures buccales et des actes courants de soins",
+      },
+      {
+        title: "Outils dentaires",
+        description: "Maîtrise des instruments rotatifs, à ultrasons et du matériel d'imagerie",
+      },
+      {
+        title: "Relation patient",
+        description: "Écoute, pédagogie et accompagnement face à l'anxiété ou à la douleur",
+      },
+      {
+        title: "Logiciels métiers",
+        description: "Utilisation des logiciels dentaires de gestion de cabinet et de télétransmission",
+      },
+      {
+        title: "Discrétion professionnelle",
+        description: "Respect du secret médical et confidentialité des informations patients",
+      },
+    ],
+  },
+  {
+    metier: "Assistant social",
+    slug: "assistant-social",
+    romes: ["K1201"],
+    description:
+      "L'assistant social accompagne des personnes ou des familles confrontées à des difficultés sociales, financières, professionnelles ou familiales. Il évalue leur situation, propose des solutions et les oriente vers les dispositifs d'aide adaptés. En alternance, il développe son sens de l'écoute, sa connaissance des dispositifs d'action sociale et sa capacité à intervenir dans des situations parfois complexes.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1240,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Accueil et écoute",
+        description: "Réception des bénéficiaires et recueil de leur situation personnelle et sociale",
+      },
+      {
+        title: "Évaluation des besoins",
+        description: "Analyse globale de la situation pour identifier les leviers d'accompagnement",
+      },
+      {
+        title: "Information et orientation",
+        description: "Présentation des aides existantes et orientation vers les structures compétentes",
+      },
+      {
+        title: "Constitution des dossiers",
+        description: "Aide à la rédaction et au montage des demandes d'aides sociales et administratives",
+      },
+      {
+        title: "Suivi des bénéficiaires",
+        description: "Accompagnement dans la durée et ajustement du plan d'aide selon l'évolution",
+      },
+      {
+        title: "Travail en réseau",
+        description: "Coordination avec les partenaires associatifs, médicaux et institutionnels",
+      },
+    ],
+    competences: [
+      {
+        title: "Connaissance des dispositifs sociaux",
+        description: "Maîtrise des aides CAF, RSA, logement, insertion professionnelle et juridiques",
+      },
+      {
+        title: "Écoute active",
+        description: "Capacité à recueillir un récit difficile sans jugement et à instaurer la confiance",
+      },
+      {
+        title: "Analyse de situation",
+        description: "Identification des problématiques prioritaires et des ressources mobilisables",
+      },
+      {
+        title: "Médiation",
+        description: "Facilitation des échanges entre la personne, sa famille et les institutions",
+      },
+      {
+        title: "Rédaction professionnelle",
+        description: "Production de rapports sociaux, notes et courriers à destination des partenaires",
+      },
+      {
+        title: "Discrétion et déontologie",
+        description: "Respect du secret professionnel et application du cadre éthique du travail social",
+      },
+    ],
+  },
+  {
+    metier: "Auxiliaire de puériculture",
+    slug: "auxiliaire-de-puericulture",
+    romes: ["J1304"],
+    description:
+      "L'auxiliaire de puériculture prend soin des bébés et des jeunes enfants au sein de structures comme les crèches, maternités ou services pédiatriques. Il assure les soins quotidiens, contribue à l'éveil et veille au bien-être physique et affectif des enfants. En alternance, il développe une expertise concrète du soin à l'enfant et un savoir-être indispensable au travail en équipe pluridisciplinaire.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1180,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Soins quotidiens",
+        description: "Réalisation des changes, repas, bains et préparation des biberons",
+      },
+      {
+        title: "Surveillance de l'enfant",
+        description: "Observation du comportement et détection des signes d'inconfort ou de maladie",
+      },
+      {
+        title: "Activités d'éveil",
+        description: "Animation de jeux, lectures et activités sensorielles adaptées à chaque âge",
+      },
+      {
+        title: "Accueil des familles",
+        description: "Échange quotidien avec les parents sur le déroulement de la journée",
+      },
+      {
+        title: "Hygiène des locaux",
+        description: "Nettoyage et désinfection des espaces, du matériel et des jouets",
+      },
+      {
+        title: "Travail en équipe",
+        description: "Coordination avec les éducateurs, infirmiers et puéricultrices de la structure",
+      },
+    ],
+    competences: [
+      {
+        title: "Soins du jeune enfant",
+        description: "Maîtrise des gestes techniques de soin et d'hygiène adaptés à la petite enfance",
+      },
+      {
+        title: "Développement de l'enfant",
+        description: "Connaissance des étapes psychomotrices et affectives de 0 à 3 ans",
+      },
+      {
+        title: "Sécurité et prévention",
+        description: "Application des règles de sécurité et identification des risques pour l'enfant",
+      },
+      {
+        title: "Patience et bienveillance",
+        description: "Posture rassurante et adaptation au rythme de chaque enfant",
+      },
+      {
+        title: "Communication avec les parents",
+        description: "Transmission claire et bienveillante des informations sur la journée de l'enfant",
+      },
+      {
+        title: "Hygiène professionnelle",
+        description: "Respect strict des protocoles sanitaires en milieu d'accueil collectif",
+      },
+    ],
+  },
+  {
+    metier: "Éducateur spécialisé",
+    slug: "educateur-specialise",
+    romes: ["K1207"],
+    description:
+      "L'éducateur spécialisé accompagne des enfants, adolescents ou adultes en situation de handicap, en difficulté sociale ou en souffrance psychique. Il met en place des actions éducatives pour favoriser leur autonomie, leur insertion sociale et leur épanouissement. En alternance, il acquiert une expérience de terrain riche et apprend à construire des projets éducatifs adaptés à chaque personne accompagnée.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1280,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Accompagnement éducatif",
+        description: "Soutien quotidien des personnes accueillies dans leurs activités et apprentissages",
+      },
+      {
+        title: "Élaboration de projets individualisés",
+        description: "Construction de parcours éducatifs adaptés aux besoins de chaque bénéficiaire",
+      },
+      {
+        title: "Animation d'activités",
+        description: "Mise en place d'ateliers éducatifs, sportifs, culturels ou de socialisation",
+      },
+      {
+        title: "Suivi du projet de vie",
+        description: "Évaluation régulière de la progression et ajustement des objectifs",
+      },
+      {
+        title: "Travail avec les familles",
+        description: "Échanges réguliers avec les proches pour cohérence du parcours éducatif",
+      },
+      {
+        title: "Coordination pluridisciplinaire",
+        description: "Travail en équipe avec psychologues, médecins, assistants sociaux et enseignants",
+      },
+    ],
+    competences: [
+      {
+        title: "Posture éducative",
+        description: "Capacité à instaurer une relation de confiance dans le cadre d'un projet éducatif",
+      },
+      {
+        title: "Connaissance des publics",
+        description: "Compréhension des troubles, handicaps et problématiques sociales rencontrées",
+      },
+      {
+        title: "Animation de groupe",
+        description: "Conduite d'activités collectives stimulantes et inclusives",
+      },
+      {
+        title: "Écoute et empathie",
+        description: "Disponibilité à recueillir la parole et accompagner les émotions",
+      },
+      {
+        title: "Rédaction d'écrits professionnels",
+        description: "Production de bilans, projets personnalisés et notes éducatives structurées",
+      },
+      {
+        title: "Travail en équipe",
+        description: "Collaboration avec les différents intervenants du parcours de la personne",
+      },
+    ],
+  },
+  {
+    metier: "Gestionnaire de paie",
+    slug: "gestionnaire-de-paie",
+    romes: ["M1507"],
+    description:
+      "Le gestionnaire de paie établit les bulletins de salaire des collaborateurs et assure le suivi administratif des éléments de rémunération. Il veille au respect du droit du travail, des conventions collectives et des obligations sociales et fiscales. En alternance, il maîtrise progressivement les logiciels de paie et développe une rigueur indispensable dans un domaine où chaque erreur a des conséquences.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1370,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Établissement des bulletins de paie",
+        description: "Production mensuelle des fiches de paie de l'ensemble des collaborateurs",
+      },
+      {
+        title: "Collecte des éléments variables",
+        description: "Recueil des heures, primes, absences et notes de frais à intégrer en paie",
+      },
+      {
+        title: "Déclarations sociales",
+        description: "Production des DSN et déclarations aux organismes URSSAF, Pôle emploi et caisses de retraite",
+      },
+      {
+        title: "Gestion administrative du personnel",
+        description: "Suivi des contrats, avenants, soldes de tout compte et certificats de travail",
+      },
+      {
+        title: "Veille réglementaire",
+        description: "Suivi des évolutions du droit social et adaptation des pratiques de paie",
+      },
+      {
+        title: "Réponse aux salariés",
+        description: "Information des collaborateurs sur leur paie, congés et droits sociaux",
+      },
+    ],
+    competences: [
+      {
+        title: "Logiciels de paie",
+        description: "Maîtrise de Sage Paie, Silae, Cegid ou ADP pour produire les bulletins",
+      },
+      {
+        title: "Droit social",
+        description: "Connaissance approfondie du Code du travail et des conventions collectives",
+      },
+      {
+        title: "Calculs de paie",
+        description: "Maîtrise des cotisations sociales, abattements et nets fiscaux",
+      },
+      {
+        title: "Rigueur et précision",
+        description: "Attention extrême aux détails pour éviter toute erreur sur les bulletins",
+      },
+      {
+        title: "Confidentialité",
+        description: "Respect strict du secret professionnel sur les éléments de rémunération",
+      },
+      {
+        title: "Maîtrise d'Excel",
+        description: "Construction de tableaux de contrôle et croisement des données de paie",
+      },
+    ],
+  },
+  {
+    metier: "Moniteur-éducateur",
+    slug: "moniteur-educateur",
+    romes: ["K1207"],
+    description:
+      "Le moniteur-éducateur accompagne au quotidien des personnes en difficulté sociale, en situation de handicap ou en perte d'autonomie. Il anime des activités éducatives et soutient les bénéficiaires dans les actes de la vie courante pour favoriser leur autonomie. En alternance, il développe sa pratique sur le terrain en travaillant aux côtés d'éducateurs spécialisés et d'autres professionnels du secteur médico-social.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1230,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Accompagnement quotidien",
+        description: "Soutien des bénéficiaires dans les gestes de la vie courante et les apprentissages",
+      },
+      {
+        title: "Animation d'activités éducatives",
+        description: "Conception et conduite d'ateliers ludiques, sportifs ou de socialisation",
+      },
+      {
+        title: "Observation des comportements",
+        description: "Suivi attentif des évolutions et des besoins des personnes accompagnées",
+      },
+      {
+        title: "Participation aux projets individuels",
+        description: "Contribution à la construction et au suivi des projets personnalisés",
+      },
+      {
+        title: "Travail en équipe pluridisciplinaire",
+        description: "Coordination avec les éducateurs, soignants et psychologues de la structure",
+      },
+      {
+        title: "Lien avec les familles",
+        description: "Échanges réguliers avec les proches pour favoriser la continuité du parcours",
+      },
+    ],
+    competences: [
+      {
+        title: "Animation de groupe",
+        description: "Conduite d'activités collectives adaptées au public accompagné",
+      },
+      {
+        title: "Posture éducative",
+        description: "Adoption d'une attitude juste, bienveillante et structurante",
+      },
+      {
+        title: "Écoute et patience",
+        description: "Capacité à accompagner des personnes fragiles dans la durée",
+      },
+      {
+        title: "Connaissance du secteur médico-social",
+        description: "Compréhension des structures, dispositifs et publics du travail social",
+      },
+      {
+        title: "Rédaction d'écrits professionnels",
+        description: "Production de comptes rendus d'observation et de notes éducatives",
+      },
+      {
+        title: "Adaptabilité",
+        description: "Ajustement du comportement et des activités selon les situations rencontrées",
+      },
+    ],
+  },
+  {
+    metier: "Préparateur en pharmacie",
+    slug: "preparateur-en-pharmacie",
+    romes: ["J1307"],
+    description:
+      "Le préparateur en pharmacie seconde le pharmacien dans la délivrance des médicaments et le conseil aux patients. Il prépare les ordonnances, gère les stocks et participe à la vente des produits parapharmaceutiques. En alternance, il développe une expertise scientifique sur les médicaments tout en cultivant un sens du service indispensable au contact quotidien de la patientèle.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1290,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Délivrance des ordonnances",
+        description: "Vérification et préparation des médicaments prescrits par le médecin",
+      },
+      {
+        title: "Conseil aux patients",
+        description: "Information sur la posologie, les effets secondaires et les précautions d'emploi",
+      },
+      {
+        title: "Préparations magistrales",
+        description: "Réalisation de mélanges et préparations spécifiques à la demande du pharmacien",
+      },
+      {
+        title: "Gestion des stocks",
+        description: "Réception, contrôle et rangement des commandes de médicaments et parapharmacie",
+      },
+      {
+        title: "Vente de parapharmacie",
+        description: "Conseil sur les produits d'hygiène, dermocosmétique et compléments alimentaires",
+      },
+      {
+        title: "Tenue de la caisse",
+        description: "Encaissement des ventes et application du tiers payant pour les patients",
+      },
+    ],
+    competences: [
+      {
+        title: "Pharmacologie",
+        description: "Connaissance des familles de médicaments, posologies et interactions",
+      },
+      {
+        title: "Lecture d'ordonnances",
+        description: "Décryptage rapide et fiable des prescriptions médicales",
+      },
+      {
+        title: "Logiciels officinaux",
+        description: "Maîtrise des logiciels de gestion d'officine et de télétransmission",
+      },
+      {
+        title: "Conseil et écoute",
+        description: "Capacité à recueillir une demande et à orienter vers la solution adaptée",
+      },
+      {
+        title: "Rigueur et vigilance",
+        description: "Contrôle strict pour éviter toute erreur de délivrance de médicament",
+      },
+      {
+        title: "Discrétion professionnelle",
+        description: "Respect de la confidentialité des informations de santé des patients",
+      },
+    ],
+  },
+  {
+    metier: "Secrétaire médicale",
+    slug: "secretaire-medicale",
+    romes: ["M1609"],
+    description:
+      "La secrétaire médicale assure l'accueil, la gestion administrative et la coordination d'un cabinet médical, d'un service hospitalier ou d'un laboratoire d'analyses. Elle prend les rendez-vous, gère les dossiers patients et facilite le travail des praticiens. En alternance, elle se forme au vocabulaire médical et acquiert les compétences administratives spécifiques au secteur de la santé.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1180,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Accueil des patients",
+        description: "Réception physique et téléphonique avec écoute et orientation adaptée",
+      },
+      {
+        title: "Gestion des rendez-vous",
+        description: "Prise et organisation des consultations selon les disponibilités du praticien",
+      },
+      {
+        title: "Tenue des dossiers médicaux",
+        description: "Mise à jour, classement et archivage des informations patients",
+      },
+      {
+        title: "Frappe de comptes rendus",
+        description: "Saisie de comptes rendus médicaux dictés par le praticien",
+      },
+      {
+        title: "Facturation et télétransmission",
+        description: "Encaissement, application du tiers payant et envoi des feuilles de soins électroniques",
+      },
+      {
+        title: "Coordination administrative",
+        description: "Lien avec les laboratoires, hôpitaux, mutuelles et caisses d'assurance maladie",
+      },
+    ],
+    competences: [
+      {
+        title: "Vocabulaire médical",
+        description: "Maîtrise des termes anatomiques, pathologiques et pharmaceutiques courants",
+      },
+      {
+        title: "Logiciels médicaux",
+        description: "Utilisation des logiciels de gestion de cabinet et de télétransmission",
+      },
+      {
+        title: "Maîtrise bureautique",
+        description: "Pratique avancée de Word, Excel et des outils de messagerie professionnelle",
+      },
+      {
+        title: "Discrétion et confidentialité",
+        description: "Respect strict du secret médical et des données de santé des patients",
+      },
+      {
+        title: "Relation patient",
+        description: "Accueil bienveillant et gestion des situations parfois sensibles ou anxiogènes",
+      },
+      {
+        title: "Organisation",
+        description: "Gestion simultanée du planning, du téléphone et des tâches administratives",
+      },
+    ],
+  },
+]
+
+export const up = async () => {
+  logger.info("Ajout de 10 nouveaux métiers SEO dans seo_metiers")
+
+  const now = new Date()
+
+  await getDbCollection("seo_metiers").insertMany(
+    metierData.map((metier) => ({ ...metier, _id: new ObjectId(), created_at: now, updated_at: now })),
+    { ordered: false, bypassDocumentValidation: true }
+  )
+
+  await updateSEO()
+
+  logger.info("Ajout de 10 métiers SEO terminé")
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/server/src/migrations/20260507130000-add-10-seo-metiers-batch-3.ts
+++ b/server/src/migrations/20260507130000-add-10-seo-metiers-batch-3.ts
@@ -1,0 +1,778 @@
+// Migration : ajout de 10 nouvelles pages métier SEO (/alternance/metier/[metier]) — batch 3
+//
+// Métiers ajoutés (ordre alphabétique) :
+//   - Aide-soignant (J1501)
+//   - Auxiliaire vétérinaire (A1501)
+//   - Coiffeur (D1202)
+//   - Électricien (F1602)
+//   - Esthéticien (D1208)
+//   - Juriste (K1903)
+//   - Manipulateur en radiologie (J1306)
+//   - Notaire (K1901)
+//   - Pâtissier (D1104)
+//   - Plombier (F1603)
+//
+// À FAIRE POUR LE DÉPLOIEMENT :
+//   1. Déposer ce fichier dans server/src/migrations/
+//   2. Vérifier que ui/app/(editorial)/alternance/_components/metier_data.tsx contient bien les 10 nouvelles entrées (ordre alphabétique)
+//   3. Lancer : yarn migrations:up
+//
+// Le up() ci-dessous :
+//   - insère les 10 métiers dans seo_metiers (pas de deleteMany — migration additive)
+//   - appelle updateSEO() qui remplit automatiquement job_count, company_count, applicant_count, entreprises, formations, villes, cards
+
+import { ObjectId } from "mongodb"
+
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { updateSEO } from "@/jobs/seo/updateSEO"
+
+const metierData = [
+  {
+    metier: "Aide-soignant",
+    slug: "aide-soignant",
+    romes: ["J1501"],
+    description:
+      "L'aide-soignant accompagne les patients dans les gestes de la vie quotidienne et participe à leurs soins en collaboration avec l'équipe infirmière. Il assure leur confort, surveille leur état de santé et contribue au maintien de leur autonomie. En alternance, il développe des gestes techniques de soin tout en acquérant les qualités humaines indispensables au contact des personnes fragilisées.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1180,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Soins d'hygiène et de confort",
+        description: "Aide à la toilette, à l'habillage et aux changes selon les besoins du patient",
+      },
+      {
+        title: "Aide aux repas",
+        description: "Distribution, installation et accompagnement des patients pendant les repas",
+      },
+      {
+        title: "Surveillance de l'état de santé",
+        description: "Observation des signes cliniques et transmission des informations à l'équipe soignante",
+      },
+      {
+        title: "Mobilisation des patients",
+        description: "Aide aux déplacements, transferts et installation au lit ou au fauteuil",
+      },
+      {
+        title: "Entretien de l'environnement",
+        description: "Hygiène des chambres, du matériel et désinfection des surfaces",
+      },
+      {
+        title: "Accompagnement relationnel",
+        description: "Écoute, soutien moral et lien avec les familles des patients",
+      },
+    ],
+    competences: [
+      {
+        title: "Gestes techniques de soin",
+        description: "Maîtrise des protocoles d'hygiène, de mobilisation et de prévention des escarres",
+      },
+      {
+        title: "Anatomie et pathologies",
+        description: "Connaissance des bases médicales pour comprendre les pathologies courantes",
+      },
+      {
+        title: "Hygiène hospitalière",
+        description: "Application stricte des règles d'asepsie et de prévention des infections nosocomiales",
+      },
+      {
+        title: "Relation au patient",
+        description: "Bienveillance, écoute et adaptation à des publics parfois vulnérables",
+      },
+      {
+        title: "Travail en équipe",
+        description: "Coordination avec infirmiers, médecins, kinés et auxiliaires de vie",
+      },
+      {
+        title: "Discrétion professionnelle",
+        description: "Respect du secret médical et de la confidentialité des informations patients",
+      },
+    ],
+  },
+  {
+    metier: "Auxiliaire vétérinaire",
+    slug: "auxiliaire-veterinaire",
+    romes: ["A1501"],
+    description:
+      "L'auxiliaire vétérinaire seconde le vétérinaire dans tous les actes de soins aux animaux et la gestion administrative de la clinique. Il assiste pendant les consultations, prépare le matériel, accueille les propriétaires et veille au confort des animaux hospitalisés. En alternance, il développe une expertise technique sur le soin animal tout en acquérant les compétences relationnelles indispensables au contact de la clientèle.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1170,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Assistance aux consultations",
+        description: "Préparation du matériel, contention de l'animal et aide pendant les soins",
+      },
+      {
+        title: "Accueil de la clientèle",
+        description: "Réception des propriétaires, prise de rendez-vous et conseils de premier niveau",
+      },
+      {
+        title: "Soins aux animaux hospitalisés",
+        description: "Surveillance, alimentation, administration de traitements et nettoyage des box",
+      },
+      {
+        title: "Stérilisation du matériel",
+        description: "Préparation et désinfection des instruments selon les protocoles vétérinaires",
+      },
+      {
+        title: "Gestion administrative",
+        description: "Tenue des dossiers, facturation et gestion des stocks de médicaments",
+      },
+      {
+        title: "Vente de produits",
+        description: "Conseil et délivrance d'aliments, antiparasitaires et accessoires",
+      },
+    ],
+    competences: [
+      {
+        title: "Soins vétérinaires de base",
+        description: "Maîtrise des gestes de contention, prises de constantes et pansements",
+      },
+      {
+        title: "Anatomie animale",
+        description: "Connaissance des espèces domestiques et de leurs spécificités physiologiques",
+      },
+      {
+        title: "Hygiène et asepsie",
+        description: "Application des protocoles de stérilisation en environnement médical",
+      },
+      {
+        title: "Relation client",
+        description: "Écoute des propriétaires, pédagogie et gestion des situations émotionnelles",
+      },
+      {
+        title: "Logiciels métiers",
+        description: "Utilisation des logiciels de gestion de clinique vétérinaire",
+      },
+      {
+        title: "Sang-froid et empathie",
+        description: "Capacité à gérer des urgences et des situations parfois éprouvantes",
+      },
+    ],
+  },
+  {
+    metier: "Coiffeur",
+    slug: "coiffeur",
+    romes: ["D1202"],
+    description:
+      "Le coiffeur réalise des coupes, colorations, brushings et soins capillaires adaptés à chaque client. Il conseille sur les coiffures et produits, en tenant compte du type de cheveux et des envies de chacun. En alternance, il développe une maîtrise technique des gestes du métier tout en acquérant le sens du conseil et de la relation client indispensable en salon.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1150,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Accueil et diagnostic capillaire",
+        description: "Écoute des attentes du client et analyse de la nature de ses cheveux",
+      },
+      {
+        title: "Réalisation de coupes",
+        description: "Exécution de coupes femme, homme et enfant selon différentes techniques",
+      },
+      {
+        title: "Coloration et mèches",
+        description: "Application de couleurs, balayages et techniques de décoloration",
+      },
+      {
+        title: "Coiffage et brushing",
+        description: "Mise en forme des cheveux pour le quotidien ou des occasions spéciales",
+      },
+      {
+        title: "Soins capillaires",
+        description: "Réalisation de masques, traitements et soins adaptés à chaque type de cheveu",
+      },
+      {
+        title: "Conseil et vente",
+        description: "Recommandation de produits adaptés et fidélisation de la clientèle",
+      },
+    ],
+    competences: [
+      {
+        title: "Techniques de coupe",
+        description: "Maîtrise des coupes au ciseau, rasoir et tondeuse pour tous types de cheveux",
+      },
+      {
+        title: "Colorimétrie",
+        description: "Compréhension des dosages et résultats des produits de coloration",
+      },
+      {
+        title: "Connaissance des produits",
+        description: "Maîtrise des familles de soins, shampoings et traitements professionnels",
+      },
+      {
+        title: "Sens artistique",
+        description: "Créativité dans la conception de coupes et coiffures personnalisées",
+      },
+      {
+        title: "Relation client",
+        description: "Écoute, conseil et création d'une expérience personnalisée en salon",
+      },
+      {
+        title: "Hygiène et sécurité",
+        description: "Application des règles sanitaires et désinfection du matériel",
+      },
+    ],
+  },
+  {
+    metier: "Électricien",
+    slug: "electricien",
+    romes: ["F1602"],
+    description:
+      "L'électricien installe, met en service et entretient les équipements électriques dans les bâtiments résidentiels, tertiaires ou industriels. Il pose les câblages, raccorde les tableaux électriques et veille au respect des normes de sécurité en vigueur. En alternance, il acquiert les gestes techniques du métier tout en se formant à la lecture de plans et aux exigences réglementaires.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1230,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Lecture de plans",
+        description: "Interprétation des schémas électriques et plans d'implantation",
+      },
+      {
+        title: "Tirage de câbles",
+        description: "Pose des gaines, chemins de câbles et passages techniques dans les bâtiments",
+      },
+      {
+        title: "Raccordement des équipements",
+        description: "Branchement des prises, interrupteurs, luminaires et tableaux électriques",
+      },
+      {
+        title: "Mise en service",
+        description: "Tests de continuité, contrôle des tensions et vérification du bon fonctionnement",
+      },
+      {
+        title: "Maintenance et dépannage",
+        description: "Diagnostic des pannes électriques et remise en état des installations",
+      },
+      {
+        title: "Respect des normes",
+        description: "Application stricte de la NF C 15-100 et des règles de sécurité électrique",
+      },
+    ],
+    competences: [
+      {
+        title: "Bases en électricité",
+        description: "Maîtrise des lois fondamentales et calculs de section de câbles",
+      },
+      {
+        title: "Lecture de schémas",
+        description: "Compréhension des plans, symboles et nomenclatures électriques",
+      },
+      {
+        title: "Outillage spécialisé",
+        description: "Utilisation des appareils de mesure, pinces et matériel de tirage de câbles",
+      },
+      {
+        title: "Habilitation électrique",
+        description: "Connaissance des règles de sécurité et préparation aux titres B0/B1V/B2V",
+      },
+      {
+        title: "Précision et minutie",
+        description: "Soin dans le câblage et le raccordement pour assurer fiabilité et durabilité",
+      },
+      {
+        title: "Travail en équipe",
+        description: "Coordination avec les autres corps de métier sur les chantiers",
+      },
+    ],
+  },
+  {
+    metier: "Esthéticien",
+    slug: "estheticien",
+    romes: ["D1208"],
+    description:
+      "L'esthéticien réalise des soins du visage, du corps, des mains et des pieds pour le bien-être et la beauté de ses clients. Il conseille sur les produits adaptés, propose des protocoles personnalisés et accompagne chaque client dans une démarche de soin globale. En alternance, il développe son expertise technique tout en acquérant le sens du conseil et de l'accueil propre à l'univers de la beauté.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1150,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Soins du visage",
+        description: "Nettoyage, gommage, masques et protocoles anti-âge ou hydratants personnalisés",
+      },
+      {
+        title: "Épilations",
+        description: "Réalisation d'épilations à la cire ou au sucre sur l'ensemble du corps",
+      },
+      {
+        title: "Manucure et beauté des pieds",
+        description: "Soins des ongles, pose de vernis et techniques de pédicure esthétique",
+      },
+      {
+        title: "Modelages corporels",
+        description: "Massages relaxants et soins du corps adaptés aux besoins du client",
+      },
+      {
+        title: "Maquillage",
+        description: "Réalisation de maquillages jour, soir ou pour des occasions spéciales",
+      },
+      {
+        title: "Conseil et vente",
+        description: "Recommandation de produits cosmétiques et accompagnement post-soin",
+      },
+    ],
+    competences: [
+      {
+        title: "Techniques esthétiques",
+        description: "Maîtrise des protocoles de soins, épilations et modelages du métier",
+      },
+      {
+        title: "Connaissance des produits",
+        description: "Compréhension des actifs cosmétiques et adaptation aux types de peau",
+      },
+      {
+        title: "Anatomie cutanée",
+        description: "Connaissance de la peau, de ses besoins et de ses réactions aux soins",
+      },
+      {
+        title: "Sens du contact",
+        description: "Écoute, discrétion et création d'une atmosphère de bien-être",
+      },
+      {
+        title: "Hygiène et sécurité",
+        description: "Application stricte des règles sanitaires et désinfection du matériel",
+      },
+      {
+        title: "Vente-conseil",
+        description: "Identification des besoins et recommandation de produits adaptés",
+      },
+    ],
+  },
+  {
+    metier: "Juriste",
+    slug: "juriste",
+    romes: ["K1903"],
+    description:
+      "Le juriste conseille et défend les intérêts juridiques d'une entreprise, d'une association ou d'une administration. Il analyse les textes, rédige des contrats et accompagne ses interlocuteurs dans la prévention et la gestion des litiges. En alternance, il développe une expertise technique du droit tout en se confrontant aux problématiques concrètes du quotidien d'un service juridique.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1430,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Analyse juridique",
+        description: "Étude de textes, jurisprudence et qualification juridique des situations rencontrées",
+      },
+      {
+        title: "Rédaction de contrats",
+        description: "Production et révision de contrats commerciaux, partenariats ou de travail",
+      },
+      {
+        title: "Conseil aux opérationnels",
+        description: "Accompagnement des équipes métiers sur les questions juridiques de leur activité",
+      },
+      {
+        title: "Veille réglementaire",
+        description: "Suivi des évolutions législatives et anticipation de leurs impacts",
+      },
+      {
+        title: "Gestion des contentieux",
+        description: "Préparation des dossiers, échanges avec les avocats et suivi des procédures",
+      },
+      {
+        title: "Conformité et risques",
+        description: "Identification des risques juridiques et mise en place d'outils de prévention",
+      },
+    ],
+    competences: [
+      {
+        title: "Maîtrise du droit",
+        description: "Connaissance approfondie du droit des contrats, du travail ou des affaires",
+      },
+      {
+        title: "Recherche juridique",
+        description: "Utilisation des bases documentaires Lexis, Dalloz, Légifrance et jurisprudence",
+      },
+      {
+        title: "Rédaction juridique",
+        description: "Production d'actes, notes et consultations claires et rigoureuses",
+      },
+      {
+        title: "Esprit d'analyse",
+        description: "Capacité à qualifier des situations complexes et à anticiper leurs conséquences",
+      },
+      {
+        title: "Pédagogie",
+        description: "Vulgarisation des règles juridiques auprès d'interlocuteurs non-juristes",
+      },
+      {
+        title: "Discrétion et déontologie",
+        description: "Respect strict de la confidentialité et des règles éthiques de la profession",
+      },
+    ],
+  },
+  {
+    metier: "Manipulateur en radiologie",
+    slug: "manipulateur-en-radiologie",
+    romes: ["J1306"],
+    description:
+      "Le manipulateur en radiologie réalise des examens d'imagerie médicale (radiographie, scanner, IRM) sous la responsabilité du médecin radiologue. Il prépare le patient, paramètre les appareils et veille à la qualité des images obtenues. En alternance, il développe une expertise technique pointue tout en acquérant le sens du contact patient indispensable à l'exercice du métier.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1310,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Accueil et préparation du patient",
+        description: "Explication de l'examen, mise en confiance et installation sur la table",
+      },
+      {
+        title: "Réalisation des examens",
+        description: "Paramétrage des appareils et acquisition des images selon le protocole médical",
+      },
+      {
+        title: "Contrôle qualité des images",
+        description: "Vérification de la netteté et de la pertinence diagnostique des clichés",
+      },
+      {
+        title: "Radioprotection",
+        description: "Application des règles de protection contre les rayonnements ionisants",
+      },
+      {
+        title: "Maintenance des équipements",
+        description: "Vérifications quotidiennes et remontée des dysfonctionnements techniques",
+      },
+      {
+        title: "Tenue du dossier patient",
+        description: "Saisie informatique et transmission des images au médecin radiologue",
+      },
+    ],
+    competences: [
+      {
+        title: "Imagerie médicale",
+        description: "Maîtrise des techniques de radiographie, scanner, IRM et échographie",
+      },
+      {
+        title: "Anatomie et pathologies",
+        description: "Connaissance des structures anatomiques visualisées en imagerie",
+      },
+      {
+        title: "Radioprotection",
+        description: "Application rigoureuse des règles de sécurité face aux rayonnements",
+      },
+      {
+        title: "Logiciels de PACS",
+        description: "Utilisation des systèmes d'archivage et de transmission d'images médicales",
+      },
+      {
+        title: "Relation patient",
+        description: "Pédagogie, empathie et accompagnement de personnes parfois anxieuses",
+      },
+      {
+        title: "Rigueur technique",
+        description: "Précision dans le positionnement et le paramétrage des examens",
+      },
+    ],
+  },
+  {
+    metier: "Notaire",
+    slug: "notaire",
+    romes: ["K1901"],
+    description:
+      "Le notaire authentifie les actes juridiques liés à l'immobilier, à la famille, aux successions et aux entreprises. Officier public, il conseille ses clients et garantit la sécurité juridique des opérations qu'il enregistre. En alternance, le futur notaire ou clerc de notaire développe une expertise technique du droit tout en se formant à la rigueur d'un métier réglementé.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1340,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Conseil aux clients",
+        description: "Accompagnement des particuliers et professionnels sur les opérations juridiques",
+      },
+      {
+        title: "Rédaction d'actes authentiques",
+        description: "Préparation des compromis, ventes, donations, successions et contrats de mariage",
+      },
+      {
+        title: "Recherches juridiques",
+        description: "Vérification des titres de propriété, états civils et situations patrimoniales",
+      },
+      {
+        title: "Authentification des actes",
+        description: "Lecture, signature et conservation des actes engageant les parties",
+      },
+      {
+        title: "Calcul des taxes et frais",
+        description: "Détermination des droits d'enregistrement, taxes et émoluments dus",
+      },
+      {
+        title: "Suivi administratif",
+        description: "Publication au service de la publicité foncière et tenue du registre des actes",
+      },
+    ],
+    competences: [
+      {
+        title: "Droit immobilier et patrimonial",
+        description: "Maîtrise du droit des biens, successions, régimes matrimoniaux et fiscalité",
+      },
+      {
+        title: "Rédaction juridique",
+        description: "Production d'actes précis, conformes aux exigences formelles du notariat",
+      },
+      {
+        title: "Logiciels notariaux",
+        description: "Utilisation des logiciels métiers comme Genapi ou Fiducial Office",
+      },
+      {
+        title: "Relation client",
+        description: "Écoute, pédagogie et accompagnement dans des moments parfois sensibles",
+      },
+      {
+        title: "Rigueur et précision",
+        description: "Vigilance extrême dans la rédaction et la vérification des actes",
+      },
+      {
+        title: "Discrétion et déontologie",
+        description: "Respect strict du secret professionnel et des règles déontologiques notariales",
+      },
+    ],
+  },
+  {
+    metier: "Pâtissier",
+    slug: "patissier",
+    romes: ["D1104"],
+    description:
+      "Le pâtissier conçoit et réalise des gâteaux, viennoiseries, entremets et créations sucrées dans une pâtisserie, un restaurant ou une boulangerie-pâtisserie. Il maîtrise les techniques de base et innove pour proposer des produits gourmands et esthétiques. En alternance, il acquiert les gestes du métier tout en développant la créativité et la rigueur indispensables à la profession.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1170,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Préparation des pâtes",
+        description: "Réalisation des pâtes feuilletée, sablée, brisée, levée et autres bases",
+      },
+      {
+        title: "Confection des entremets",
+        description: "Production de gâteaux à étages, mousses, bavarois et desserts à l'assiette",
+      },
+      {
+        title: "Cuisson et finitions",
+        description: "Maîtrise des cuissons, glaçages, décors et présentations des produits",
+      },
+      {
+        title: "Travail du chocolat",
+        description: "Tempérage, moulage et création de pièces et bonbons en chocolat",
+      },
+      {
+        title: "Gestion des stocks",
+        description: "Réception, stockage et rotation des matières premières et ingrédients",
+      },
+      {
+        title: "Hygiène et nettoyage",
+        description: "Entretien du laboratoire et application stricte des règles HACCP",
+      },
+    ],
+    competences: [
+      {
+        title: "Techniques de pâtisserie",
+        description: "Maîtrise des recettes de base et des gestes fondamentaux du métier",
+      },
+      {
+        title: "Connaissance des matières premières",
+        description: "Compréhension des farines, beurres, chocolats et leurs utilisations",
+      },
+      {
+        title: "Sens artistique",
+        description: "Créativité dans le décor et la mise en valeur visuelle des produits",
+      },
+      {
+        title: "Rigueur et précision",
+        description: "Respect strict des dosages, températures et temps de repos",
+      },
+      {
+        title: "Hygiène alimentaire",
+        description: "Application des règles HACCP et de traçabilité des ingrédients",
+      },
+      {
+        title: "Endurance physique",
+        description: "Capacité à travailler debout, en horaires décalés et en cadence soutenue",
+      },
+    ],
+  },
+  {
+    metier: "Plombier",
+    slug: "plombier",
+    romes: ["F1603"],
+    description:
+      "Le plombier installe, entretient et répare les réseaux d'eau, de gaz et les équipements sanitaires des bâtiments. Il intervient sur des chantiers neufs ou en rénovation, chez des particuliers comme dans le tertiaire et l'industrie. En alternance, il acquiert les gestes techniques du métier tout en se formant à la lecture de plans et aux normes de sécurité du bâtiment.",
+    job_count: 0,
+    company_count: 0,
+    applicant_count: 0,
+    salaire: {
+      salaire_brut_moyen: 1240,
+      salaire_1ere_annee: 0,
+      salaire_2eme_annee: 0,
+      salaire_median: 0,
+    },
+    entreprises: [],
+    formations: [],
+    villes: [],
+    cards: [],
+    missions: [
+      {
+        title: "Lecture de plans",
+        description: "Interprétation des plans d'installation et schémas hydrauliques",
+      },
+      {
+        title: "Pose des canalisations",
+        description: "Découpe, soudure et raccordement des tuyauteries cuivre, PER ou multicouche",
+      },
+      {
+        title: "Installation sanitaire",
+        description: "Pose de lavabos, douches, WC et raccordement aux réseaux",
+      },
+      {
+        title: "Mise en service",
+        description: "Tests d'étanchéité, mise en pression et vérification du bon fonctionnement",
+      },
+      {
+        title: "Maintenance et dépannage",
+        description: "Diagnostic des fuites, débouchage et réparation des installations",
+      },
+      {
+        title: "Conseil client",
+        description: "Recommandation d'équipements et explication des interventions réalisées",
+      },
+    ],
+    competences: [
+      {
+        title: "Techniques de pose",
+        description: "Maîtrise du cintrage, du brasage et du sertissage des tuyauteries",
+      },
+      {
+        title: "Lecture de plans",
+        description: "Compréhension des schémas, symboles et nomenclatures hydrauliques",
+      },
+      {
+        title: "Outillage spécialisé",
+        description: "Utilisation des fers à souder, sertisseuses et appareils de détection",
+      },
+      {
+        title: "Normes du bâtiment",
+        description: "Application des DTU plomberie et règles de sécurité gaz",
+      },
+      {
+        title: "Diagnostic technique",
+        description: "Identification rapide des causes de panne et solutions adaptées",
+      },
+      {
+        title: "Relation client",
+        description: "Écoute, pédagogie et professionnalisme lors des interventions à domicile",
+      },
+    ],
+  },
+]
+
+export const up = async () => {
+  logger.info("Ajout de 10 nouveaux métiers SEO dans seo_metiers (batch 3)")
+
+  const now = new Date()
+
+  await getDbCollection("seo_metiers").bulkWrite(
+    metierData.map((metier) => ({
+      updateOne: {
+        filter: { slug: metier.slug },
+        update: {
+          $set: { ...metier, updated_at: now },
+          $setOnInsert: { _id: new ObjectId(), created_at: now },
+        },
+        upsert: true,
+      },
+    })),
+    { ordered: false, bypassDocumentValidation: true }
+  )
+
+  await updateSEO()
+
+  logger.info("Ajout de 10 métiers SEO terminé (batch 3)")
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/ui/app/(editorial)/alternance/_components/metier_data.tsx
+++ b/ui/app/(editorial)/alternance/_components/metier_data.tsx
@@ -1,5 +1,10 @@
 export const metierData = [
   {
+    metier: "Aide-soignant",
+    slug: "aide-soignant",
+    romes: ["J1501"],
+  },
+  {
     metier: "Ambulancier",
     slug: "ambulancier",
     romes: ["J1305"],
@@ -40,6 +45,11 @@ export const metierData = [
     romes: ["J1304"],
   },
   {
+    metier: "Auxiliaire vétérinaire",
+    slug: "auxiliaire-veterinaire",
+    romes: ["A1501"],
+  },
+  {
     metier: "Chargé de communication",
     slug: "charge-de-communication",
     romes: ["E1103"],
@@ -48,6 +58,11 @@ export const metierData = [
     metier: "Chargé de recrutement",
     slug: "charge-de-recrutement",
     romes: ["M1502"],
+  },
+  {
+    metier: "Coiffeur",
+    slug: "coiffeur",
+    romes: ["D1202"],
   },
   {
     metier: "Comptable",
@@ -80,14 +95,49 @@ export const metierData = [
     romes: ["K1207"],
   },
   {
+    metier: "Électricien",
+    slug: "electricien",
+    romes: ["F1602"],
+  },
+  {
+    metier: "Esthéticien",
+    slug: "estheticien",
+    romes: ["D1208"],
+  },
+  {
     metier: "Gestionnaire de paie",
     slug: "gestionnaire-de-paie",
     romes: ["M1507"],
   },
   {
+    metier: "Juriste",
+    slug: "juriste",
+    romes: ["K1903"],
+  },
+  {
+    metier: "Manipulateur en radiologie",
+    slug: "manipulateur-en-radiologie",
+    romes: ["J1306"],
+  },
+  {
     metier: "Moniteur-éducateur",
     slug: "moniteur-educateur",
     romes: ["K1207"],
+  },
+  {
+    metier: "Notaire",
+    slug: "notaire",
+    romes: ["K1901"],
+  },
+  {
+    metier: "Pâtissier",
+    slug: "patissier",
+    romes: ["D1104"],
+  },
+  {
+    metier: "Plombier",
+    slug: "plombier",
+    romes: ["F1603"],
   },
   {
     metier: "Préparateur en pharmacie",

--- a/ui/app/(editorial)/alternance/_components/metier_data.tsx
+++ b/ui/app/(editorial)/alternance/_components/metier_data.tsx
@@ -1,8 +1,23 @@
 export const metierData = [
   {
+    metier: "Ambulancier",
+    slug: "ambulancier",
+    romes: ["J1305"],
+  },
+  {
+    metier: "Architecte d'intérieur",
+    slug: "architecte-d-interieur",
+    romes: ["F1102"],
+  },
+  {
     metier: "Assistant administratif",
     slug: "assistant-administratif",
     romes: ["M1607"],
+  },
+  {
+    metier: "Assistant dentaire",
+    slug: "assistant-dentaire",
+    romes: ["J1312"],
   },
   {
     metier: "Assistant marketing",
@@ -13,6 +28,16 @@ export const metierData = [
     metier: "Assistant ressources humaines",
     slug: "assistant-ressources-humaines",
     romes: ["M1501"],
+  },
+  {
+    metier: "Assistant social",
+    slug: "assistant-social",
+    romes: ["K1201"],
+  },
+  {
+    metier: "Auxiliaire de puériculture",
+    slug: "auxiliaire-de-puericulture",
+    romes: ["J1304"],
   },
   {
     metier: "Chargé de communication",
@@ -48,5 +73,30 @@ export const metierData = [
     metier: "Développeur web",
     slug: "developpeur-web",
     romes: ["M1805"],
+  },
+  {
+    metier: "Éducateur spécialisé",
+    slug: "educateur-specialise",
+    romes: ["K1207"],
+  },
+  {
+    metier: "Gestionnaire de paie",
+    slug: "gestionnaire-de-paie",
+    romes: ["M1507"],
+  },
+  {
+    metier: "Moniteur-éducateur",
+    slug: "moniteur-educateur",
+    romes: ["K1207"],
+  },
+  {
+    metier: "Préparateur en pharmacie",
+    slug: "preparateur-en-pharmacie",
+    romes: ["J1307"],
+  },
+  {
+    metier: "Secrétaire médicale",
+    slug: "secretaire-medicale",
+    romes: ["M1609"],
   },
 ]


### PR DESCRIPTION
> 🔗 **Cette PR fait partie d'une série de 2 PRs qui se complètent.**
> - **#2893 (cette PR) — batch 2 :** 10 premières pages métier (à merger en **premier**)
> - **#2894 — batch 3 :** 10 pages métier supplémentaires (à merger ensuite, retargetée auto par GitHub)
>
> Objectif final : **30 pages métier** au total pour atteindre la parité avec les 30 pages villes existantes.

---

## 🎯 Le chantier

Ajout de **10 nouvelles pages SEO `/alternance/metier/[slug]`** pour combler les requêtes GSC à fort volume aujourd'hui non couvertes par une page dédiée.

### Pourquoi ces 10 métiers ?

Sélection croisée à partir de la **Google Search Console** (90 derniers jours) :
- Métiers ayant un volume d'impressions cumulé significatif sur des requêtes type *« alternance [métier] »* / *« [métier] alternance »*
- ET un CTR déjà observé sur la page de recherche LBA correspondante (preuve d'intent transactionnel)
- ET non couverts par les 10 premières pages SEO métiers existantes

| # | Métier | Slug | ROME | Salaire moyen alternant (estimé) |
|---|---|---|---|---|
| 1 | Ambulancier | `ambulancier` | J1305 | 1 280 € |
| 2 | Architecte d'intérieur | `architecte-d-interieur` | F1102 | 1 310 € |
| 3 | Assistant dentaire | `assistant-dentaire` | J1312 | 1 220 € |
| 4 | Assistant social | `assistant-social` | K1201 | 1 240 € |
| 5 | Auxiliaire de puériculture | `auxiliaire-de-puericulture` | J1304 | 1 180 € |
| 6 | Éducateur spécialisé | `educateur-specialise` | K1207 | 1 280 € |
| 7 | Gestionnaire de paie | `gestionnaire-de-paie` | M1507 | 1 370 € |
| 8 | Moniteur-éducateur | `moniteur-educateur` | K1207 | 1 230 € |
| 9 | Préparateur en pharmacie | `preparateur-en-pharmacie` | J1307 | 1 290 € |
| 10 | Secrétaire médicale | `secretaire-medicale` | M1609 | 1 180 € |

> ℹ️ Codes ROME validés en croisant avec les `romes` déjà utilisés par la barre de recherche LBA pour ces mêmes intitulés (cohérence garantie avec le système existant).

> ℹ️ **Cas K1207** : Éducateur spécialisé et Moniteur-éducateur partagent le même ROME (référentiel France Travail). Pages distinctes au niveau du slug, des contenus éditoriaux et des H1 — les stats côté offres seront les mêmes.

## 🛠 Ce que le dev doit faire

1. **Reviewer la migration** `server/src/migrations/20260507120000-add-10-seo-metiers-batch-2.ts`
   - Strictement calquée sur la migration d'init `20260218011730-initialisation-seo-metier.ts`
   - **Différence volontaire** : pas de `deleteMany({})` (migration additive — on ne veut pas supprimer les 10 métiers existants)
   - L'appel à `updateSEO()` en fin de `up()` remplit automatiquement `job_count`, `company_count`, `applicant_count`, `entreprises[]`, `formations[]`, `villes[]`, `cards[]`
2. **Reviewer la mise à jour de `ui/app/(editorial)/alternance/_components/metier_data.tsx`**
   - 20 entrées au total (10 existantes + 10 nouvelles), ordre alphabétique strict
   - Sans cette mise à jour, les nouvelles pages ne s'affichent pas dans le footer ni le plan du site
3. **Au déploiement** : `yarn migrations:up` (les migrations LBA tournent en general automatiquement)

## ✅ Ce qui est à vérifier après déploiement

- [ ] Les 10 URLs `/alternance/metier/[slug]` répondent en 200 (cf table ci-dessus)
- [ ] Les compteurs (offres, entreprises, candidats) sont bien renseignés sur chaque page (preuve que `updateSEO()` a tourné)
- [ ] Les 10 nouveaux métiers apparaissent dans le footer et `/plan-du-site` en ordre alphabétique
- [ ] Pas d'erreur sur la sitemap

## 📝 Contexte SEO

Les pages `/alternance/metier/*` (nouveau format, lancé récemment avec les 10 premières) capturent l'intent transactionnel précis (« alternance [métier] »), complémentaires des pages `/metiers/[slug]` (anciennes, plus larges, intent de découverte). Voir la conversation Claude associée pour l'analyse détaillée GSC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
