### PR TITLE
chore: améliorer les notifications Slack MEP et release (Block Kit)

### DIFF
--- a/.github/scripts/slack-release-payload.cjs
+++ b/.github/scripts/slack-release-payload.cjs
@@ -22,7 +22,7 @@ function parseSection(notes, heading) {
 
 module.exports = function slackReleasePayload({ releasedVersion, releaseNotes, repoURL }) {
   const today = new Date().toISOString().slice(0, 10)
-  const releaseUrl = `${repoURL}/releases/tag/v${releasedVersion}`
+  const releaseUrl = `${repoURL.replace(/\.git$/, "")}/releases/tag/v${releasedVersion}`
   const features = parseSection(releaseNotes, "Features")
   const fixes = parseSection(releaseNotes, "Bug Fixes")
 

--- a/.github/scripts/slack-release-payload.cjs
+++ b/.github/scripts/slack-release-payload.cjs
@@ -1,0 +1,61 @@
+"use strict"
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function parseSection(notes, heading) {
+  if (!notes) return []
+  const regex = new RegExp(`### ${escapeRegex(heading)}\\s*\\n([\\s\\S]*?)(?=\\n###|\\n##|$)`)
+  const match = notes.match(regex)
+  if (!match) return []
+  return match[1]
+    .split("\n")
+    .map((l) =>
+      l
+        .replace(/^\*\s+/, "")
+        .replace(/\s*\(?\[.*?\]\(.*?\)\)?\s*$/, "")
+        .trim()
+    )
+    .filter(Boolean)
+}
+
+module.exports = function slackReleasePayload({ releasedVersion, releaseNotes, repoURL }) {
+  const today = new Date().toISOString().slice(0, 10)
+  const releaseUrl = `${repoURL}/releases/tag/v${releasedVersion}`
+  const features = parseSection(releaseNotes, "Features")
+  const fixes = parseSection(releaseNotes, "Bug Fixes")
+
+  const blocks = [
+    { type: "header", text: { type: "plain_text", text: `📦 Nouvelle release — v${releasedVersion}` } },
+    { type: "section", text: { type: "mrkdwn", text: `\`mna-lba\` · v${releasedVersion} · ${today}` } },
+    { type: "divider" },
+  ]
+
+  if (features.length > 0) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:large_green_circle: *Features*\n${features.map((f) => `• ${f}`).join("\n")}`,
+      },
+    })
+  }
+
+  if (fixes.length > 0) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:red_circle: *Bug Fixes*\n${fixes.map((f) => `• ${f}`).join("\n")}`,
+      },
+    })
+  }
+
+  blocks.push({
+    type: "context",
+    elements: [{ type: "mrkdwn", text: `<${releaseUrl}|Voir la release →>` }],
+  })
+
+  return { attachments: [{ color: "#e3e3fd", blocks }] }
+}

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -98,15 +98,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      - name: Notify new deployment on Slack
-        uses: ravsamhq/notify-slack-action@v2
-        if: always()
-        with:
-          status: ${{ job.status }}
-          notification_title: "Déploiement ${{ needs.version.outputs.VERSION }} en ${{ inputs.environment }} initié..."
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-
       - name: Get Action IP
         run: curl -4 ifconfig.me
 
@@ -264,13 +255,35 @@ jobs:
             exit 0
           fi
 
-          MESSAGE=":rocket: *Déployé en production !*${NL}${PREV_TAG} → *${CURRENT_TAG}* (${TODAY})${NL}"
-          [ -n "$FEAT_LINES" ] && MESSAGE+="${NL}*Nouvelles fonctionnalités*${NL}${NL}${FEAT_LINES}"
-          [ -n "$FIX_LINES" ]  && MESSAGE+="${NL}*Corrections*${NL}${NL}${FIX_LINES}"
-          [ -n "$CHORE_LINES" ] && MESSAGE+="${NL}*Maintenance*${NL}${NL}${CHORE_LINES}"
-          [ -n "$OTHER_LINES" ] && MESSAGE+="${NL}*Autres changements*${NL}${NL}${OTHER_LINES}"
+          DIFF_URL="https://github.com/${GITHUB_REPOSITORY}/compare/${PREV_TAG}...${CURRENT_TAG}"
 
-          jq -n --arg text "$MESSAGE" '{text: $text}' \
+          BLOCKS=$(jq -n \
+            --arg version "$CURRENT_TAG" \
+            --arg prev "$PREV_TAG" \
+            --arg date "$TODAY" \
+            '[
+              {"type":"header","text":{"type":"plain_text","text":"🚀 Déployé en production — \($version)"}},
+              {"type":"section","text":{"type":"mrkdwn","text":"`\($prev)` → `\($version)` · \($date)"}},
+              {"type":"divider"}
+            ]')
+
+          if [ -n "$FEAT_LINES" ]; then
+            FEAT_TEXT=$':large_green_circle: *Nouvelles fonctionnalités*\n'"$FEAT_LINES"
+            BLOCKS=$(echo "$BLOCKS" | jq --arg text "$FEAT_TEXT" \
+              '. + [{"type":"section","text":{"type":"mrkdwn","text":$text}}]')
+          fi
+
+          if [ -n "$FIX_LINES" ]; then
+            FIX_TEXT=$':red_circle: *Corrections*\n'"$FIX_LINES"
+            BLOCKS=$(echo "$BLOCKS" | jq --arg text "$FIX_TEXT" \
+              '. + [{"type":"section","text":{"type":"mrkdwn","text":$text}}]')
+          fi
+
+          BLOCKS=$(echo "$BLOCKS" | jq --arg url "$DIFF_URL" \
+            '. + [{"type":"context","elements":[{"type":"mrkdwn","text":"<\($url)|Voir le diff complet →>"}]}]')
+
+          jq -n --argjson blocks "$BLOCKS" \
+            '{"attachments":[{"color":"#00a95f","blocks":$blocks}]}' \
           | curl -s -X POST "$SLACK_WEBHOOK_URL" \
               -H 'Content-type: application/json' \
               --data @-

--- a/release.config.js
+++ b/release.config.js
@@ -17,7 +17,7 @@ module.exports = {
       {
         notifyOnSuccess: true,
         notifyOnFail: true,
-        markdownReleaseNotes: true,
+        onSuccessFunction: ".github/scripts/slack-release-payload.cjs",
       },
     ],
   ],


### PR DESCRIPTION
Closes #4750

## Changements

- Suppression de la notification "déploiement initié" (redondante avec la notif de succès)
- Remplacement du payload texte MEP par une structure Block Kit : barre verte `#00a95f`, header, sections feat/fix conditionnelles, lien diff GitHub
- Remplacement du message `semantic-release-slack-bot` par un script custom (`.github/scripts/slack-release-payload.cjs`) : barre grise DSFR `#e3e3fd`, sections conditionnelles, lien GitHub release

## Plan de test

- [ ] Déclencher un déploiement en production et vérifier que la notif "initié" n'apparaît plus sur Slack
- [ ] Vérifier que la notif MEP affiche la barre verte, le header, les sections feat/fix et le lien diff
- [ ] Déclencher une release semantic-release et vérifier le nouveau format (barre grise, sections conditionnelles, lien release)
- [ ] Vérifier que les sections feat/fix sont absentes si la liste est vide