### PR TITLE
fix: standardisation des titres

### DIFF
--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep1.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep1.tsx
@@ -14,6 +14,7 @@ import * as Yup from "yup"
 import { InfosDiffusionOffre } from "@/components/DepotOffre/InfosDiffusionOffre"
 import type { RomeCompetenceKey } from "@/components/DepotOffre/RomeDetail"
 import { RomeDetailWithQuery } from "@/components/DepotOffre/RomeDetailWithQuery"
+import { LbaTitle } from "@/components/dsfr/LbaTitle"
 import { getRomeDetail } from "@/utils/api"
 import { FormulaireEditionOffreButtons } from "./FormulaireEditionOffreButtons"
 import { FormulaireEditionOffreFields } from "./FormulaireEditionOffreFields"
@@ -179,28 +180,20 @@ export const FormulaireEditionOffreStep1 = ({
       >
         {({ values }) => (
           <div>
-            <Typography
-              component="h1"
-              sx={(theme) => ({
-                fontWeight: 700,
+            <LbaTitle
+              component="p"
+              sx={{
                 color: "#000091",
                 mb: fr.spacing("6v"),
-                [theme.breakpoints.up("xs")]: {
-                  fontSize: "18px !important",
-                  lineHeight: "24px !important",
-                },
-                [theme.breakpoints.up("md")]: {
-                  fontSize: "20px !important",
-                  lineHeight: "28px !important",
-                },
-              })}
+                fontSize: { xs: "18px !important", md: "20px !important" },
+                lineHeight: { xs: "24px !important", md: "28px !important" },
+                fontWeight: 700,
+              }}
             >
               Étape 1/2 : Description de l’offre
-            </Typography>
-            <Typography component="h2" sx={{ fontWeight: 700 }}>
-              Votre offre
-            </Typography>
-            <Typography component="h6" sx={{ fontSize: "0.875rem", my: fr.spacing("4v"), color: fr.colors.decisions.text.default.grey.default }}>
+            </LbaTitle>
+            <LbaTitle component="h1">Votre offre</LbaTitle>
+            <Typography sx={{ fontSize: "0.875rem", my: fr.spacing("4v"), color: fr.colors.decisions.text.default.grey.default }}>
               Tous les champs sont obligatoires, sauf mention contraire "Facultatif".
             </Typography>
             <Box
@@ -237,14 +230,14 @@ export const FormulaireEditionOffreStep1 = ({
 
               {/* Colonne droite : présentation + description de l'offre + Rome/InfosDiffusion */}
               <Box>
-                <Typography variant="h4" sx={{ color: fr.colors.decisions.artwork.major.blueFrance.default }}>
+                <Typography component="h3" sx={{ color: fr.colors.decisions.artwork.major.blueFrance.default }}>
                   La présentation de l'entreprise
                 </Typography>
                 <Box sx={{ mt: fr.spacing("4v") }}>
                   <EmployerDescriptionField />
                 </Box>
 
-                <Typography variant="h4" sx={{ color: fr.colors.decisions.artwork.major.blueFrance.default, mt: fr.spacing("8v") }}>
+                <Typography component="h3" sx={{ color: fr.colors.decisions.artwork.major.blueFrance.default, mt: fr.spacing("8v") }}>
                   La description de l'offre
                 </Typography>
                 <Box sx={{ mt: fr.spacing("4v") }}>

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep2.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep2.tsx
@@ -8,6 +8,7 @@ import { Formik, useField, useFormikContext } from "formik"
 import { type IJob, ZJobFields } from "shared"
 import type z from "zod"
 import { toFormikValidationSchema } from "zod-formik-adapter"
+import { LbaTitle } from "@/components/dsfr/LbaTitle"
 
 const questions = [
   "Pourquoi souhaitez-vous rejoindre notre entreprise ?",
@@ -38,41 +39,21 @@ export const FormulaireEditionOffreStep2 = ({ offre, onSubmit, onCancel }: { off
     >
       {({ values }) => (
         <>
-          <Typography
-            component="h1"
-            sx={(theme) => ({
-              fontWeight: 700,
+          <LbaTitle
+            component="p"
+            sx={{
               color: "#000091",
               mb: fr.spacing("6v"),
-              [theme.breakpoints.up("xs")]: {
-                fontSize: "18px !important",
-                lineHeight: "24px !important",
-              },
-              [theme.breakpoints.up("md")]: {
-                fontSize: "20px !important",
-                lineHeight: "28px !important",
-              },
-            })}
+              fontSize: { xs: "18px !important", md: "20px !important" },
+              lineHeight: { xs: "24px !important", md: "28px !important" },
+              fontWeight: 700,
+            }}
           >
             Étape 2/2 : Questions pour les candidats
-          </Typography>
-          <Typography
-            component="h2"
-            sx={(theme) => ({
-              fontWeight: 700,
-              mb: fr.spacing("6v"),
-              [theme.breakpoints.up("xs")]: {
-                fontSize: "22px !important",
-                lineHeight: "28px !important",
-              },
-              [theme.breakpoints.up("md")]: {
-                fontSize: "32px !important",
-                lineHeight: "40px !important",
-              },
-            })}
-          >
+          </LbaTitle>
+          <LbaTitle component="h1" sx={{ mb: fr.spacing("6v") }}>
             Vos questions pour les candidats (Facultatif)
-          </Typography>
+          </LbaTitle>
           <Checkboxs
             name="to_applicant_questions"
             label="Sélectionnez jusqu’à 3 questions pour mieux comprendre les motivations des candidats."

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/InformationLegaleEntreprise.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/InformationLegaleEntreprise.tsx
@@ -9,6 +9,7 @@ import { FieldWithValue } from "@/app/(espace-pro)/_components/FieldWithValue"
 import { InfoTooltip } from "@/app/(espace-pro)/_components/InfoToolTip"
 import type { AUTHTYPE } from "@/common/contants"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { LbaTitle } from "@/components/dsfr/LbaTitle"
 import { BorderedBox } from "@/components/espace_pro/common/components/BorderedBox"
 import { getCfaInformation, getEntrepriseInformation } from "@/utils/api"
 
@@ -34,9 +35,9 @@ const InformationLegaleEntreprise = ({ siret, type, opco, viewerType }: { siret:
 
   return (
     <BorderedBox>
-      <Typography fontWeight={700} component="h2" mb={2}>
+      <LbaTitle component="h2" sx={{ mb: fr.spacing("4v") }}>
         {type === ENTREPRISE ? "Informations de l'entreprise" : "Informations légales"}
-      </Typography>
+      </LbaTitle>
       {!raisonSociale && (
         <Box sx={{ display: "flex", alignItems: "flex-start", mb: fr.spacing("8v") }}>
           <Typography color={fr.colors.decisions.text.mention.grey.default} className={fr.cx("fr-icon-information-line")} />

--- a/ui/app/(espace-pro-creation-compte)/_components/InformationCreationCompte/InformationCreationCompte.tsx
+++ b/ui/app/(espace-pro-creation-compte)/_components/InformationCreationCompte/InformationCreationCompte.tsx
@@ -17,6 +17,7 @@ import { OpcoSelect } from "@/app/(espace-pro)/_components/OpcoSelect"
 import InformationLegaleEntreprise from "@/app/(espace-pro)/espace-pro/(connected)/_components/InformationLegaleEntreprise"
 import { AUTHTYPE } from "@/common/contants"
 import { phoneValidation } from "@/common/validation/fieldValidations"
+import { LbaTitle } from "@/components/dsfr/LbaTitle"
 import { AnimationContainer } from "@/components/espace_pro/index"
 import { WidgetContext } from "@/context/contextWidget"
 import { ArrowRightLine } from "@/theme/components/icons"
@@ -159,9 +160,7 @@ const FormulaireLayout = ({ left, right, type }: { left: React.ReactNode; right:
       }}
     >
       <Box>
-        <Typography component="h2" sx={{ fontSize: "24px", fontWeight: "bold" }}>
-          {type === AUTHTYPE.ENTREPRISE ? "Vos informations de contact" : "Créez votre compte"}
-        </Typography>
+        <LbaTitle component="h1">{type === AUTHTYPE.ENTREPRISE ? "Vos informations de contact" : "Créez votre compte"}</LbaTitle>
         <Typography sx={{ fontSize: "20px", pt: fr.spacing("2v"), pb: fr.spacing("4v") }}>
           {type === AUTHTYPE.ENTREPRISE
             ? "Seul le numéro de téléphone sera visible sur vos offres. Vous recevrez les candidatures sur l'email renseigné."

--- a/ui/components/dsfr/LbaTitle.tsx
+++ b/ui/components/dsfr/LbaTitle.tsx
@@ -1,0 +1,31 @@
+import { Typography, type TypographyProps } from "@mui/material"
+import type React from "react"
+
+type LbaTitleProps = {
+  component: NonNullable<TypographyProps["component"]>
+  sx?: TypographyProps["sx"]
+  children: React.ReactNode
+}
+
+const defaultSxByComponent: Partial<Record<string, TypographyProps["sx"]>> = {
+  h1: {
+    fontSize: { xs: "22px !important", md: "32px !important" },
+    lineHeight: { xs: "28px !important", md: "40px !important" },
+    fontWeight: 700,
+  },
+  h2: {
+    fontSize: { xs: "18px !important", md: "20px !important" },
+    lineHeight: { xs: "24px !important", md: "28px !important" },
+    fontWeight: 700,
+  },
+}
+
+export const LbaTitle = ({ component, sx, children }: LbaTitleProps) => {
+  const componentStr = typeof component === "string" ? component : undefined
+  const defaultSx = componentStr ? defaultSxByComponent[componentStr] : undefined
+  return (
+    <Typography component={component as React.ElementType} sx={[defaultSx ?? {}, ...(Array.isArray(sx) ? sx : [sx ?? {}])]}>
+      {children}
+    </Typography>
+  )
+}

--- a/ui/components/espace_pro/Authentification/CreationCompte.tsx
+++ b/ui/components/espace_pro/Authentification/CreationCompte.tsx
@@ -10,6 +10,7 @@ import { BusinessErrorCodes } from "shared/constants/errorCodes"
 import type { BandeauProps } from "@/app/(espace-pro)/_components/Bandeau"
 import { Bandeau } from "@/app/(espace-pro)/_components/Bandeau"
 import { AUTHTYPE } from "@/common/contants"
+import { LbaTitle } from "@/components/dsfr/LbaTitle"
 import { InformationsSiret } from "@/components/espace_pro/CreationRecruteur/InformationsSiret"
 import { BorderedBox } from "@/components/espace_pro/common/components/BorderedBox"
 import { publicConfig } from "@/config.public"
@@ -197,9 +198,7 @@ export default function CreationCompte({ type, isWidget = false, origin = "lba" 
             mb: fr.spacing("8v"),
           }}
         >
-          <Typography component="h1" sx={{ fontSize: "32px", fontWeight: 700 }}>
-            Vous recrutez des alternants ?
-          </Typography>
+          <LbaTitle component="h1">Vous recrutez des alternants ?</LbaTitle>
           <Typography component="div" sx={{ fontSize: "20px", lineHeight: "24px", mb: fr.spacing("4v"), mt: fr.spacing("8v") }}>
             Pour diffuser gratuitement vos offres, précisez le nom ou le SIRET de votre établissement.
           </Typography>


### PR DESCRIPTION
Closes #4358

## Changements

- Création du composant `LbaTitle` avec styles responsive par défaut pour `h1` et `h2`
- Remplacement des `Typography` avec styles inline par `LbaTitle` dans les écrans espace pro

## Plan de test

- [ ] Vérifier l'affichage des titres h1 sur mobile et desktop dans les formulaires espace pro
- [ ] Vérifier l'affichage des titres h2 sur mobile et desktop
- [ ] Contrôler que les surcharges via la prop `sx` s'appliquent correctement