### PR TITLE
feat: ajouter OPCO EP à la whitelist pour éviter la classification erronée en offre CFA

### DIFF
--- a/server/src/jobs/offrePartenaire/fillComputedJobsPartners.test.ts
+++ b/server/src/jobs/offrePartenaire/fillComputedJobsPartners.test.ts
@@ -5,9 +5,12 @@ import nock from "nock"
 import { OPCOS_LABEL } from "shared/constants/index"
 import { generateCacheInfoSiretForSiret } from "shared/fixtures/cacheInfoSiret.fixture"
 import type { IComputedJobsPartners } from "shared/models/jobsPartnersComputed.model"
+import { COMPUTED_ERROR_SOURCE } from "shared/models/jobsPartnersComputed.model"
 import { entriesToTypedRecord } from "shared/utils/index"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { blockJobsPartnersFromCfaList } from "./blockJobsPartnersFromCfaList"
+import { detectClassificationJobsPartners } from "./detectClassificationJobsPartners"
 import { fillComputedJobsPartners } from "./fillComputedJobsPartners"
 
 const now = new Date("2024-07-21T04:49:06.000+02:00")
@@ -58,6 +61,43 @@ describe("fillComputedJobsPartners", () => {
     // then
     expect.soft(await getDbCollection("computed_jobs_partners").countDocuments({ validated: false })).toEqual(1)
   }, 10_000)
+  describe("PARTNER_WHITELIST filtering for OPCO EP", () => {
+    it("should not apply BLOCK_CFA_NAME to a job with partner_label 'OPCO EP'", async () => {
+      // given: an "OPCO EP" job whose workplace_name contains a blocked CFA name
+      await givenSomeComputedJobPartners([
+        {
+          partner_label: "OPCO EP",
+          workplace_name: "13 EN FORM",
+          business_error: null,
+        },
+      ])
+      // when
+      await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+      // then
+      const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
+      expect.soft(job.business_error).toBeNull()
+      expect.soft(job.jobs_in_success).not.toContain(COMPUTED_ERROR_SOURCE.BLOCK_CFA_NAME)
+    })
+
+    it("should not apply CLASSIFICATION to a job with partner_label 'OPCO EP'", async () => {
+      // given: an "OPCO EP" job with content that would normally trigger classification
+      await givenSomeComputedJobPartners([
+        {
+          partner_label: "OPCO EP",
+          offer_title: "formateur CFA",
+          workplace_name: "école de formation",
+          business_error: null,
+        },
+      ])
+      // when — no lab API nock needed: OPCO EP is filtered out by the query so getData is never called
+      await detectClassificationJobsPartners({ shouldNotifySlack: false })
+      // then
+      const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
+      expect.soft(job.business_error).toBeNull()
+      expect.soft(job.jobs_in_success).not.toContain(COMPUTED_ERROR_SOURCE.CLASSIFICATION)
+    })
+  })
+
   // TODO à activer quand tous les enrichissements sont implémentés
   it.skip("should enrich when siret is present", async () => {
     // given

--- a/shared/src/models/jobsPartnersComputed.model.ts
+++ b/shared/src/models/jobsPartnersComputed.model.ts
@@ -25,6 +25,7 @@ export const PARTNER_WHITELIST: string[] = [
   "GRDF",
   "Institut Pasteur",
   "L'Oreal",
+  "OPCO EP",
   "Serpe",
   "Thales",
   "Veritone",


### PR DESCRIPTION
Closes #4778

## Changements

- Ajout de `"OPCO EP"` dans `PARTNER_WHITELIST` (`shared/src/models/jobsPartnersComputed.model.ts`) : les offres OPCO EP sont désormais exclues des jobs `BLOCK_CFA_NAME` et `CLASSIFICATION`
- Ajout de deux tests dans `fillComputedJobsPartners.test.ts` couvrant le filtrage OPCO EP pour ces deux jobs

## Plan de test

- [ ] Vérifier que les tests `PARTNER_WHITELIST filtering for OPCO EP` passent : `npx vitest run server/src/jobs/offrePartenaire/fillComputedJobsPartners.test.ts`
- [ ] Vérifier qu'aucun test existant ne régresse
- [ ] En staging/prod : constater la baisse du taux de dépublication des offres OPCO EP (actuellement ~44 %)