### PR TITLE
feat: génère un fichier llms.txt à la racine du site

### DIFF
--- a/ui/app/llms.txt/route.ts
+++ b/ui/app/llms.txt/route.ts
@@ -1,0 +1,11 @@
+import { generateLlmsTxt } from "@/services/generateLlmsTxt"
+
+export async function GET(request: Request) {
+  const llmsTxt = generateLlmsTxt(request)
+  return new Response(llmsTxt, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  })
+}

--- a/ui/services/generateLlmsTxt.test.ts
+++ b/ui/services/generateLlmsTxt.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/utils/getStaticData", () => ({
+  getStaticMetiers: () => [{ name: "Développeur web", slug: "developpeur-web", romes: ["M1805"] }],
+}))
+
+import { generateLlmsTxt } from "./generateLlmsTxt"
+import { generateMainSitemap } from "./generateMainSitemap"
+
+const host = "labonnealternance.apprentissage.beta.gouv.fr"
+const request = {
+  headers: { get: (name: string) => (name === "host" ? host : null) },
+} as unknown as Request
+
+describe("generateLlmsTxt", () => {
+  const llmsTxt = generateLlmsTxt(request)
+
+  it("commence par le H1 et le blockquote de présentation (spec llmstxt.org)", () => {
+    expect(llmsTxt.startsWith("# La bonne alternance\n")).toBe(true)
+    expect(llmsTxt).toContain("> La bonne alternance est le service public")
+  })
+
+  it("explique que les offres d'emploi sont volontairement exclues", () => {
+    expect(llmsTxt).toContain("/sitemap-offers.xml")
+  })
+
+  it("liste les pages issues de la même source que le sitemap, en URLs absolues", () => {
+    expect(llmsTxt).toContain("## L'alternance par ville")
+    expect(llmsTxt).toContain(`- [Alternance à Bordeaux](https://${host}/alternance/ville/bordeaux):`)
+    expect(llmsTxt).toContain(`- [Développeur web](https://${host}/metiers/developpeur-web):`)
+  })
+
+  it("regroupe les pages légales sous une section ## Optional placée en dernier", () => {
+    expect(llmsTxt).toContain("## Optional")
+    expect(llmsTxt).toContain(`- [Mentions légales](https://${host}/mentions-legales):`)
+    expect(llmsTxt.lastIndexOf("## ")).toBe(llmsTxt.indexOf("## Optional"))
+  })
+})
+
+describe("generateMainSitemap (non-régression)", () => {
+  const sitemap = generateMainSitemap(request)
+
+  it("conserve la home en priorité 1 puis les pages fixes en 0.9", () => {
+    expect(sitemap).toContain(`<loc>https://${host}</loc>\n<priority>1</priority>`)
+    expect(sitemap).toContain(`<loc>https://${host}/a-propos</loc>\n<priority>0.9</priority>`)
+  })
+
+  it("conserve l'ordre d'origine : pages légales (0.9) avant les villes (0.95)", () => {
+    const legalIndex = sitemap.indexOf("/mentions-legales")
+    const villeIndex = sitemap.indexOf("/alternance/ville/bordeaux")
+    expect(legalIndex).toBeGreaterThan(-1)
+    expect(villeIndex).toBeGreaterThan(-1)
+    expect(legalIndex).toBeLessThan(villeIndex)
+  })
+
+  it("conserve les priorités des pages dynamiques (villes 0.95, fiches métiers 0.8)", () => {
+    expect(sitemap).toContain(`<loc>https://${host}/alternance/ville/bordeaux</loc>\n<priority>0.95</priority>`)
+    expect(sitemap).toContain(`<loc>https://${host}/metiers/developpeur-web</loc>\n<priority>0.8</priority>`)
+  })
+})

--- a/ui/services/generateLlmsTxt.ts
+++ b/ui/services/generateLlmsTxt.ts
@@ -1,0 +1,40 @@
+import { getMainSitemapPageGroups } from "@/services/generateMainSitemap"
+import { getHostFromHeader } from "@/utils/requestUtils"
+
+/**
+ * Génère le contenu du fichier /llms.txt (standard llmstxt.org) : un index Markdown destiné aux LLMs.
+ *
+ * Il partage exactement la même source de pages que le sitemap principal (getMainSitemapPageGroups) :
+ * toute page ajoutée au sitemap apparaît donc automatiquement ici. Les offres d'emploi, dynamiques et
+ * volatiles, sont volontairement exclues (cf. /sitemap-offers.xml) pour éviter les liens morts.
+ */
+export function generateLlmsTxt(request: Request) {
+  const host = getHostFromHeader(request)
+  const groups = getMainSitemapPageGroups()
+
+  const renderSection = (title: string, pages: { path: string; label: string; description: string }[]) =>
+    [`## ${title}`, "", ...pages.map((page) => `- [${page.label}](${host}${page.path}): ${page.description}`)].join("\n")
+
+  const mainSections = groups.filter((group) => !group.optional).map((group) => renderSection(group.title, group.pages))
+  const optionalPages = groups.filter((group) => group.optional).flatMap((group) => group.pages)
+
+  const blocks = [
+    "# La bonne alternance",
+    "",
+    "> La bonne alternance est le service public gratuit, opéré par l'État (mission interministérielle pour l'apprentissage, beta.gouv.fr), qui aide les jeunes à trouver une formation en alternance et un employeur (contrat d'apprentissage ou de professionnalisation) et accompagne les entreprises et les CFA dans le recrutement d'alternants.",
+    "",
+    "La bonne alternance met en relation les candidats à l'alternance, les centres de formation (CFA) et les entreprises, partout en France. Le site permet de rechercher des formations en alternance, des offres d'emploi en alternance et des entreprises susceptibles de recruter.",
+    "",
+    `- Site officiel : ${host}`,
+    "- Service public gratuit, sans publicité.",
+    "- Les offres d'emploi en alternance, nombreuses et changeantes, ne sont pas listées dans ce fichier : elles sont accessibles via le moteur de recherche du site et le sitemap dédié (/sitemap-offers.xml).",
+    "",
+    ...mainSections.flatMap((section) => [section, ""]),
+  ]
+
+  if (optionalPages.length > 0) {
+    blocks.push(renderSection("Optional", optionalPages), "")
+  }
+
+  return `${blocks.join("\n").trimEnd()}\n`
+}

--- a/ui/services/generateMainSitemap.ts
+++ b/ui/services/generateMainSitemap.ts
@@ -12,52 +12,192 @@ import { getHostFromHeader } from "@/utils/requestUtils"
 // Attention ! Il faut mettre à jour cette date lorsque le sitemap généré par ce fichier change
 export const mainSitemapLastModificationDate = new Date("2026-05-21T00:00:00.000Z")
 
-export function generateMainSitemap(request: Request) {
+// Une page référencée à la fois dans le sitemap et dans le llms.txt.
+// `label` et `description` ne servent qu'au llms.txt (le sitemap n'utilise que le path).
+export type SitemapPage = {
+  path: string
+  label: string
+  description: string
+}
+
+// Un groupe de pages partageant la même priorité dans le sitemap et une même section dans le llms.txt.
+// `optional: true` => la section est regroupée sous "## Optional" dans le llms.txt (cf. spec llmstxt.org).
+export type SitemapPageGroup = {
+  title: string
+  priority: number
+  optional?: boolean
+  pages: SitemapPage[]
+}
+
+/**
+ * Source de vérité unique des pages "fixes" du site (hors offres d'emploi, qui sont dynamiques
+ * et servies par /sitemap-offers.xml). Cette liste alimente à la fois le sitemap principal et le
+ * llms.txt : ajouter une page ici (ou une entrée dans villeData / metierData / diplomeData /
+ * metiers.txt) la référence automatiquement dans les deux fichiers.
+ *
+ * Attention : l'ordre des groupes définit l'ordre des URLs du sitemap. Ne pas réordonner sans
+ * mettre à jour mainSitemapLastModificationDate.
+ */
+export function getMainSitemapPageGroups(): SitemapPageGroup[] {
   const txtDirectory = path.join(process.cwd(), "config")
   const dataJobs = getStaticMetiers(txtDirectory)
 
-  const host = getHostFromHeader(request)
-
-  const paths = [
-    `/a-propos`,
-    `/contact`,
-    `/developpeurs`,
-    `/faq`,
-    `/guide-alternant`,
-    `/guide-alternant/preparer-son-projet-en-alternance`,
-    `/guide-alternant/se-faire-accompagner`,
-    `/guide-alternant/la-rupture-de-contrat`,
-    `/guide-alternant/comprendre-la-remuneration`,
-    `/guide-alternant/comment-signer-un-contrat-en-alternance`,
-    `/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur`,
-    `/guide-alternant/a-propos-des-formations`,
-    `/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur`,
-    `/guide-alternant/les-aides-financieres-et-materielles`,
-    `/guide-recruteur`,
-    `/guide-recruteur/je-suis-employeur-public`,
-    `/guide-recruteur/cerfa-apprentissage-et-professionnalisation`,
-    `/guide-cfa`,
-    `/guide-cfa/la-carte-etudiant-des-metiers`,
-    `/guide/decouvrir-l-alternance`,
-    `/guide/apprentissage-et-handicap`,
-    `/guide/prevention-des-risques-professionnels-pour-les-apprentis`,
-    `/metiers`,
-    `/mentions-legales`,
-    `/cgu`,
-    `/politique-de-confidentialite`,
+  return [
+    {
+      title: "Le service La bonne alternance",
+      priority: 0.9,
+      pages: [
+        { path: "/a-propos", label: "À propos", description: "Présentation de La bonne alternance, service public gratuit d'aide à l'alternance." },
+        { path: "/contact", label: "Contact", description: "Contacter l'équipe de La bonne alternance." },
+        { path: "/developpeurs", label: "Espace développeurs", description: "API publique et documentation technique pour réutiliser les données de La bonne alternance." },
+        { path: "/faq", label: "Foire aux questions", description: "Réponses aux questions fréquentes des candidats, recruteurs et CFA." },
+      ],
+    },
+    {
+      title: "Guide de l'alternant",
+      priority: 0.9,
+      pages: [
+        { path: "/guide-alternant", label: "Guide de l'alternant", description: "Tout savoir sur l'alternance quand on est candidat ou alternant." },
+        {
+          path: "/guide-alternant/preparer-son-projet-en-alternance",
+          label: "Préparer son projet en alternance",
+          description: "Définir son projet professionnel et sa formation en alternance.",
+        },
+        {
+          path: "/guide-alternant/se-faire-accompagner",
+          label: "Se faire accompagner",
+          description: "Les acteurs et dispositifs pour être accompagné dans sa recherche d'alternance.",
+        },
+        { path: "/guide-alternant/la-rupture-de-contrat", label: "La rupture de contrat", description: "Comprendre les règles de rupture d'un contrat d'alternance." },
+        {
+          path: "/guide-alternant/comprendre-la-remuneration",
+          label: "Comprendre la rémunération",
+          description: "Comment est calculé le salaire d'un alternant selon l'âge et l'année de formation.",
+        },
+        {
+          path: "/guide-alternant/comment-signer-un-contrat-en-alternance",
+          label: "Signer un contrat en alternance",
+          description: "Les étapes pour signer un contrat d'apprentissage ou de professionnalisation.",
+        },
+        {
+          path: "/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur",
+          label: "Rôle du maître d'apprentissage ou tuteur",
+          description: "Les missions du maître d'apprentissage et du tuteur auprès de l'alternant.",
+        },
+        { path: "/guide-alternant/a-propos-des-formations", label: "À propos des formations", description: "Comprendre les formations accessibles en alternance." },
+        {
+          path: "/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur",
+          label: "Conseils pour trouver un employeur",
+          description: "Conseils et astuces pour décrocher un contrat en alternance.",
+        },
+        {
+          path: "/guide-alternant/les-aides-financieres-et-materielles",
+          label: "Les aides financières et matérielles",
+          description: "Les aides financières et matérielles dont peut bénéficier un alternant.",
+        },
+      ],
+    },
+    {
+      title: "Guide du recruteur",
+      priority: 0.9,
+      pages: [
+        { path: "/guide-recruteur", label: "Guide du recruteur", description: "Tout savoir sur le recrutement d'un alternant pour une entreprise." },
+        { path: "/guide-recruteur/je-suis-employeur-public", label: "Je suis employeur public", description: "Recruter un alternant dans la fonction publique." },
+        {
+          path: "/guide-recruteur/cerfa-apprentissage-et-professionnalisation",
+          label: "Cerfa apprentissage et professionnalisation",
+          description: "Les formulaires Cerfa pour les contrats d'apprentissage et de professionnalisation.",
+        },
+      ],
+    },
+    {
+      title: "Guide du CFA",
+      priority: 0.9,
+      pages: [
+        { path: "/guide-cfa", label: "Guide du CFA", description: "Informations destinées aux centres de formation d'apprentis (CFA)." },
+        {
+          path: "/guide-cfa/la-carte-etudiant-des-metiers",
+          label: "La carte étudiant des métiers",
+          description: "Tout savoir sur la carte d'étudiant des métiers pour les apprentis.",
+        },
+      ],
+    },
+    {
+      title: "Comprendre l'alternance",
+      priority: 0.9,
+      pages: [
+        { path: "/guide/decouvrir-l-alternance", label: "Découvrir l'alternance", description: "Comprendre ce qu'est l'alternance (apprentissage et professionnalisation)." },
+        { path: "/guide/apprentissage-et-handicap", label: "Apprentissage et handicap", description: "L'alternance pour les personnes en situation de handicap." },
+        {
+          path: "/guide/prevention-des-risques-professionnels-pour-les-apprentis",
+          label: "Prévention des risques professionnels",
+          description: "La prévention des risques professionnels pour les apprentis.",
+        },
+      ],
+    },
+    {
+      title: "Explorer les métiers",
+      priority: 0.9,
+      pages: [{ path: "/metiers", label: "Tous les métiers en alternance", description: "Liste des fiches métiers accessibles en alternance." }],
+    },
+    {
+      // Pages légales : conservées ici pour que l'ordre du sitemap reste identique. Le llms.txt les
+      // regroupe sous "## Optional" grâce au flag `optional`.
+      title: "Optional",
+      priority: 0.9,
+      optional: true,
+      pages: [
+        { path: "/mentions-legales", label: "Mentions légales", description: "Mentions légales du site La bonne alternance." },
+        { path: "/cgu", label: "Conditions générales d'utilisation", description: "Conditions générales d'utilisation du service." },
+        { path: "/politique-de-confidentialite", label: "Politique de confidentialité", description: "Politique de confidentialité et traitement des données personnelles." },
+      ],
+    },
+    {
+      title: "L'alternance par ville",
+      priority: 0.95,
+      pages: villeData.map((ville) => ({
+        path: `/alternance/ville/${ville.slug}`,
+        label: `Alternance à ${ville.ville}`,
+        description: `Offres d'emploi et formations en alternance à ${ville.ville}.`,
+      })),
+    },
+    {
+      title: "L'alternance par métier",
+      priority: 0.95,
+      pages: metierData.map((metier) => ({
+        path: `/alternance/metier/${metier.slug}`,
+        label: `${metier.metier} en alternance`,
+        description: `${metier.metier} : offres d'emploi et formations en alternance pour ce métier.`,
+      })),
+    },
+    {
+      title: "L'alternance par diplôme",
+      priority: 0.95,
+      pages: diplomeData.map((diplome) => ({
+        path: `/alternance/diplome/${diplome.slug}`,
+        label: `${diplome.titre} en alternance`,
+        description: `${diplome.titre} : formations et offres d'alternance pour préparer ce diplôme.`,
+      })),
+    },
+    {
+      title: "Fiches métiers",
+      priority: 0.8,
+      pages: dataJobs.map((job) => ({
+        path: `/metiers/${job.slug}`,
+        label: job.name,
+        description: `Fiche métier ${job.name} : missions, formations et offres en alternance.`,
+      })),
+    },
   ]
-  const villePaths = villeData.map((ville) => `/alternance/ville/${ville.slug}`)
-  const metierPaths = metierData.map((metier) => `/alternance/metier/${metier.slug}`)
-  const diplomePaths = diplomeData.map((diplome) => `/alternance/diplome/${diplome.slug}`)
-  const jobPaths = dataJobs.map((job) => `/metiers/${job.slug}`)
+}
+
+export function generateMainSitemap(request: Request) {
+  const host = getHostFromHeader(request)
+  const groups = getMainSitemapPageGroups()
 
   const sitemapEntries: SitemapUrlEntry[] = [
     { loc: host, priority: 1 },
-    ...paths.map((path) => ({ loc: host + path, priority: 0.9 })),
-    ...villePaths.map((path) => ({ loc: host + path, priority: 0.95 })),
-    ...metierPaths.map((path) => ({ loc: host + path, priority: 0.95 })),
-    ...diplomePaths.map((path) => ({ loc: host + path, priority: 0.95 })),
-    ...jobPaths.map((path) => ({ loc: host + path, priority: 0.8 })),
+    ...groups.flatMap((group) => group.pages.map((page) => ({ loc: host + page.path, priority: group.priority }))),
   ]
 
   return generateSitemapFromUrlEntries(sitemapEntries)


### PR DESCRIPTION
Closes #4421

## Changements

- Ajoute la route `GET /llms.txt` servant un index Markdown du site au standard [llmstxt.org](https://llmstxt.org) (`text/plain`).
- Refactore `generateMainSitemap.ts` : la liste des pages fixes devient une **source de vérité unique** (`getMainSitemapPageGroups()`) partagée entre le sitemap principal et le `llms.txt`. Toute page ajoutée au sitemap apparaît donc automatiquement dans le `llms.txt`.
- Le `llms.txt` comprend un H1, un blockquote de présentation du service, les sections par groupe de pages (villes, métiers, diplômes, guides, fiches métiers) et les pages légales regroupées sous `## Optional`.
- Les offres d'emploi (dynamiques et volatiles) sont volontairement exclues pour éviter les liens morts — elles restent servies par `/sitemap-offers.xml`.

## Plan de test

- [ ] `yarn vitest run ui/services/generateLlmsTxt.test.ts` passe (7 tests : structure llms.txt + non-régression sitemap).
- [ ] Ouvrir `/llms.txt` en local et vérifier le rendu Markdown (URLs absolues, section `## Optional` en dernier).
- [ ] Vérifier que `/sitemap.xml` est inchangé (ordre et priorités des URLs identiques).