### PR TITLE
feat: supprimer le champ establishment_id de jobs_partners

### DIFF
--- a/server/src/http/controllers/etablissementRecruteur.controller.ts
+++ b/server/src/http/controllers/etablissementRecruteur.controller.ts
@@ -202,7 +202,7 @@ export default (server: Server) => {
     },
     async (req, res) => {
       const { cfaId: cfaIdString, establishment_id } = req.params
-      const { siret, userId } = await establishmentIdToUserIdAndSiret(establishment_id)
+      const { siret, userId } = establishmentIdToUserIdAndSiret(establishment_id)
 
       const cfaId = new ObjectId(cfaIdString)
 

--- a/server/src/http/controllers/formulaire.controller.ts
+++ b/server/src/http/controllers/formulaire.controller.ts
@@ -168,7 +168,7 @@ export default (server: Server) => {
       const { establishment_id } = req.params
       const user = getUserFromRequest(req, zRoutes.post["/formulaire/:establishment_id/offre"]).value
 
-      const { siret } = await establishmentIdToUserIdAndSiret(establishment_id)
+      const { siret } = establishmentIdToUserIdAndSiret(establishment_id)
       const {
         job_type,
         delegations,
@@ -229,7 +229,7 @@ export default (server: Server) => {
         throw internal(`inattendu : impossible de récupérer l'utilisateur de type token ayant pour email=${email}`)
       }
 
-      const { siret } = await establishmentIdToUserIdAndSiret(establishment_id)
+      const { siret } = establishmentIdToUserIdAndSiret(establishment_id)
       const {
         job_type,
         delegations,

--- a/server/src/jobs/partenaireExport/exportJobsToS3.ts
+++ b/server/src/jobs/partenaireExport/exportJobsToS3.ts
@@ -76,7 +76,6 @@ async function exportLbaJobsToS3() {
       first_name: 0,
       last_name: 0,
       is_disabled_elligible: 0,
-      establishment_id: 0,
       origin: 0,
       recruiterStatus: 0,
       job_delegation_count: 0,

--- a/server/src/migrations/20260304120000-suppression-recruiters.ts
+++ b/server/src/migrations/20260304120000-suppression-recruiters.ts
@@ -10,10 +10,7 @@ import { groupStreamData } from "@/common/utils/streamUtils"
 
 const BULK_GROUP_SIZE = 1000
 
-type RecruiterJobUpdate = Pick<
-  IJobsPartnersOfferPrivate,
-  "_id" | "establishment_id" | "relance_mail_expiration_J7" | "relance_mail_expiration_J1" | "offer_rome_appellation" | "mer_sent"
-> & {
+type RecruiterJobUpdate = Pick<IJobsPartnersOfferPrivate, "_id" | "relance_mail_expiration_J7" | "relance_mail_expiration_J1" | "offer_rome_appellation" | "mer_sent"> & {
   managed_by?: string
 }
 
@@ -30,7 +27,6 @@ export const up = async () => {
           $project: {
             _id: "$jobs._id",
             managed_by: "$managed_by",
-            establishment_id: 1,
             relance_mail_expiration_J7: "$jobs.relance_mail_expiration_J7",
             relance_mail_expiration_J1: "$jobs.relance_mail_expiration_J1",
             offer_rome_appellation: "$jobs.rome_appellation_label",
@@ -53,7 +49,7 @@ export const up = async () => {
       counters.total += documents.length
 
       const operations: AnyBulkWriteOperation<IJobsPartnersOfferPrivate>[] = documents.map(
-        ({ _id, managed_by, relance_mail_expiration_J1, relance_mail_expiration_J7, mer_sent, establishment_id, offer_rome_appellation }) => {
+        ({ _id, managed_by, relance_mail_expiration_J1, relance_mail_expiration_J7, mer_sent, offer_rome_appellation }) => {
           if (!managed_by || !ObjectId.isValid(managed_by)) {
             logger.warn(`[migration:20260304120000-suppression-recruiters] document id=${_id} managed_by is not an ObjectId`)
           }
@@ -63,7 +59,6 @@ export const up = async () => {
               update: {
                 $set: {
                   managed_by: managed_by && ObjectId.isValid(managed_by) ? new ObjectId(managed_by) : null,
-                  establishment_id,
                   relance_mail_expiration_J7,
                   relance_mail_expiration_J1,
                   offer_rome_appellation,

--- a/server/src/migrations/20260603120000-remove-establishment-id-from-jobs-partners.ts
+++ b/server/src/migrations/20260603120000-remove-establishment-id-from-jobs-partners.ts
@@ -6,7 +6,6 @@ export const up = async () => {
   await getDbCollection("jobs_partners").updateMany({ establishment_id: { $exists: true } }, { $unset: { establishment_id: "" } })
   logger.info("establishment_id field removed from jobs_partners collection")
 }
-}
 
 // set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
 export const requireShutdown: boolean = false

--- a/server/src/migrations/20260603120000-remove-establishment-id-from-jobs-partners.ts
+++ b/server/src/migrations/20260603120000-remove-establishment-id-from-jobs-partners.ts
@@ -3,8 +3,9 @@ import { getDbCollection } from "@/common/utils/mongodbUtils"
 
 export const up = async () => {
   logger.info("Removing establishment_id field from jobs_partners collection")
-  await getDbCollection("jobs_partners").updateMany({}, { $unset: { establishment_id: "" } })
+  await getDbCollection("jobs_partners").updateMany({ establishment_id: { $exists: true } }, { $unset: { establishment_id: "" } })
   logger.info("establishment_id field removed from jobs_partners collection")
+}
 }
 
 // set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)

--- a/server/src/migrations/20260603120000-remove-establishment-id-from-jobs-partners.ts
+++ b/server/src/migrations/20260603120000-remove-establishment-id-from-jobs-partners.ts
@@ -1,0 +1,11 @@
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+
+export const up = async () => {
+  logger.info("Removing establishment_id field from jobs_partners collection")
+  await getDbCollection("jobs_partners").updateMany({}, { $unset: { establishment_id: "" } })
+  logger.info("establishment_id field removed from jobs_partners collection")
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/server/src/security/authorisationService.ts
+++ b/server/src/security/authorisationService.ts
@@ -123,7 +123,7 @@ async function getJobsResource<S extends WithSecurityScheme>(schema: S, req: IRe
           return result ? [result] : null
         } else if ("establishment_id" in jobDef) {
           const establishmentIdValue = getAccessResourcePathValue(jobDef.establishment_id, req)
-          const { siret } = await establishmentIdToUserIdAndSiret(establishmentIdValue)
+          const { siret } = establishmentIdToUserIdAndSiret(establishmentIdValue)
           const userWithType = getUserFromRequest(req, schema)
           if (userWithType.type !== "IUser2") {
             return []

--- a/server/src/services/__snapshots__/formulaire.service.test.ts.snap
+++ b/server/src/services/__snapshots__/formulaire.service.test.ts.snap
@@ -20,7 +20,6 @@ exports[`createJob > should insert a job 1`] = `
   ],
   "delegations": undefined,
   "duplicates": [],
-  "establishment_id": "670ce1ded6ce30c3c90a0e1d_42476141900045",
   "is_delegated": false,
   "job_delegation_count": 0,
   "job_last_prolongation_date": null,

--- a/server/src/services/etablissement.service.ts
+++ b/server/src/services/etablissement.service.ts
@@ -703,21 +703,7 @@ export function buildEstablishmentId(userId: ObjectId, siret: string) {
   return `${userId}_${siret}`
 }
 
-export async function establishmentIdToUserIdAndSiret(establishment_id: string): Promise<{ userId: ObjectId; siret: string }> {
-  if (establishment_id.includes("_")) {
-    const [userId, siret] = establishment_id.split("_")
-    return { userId: new ObjectId(userId), siret }
-  }
-  const offer = await getDbCollection("jobs_partners").findOne({ establishment_id })
-  if (offer) {
-    const { managed_by, workplace_siret } = offer
-    if (!managed_by) {
-      throw new Error(`managed_by vide pour l offre id=${offer._id}`)
-    }
-    if (!workplace_siret) {
-      throw new Error(`workplace_siret vide pour l offre id=${offer._id}`)
-    }
-    return { userId: managed_by, siret: workplace_siret }
-  }
-  throw new Error(`could not find user and siret from establishment_id=${establishment_id}`)
+export function establishmentIdToUserIdAndSiret(establishment_id: string): { userId: ObjectId; siret: string } {
+  const [userId, siret] = establishment_id.split("_")
+  return { userId: new ObjectId(userId), siret }
 }

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -1209,7 +1209,6 @@ async function jobCreateToJobsPartner({
     applicationCount: 0,
     duplicates: [],
     apply_recipient_id: newId.toString(),
-    establishment_id: buildEstablishmentId(user._id, entreprise.siret),
     to_applicant_questions: job.to_applicant_questions,
   }
   return jobPartner

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -360,7 +360,7 @@ export const getJobWithRomeDetail = async (id: string): Promise<IJobWithRomeDeta
 }
 
 export const getFormulaireWithRomeDetail = async ({ establishment_id }: { establishment_id: string }): Promise<IRecruiter | null> => {
-  const { userId, siret } = await establishmentIdToUserIdAndSiret(establishment_id)
+  const { userId, siret } = establishmentIdToUserIdAndSiret(establishment_id)
   const recruiter = await getRecruiterFromJobsPartnerFilter({ userId, siret, addApplicationCounts: false })
   recruiter?.jobs.forEach((job) => {
     // @ts-expect-error
@@ -376,7 +376,7 @@ export const getFormulaireWithRomeDetailAndApplicationCount = async ({
 }: {
   establishment_id: string
 }): Promise<IRecruiterWithRomeDetailAndApplicationCount | null> => {
-  const { userId, siret } = await establishmentIdToUserIdAndSiret(establishment_id)
+  const { userId, siret } = establishmentIdToUserIdAndSiret(establishment_id)
   return getRecruiterFromJobsPartnerFilter({ userId, siret, addApplicationCounts: true })
 }
 
@@ -521,7 +521,7 @@ const getRecruiterFromJobsPartnerFilter = async ({
  * @description Archive existing formulaire and cancel all its job offers
  */
 export const archiveFormulaireByEstablishmentId = async (id: string) => {
-  const { userId, siret } = await establishmentIdToUserIdAndSiret(id)
+  const { userId, siret } = establishmentIdToUserIdAndSiret(id)
   await archiveFormulaire(userId, siret)
 }
 
@@ -943,7 +943,7 @@ export const updateCfaManagedRecruiter = async (user: IUserWithAccount, establis
     throw new Error(`inattendu: mainRole doit être de type CFA pour le user id=${user._id}`)
   }
   const cfaId = new ObjectId(mainRole.authorized_id)
-  const { siret } = await establishmentIdToUserIdAndSiret(establishment_id)
+  const { siret } = establishmentIdToUserIdAndSiret(establishment_id)
   const entreprise = await getDbCollection("entreprises").findOne({ siret })
   if (!entreprise) {
     throw new Error(`inattendu: entreprise non trouvée pour l'establishment_id=${establishment_id}`)

--- a/shared/src/models/jobsPartners.model.ts
+++ b/shared/src/models/jobsPartners.model.ts
@@ -187,7 +187,6 @@ const ZJobsPartnersRecruiterPrivateFields = z.object({
   updated_at: z.date().describe("Date de mise à jour de l'offre"),
 
   managed_by: zObjectId.nullish().describe("Id du userwithaccount si l'offre est une offre géré par LBA"),
-  establishment_id: z.string().nullish().describe("ancien recruiter.etablishment_id si l'offre est une offre géré par LBA"),
   relance_mail_expiration_J7: z.date().nullish().describe("Date de l'envoi du mail de relance avant expiration à J-7"),
   relance_mail_expiration_J1: z.date().nullish().describe("Date de l'envoi du mail de relance avant expiration à J-1"),
   job_last_prolongation_date: z.date().nullish().describe("Date de dernière prolongation de l'offre"),
@@ -327,7 +326,6 @@ export default {
     [{ "duplicates.partner_job_label": 1 }, {}],
 
     [{ managed_by: 1 }, {}],
-    [{ establishment_id: 1 }, {}],
     [{ relance_mail_expiration_J7: 1 }, {}],
     [{ relance_mail_expiration_J1: 1 }, {}],
     [{ offer_rome_appellation: 1 }, {}],


### PR DESCRIPTION
Closes #4276

## Changements

- Suppression de la branche DB morte dans `establishmentIdToUserIdAndSiret` : tous les appelants passent un `userId_siret`, la requête `jobs_partners.findOne({ establishment_id })` n'était jamais atteinte
- La fonction est rendue synchrone (suppression de l'`async` et de tous les `await` associés)
- Suppression du champ `establishment_id` du modèle Zod `ZJobsPartnersRecruiterPrivateFields` et de l'index correspondant
- Ajout d'une migration `$unset` sur la collection `jobs_partners`
- Suppression de la projection d'exclusion `establishment_id: 0` dans `exportJobsToS3`

## Plan de test

- [ ] Vérifier que les tests `formulaire.controller.test.ts` passent
- [ ] Vérifier que la migration s'exécute sans erreur sur un environnement de recette
- [ ] Vérifier que la création/modification d'offre fonctionne toujours via l'espace pro entreprise