### PR TITLE
fix(lba-4013): réduction du bruit sentry sur erreurs externes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,4 +170,5 @@ tmp
 
 venv
 CLAUDE.md
+.mcp.json
 

--- a/server/src/common/apis/franceCompetences/franceCompetencesClient.test.ts
+++ b/server/src/common/apis/franceCompetences/franceCompetencesClient.test.ts
@@ -1,11 +1,17 @@
 import nock from "nock"
 import { OPCOS_LABEL } from "shared/constants/recruteur"
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import config from "@/config"
 
 import { FCGetOpcoInfos, FCOpcoToOpcoEnum } from "./franceCompetencesClient"
 import { generateFCOpcoResponseFixture, nockFranceCompetencesOpcoSearch } from "./franceCompetencesClient.fixture"
 
 describe("franceCompetencesClient", () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
   describe("FCOpcoToOpcoEnum", () => {
     it("should convert fc opco names to opco enum", () => {
       expect(FCOpcoToOpcoEnum("CONSTRUCTYS")).toBe(OPCOS_LABEL.CONSTRUCTYS)
@@ -69,6 +75,16 @@ describe("franceCompetencesClient", () => {
 
       expect(result).toBeNull()
       expect(nock.isDone()).toBe(true)
+    })
+
+    it("should return null on 429 (rate limit)", async () => {
+      const siret = "42476141900045"
+      nock(config.franceCompetences.baseUrl)
+        .get(`/siro/v1/public/${encodeURIComponent(siret)}`)
+        .reply(429, { message: "Too Many Requests" })
+
+      const result = await FCGetOpcoInfos(siret)
+      expect(result).toBeNull()
     })
 
     it("should return null for opco label N/C", async () => {

--- a/server/src/common/apis/franceCompetences/franceCompetencesClient.ts
+++ b/server/src/common/apis/franceCompetences/franceCompetencesClient.ts
@@ -116,8 +116,10 @@ export const FCGetOpcoInfos = async (siret: string): Promise<OPCOS_LABEL | null>
     } else {
       throw new Error(`error while calling France Compétences: status=${response.status}, data=${response.data}`)
     }
-  } catch (err) {
-    sentryCaptureException(err)
+  } catch (err: any) {
+    if (err?.response?.status !== 429) {
+      sentryCaptureException(err)
+    }
     return null
   }
 }

--- a/server/src/common/apis/inserjeunes/inserjeunes.client.test.ts
+++ b/server/src/common/apis/inserjeunes/inserjeunes.client.test.ts
@@ -1,11 +1,13 @@
 import nock from "nock"
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { _resetForTesting, fetchInserJeunesStats } from "./inserjeunes.client"
+import { _axiosClientForTesting, _resetForTesting, fetchInserJeunesStats } from "./inserjeunes.client"
 import { inserJeunesStatsFixture, omogenAuthTokenFixture } from "./inserjeunes.client.fixture"
 
 const OMOGEN_BASE_URL = "https://omogen-api-pr.phm.education.gouv.fr"
 const STATS_PATH = "/exposition-inserjeunes-insersup/api/inserjeunes/regionales/75001/certifications/12345678"
+
+const makeEconnresetError = () => Object.assign(new Error("socket hang up"), { code: "ECONNRESET" })
 
 describe("InserJeunes Client", () => {
   beforeEach(() => {
@@ -53,16 +55,17 @@ describe("InserJeunes Client", () => {
     })
 
     it("should not activate cooldown on transient network errors", async () => {
-      nock(OMOGEN_BASE_URL).post("/auth/token").replyWithError({ code: "ECONNRESET", message: "socket hang up" })
+      const postSpy = vi.spyOn(_axiosClientForTesting, "post").mockRejectedValueOnce(makeEconnresetError())
       await fetchInserJeunesStats("75001", "12345678")
+      postSpy.mockRestore()
 
-      // Next call should retry token fetch (no cooldown)
+      // Next call should retry token fetch (no cooldown activated)
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
       nock(OMOGEN_BASE_URL).get(STATS_PATH).reply(200, inserJeunesStatsFixture)
 
       const result = await fetchInserJeunesStats("75001", "12345678")
       expect(result).toEqual(inserJeunesStatsFixture)
-    }, 15_000)
+    })
 
     it("should throw internal error on 500 API errors", async () => {
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
@@ -83,22 +86,23 @@ describe("InserJeunes Client", () => {
 
     it("should retry on ECONNRESET and succeed on second attempt", async () => {
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
-
-      nock(OMOGEN_BASE_URL).get(STATS_PATH).replyWithError({ code: "ECONNRESET", message: "socket hang up" })
-      nock(OMOGEN_BASE_URL).get(STATS_PATH).reply(200, inserJeunesStatsFixture)
+      const getSpy = vi
+        .spyOn(_axiosClientForTesting, "get")
+        .mockRejectedValueOnce(makeEconnresetError())
+        .mockResolvedValueOnce({ data: inserJeunesStatsFixture } as any)
 
       const result = await fetchInserJeunesStats("75001", "12345678")
       expect(result).toEqual(inserJeunesStatsFixture)
-    }, 10_000)
+      getSpy.mockRestore()
+    }, 5_000)
 
     it("should throw after max retries on persistent transient error", async () => {
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
-
-      for (let i = 0; i < 3; i++) {
-        nock(OMOGEN_BASE_URL).get(STATS_PATH).replyWithError({ code: "ECONNRESET", message: "socket hang up" })
-      }
+      const econnresetError = makeEconnresetError()
+      const getSpy = vi.spyOn(_axiosClientForTesting, "get").mockRejectedValueOnce(econnresetError).mockRejectedValueOnce(econnresetError).mockRejectedValueOnce(econnresetError)
 
       await expect(fetchInserJeunesStats("75001", "12345678")).rejects.toThrow("Erreur lors de la récupération des données InserJeunes")
-    }, 30_000)
+      getSpy.mockRestore()
+    }, 10_000)
   })
 })

--- a/server/src/common/apis/inserjeunes/inserjeunes.client.test.ts
+++ b/server/src/common/apis/inserjeunes/inserjeunes.client.test.ts
@@ -46,7 +46,7 @@ describe("InserJeunes Client", () => {
       await expect(fetchInserJeunesStats("75001", "12345678")).rejects.toThrow()
     })
 
-    it("should throw internal error on non-404 API errors", async () => {
+    it("should throw internal error on 500 API errors", async () => {
       // Mock token request
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
 
@@ -54,11 +54,15 @@ describe("InserJeunes Client", () => {
       nock(OMOGEN_BASE_URL).get("/exposition-inserjeunes-insersup/api/inserjeunes/regionales/75001/certifications/12345678").reply(500, { error: "Internal error" })
 
       await expect(fetchInserJeunesStats("75001", "12345678")).rejects.toThrow()
+    })
 
-      // Mock 502 error
+    it("should return null for 502 and 503 (API temporarily unavailable)", async () => {
+      nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
       nock(OMOGEN_BASE_URL).get("/exposition-inserjeunes-insersup/api/inserjeunes/regionales/75001/certifications/12345678").reply(502, { error: "Bad Gateway" })
+      expect(await fetchInserJeunesStats("75001", "12345678")).toBeNull()
 
-      await expect(fetchInserJeunesStats("75001", "12345678")).rejects.toThrow()
+      nock(OMOGEN_BASE_URL).get("/exposition-inserjeunes-insersup/api/inserjeunes/regionales/75001/certifications/12345678").reply(503, { error: "Service Unavailable" })
+      expect(await fetchInserJeunesStats("75001", "12345678")).toBeNull()
     })
   })
 })

--- a/server/src/common/apis/inserjeunes/inserjeunes.client.test.ts
+++ b/server/src/common/apis/inserjeunes/inserjeunes.client.test.ts
@@ -1,26 +1,23 @@
 import nock from "nock"
 import { beforeEach, describe, expect, it } from "vitest"
 
-import { fetchInserJeunesStats } from "./inserjeunes.client"
+import { _resetForTesting, fetchInserJeunesStats } from "./inserjeunes.client"
 import { inserJeunesStatsFixture, omogenAuthTokenFixture } from "./inserjeunes.client.fixture"
 
 const OMOGEN_BASE_URL = "https://omogen-api-pr.phm.education.gouv.fr"
+const STATS_PATH = "/exposition-inserjeunes-insersup/api/inserjeunes/regionales/75001/certifications/12345678"
 
 describe("InserJeunes Client", () => {
   beforeEach(() => {
     nock.cleanAll()
+    _resetForTesting()
   })
 
   describe("fetchInserJeunesStats", () => {
     it("should fetch InserJeunes stats with valid token", async () => {
-      // Mock token request
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
 
-      // Mock stats request
-      nock(OMOGEN_BASE_URL)
-        .get("/exposition-inserjeunes-insersup/api/inserjeunes/regionales/75001/certifications/12345678")
-        .matchHeader("authorization", `Bearer ${omogenAuthTokenFixture.access_token}`)
-        .reply(200, inserJeunesStatsFixture)
+      nock(OMOGEN_BASE_URL).get(STATS_PATH).matchHeader("authorization", `Bearer ${omogenAuthTokenFixture.access_token}`).reply(200, inserJeunesStatsFixture)
 
       const result = await fetchInserJeunesStats("75001", "12345678")
 
@@ -28,10 +25,8 @@ describe("InserJeunes Client", () => {
     })
 
     it("should return null for 404 responses", async () => {
-      // Mock token request
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
 
-      // Mock 404 response
       nock(OMOGEN_BASE_URL).get("/exposition-inserjeunes-insersup/api/inserjeunes/regionales/99999/certifications/00000000").reply(404)
 
       const result = await fetchInserJeunesStats("99999", "00000000")
@@ -39,30 +34,71 @@ describe("InserJeunes Client", () => {
       expect(result).toBeNull()
     })
 
-    it("should throw internal error on auth failure", async () => {
-      // Mock failed token request
+    it("should return null on auth failure", async () => {
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(401, { error: "invalid_client" })
 
-      await expect(fetchInserJeunesStats("75001", "12345678")).rejects.toThrow()
+      const result = await fetchInserJeunesStats("75001", "12345678")
+
+      expect(result).toBeNull()
     })
 
+    it("should return null during cooldown without retrying token requests", async () => {
+      nock(OMOGEN_BASE_URL).post("/auth/token").reply(401, { error: "invalid_client" })
+      await fetchInserJeunesStats("75001", "12345678")
+
+      // During cooldown: no token request should be made
+      const result = await fetchInserJeunesStats("75001", "12345678")
+      expect(result).toBeNull()
+      expect(nock.pendingMocks()).toHaveLength(0)
+    })
+
+    it("should not activate cooldown on transient network errors", async () => {
+      nock(OMOGEN_BASE_URL).post("/auth/token").replyWithError({ code: "ECONNRESET", message: "socket hang up" })
+      await fetchInserJeunesStats("75001", "12345678")
+
+      // Next call should retry token fetch (no cooldown)
+      nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
+      nock(OMOGEN_BASE_URL).get(STATS_PATH).reply(200, inserJeunesStatsFixture)
+
+      const result = await fetchInserJeunesStats("75001", "12345678")
+      expect(result).toEqual(inserJeunesStatsFixture)
+    }, 15_000)
+
     it("should throw internal error on 500 API errors", async () => {
-      // Mock token request
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
 
-      // Mock 500 error
-      nock(OMOGEN_BASE_URL).get("/exposition-inserjeunes-insersup/api/inserjeunes/regionales/75001/certifications/12345678").reply(500, { error: "Internal error" })
+      nock(OMOGEN_BASE_URL).get(STATS_PATH).reply(500, { error: "Internal error" })
 
       await expect(fetchInserJeunesStats("75001", "12345678")).rejects.toThrow()
     })
 
     it("should return null for 502 and 503 (API temporarily unavailable)", async () => {
       nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
-      nock(OMOGEN_BASE_URL).get("/exposition-inserjeunes-insersup/api/inserjeunes/regionales/75001/certifications/12345678").reply(502, { error: "Bad Gateway" })
+      nock(OMOGEN_BASE_URL).get(STATS_PATH).reply(502, { error: "Bad Gateway" })
       expect(await fetchInserJeunesStats("75001", "12345678")).toBeNull()
 
-      nock(OMOGEN_BASE_URL).get("/exposition-inserjeunes-insersup/api/inserjeunes/regionales/75001/certifications/12345678").reply(503, { error: "Service Unavailable" })
+      nock(OMOGEN_BASE_URL).get(STATS_PATH).reply(503, { error: "Service Unavailable" })
       expect(await fetchInserJeunesStats("75001", "12345678")).toBeNull()
     })
+
+    it("should retry on ECONNRESET and succeed on second attempt", async () => {
+      nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
+
+      nock(OMOGEN_BASE_URL).get(STATS_PATH).replyWithError({ code: "ECONNRESET", message: "socket hang up" })
+      nock(OMOGEN_BASE_URL).get(STATS_PATH).reply(200, inserJeunesStatsFixture)
+
+      const result = await fetchInserJeunesStats("75001", "12345678")
+      expect(result).toEqual(inserJeunesStatsFixture)
+    }, 10_000)
+
+    it("should throw after max retries on persistent transient error", async () => {
+      nock(OMOGEN_BASE_URL).post("/auth/token").reply(200, omogenAuthTokenFixture)
+
+      for (let i = 0; i < 3; i++) {
+        nock(OMOGEN_BASE_URL).get(STATS_PATH).replyWithError({ code: "ECONNRESET", message: "socket hang up" })
+      }
+
+      await expect(fetchInserJeunesStats("75001", "12345678")).rejects.toThrow("Erreur lors de la récupération des données InserJeunes")
+    }, 30_000)
   })
 })

--- a/server/src/common/apis/inserjeunes/inserjeunes.client.ts
+++ b/server/src/common/apis/inserjeunes/inserjeunes.client.ts
@@ -82,6 +82,8 @@ const getOmogenToken = async (): Promise<string | null> => {
   return tokenFetchPromise
 }
 
+export const _axiosClientForTesting = axiosClient
+
 export const _resetForTesting = () => {
   omogenToken = null
   tokenFetchPromise = null

--- a/server/src/common/apis/inserjeunes/inserjeunes.client.ts
+++ b/server/src/common/apis/inserjeunes/inserjeunes.client.ts
@@ -17,19 +17,19 @@ const axiosClient = getApiClient({})
 
 let omogenToken: string | null = null
 let tokenRefreshTimeout: NodeJS.Timeout | null = null
-let tokenFetchPromise: Promise<string> | null = null
+let tokenFetchPromise: Promise<string | null> | null = null
 let tokenFailureCooldownUntil: number = 0
 const TOKEN_FAILURE_COOLDOWN_MS = 60_000
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-const getOmogenToken = async (): Promise<string> => {
+const getOmogenToken = async (): Promise<string | null> => {
   if (omogenToken) return omogenToken
 
   if (tokenFetchPromise) return tokenFetchPromise
 
   if (Date.now() < tokenFailureCooldownUntil) {
-    throw internal("impossible d'obtenir un token pour l'API Omogen")
+    return null
   }
 
   tokenFetchPromise = (async () => {
@@ -68,15 +68,26 @@ const getOmogenToken = async (): Promise<string> => {
 
       return validation.data.access_token
     } catch (error: any) {
-      tokenFailureCooldownUntil = Date.now() + TOKEN_FAILURE_COOLDOWN_MS
+      const status: number | undefined = error.response?.status
+      if (status === 401 || status === 403) {
+        tokenFailureCooldownUntil = Date.now() + TOKEN_FAILURE_COOLDOWN_MS
+      }
       sentryCaptureException(error, { extra: { responseData: error.response?.data } })
-      throw internal("impossible d'obtenir un token pour l'API Omogen")
+      return null
     } finally {
       tokenFetchPromise = null
     }
   })()
 
   return tokenFetchPromise
+}
+
+export const _resetForTesting = () => {
+  omogenToken = null
+  tokenFetchPromise = null
+  tokenFailureCooldownUntil = 0
+  if (tokenRefreshTimeout) clearTimeout(tokenRefreshTimeout)
+  tokenRefreshTimeout = null
 }
 
 const TRANSIENT_CODES = new Set(["ECONNRESET", "ECONNABORTED", "ETIMEDOUT"])
@@ -88,6 +99,8 @@ const SILENT_HTTP_STATUSES = new Set([404, 502, 503])
 export const fetchInserJeunesStats = async (zipcode: string, cfd: string, attempt = 0): Promise<unknown> => {
   try {
     const token = await getOmogenToken()
+    if (!token) return null
+
     const { data } = await axiosClient.get(`${OMOGEN_BASE_URL}/exposition-inserjeunes-insersup/api/inserjeunes/regionales/${zipcode}/certifications/${cfd}`, {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/server/src/common/apis/inserjeunes/inserjeunes.client.ts
+++ b/server/src/common/apis/inserjeunes/inserjeunes.client.ts
@@ -18,14 +18,20 @@ const axiosClient = getApiClient({})
 let omogenToken: string | null = null
 let tokenRefreshTimeout: NodeJS.Timeout | null = null
 let tokenFetchPromise: Promise<string> | null = null
+let tokenFailureCooldownUntil: number = 0
+const TOKEN_FAILURE_COOLDOWN_MS = 60_000
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const getOmogenToken = async (): Promise<string> => {
   if (omogenToken) return omogenToken
 
-  // If a token fetch is already in progress, wait for it
   if (tokenFetchPromise) return tokenFetchPromise
 
-  // Start a new token fetch
+  if (Date.now() < tokenFailureCooldownUntil) {
+    throw internal("impossible d'obtenir un token pour l'API Omogen")
+  }
+
   tokenFetchPromise = (async () => {
     try {
       const requestBody = new URLSearchParams({
@@ -48,12 +54,10 @@ const getOmogenToken = async (): Promise<string> => {
 
       omogenToken = validation.data.access_token
 
-      // Clear any existing timeout
       if (tokenRefreshTimeout) {
         clearTimeout(tokenRefreshTimeout)
       }
 
-      // Refresh token before it expires (90% of expiration time)
       tokenRefreshTimeout = setTimeout(
         () => {
           omogenToken = null
@@ -64,6 +68,7 @@ const getOmogenToken = async (): Promise<string> => {
 
       return validation.data.access_token
     } catch (error: any) {
+      tokenFailureCooldownUntil = Date.now() + TOKEN_FAILURE_COOLDOWN_MS
       sentryCaptureException(error, { extra: { responseData: error.response?.data } })
       throw internal("impossible d'obtenir un token pour l'API Omogen")
     } finally {
@@ -74,10 +79,13 @@ const getOmogenToken = async (): Promise<string> => {
   return tokenFetchPromise
 }
 
+const TRANSIENT_CODES = new Set(["ECONNRESET", "ECONNABORTED", "ETIMEDOUT"])
+const SILENT_HTTP_STATUSES = new Set([404, 502, 503])
+
 /**
  * Fetch InserJeune statistics for a specific certification and region
  */
-export const fetchInserJeunesStats = async (zipcode: string, cfd: string) => {
+export const fetchInserJeunesStats = async (zipcode: string, cfd: string, attempt = 0): Promise<unknown> => {
   try {
     const token = await getOmogenToken()
     const { data } = await axiosClient.get(`${OMOGEN_BASE_URL}/exposition-inserjeunes-insersup/api/inserjeunes/regionales/${zipcode}/certifications/${cfd}`, {
@@ -87,10 +95,23 @@ export const fetchInserJeunesStats = async (zipcode: string, cfd: string) => {
     })
     return data
   } catch (error: any) {
-    if (error.response?.status === 404) {
+    const status: number | undefined = error.response?.status
+    const code: string | undefined = error.code
+
+    if (status === 404) {
       return null
     }
-    if (error.response?.status !== 502) {
+
+    if (status === 503 || status === 502) {
+      return null
+    }
+
+    if (code && TRANSIENT_CODES.has(code) && attempt < 2) {
+      await delay(500 * 2 ** attempt)
+      return fetchInserJeunesStats(zipcode, cfd, attempt + 1)
+    }
+
+    if (!SILENT_HTTP_STATUSES.has(status as number)) {
       sentryCaptureException(error, { extra: { responseData: error.response?.data, zipcode, cfd } })
     }
     throw internal("Erreur lors de la récupération des données InserJeunes")

--- a/server/src/common/apis/inserjeunes/inserjeunes.client.ts
+++ b/server/src/common/apis/inserjeunes/inserjeunes.client.ts
@@ -2,6 +2,7 @@ import { internal } from "@hapi/boom"
 import { z } from "zod"
 
 import getApiClient from "@/common/apis/client"
+import { delay } from "@/common/utils/asyncUtils"
 import { sentryCaptureException } from "@/common/utils/sentryUtils"
 import config from "@/config"
 
@@ -20,8 +21,6 @@ let tokenRefreshTimeout: NodeJS.Timeout | null = null
 let tokenFetchPromise: Promise<string | null> | null = null
 let tokenFailureCooldownUntil: number = 0
 const TOKEN_FAILURE_COOLDOWN_MS = 60_000
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const getOmogenToken = async (): Promise<string | null> => {
   if (omogenToken) return omogenToken

--- a/server/src/http/StreamProcessorServer.ts
+++ b/server/src/http/StreamProcessorServer.ts
@@ -59,7 +59,9 @@ export const bindStreamProcessorServer = async (): Promise<Server> => {
   const app: Server = fastify({
     logger: logMiddleware(),
     trustProxy: 1,
-    caseSensitive: false,
+    routerOptions: {
+      caseSensitive: false,
+    },
   }).withTypeProvider<ZodTypeProvider>()
 
   return bind(app)

--- a/server/src/http/jobProcessorServer.ts
+++ b/server/src/http/jobProcessorServer.ts
@@ -34,7 +34,9 @@ export const bindProcessorServer = async (): Promise<Server> => {
   const app: Server = fastify({
     logger: logMiddleware(),
     trustProxy: 1,
-    caseSensitive: false,
+    routerOptions: {
+      caseSensitive: false,
+    },
   }).withTypeProvider<ZodTypeProvider>()
 
   return bind(app)

--- a/server/src/security/authenticationService.ts
+++ b/server/src/security/authenticationService.ts
@@ -100,14 +100,21 @@ async function authApiKey(req: FastifyRequest): Promise<AccessUserCredential | n
 }
 
 async function authApiApprentissage(req: FastifyRequest): Promise<AccessApiApprentissage | null> {
-  const result = await parseApiAlternanceToken({
-    token: req.headers.authorization ?? "",
-    publicKey: config.auth.apiApprentissage.publicKey,
-  })
+  try {
+    const result = await parseApiAlternanceToken({
+      token: req.headers.authorization ?? "",
+      publicKey: config.auth.apiApprentissage.publicKey,
+    })
 
-  if (result.success) return { type: "IApiApprentissage", value: result.data }
+    if (result.success) return { type: "IApiApprentissage", value: result.data }
 
-  throw unauthorized(`Unable to parse token ${result.reason}`)
+    throw unauthorized(`Unable to parse token ${result.reason}`)
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw unauthorized("Invalid token algorithm")
+    }
+    throw error
+  }
 }
 
 const bearerRegex = /^bearer\s+(\S+)$/i

--- a/server/src/services/bal.service.ts
+++ b/server/src/services/bal.service.ts
@@ -60,7 +60,9 @@ export const validationOrganisation = async (siret: string, email: string): Prom
       )
       return data // is_valid: boolean, on: string "domain"|"email"
     } catch (error: any) {
-      sentryCaptureException(error)
+      if (error?.response?.status !== 500) {
+        sentryCaptureException(error)
+      }
       return { is_valid: false }
     }
   })


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-4013

---

## Contexte

Issues Sentry corrigées (classées par nombre d'occurrences) :

### lba-server

| ID | Erreur | Events |
|----|--------|--------|
| [LBA-SERVER-5J7KF4ZZZT6KT](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-SERVER-5J7KF4ZZZT6KT) | Erreur lors de la récupération des données InserJeunes | 9 718 |
| [LBA-SERVER-5J7KF4ZZZT6M5](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-SERVER-5J7KF4ZZZT6M5) | impossible d'obtenir un token pour l'API Omogen | 9 393 |
| [LBA-SERVER-27W](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-SERVER-27W) | FastifyWarning: caseSensitive deprecated (FSTDEP022) | 3 120 |
| [LBA-SERVER-5J7KF4ZZZT6M4](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-SERVER-5J7KF4ZZZT6M4) | read ECONNRESET (InserJeunes) | 2 644 |
| [LBA-SERVER-5J7KF4ZZZT6GH](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-SERVER-5J7KF4ZZZT6GH) | Erreur lors de la récupération des données InserJeunes | 526 |
| [LBA-SERVER-5J7KF4ZZZT6RN](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-SERVER-5J7KF4ZZZT6RN) | AxiosError 429 FCGetOpcoInfos | 460 |
| [LBA-SERVER-5J7KF4ZZZT6TK](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-SERVER-5J7KF4ZZZT6TK) | TypeError: CryptoKey instances for symmetric algorithms must be of type "secret" | ~50 |
| [LBA-SERVER-5J7KF4ZZZT6SH](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-SERVER-5J7KF4ZZZT6SH) | AxiosError 500 (BAL organisation/validation) | 3 |

### lba-ui

| ID | Erreur | Events | Page |
|----|--------|--------|------|
| [LBA-UI-1F0](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-1F0) | HTTP 503 (cascade InserJeunes) | 341 705 | /emploi/:type/:id |
| [LBA-UI-31T](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-31T) | InserJeunes API error 503 | 3 532 | /formation/:id |
| [LBA-UI-1SPGQ](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/LBA-UI-1SPGQ) | HTTP 503 | 10 637 | /formation/:id |

---

## Changements

- **InserJeunes / Omogen** : cooldown 60s après un échec d'authentification pour éviter l'avalanche de captures Sentry (9 700+ events en 11 jours)
- **InserJeunes** : retry exponentiel (500ms, 1s) sur `ECONNRESET` / `ETIMEDOUT` / `ECONNABORTED`
- **InserJeunes** : 502 et 503 retournent `null` (→ 404 controller) au lieu de propager une erreur 500 vers l'UI
- **France Compétences** : les 429 (rate limit attendu) ne sont plus capturés dans Sentry
- **Fastify** : `caseSensitive: false` déplacé dans `routerOptions` sur `jobProcessorServer` et `StreamProcessorServer` (suppression du warning de dépréciation)
- **Auth api-apprentissage** : le `TypeError` de jose (token HS256 vérifié contre une clé ES512) est maintenant catchable et retourne 401 au lieu de propager un 500 — des appelants externes utilisent un mauvais algorithme de signature depuis le déploiement de 1.797.0
- **BAL** : les erreurs 500 de `bal.apprentissage.beta.gouv.fr` ne sont plus capturées dans Sentry (le service lui-même est instable, LBA retourne déjà `{ is_valid: false }` correctement)

## Plan de test

- [ ] Vérifier que l'endpoint `/api/inserjeunes/:zipcode/:cfd` retourne 404 quand InserJeunes est indisponible (503)
- [ ] Vérifier que le warning Fastify `FSTDEP022` n'apparaît plus dans les logs
- [ ] Vérifier dans Sentry que les groupes d'erreurs InserJeunes / Omogen / FC ne croissent plus
- [ ] Vérifier qu'un appel à `GET /api/v3/jobs/search` avec un token HS256 retourne 401 et non 500