### PR TITLE
feat: scroll et focus sur le premier champ en erreur à la soumission du formulaire de candidature

### DIFF
--- a/ui/components/ItemDetail/CandidatureLba/CandidatureLbaFileDropzone.tsx
+++ b/ui/components/ItemDetail/CandidatureLba/CandidatureLbaFileDropzone.tsx
@@ -93,6 +93,7 @@ export const CandidatureLbaFileDropzone = ({ setFileValue, formik }) => {
 
   return (
     <Box
+      id="applicant_attachment_name"
       sx={{
         border: isDragActive ? "1px dashed" : "1px solid",
         borderColor: isDragActive ? "grey.600" : "transparent",

--- a/ui/components/ItemDetail/CandidatureLba/CandidatureLbaModalBody.tsx
+++ b/ui/components/ItemDetail/CandidatureLba/CandidatureLbaModalBody.tsx
@@ -76,7 +76,7 @@ export const CandidatureLbaModalBody = ({
   const isOffre =
     kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA || kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES || kind === LBA_ITEM_TYPE_OLD.MATCHA || kind === LBA_ITEM_TYPE_OLD.PARTNER_JOB
 
-  const handleSubmitWithScroll = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmitWithScrollOnFirstError = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const errors = await formik.validateForm()
     await formik.setTouched(Object.fromEntries(Object.keys(errors).map((k) => [k, true])))
@@ -102,7 +102,7 @@ export const CandidatureLbaModalBody = ({
         },
       }}
     >
-      <form onSubmit={handleSubmitWithScroll} style={{ position: "relative" }}>
+      <form onSubmit={handleSubmitWithScrollOnFirstError} style={{ position: "relative" }}>
         <Box sx={{ margin: { xs: fr.spacing("4v"), md: fr.spacing("6v") }, mb: 0 }}>
           {!fromWidget && (
             <>

--- a/ui/components/ItemDetail/CandidatureLba/CandidatureLbaModalBody.tsx
+++ b/ui/components/ItemDetail/CandidatureLba/CandidatureLbaModalBody.tsx
@@ -79,9 +79,9 @@ export const CandidatureLbaModalBody = ({
   const handleSubmitWithScrollOnFirstError = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const errors = await formik.validateForm()
-    await formik.setTouched(Object.fromEntries(Object.keys(errors).map((k) => [k, true])))
 
     if (Object.keys(errors).length > 0) {
+      await formik.setTouched(Object.fromEntries(Object.keys(errors).map((k) => [k, true])))
       const errorElements = Object.keys(errors)
         .map((field) => document.getElementById(field) ?? document.querySelector<HTMLElement>(`[name="${field}"]`))
         .filter(Boolean) as HTMLElement[]

--- a/ui/components/ItemDetail/CandidatureLba/CandidatureLbaModalBody.tsx
+++ b/ui/components/ItemDetail/CandidatureLba/CandidatureLbaModalBody.tsx
@@ -76,6 +76,24 @@ export const CandidatureLbaModalBody = ({
   const isOffre =
     kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA || kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES || kind === LBA_ITEM_TYPE_OLD.MATCHA || kind === LBA_ITEM_TYPE_OLD.PARTNER_JOB
 
+  const handleSubmitWithScroll = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const errors = await formik.validateForm()
+    await formik.setTouched(Object.fromEntries(Object.keys(errors).map((k) => [k, true])))
+
+    if (Object.keys(errors).length > 0) {
+      const errorElements = Object.keys(errors)
+        .map((field) => document.getElementById(field) ?? document.querySelector<HTMLElement>(`[name="${field}"]`))
+        .filter(Boolean) as HTMLElement[]
+      const firstEl = errorElements.sort((a, b) => (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1))[0]
+      firstEl?.scrollIntoView({ behavior: "smooth", block: "center" })
+      firstEl?.focus()
+      return
+    }
+
+    formik.submitForm()
+  }
+
   return (
     <Box
       sx={{
@@ -84,7 +102,7 @@ export const CandidatureLbaModalBody = ({
         },
       }}
     >
-      <form onSubmit={formik.handleSubmit} style={{ position: "relative" }}>
+      <form onSubmit={handleSubmitWithScroll} style={{ position: "relative" }}>
         <Box sx={{ margin: { xs: fr.spacing("4v"), md: fr.spacing("6v") }, mb: 0 }}>
           {!fromWidget && (
             <>


### PR DESCRIPTION
Closes #4361

## Changements

- Au clic sur le bouton de soumission, si le formulaire contient des erreurs, scroll automatique et focus sur le premier champ en erreur dans l'ordre du DOM
- Utilise `compareDocumentPosition` pour déterminer l'ordre des champs sans tableau statique à maintenir
- Tous les champs en erreur sont marqués comme `touched` pour afficher leurs messages d'erreur

## Plan de test

- [ ] Remplir le formulaire de candidature en laissant des champs obligatoires vides
- [ ] Cliquer sur "J'envoie ma candidature" → vérifier que le scroll se fait sur le premier champ en erreur
- [ ] Vérifier que le champ reçoit le focus
- [ ] Vérifier que tous les messages d'erreur s'affichent