### PR TITLE
fix: classification cfa: suppression du passage de l id

### DIFF
--- a/server/src/common/apis/classification/classification.client.test.ts
+++ b/server/src/common/apis/classification/classification.client.test.ts
@@ -28,7 +28,7 @@ describe("getLabClassification - get batch classification", () => {
     offer_description: jobFixture.offer_description,
   }
   const apiPayload = {
-    id: jobFixture.partner_job_id,
+    id: "0",
     workplace_name: jobFixture.workplace_name ?? undefined,
     workplace_description: jobFixture.workplace_description ?? undefined,
     offer_title: jobFixture.offer_title ?? undefined,
@@ -36,7 +36,7 @@ describe("getLabClassification - get batch classification", () => {
   }
   const apiResponse: IClassificationLabBatchResponse = [
     {
-      id: jobFixture.partner_job_id,
+      id: "0",
       label: "unpublish",
       model: "model",
       scores: { publish: 0.4, unpublish: 0.5 },
@@ -79,19 +79,65 @@ describe("getLabClassification - get batch classification", () => {
 
     // The uncached job triggers the API call — only it is sent to the API
     const uncachedApiPayload = {
-      id: jobFixture.partner_job_id,
+      id: "1",
       workplace_name: jobFixture.workplace_name ?? undefined,
       workplace_description: jobFixture.workplace_description ?? undefined,
       offer_title: jobFixture.offer_title ?? undefined,
       offer_description: jobFixture.offer_description ?? undefined,
     }
-    nockLabClassification([uncachedApiPayload], apiResponse)
+    nockLabClassification([uncachedApiPayload], [{ ...apiResponse[0], id: "1" }])
 
     const result = await getClassificationFromLab([cachedPayload, payload])
     // cachedJob should return human_verification ("unpublish"), not classification ("publish")
     expect(result[0]).toBe("unpublish")
     // uncached job should return the API result
     expect(result[1]).toBe(apiResponse[0].label)
+  })
+
+  it("should map results by index when two jobs share the same partner identifiers", async () => {
+    const duplicatedPartnerJobId = `duplicate-${jobFixture.partner_job_id}`
+    const duplicatedPartnerLabel = `duplicate-${jobFixture.partner_label}`
+    const duplicatedPayloads: TJobClassification[] = [
+      {
+        ...payload,
+        partner_job_id: duplicatedPartnerJobId,
+        partner_label: duplicatedPartnerLabel,
+        offer_title: "First duplicated job",
+      },
+      {
+        ...payload,
+        partner_job_id: duplicatedPartnerJobId,
+        partner_label: duplicatedPartnerLabel,
+        offer_title: "Second duplicated job",
+      },
+    ]
+
+    nockLabClassification(
+      [
+        {
+          id: "0",
+          workplace_name: duplicatedPayloads[0].workplace_name ?? undefined,
+          workplace_description: duplicatedPayloads[0].workplace_description ?? undefined,
+          offer_title: duplicatedPayloads[0].offer_title ?? undefined,
+          offer_description: duplicatedPayloads[0].offer_description ?? undefined,
+        },
+        {
+          id: "1",
+          workplace_name: duplicatedPayloads[1].workplace_name ?? undefined,
+          workplace_description: duplicatedPayloads[1].workplace_description ?? undefined,
+          offer_title: duplicatedPayloads[1].offer_title ?? undefined,
+          offer_description: duplicatedPayloads[1].offer_description ?? undefined,
+        },
+      ],
+      [
+        { id: "0", label: "publish", model: "model", scores: { publish: 0.9, unpublish: 0.1 } },
+        { id: "1", label: "unpublish", model: "model", scores: { publish: 0.1, unpublish: 0.9 } },
+      ]
+    )
+
+    const result = await getClassificationFromLab(duplicatedPayloads)
+
+    expect(result).toEqual(["publish", "unpublish"])
   })
 
   it("should store model and created_at in cache when saving classification", async () => {

--- a/server/src/jobs/offrePartenaire/detectClassificationJobsPartners.test.ts
+++ b/server/src/jobs/offrePartenaire/detectClassificationJobsPartners.test.ts
@@ -125,7 +125,7 @@ describe("detectClassificationJobsPartners", () => {
     nock.cleanAll()
     const unpublishResponse: IClassificationLabBatchResponse = [
       {
-        id: partner_job_id,
+        id: "0",
         label: "unpublish",
         model: "model",
         scores: { publish: 0.3, unpublish: 0.7 },

--- a/server/src/services/cacheClassification.service.ts
+++ b/server/src/services/cacheClassification.service.ts
@@ -72,8 +72,6 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
     await getDbCollection("cache_classification").insertMany(payloads)
   }
 
-  const newClassificationsByIndex = new Map(zippedJobsNotFound.map(({ index, classificationResult }) => [index, classificationResult.label]))
-
   // Return results in the same order as input jobs
   return jobs.map((_job, index) => {
     const cached = cachedClassifications[index]
@@ -81,6 +79,6 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
       return cached.human_verification ? cached.human_verification : cached.classification
     }
 
-    return newClassificationsByIndex.get(index) ?? null
+    return classificationsById.get(index.toString())?.label ?? null
   })
 }

--- a/server/src/services/cacheClassification.service.ts
+++ b/server/src/services/cacheClassification.service.ts
@@ -22,15 +22,19 @@ const getClassificationFromDB = async (jobs: TJobClassification[]): Promise<(ICl
 
 export const getClassificationFromLab = async (jobs: TJobClassification[]): Promise<(string | null)[]> => {
   const cachedClassifications = await getClassificationFromDB(jobs)
-  const notFoundJobs = jobs.filter((_job, index) => {
-    return cachedClassifications[index] === null
+  const notFoundJobs = jobs.flatMap((job, index) => {
+    if (cachedClassifications[index] !== null) {
+      return []
+    }
+
+    return [{ job, index }]
   })
 
   if (!notFoundJobs.length) {
     return cachedClassifications.map((cached) => (cached?.human_verification ? cached.human_verification : (cached?.classification ?? null)))
   }
 
-  const classificationPayload = notFoundJobs.map((job, index) => ({
+  const classificationPayload = notFoundJobs.map(({ job, index }) => ({
     id: index.toString(),
     workplace_name: job.workplace_name,
     workplace_description: job.workplace_description,
@@ -39,14 +43,16 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
   }))
 
   const classificationsFromLab = await getLabClassificationBatch(classificationPayload)
+  const classificationsById = new Map(classificationsFromLab.map((result) => [result.id, result]))
 
   const now = new Date()
-  const zippedJobsNotFound = notFoundJobs.flatMap((job, index) => {
-    const result = classificationsFromLab.find((result) => result.id === index.toString())
+  const zippedJobsNotFound = notFoundJobs.flatMap(({ job, index }) => {
+    const result = classificationsById.get(index.toString())
     if (!result) return []
 
     return [
       {
+        index,
         dbClassification: {
           _id: new ObjectId(),
           partner_label: job.partner_label,
@@ -66,13 +72,15 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
     await getDbCollection("cache_classification").insertMany(payloads)
   }
 
+  const newClassificationsByIndex = new Map(zippedJobsNotFound.map(({ index, classificationResult }) => [index, classificationResult.label]))
+
   // Return results in the same order as input jobs
-  return jobs.map((job, index) => {
+  return jobs.map((_job, index) => {
     const cached = cachedClassifications[index]
     if (cached) {
       return cached.human_verification ? cached.human_verification : cached.classification
     }
-    const found = zippedJobsNotFound.find(({ dbClassification }) => dbClassification.partner_job_id === job.partner_job_id && dbClassification.partner_label === job.partner_label)
-    return found?.classificationResult.label ?? null
+
+    return newClassificationsByIndex.get(index) ?? null
   })
 }

--- a/server/src/services/cacheClassification.service.ts
+++ b/server/src/services/cacheClassification.service.ts
@@ -21,21 +21,17 @@ const getClassificationFromDB = async (jobs: TJobClassification[]): Promise<(ICl
 }
 
 export const getClassificationFromLab = async (jobs: TJobClassification[]): Promise<(string | null)[]> => {
-  const now = new Date()
   const cachedClassifications = await getClassificationFromDB(jobs)
-  const notFoundJobs = jobs.flatMap((job, index) => {
-    if (cachedClassifications[index] !== null) {
-      return []
-    }
-    return [{ ...job, originalIndex: index }]
+  const notFoundJobs = jobs.filter((_job, index) => {
+    return cachedClassifications[index] === null
   })
 
   if (!notFoundJobs.length) {
     return cachedClassifications.map((cached) => (cached?.human_verification ? cached.human_verification : (cached?.classification ?? null)))
   }
 
-  const classificationPayload = notFoundJobs.map((job) => ({
-    id: job.partner_job_id,
+  const classificationPayload = notFoundJobs.map((job, index) => ({
+    id: index.toString(),
     workplace_name: job.workplace_name,
     workplace_description: job.workplace_description,
     offer_title: job.offer_title,
@@ -44,22 +40,14 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
 
   const classificationsFromLab = await getLabClassificationBatch(classificationPayload)
 
-  // Create a map from job ID to classification result for safe lookup
-  const classificationMap = new Map<string, { label: string; scores: any; model: string }>()
-  if (classificationsFromLab && classificationsFromLab.length) {
-    classificationsFromLab.forEach((result) => {
-      if (result?.label && result?.id) {
-        classificationMap.set(result.id, { label: result.label, scores: result.scores, model: result.model })
-      }
-    })
+  const now = new Date()
+  const zippedJobsNotFound = notFoundJobs.flatMap((job, index) => {
+    const result = classificationsFromLab.find((result) => result.id === index.toString())
+    if (!result) return []
 
-    // Save to database using the map for safe lookups
-    const payloads = notFoundJobs
-      .map((job) => {
-        const result = classificationMap.get(job.partner_job_id)
-        if (!result) return null
-
-        return {
+    return [
+      {
+        dbClassification: {
           _id: new ObjectId(),
           partner_label: job.partner_label,
           partner_job_id: job.partner_job_id,
@@ -67,22 +55,24 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
           scores: result.scores,
           model: result.model,
           created_at: now,
-        }
-      })
-      .filter((payload): payload is NonNullable<typeof payload> => payload !== null)
+        },
+        classificationResult: result,
+      },
+    ]
+  })
 
-    if (payloads.length > 0) {
-      await getDbCollection("cache_classification").insertMany(payloads)
-    }
+  if (zippedJobsNotFound.length) {
+    const payloads = zippedJobsNotFound.map(({ dbClassification }) => dbClassification)
+    await getDbCollection("cache_classification").insertMany(payloads)
   }
 
   // Return results in the same order as input jobs
   return jobs.map((job, index) => {
     const cached = cachedClassifications[index]
-    if (cached) return cached.human_verification ? cached.human_verification : cached.classification
-
-    // Use the map for safe lookup
-    const result = classificationMap.get(job.partner_job_id)
-    return result?.label ?? null
+    if (cached) {
+      return cached.human_verification ? cached.human_verification : cached.classification
+    }
+    const found = zippedJobsNotFound.find(({ dbClassification }) => dbClassification.partner_job_id === job.partner_job_id && dbClassification.partner_label === job.partner_label)
+    return found?.classificationResult.label ?? null
   })
 }


### PR DESCRIPTION
Closes https://github.com/mission-apprentissage/labonnealternance/issues/4786

## Changes

- Updated [server/src/services/cacheClassification.service.ts](server/src/services/cacheClassification.service.ts) to stop sending partner job IDs to LAB in the request payload.
- Replaced payload IDs with local sequential string IDs (`index.toString()`) for each non-cached job.
- Simplified non-cached job selection by filtering on missing cache entries.
- Reworked LAB response matching logic:
  - Removed the `classificationMap` keyed by `partner_job_id`.
  - Added a zip-like reconstruction (`zippedJobsNotFound`) by matching LAB response IDs to local indexes.
- Kept cache insert behavior, now built from reconstructed matched pairs before `insertMany`.
- Preserved output ordering and fallback logic:
  - Return cached `human_verification` first, then cached `classification`.
  - For newly fetched items, return the matched LAB `label`.
  - Return `null` when no match is found.

## Why

- Ensures external LAB requests no longer expose partner job identifiers.
- Keeps deterministic mapping between request items and responses without relying on business IDs.

## Impact

- No functional change expected for classification results ordering.
- Reduced coupling between LAB response matching and partner job identifiers.