### PR TITLE
fix: bug de maj de la description de l offre

### DIFF
--- a/server/src/http/controllers/formulaire.controller.test.ts
+++ b/server/src/http/controllers/formulaire.controller.test.ts
@@ -119,6 +119,53 @@ describe("formulaire.controller", () => {
   }, 10_000)
 
   describe("mise à jour", () => {
+    it("met à jour la description publique quand le ROME est modifié", async () => {
+      // given
+      const { cookies, formulaire } = await entrepriseSdkInstance.createAndGetConnectedUser()
+
+      const createOfferResponse = await entrepriseSdkInstance.createOffer({
+        establishment_id: formulaire!.establishment_id,
+        cookies,
+        job: buildCreateJobDataFromReferentiel(referentielRome),
+      })
+
+      const { _id: jobObjectId } = createOfferResponse.json() as OfferCreationResponse
+      const jobId = jobObjectId.toString()
+
+      const newRome = generateReferentielRome({
+        rome: {
+          code_rome: "D1106",
+          intitule: "Vente en alimentation",
+          code_ogr: "335",
+        },
+        definition: "Réalise la vente de produits alimentaires (frais et hors frais) selon la réglementation du commerce, les règles d'hygiène et de sécurité alimentaires.",
+      })
+      await getDbCollection("referentielromes").insertOne(newRome)
+
+      const offerResponse = await entrepriseSdkInstance.getOffer({ jobId, cookies })
+      const job = offerResponse.json() as GetOfferResponse
+
+      // when
+      const response = await entrepriseSdkInstance.updateOffer({
+        jobId,
+        cookies,
+        body: {
+          ...jobToJobPatch(job),
+          rome_code: [newRome.rome.code_rome],
+          rome_label: newRome.rome.intitule,
+          rome_appellation_label: newRome.appellations[0].libelle,
+          competences_rome: newRome.competences,
+        },
+      })
+
+      // then
+      expect.soft(response.statusCode).toBe(200)
+
+      const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: new ObjectId(jobId) })
+      expect.soft(updatedJob?.offer_description).toEqual(newRome.definition)
+      expect.soft(updatedJob?.offer_rome_codes).toEqual([newRome.rome.code_rome])
+    })
+
     it("met à jour une offre active", async () => {
       // given
       const { cookies: entrepriseCookies, formulaire, opco } = await entrepriseSdkInstance.createAndGetConnectedUser()

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -568,14 +568,15 @@ type PatchOffreBody = z.output<(typeof zRoutes.put)["/formulaire/offre/:jobId"][
 export const patchOffre = async (id: ObjectId, payload: PatchOffreBody): Promise<void> => {
   await validateFieldsFromReferentielRome(payload)
 
-  const job = payload
-  const now = new Date()
-
-  const romeDetails = await getRomeDetailsFromDB(job.rome_code[0])
   const existingJob = await getDbCollection("jobs_partners").findOne({ _id: id })
   if (!existingJob) {
     throw internal("Job not found")
   }
+
+  const job = payload
+  const now = new Date()
+
+  const romeDetails = await getRomeDetailsFromDB(job.rome_code[0])
 
   const jobPartnerUpdate: Partial<IJobsPartnersOfferPrivate> = {
     offer_opening_count: job.job_count ?? 1,
@@ -591,6 +592,8 @@ export const patchOffre = async (id: ObjectId, payload: PatchOffreBody): Promise
       [],
     offer_to_be_acquired_skills: getSkillsFromRome(job.competences_rome?.savoir_faire, romeDetails?.competences?.savoir_faire),
     offer_to_be_acquired_knowledge: getSkillsFromRome(job.competences_rome?.savoirs, romeDetails?.competences?.savoirs),
+    offer_access_conditions: romeDetails?.acces_metier ? [romeDetails.acces_metier] : [],
+    offer_description: romeDetails?.definition,
     contract_duration: job.job_duration ?? null,
     offer_target_diploma: getDiplomaLevel(job.job_level_label) ?? null,
     offer_title: job.offer_title_custom ?? job.rome_appellation_label ?? existingJob.offer_title,


### PR DESCRIPTION
Closes https://github.com/mission-apprentissage/labonnealternance/issues/4794

## Changes

- **Fix**: `patchOffre` now correctly updates `offer_description` and `offer_access_conditions` when the ROME code is modified on an existing offer.
- Moved the `existingJob` lookup before the `romeDetails` fetch to ensure the job exists before doing unnecessary DB work.
- Added `offer_access_conditions` (from `romeDetails.acces_metier`) and `offer_description` (from `romeDetails.definition`) to the `jobPartnerUpdate` patch object — these fields were previously omitted during updates.

## Testing

- Added integration test: *"met à jour la description publique quand le ROME est modifié"* — creates an offer, then updates it with a new ROME code and asserts that `offer_description` and `offer_rome_codes` are correctly persisted in the database.