### PR TITLE
fix: corriger le conflit _id lors de l'upsert des recruteurs lba

### DIFF
--- a/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
@@ -124,8 +124,31 @@ export const importRecruteurLbaToComputed = async () => {
       for (const document of documents) {
         try {
           const parsedDocument = ZRecruteursLbaRaw.parse(document)
-          const { apply_email, apply_phone, updated_at, offer_creation, _id: _unusedId, ...rest } = recruteursLbaToJobPartners(parsedDocument)
-          const { workplace_address_zipcode } = rest
+          const {
+            partner_label,
+            partner_job_id,
+            workplace_siret,
+            workplace_brand,
+            workplace_legal_name,
+            workplace_naf_code,
+            workplace_naf_label,
+            workplace_address_city,
+            workplace_address_street_label,
+            workplace_address_zipcode,
+            workplace_address_label,
+            workplace_geopoint,
+            workplace_size,
+            offer_rome_codes,
+            offer_title,
+            offer_description,
+            offer_multicast,
+            apply_email,
+            apply_phone,
+            offer_creation,
+            _id: _unusedId,
+            updated_at: _unusedUpdatedAt,
+            ...blankMetaFields
+          } = recruteursLbaToJobPartners(parsedDocument)
 
           if (workplace_address_zipcode) {
             if (!extensions.zipCode().safeParse(workplace_address_zipcode).success) {
@@ -136,16 +159,31 @@ export const importRecruteurLbaToComputed = async () => {
 
           operations.push({
             updateOne: {
-              filter: { workplace_siret: rest.workplace_siret },
+              filter: { partner_label, workplace_siret },
               update: {
                 $set: {
-                  ...rest,
+                  workplace_brand,
+                  workplace_legal_name,
+                  workplace_naf_code,
+                  workplace_naf_label,
+                  workplace_address_city,
+                  workplace_address_street_label,
+                  workplace_address_zipcode,
+                  workplace_address_label,
+                  workplace_geopoint,
+                  workplace_size,
+                  offer_rome_codes,
+                  offer_title,
+                  offer_description,
+                  offer_multicast,
                   apply_email,
                   apply_phone,
                   offer_creation,
                   updated_at: importDate,
                 },
                 $setOnInsert: {
+                  ...blankMetaFields,
+                  partner_job_id,
                   offer_status_history: [],
                   _id: new ObjectId(),
                 },

--- a/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/importRecruteursLbaRaw.ts
@@ -124,7 +124,7 @@ export const importRecruteurLbaToComputed = async () => {
       for (const document of documents) {
         try {
           const parsedDocument = ZRecruteursLbaRaw.parse(document)
-          const { apply_email, apply_phone, updated_at, offer_creation, ...rest } = recruteursLbaToJobPartners(parsedDocument)
+          const { apply_email, apply_phone, updated_at, offer_creation, _id: _unusedId, ...rest } = recruteursLbaToJobPartners(parsedDocument)
           const { workplace_address_zipcode } = rest
 
           if (workplace_address_zipcode) {
@@ -139,13 +139,13 @@ export const importRecruteurLbaToComputed = async () => {
               filter: { workplace_siret: rest.workplace_siret },
               update: {
                 $set: {
+                  ...rest,
                   apply_email,
                   apply_phone,
                   offer_creation,
                   updated_at: importDate,
                 },
                 $setOnInsert: {
-                  ...rest,
                   offer_status_history: [],
                   _id: new ObjectId(),
                 },

--- a/server/src/jobs/offrePartenaire/recruteur-lba/processRecruteursLba.test.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/processRecruteursLba.test.ts
@@ -5,6 +5,7 @@ import omit from "lodash-es/omit"
 import { ObjectId } from "mongodb"
 import { JOB_STATUS_ENGLISH } from "shared"
 import { OPCOS_LABEL } from "shared/constants/recruteur"
+import { generateComputedJobsPartnersFixture } from "shared/fixtures/jobPartners.fixture"
 import { generateRecruiterRawFixture } from "shared/fixtures/recruiterRaw.fixture"
 import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
 import type { IRecruteursLbaRaw } from "shared/models/rawRecruteursLba.model"
@@ -105,6 +106,42 @@ describe("importRecruteursLbaRaw", () => {
     const [job] = publishedJobPartners
     expect.soft(job.apply_email).toBe(null)
   })
+
+  it("should refresh raw recruiter fields when computed document already exists", async () => {
+    const rawRecruiter = generateRecruiterRawFixture({
+      siret: "13002526500013",
+      enseigne: "ETABLISSEMENTS DINUM",
+      raison_sociale: "ETABLISSEMENTS DINUM",
+    })
+
+    await getDbCollection("computed_jobs_partners").insertOne(
+      generateComputedJobsPartnersFixture({
+        _id: new ObjectId(),
+        partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+        partner_job_id: rawRecruiter.siret,
+        workplace_siret: rawRecruiter.siret,
+        workplace_brand: rawRecruiter.siret,
+        workplace_legal_name: "ANCIEN NOM",
+      })
+    )
+
+    await processRecruteursLbaFromObjects([rawRecruiter])
+
+    const computedRecruiter = await getDbCollection("computed_jobs_partners").findOne({
+      partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+      workplace_siret: rawRecruiter.siret,
+    })
+    const publishedRecruiter = await getDbCollection("jobs_partners").findOne({
+      partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+      partner_job_id: rawRecruiter.siret,
+    })
+
+    expect.soft(computedRecruiter?.workplace_brand).toBe(rawRecruiter.enseigne)
+    expect.soft(computedRecruiter?.workplace_legal_name).toBe(rawRecruiter.raison_sociale)
+    expect.soft(publishedRecruiter?.workplace_brand).toBe(rawRecruiter.enseigne)
+    expect.soft(publishedRecruiter?.workplace_legal_name).toBe(rawRecruiter.raison_sociale)
+  })
+
   it("should not import recruiters that opted out", async () => {
     // given
     const siret = "13002526500013"

--- a/server/src/jobs/offrePartenaire/recruteur-lba/processRecruteursLba.test.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/processRecruteursLba.test.ts
@@ -113,6 +113,7 @@ describe("importRecruteursLbaRaw", () => {
       enseigne: "ETABLISSEMENTS DINUM",
       raison_sociale: "ETABLISSEMENTS DINUM",
     })
+    const originalCreatedAt = new Date("2020-01-01")
 
     await getDbCollection("computed_jobs_partners").insertOne(
       generateComputedJobsPartnersFixture({
@@ -120,8 +121,9 @@ describe("importRecruteursLbaRaw", () => {
         partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
         partner_job_id: rawRecruiter.siret,
         workplace_siret: rawRecruiter.siret,
-        workplace_brand: rawRecruiter.siret,
+        workplace_brand: "ANCIEN NOM",
         workplace_legal_name: "ANCIEN NOM",
+        created_at: originalCreatedAt,
       })
     )
 
@@ -138,8 +140,34 @@ describe("importRecruteursLbaRaw", () => {
 
     expect.soft(computedRecruiter?.workplace_brand).toBe(rawRecruiter.enseigne)
     expect.soft(computedRecruiter?.workplace_legal_name).toBe(rawRecruiter.raison_sociale)
+    expect.soft(computedRecruiter?.created_at).toEqual(originalCreatedAt)
     expect.soft(publishedRecruiter?.workplace_brand).toBe(rawRecruiter.enseigne)
     expect.soft(publishedRecruiter?.workplace_legal_name).toBe(rawRecruiter.raison_sociale)
+  })
+
+  it("should not update a computed document with the same siret but a different partner_label", async () => {
+    const siret = "13002526500013"
+    const rawRecruiter = generateRecruiterRawFixture({ siret, enseigne: "NOUVEAU NOM" })
+    const otherPartnerBrand = "AUTRE PARTENAIRE"
+
+    await getDbCollection("computed_jobs_partners").insertOne(
+      generateComputedJobsPartnersFixture({
+        _id: new ObjectId(),
+        partner_label: JOBPARTNERS_LABEL.HELLOWORK,
+        partner_job_id: "hellowork-job-42",
+        workplace_siret: siret,
+        workplace_brand: otherPartnerBrand,
+      })
+    )
+
+    await processRecruteursLbaFromObjects([rawRecruiter])
+
+    const otherPartnerDoc = await getDbCollection("computed_jobs_partners").findOne({
+      partner_label: JOBPARTNERS_LABEL.HELLOWORK,
+      workplace_siret: siret,
+    })
+
+    expect.soft(otherPartnerDoc?.workplace_brand).toBe(otherPartnerBrand)
   })
 
   it("should not import recruiters that opted out", async () => {


### PR DESCRIPTION
Closes #4706

## Changements

- Déplace `...rest` de `$setOnInsert` vers `$set` dans l'upsert de `computed_jobs_partners` pour que les champs du recruteur (nom, enseigne, NAF…) soient rafraîchis à chaque import
- Exclut `_id` du spread `...rest` pour éviter le conflit MongoDB entre `$set._id` et `$setOnInsert._id`
- Ajoute un test couvrant le cas où le document existe déjà et vérifie que les champs sont bien mis à jour

## Plan de test

- [ ] Lancer `yarn test server/src/jobs/offrePartenaire/recruteur-lba/processRecruteursLba.test.ts` → 5 tests passent
- [ ] Vérifier qu'après un import, les champs `workplace_brand` et `workplace_legal_name` d'un recruteur existant sont bien mis à jour dans `computed_jobs_partners` et `jobs_partners`