### PR TITLE
feat: renommer le libellé du filtre "candidatures spontanées" en "entreprise à contacter"

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheTypeEmploiSelect.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheTypeEmploiSelect.tsx
@@ -6,6 +6,14 @@ import type { IUseRechercheResults } from "@/app/(candidat)/(recherche)/recherch
 import { type DisplayedJob, matchesTypeEmploi } from "@/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults"
 import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
 
+// Libellés d'affichage découplés de la valeur d'enum (qui sert aussi de param d'URL / dimension Matomo).
+// Ne pas modifier les valeurs de TYPE_EMPLOI_OPTIONS pour renommer un type : changer uniquement ici.
+const TYPE_EMPLOI_LABELS: Record<ITypeEmploi, string> = {
+  [TYPE_EMPLOI_OPTIONS.alternance]: TYPE_EMPLOI_OPTIONS.alternance,
+  [TYPE_EMPLOI_OPTIONS.formation_incluse]: TYPE_EMPLOI_OPTIONS.formation_incluse,
+  [TYPE_EMPLOI_OPTIONS.candidatures_spontanees]: "Entreprise à contacter",
+}
+
 const TYPE_EMPLOI_DESCRIPTIONS: Partial<Record<ITypeEmploi, string>> = {
   [TYPE_EMPLOI_OPTIONS.formation_incluse]: "Vous devrez vous inscrire dans la formation associée à l'offre",
   [TYPE_EMPLOI_OPTIONS.candidatures_spontanees]: "Entreprises susceptibles de recruter en alternance",
@@ -22,7 +30,7 @@ function buildOptions(allJobs: DisplayedJob[], hasResults: boolean): MultiSelect
     const count = hasResults ? countByTypeEmploi(allJobs, value) : undefined
     return {
       value,
-      label: `${value}${count !== undefined ? ` (${count})` : ""}`,
+      label: `${TYPE_EMPLOI_LABELS[value]}${count !== undefined ? ` (${count})` : ""}`,
       hintText: TYPE_EMPLOI_DESCRIPTIONS[value],
     }
   })
@@ -30,7 +38,7 @@ function buildOptions(allJobs: DisplayedJob[], hasResults: boolean): MultiSelect
 
 function getLabel(selected: MultiSelectOption[], allOptions: MultiSelectOption[]): string {
   if (selected.length === 0 || selected.length === allOptions.length) return "Indifférent"
-  if (selected.length === 1) return selected[0].value
+  if (selected.length === 1) return TYPE_EMPLOI_LABELS[selected[0].value as ITypeEmploi]
   return `${selected.length} types sélectionnés`
 }
 


### PR DESCRIPTION
Closes #4787

## Changements

- Renommage du libellé du filtre secondaire « Candidatures spontanées » → « **Entreprise à contacter** » côté affichage.
- Découplage du **libellé d'affichage** et de la **valeur d'enum** : ajout d'un map `TYPE_EMPLOI_LABELS` dans `RechercheTypeEmploiSelect.tsx`. La valeur `TYPE_EMPLOI_OPTIONS.candidatures_spontanees` reste inchangée.
- Conséquence : les URLs / liens partagés, la validation des params (`zTypesEmploiParam`) et les dimensions Matomo ne sont **pas impactés** — seul le texte affiché change.

## Plan de test

- [ ] Sur la page recherche, ouvrir le filtre « Type d'offres d'emploi » : la 3e option affiche « Entreprise à contacter (N) ».
- [ ] Sélectionner uniquement cette option : le libellé du bouton affiche « Entreprise à contacter ».
- [ ] Vérifier que le filtrage des résultats fonctionne toujours (entreprises susceptibles de recruter).
- [ ] Vérifier qu'un ancien lien partagé avec `typesEmploi=Candidatures spontanées` continue de filtrer correctement.