### PR TITLE
fix(seo): ajout des pages diplôme au sitemap principal

### DIFF
--- a/ui/services/generateMainSitemap.ts
+++ b/ui/services/generateMainSitemap.ts
@@ -3,13 +3,14 @@ import path from "path"
 import type { SitemapUrlEntry } from "shared/utils/sitemapUtils"
 import { generateSitemapFromUrlEntries } from "shared/utils/sitemapUtils"
 
+import { diplomeData } from "@/app/(editorial)/alternance/_components/diplome_data"
 import { metierData } from "@/app/(editorial)/alternance/_components/metier_data"
 import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 import { getStaticMetiers } from "@/utils/getStaticData"
 import { getHostFromHeader } from "@/utils/requestUtils"
 
 // Attention ! Il faut mettre à jour cette date lorsque le sitemap généré par ce fichier change
-export const mainSitemapLastModificationDate = new Date("2026-03-30T15:00:00.000Z")
+export const mainSitemapLastModificationDate = new Date("2026-05-21T00:00:00.000Z")
 
 export function generateMainSitemap(request: Request) {
   const txtDirectory = path.join(process.cwd(), "config")
@@ -47,6 +48,7 @@ export function generateMainSitemap(request: Request) {
   ]
   const villePaths = villeData.map((ville) => `/alternance/ville/${ville.slug}`)
   const metierPaths = metierData.map((metier) => `/alternance/metier/${metier.slug}`)
+  const diplomePaths = diplomeData.map((diplome) => `/alternance/diplome/${diplome.slug}`)
   const jobPaths = dataJobs.map((job) => `/metiers/${job.slug}`)
 
   const sitemapEntries: SitemapUrlEntry[] = [
@@ -54,6 +56,7 @@ export function generateMainSitemap(request: Request) {
     ...paths.map((path) => ({ loc: host + path, priority: 0.9 })),
     ...villePaths.map((path) => ({ loc: host + path, priority: 0.95 })),
     ...metierPaths.map((path) => ({ loc: host + path, priority: 0.95 })),
+    ...diplomePaths.map((path) => ({ loc: host + path, priority: 0.95 })),
     ...jobPaths.map((path) => ({ loc: host + path, priority: 0.8 })),
   ]
 


### PR DESCRIPTION
## Summary
- Les 10 pages `/alternance/diplome/[slug]` (mises en ligne le 2026-05-11) n'étaient pas référencées dans `sitemap-main.xml` — elles ne sont donc pas découvrables par les crawlers via le sitemap.
- Ajout de `diplomeData` à `generateMainSitemap.ts` (même pattern que `villeData` et `metierData`, priority `0.95`).
- Bump de `mainSitemapLastModificationDate` (figée au 2026-03-30) pour forcer Google à reprendre en compte le sitemap — depuis cette date, 20 villes + 20 métiers + 10 diplômes ont été ajoutés sans signal `lastmod`.

## Contexte
RETEX SEO sur les pages programmatiques : audit GSC du sitemap a révélé que `sitemap-main.xml` ne contenait pas les pages diplôme, et que `lastmod` n'avait pas été mise à jour malgré 3 batches de pages ajoutées.

## Test plan
- [ ] Vérifier que `https://labonnealternance.apprentissage.beta.gouv.fr/sitemap-main.xml` contient bien les 10 URLs `/alternance/diplome/*` après MEP
- [ ] Vérifier que la balise `<lastmod>` du sitemap reflète la nouvelle date
- [ ] Soumettre/Re-soumettre le sitemap dans Google Search Console pour accélérer la prise en compte

🤖 Generated with [Claude Code](https://claude.com/claude-code)