### PR TITLE
fix: onSuccessFunction doit être une fonction, pas un chemin

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -17,7 +17,8 @@ module.exports = {
       {
         notifyOnSuccess: true,
         notifyOnFail: true,
-        onSuccessFunction: ".github/scripts/slack-release-payload.cjs",
+        // biome-ignore lint/style/noCommonJs: fonction injectée dans semantic-release-slack-bot
+        onSuccessFunction: require("./.github/scripts/slack-release-payload.cjs"),
       },
     ],
   ],


### PR DESCRIPTION
Fix du bug introduit dans #4751 — `semantic-release-slack-bot` attend une fonction, pas un chemin de fichier.

## Changement

`release.config.js` : remplace la string par `require()`.