### PR TITLE
fix: corriger la signature de onSuccessFunction (pluginConfig, context)

### DIFF
--- a/.github/scripts/slack-release-payload.cjs
+++ b/.github/scripts/slack-release-payload.cjs
@@ -20,15 +20,17 @@ function parseSection(notes, heading) {
     .filter(Boolean)
 }
 
-module.exports = function slackReleasePayload({ releasedVersion, releaseNotes, repoURL }) {
+module.exports = function slackReleasePayload(_pluginConfig, context) {
+  const { nextRelease, options } = context
   const today = new Date().toISOString().slice(0, 10)
-  const releaseUrl = `${repoURL.replace(/\.git$/, "")}/releases/tag/v${releasedVersion}`
-  const features = parseSection(releaseNotes, "Features")
-  const fixes = parseSection(releaseNotes, "Bug Fixes")
+  const repoUrl = options.repositoryUrl.replace(/\.git$/, "")
+  const releaseUrl = `${repoUrl}/releases/tag/${nextRelease.gitTag}`
+  const features = parseSection(nextRelease.notes, "Features")
+  const fixes = parseSection(nextRelease.notes, "Bug Fixes")
 
   const blocks = [
-    { type: "header", text: { type: "plain_text", text: `📦 Nouvelle release — v${releasedVersion}` } },
-    { type: "section", text: { type: "mrkdwn", text: `\`mna-lba\` · v${releasedVersion} · ${today}` } },
+    { type: "header", text: { type: "plain_text", text: `📦 Nouvelle release — ${nextRelease.gitTag}` } },
+    { type: "section", text: { type: "mrkdwn", text: `\`mna-lba\` · ${nextRelease.gitTag} · ${today}` } },
     { type: "divider" },
   ]
 

--- a/release.config.js
+++ b/release.config.js
@@ -17,7 +17,8 @@ module.exports = {
       {
         notifyOnSuccess: true,
         notifyOnFail: true,
-        onSuccessFunction: ".github/scripts/slack-release-payload.cjs",
+        // biome-ignore lint/style/noCommonJs: fonction injectée dans semantic-release-slack-bot
+        onSuccessFunction: require("./.github/scripts/slack-release-payload.cjs"),
       },
     ],
   ],


### PR DESCRIPTION
Suite de #4763 — la signature passée à `onSuccessFunction` était incorrecte.

## Problème

Le plugin appelle `onSuccessFunction(pluginConfig, context)` (confirmé dans `success.js` et la doc du package). Notre fonction utilisait `{ releasedVersion, releaseNotes, repoURL }` → `repoURL` était `undefined`.

## Changement

`.github/scripts/slack-release-payload.cjs` : signature mise à jour pour utiliser `(_pluginConfig, context)` avec `context.nextRelease` et `context.options.repositoryUrl`.