### PR TITLE
fix(lba-4011): activer heartbeat timer et heatmaps matomo

### DIFF
--- a/ui/tracking/trackingMatomo.tsx
+++ b/ui/tracking/trackingMatomo.tsx
@@ -15,6 +15,8 @@ export const Matomo = () => {
       _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
       _paq.push(['setConsentGiven']);
       _paq.push(['rememberConsentGiven']);
+      _paq.push(['enableHeartBeatTimer']);
+      _paq.push(['HeatmapSessionRecording::enable']);
       (function() {
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.async=true; g.src='${publicConfig.matomo.url}/${publicConfig.matomo.jsTrackerFile}'; s.parentNode.insertBefore(g,s);


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-4011

---

## Changements

- Activation de `enableHeartBeatTimer` pour mesurer le temps réel passé sur chaque page
- Activation du plugin `HeatmapSessionRecording` pour les heatmaps Matomo

## Plan de test

- [ ] Vérifier dans la console Matomo que les pings heartbeat arrivent bien
- [ ] Vérifier que les heatmaps s'enregistrent sur les pages concernées