### PR TITLE
fix: configurer le merge driver sops pour les fichiers d'environnement chiffrés

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -76,8 +76,8 @@
 *.woff      binary
 *.woff2     binary
 .infra/files/configs/mongodb/seed.gpg filter=lfs diff=lfs merge=lfs -text
-.infra/env.global.yml diff=sopsdiffer
-.infra/env.production.yml diff=sopsdiffer
-.infra/env.recette.yml diff=sopsdiffer
-.infra/env.preview.yml diff=sopsdiffer
-.infra/env.local.yml diff=sopsdiffer
+.infra/env.global.yml diff=sopsdiffer merge=sops
+.infra/env.production.yml diff=sopsdiffer merge=sops
+.infra/env.recette.yml diff=sopsdiffer merge=sops
+.infra/env.preview.yml diff=sopsdiffer merge=sops
+.infra/env.local.yml diff=sopsdiffer merge=sops

--- a/.gitattributes
+++ b/.gitattributes
@@ -76,8 +76,4 @@
 *.woff      binary
 *.woff2     binary
 .infra/files/configs/mongodb/seed.gpg filter=lfs diff=lfs merge=lfs -text
-.infra/env.global.yml diff=sopsdiffer merge=sops
-.infra/env.production.yml diff=sopsdiffer merge=sops
-.infra/env.recette.yml diff=sopsdiffer merge=sops
-.infra/env.preview.yml diff=sopsdiffer merge=sops
-.infra/env.local.yml diff=sopsdiffer merge=sops
+.infra/env.*.yml diff=sopsdiffer merge=sops

--- a/README.md
+++ b/README.md
@@ -267,6 +267,36 @@ Par défaut, le fichier `.infra/env.global.yml` est édité.
 
 Si un environnement est renseigné, le fichier associé `.infra/env.<env>.yml` à cet environnement est édité.
 
+##### Merge driver SOPS (à configurer une fois par développeur)
+
+Les fichiers `.infra/env.*.yml` utilisent un merge driver git pour résoudre automatiquement les conflits sur les fichiers chiffrés SOPS. Il faut l'activer localement :
+
+```bash
+git config merge.sops.name "sops merge driver"
+git config merge.sops.driver "sops merge %O %A %B"
+```
+
+Sans cette configuration, git ne sait pas merger des fichiers chiffrés et les marqueurs de conflit (`<<<<<<<`) corrompent le YAML. En cas de conflit non résolu automatiquement, procédure manuelle :
+
+```bash
+# Extraire les trois versions propres
+git show :1:.infra/env.production.yml > /tmp/base.yml
+git show :2:.infra/env.production.yml > /tmp/ours.yml
+git show :3:.infra/env.production.yml > /tmp/theirs.yml
+
+# Déchiffrer
+sops -d /tmp/base.yml   > /tmp/base.plain.yml
+sops -d /tmp/ours.yml   > /tmp/ours.plain.yml
+sops -d /tmp/theirs.yml > /tmp/theirs.plain.yml
+
+# Merger en clair, résoudre les conflits
+git merge-file /tmp/ours.plain.yml /tmp/base.plain.yml /tmp/theirs.plain.yml
+
+# Re-chiffrer et valider
+sops -e /tmp/ours.plain.yml > .infra/env.production.yml
+git add .infra/env.production.yml
+```
+
 #### Linter
 
 Lint global du projet

--- a/README.md
+++ b/README.md
@@ -279,10 +279,13 @@ git config merge.sops.driver "sops merge %O %A %B"
 Sans cette configuration, git ne sait pas merger des fichiers chiffrés et les marqueurs de conflit (`<<<<<<<`) corrompent le YAML. En cas de conflit non résolu automatiquement, procédure manuelle :
 
 ```bash
+# Remplacer par le fichier en conflit (ex: env.production.yml, env.recette.yml…)
+FILE=.infra/env.production.yml
+
 # Extraire les trois versions propres
-git show :1:.infra/env.production.yml > /tmp/base.yml
-git show :2:.infra/env.production.yml > /tmp/ours.yml
-git show :3:.infra/env.production.yml > /tmp/theirs.yml
+git show :1:$FILE > /tmp/base.yml
+git show :2:$FILE > /tmp/ours.yml
+git show :3:$FILE > /tmp/theirs.yml
 
 # Déchiffrer
 sops -d /tmp/base.yml   > /tmp/base.plain.yml
@@ -293,8 +296,8 @@ sops -d /tmp/theirs.yml > /tmp/theirs.plain.yml
 git merge-file /tmp/ours.plain.yml /tmp/base.plain.yml /tmp/theirs.plain.yml
 
 # Re-chiffrer et valider
-sops -e /tmp/ours.plain.yml > .infra/env.production.yml
-git add .infra/env.production.yml
+sops -e /tmp/ours.plain.yml > $FILE
+git add $FILE
 ```
 
 #### Linter


### PR DESCRIPTION
Closes #4735

## Changements

- Ajout de `merge=sops` dans `.gitattributes` pour les 5 fichiers `env.*.yml` (ils avaient déjà `diff=sopsdiffer`)
- Documentation du merge driver dans le README : commande de configuration + procédure manuelle de fallback

## Plan de test

- [ ] Vérifier que `git config merge.sops.driver "sops merge %O %A %B"` est documenté dans le README
- [ ] Simuler un conflit sur un fichier `.infra/env.*.yml` et vérifier que le merge driver se déclenche