### PR TITLE
feat: appliquer le seuil de 80 candidatures aux offres partenaires en smart apply

### DIFF
--- a/server/src/services/application.service.test.ts
+++ b/server/src/services/application.service.test.ts
@@ -626,6 +626,34 @@ describe("checkMaxApplicationCount", () => {
     const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: jobId })
     expect(updatedJob?.offer_status).toBe(JOB_STATUS_ENGLISH.ANNULEE)
   })
+
+  it("Should update offer status to ANNULEE when application count exceeds limit (OFFRES_EMPLOI_PARTENAIRES)", async () => {
+    const jobId = new ObjectId("6081289803569600282e0034")
+
+    await getDbCollection("referentielromes").insertOne(generateReferentielRome({ rome: { code_rome: "A1101", intitule: "Opérations administratives", code_ogr: "475" } }))
+    await getDbCollection("jobs_partners").insertOne(
+      generateJobsPartnersOfferPrivate({
+        _id: jobId,
+        offer_status: JOB_STATUS_ENGLISH.ACTIVE,
+        apply_email: "employer@test.fr",
+        partner_label: JOBPARTNERS_LABEL.FRANCE_TRAVAIL,
+      })
+    )
+
+    // 80 existing + current submission = 81 total, condition (80+1) > 80 is true
+    const applications = Array.from({ length: 80 }, () => generateApplicationFixture({ job_id: jobId, created_at: new Date() }))
+    await getDbCollection("applications").insertMany(applications)
+
+    await sendApplicationV2({
+      newApplication: {
+        ...fakeApplication,
+        recipient_id: { collectionName: "partners", jobId: jobId.toString() },
+      },
+    })
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: jobId })
+    expect(updatedJob?.offer_status).toBe(JOB_STATUS_ENGLISH.ANNULEE)
+  })
 })
 
 describe("processApplicationEmails.sendEmailsIfNeeded", () => {

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -633,8 +633,8 @@ const checkUserApplicationCountV2 = async (applicantId: ObjectId, LbaJob: IJobOr
 const checkMaxApplicationCount = async (lbaJob: IJobOrCompanyV2) => {
   const { job, type } = lbaJob
 
-  // règle qui ne concerne que les offres LBA
-  if (type !== LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA) {
+  // règle qui ne concerne que les offres LBA et partenaires
+  if (type === LBA_ITEM_TYPE.RECRUTEURS_LBA) {
     return
   }
 
@@ -644,7 +644,7 @@ const checkMaxApplicationCount = async (lbaJob: IJobOrCompanyV2) => {
 
   if (applicationCount + 1 > MAX_APPLICATIONS_PER_OFFER) {
     await getDbCollection("jobs_partners").updateOne(
-      { _id: job._id, partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA },
+      { _id: job._id, partner_label: job.partner_label },
       {
         $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: new Date() },
         $push: {


### PR DESCRIPTION
Closes #4759

## Changements

- Le seuil de 80 candidatures (`MAX_APPLICATIONS_PER_OFFER`) s'applique désormais aux offres partenaires en smart apply (`OFFRES_EMPLOI_PARTENAIRES`), en plus des offres LBA. Seules les offres `RECRUTEURS_LBA` restent exclues.
- La requête de passage en statut `ANNULEE` cible le `partner_label` réel de l'offre, afin de matcher aussi les labels partenaires (France Travail, etc.) et pas uniquement `OFFRES_EMPLOI_LBA`.
- Ajout d'un test couvrant le cas `OFFRES_EMPLOI_PARTENAIRES` (offre annulée au dépassement du seuil), en miroir du cas LBA existant.

## Plan de test

- [ ] Une offre partenaire active dépassant 80 candidatures passe en statut `ANNULEE`
- [ ] Une offre `RECRUTEURS_LBA` n'est pas affectée par le seuil
- [ ] Aucune régression sur les offres LBA existantes
- [ ] `yarn typecheck` et `yarn lint` passent