### PR TITLE
fix: retirer le rate-limit par IP sur les routes consommées via api-apprentissage

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -117,10 +117,19 @@ const config = {
   apiApprentissage: {
     baseUrl: "https://api.apprentissage.beta.gouv.fr/api",
     apiKey: env.get("LBA_API_APPRENTISSAGE_KEY").required().asString(),
-    // IPs des serveurs api-apprentissage qui forwardent vers LBA.
+    // IPs des serveurs api-apprentissage qui forwardent vers LBA, par environnement.
     // Le rate-limit par consommateur est posé côté api-apprentissage (cf. issue #4806) ;
     // ces IPs sont allowlistées pour éviter qu'un consommateur sature le bucket des autres.
-    serverIps: ["54.38.65.110", "162.19.79.129"],
+    // On ne charge que l'IP de l'environnement courant pour ne pas élargir la surface.
+    serverIps: (
+      {
+        production: ["54.38.65.110"],
+        recette: ["162.19.79.129"],
+        local: [],
+        pentest: [],
+        preview: [],
+      } as const
+    )[env.get("LBA_ENV").required().asEnum(["local", "recette", "pentest", "production", "preview"])],
   },
   parcoursupPeriods: {
     start: {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -117,6 +117,10 @@ const config = {
   apiApprentissage: {
     baseUrl: "https://api.apprentissage.beta.gouv.fr/api",
     apiKey: env.get("LBA_API_APPRENTISSAGE_KEY").required().asString(),
+    // IPs des serveurs api-apprentissage qui forwardent vers LBA.
+    // Le rate-limit par consommateur est posé côté api-apprentissage (cf. issue #4806) ;
+    // ces IPs sont allowlistées pour éviter qu'un consommateur sature le bucket des autres.
+    serverIps: ["54.38.65.110", "162.19.79.129"],
   },
   parcoursupPeriods: {
     start: {

--- a/server/src/http/controllers/v2/application.controller.v2.ts
+++ b/server/src/http/controllers/v2/application.controller.v2.ts
@@ -10,12 +10,8 @@ export default function (server: Server) {
     {
       schema: zRoutes.post["/v2/application"],
       onRequest: server.auth(zRoutes.post["/v2/application"]),
-      config: {
-        rateLimit: {
-          max: 5,
-          timeWindow: "5s",
-        },
-      },
+      // Rate-limit posé côté api-apprentissage par consommateur (issue #4806).
+      // La route /v2/_private/application en revanche reste rate-limitée car appelée par le front LBA.
       bodyLimit: 5 * 1024 ** 2, // 5MB
     },
     async (req, res) => {

--- a/server/src/http/controllers/v3/jobs/jobs.controller.v3.ts
+++ b/server/src/http/controllers/v3/jobs/jobs.controller.v3.ts
@@ -34,7 +34,7 @@ export const jobsApiV3Routes = (server: Server) => {
     {
       schema: zRoutes.post["/v3/jobs"],
       onRequest: server.auth(zRoutes.post["/v3/jobs"]),
-      config,
+      // Rate-limit posé côté api-apprentissage par consommateur (issue #4806)
     },
     async (req, res) => {
       const user = getUserFromRequest(req, zRoutes.post["/v3/jobs"]).value
@@ -48,7 +48,7 @@ export const jobsApiV3Routes = (server: Server) => {
     {
       schema: zRoutes.put["/v3/jobs/:id"],
       onRequest: server.auth(zRoutes.put["/v3/jobs/:id"]),
-      config,
+      // Rate-limit posé côté api-apprentissage par consommateur (issue #4806)
     },
     async (req, res) => {
       const user = getUserFromRequest(req, zRoutes.put["/v3/jobs/:id"]).value
@@ -67,7 +67,7 @@ export const jobsApiV3Routes = (server: Server) => {
     {
       schema: zRoutes.post["/v3/jobs/multi-partner"],
       onRequest: server.auth(zRoutes.post["/v3/jobs/multi-partner"]),
-      config,
+      // Rate-limit posé côté api-apprentissage par consommateur (issue #4806)
     },
     async (req, res) => {
       const { partner_label, partner_job_id } = req.body
@@ -82,7 +82,7 @@ export const jobsApiV3Routes = (server: Server) => {
     {
       schema: zRoutes.post["/v4/jobs/multi-partner"],
       onRequest: server.auth(zRoutes.post["/v4/jobs/multi-partner"]),
-      config,
+      // Rate-limit posé côté api-apprentissage par consommateur (issue #4806)
     },
     async (req, res) => {
       const user = getUserFromRequest(req, zRoutes.post["/v4/jobs/multi-partner"]).value
@@ -99,7 +99,7 @@ export const jobsApiV3Routes = (server: Server) => {
     {
       schema: zRoutes.post["/v4/jobs/multi-partner/bulk"],
       onRequest: server.auth(zRoutes.post["/v4/jobs/multi-partner/bulk"]),
-      config,
+      // Rate-limit posé côté api-apprentissage par consommateur (issue #4806)
     },
     async (req, res) => {
       const user = getUserFromRequest(req, zRoutes.post["/v4/jobs/multi-partner/bulk"]).value
@@ -191,12 +191,7 @@ export const jobsApiV3Routes = (server: Server) => {
     {
       schema: zRoutes.get["/v3/jobs/export"],
       onRequest: server.auth(zRoutes.get["/v3/jobs/export"]),
-      config: {
-        rateLimit: {
-          max: 1,
-          timeWindow: "1s",
-        },
-      },
+      // Rate-limit posé côté api-apprentissage par consommateur (issue #4806)
     },
     async (_, res) => {
       const url = await s3SignedUrl("storage", EXPORT_JOBS_TO_S3_V2_FILENAME, { expiresIn: 120 })

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -71,7 +71,7 @@ export async function bind(app: Server) {
   app.setSerializerCompiler(serializerCompiler)
 
   const allowedIps = [
-    new Netmask("127.0.0.0/16"),
+    new Netmask("127.0.0.0/8"),
     new Netmask("10.0.0.0/8"),
     new Netmask("172.16.0.0/12"),
     new Netmask("192.168.0.0/16"),

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -70,11 +70,18 @@ export async function bind(app: Server) {
   app.setValidatorCompiler(validatorCompiler)
   app.setSerializerCompiler(serializerCompiler)
 
-  const allowedIps = [new Netmask("127.0.0.0/16"), new Netmask("10.0.0.0/8"), new Netmask("172.16.0.0/12"), new Netmask("192.168.0.0/16")]
+  const allowedIps = [
+    new Netmask("127.0.0.0/16"),
+    new Netmask("10.0.0.0/8"),
+    new Netmask("172.16.0.0/12"),
+    new Netmask("192.168.0.0/16"),
+    ...config.apiApprentissage.serverIps.map((ip) => new Netmask(`${ip}/32`)),
+  ]
   await app.register(fastifyRateLimt, {
     global: false,
     allowList: (req) => {
-      // Do not rate-limit private & internal IPs
+      // Ne pas rate-limiter les IPs privées/internes ni les serveurs api-apprentissage
+      // (rate-limit posé en amont par consommateur, cf. issue #4806)
       return allowedIps.some((block) => block.contains(req.ip))
     },
   })


### PR DESCRIPTION
Closes #4806

## Contexte

Réponse à l'incident [Sentry #14911](https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/14911) (deux consommateurs ont saturé `/api/formation/v1/appointment/generate-link` et `/api/job/v1/search` avec 5765 + 2140 appels en une nuit → 500 en cascade).

Les routes concernées ne sont accessibles **qu'à travers** le serveur api-apprentissage. Toutes les requêtes arrivent depuis la même IP côté LBA, donc le rate-limit par IP empêche un consommateur de saturer le bucket des autres mais bloque aussi tous les consommateurs ensemble en cas de pic légitime. Le rate-limit a été déplacé **par consommateur** (clé api/email JWT) côté api-apprentissage dans la PR jumelle : mission-apprentissage/api-apprentissage#493.

⚠️ **Ne pas merger avant que la PR jumelle soit en prod** pour éviter une fenêtre sans protection.

## Changements

- `server/src/config.ts` : nouvelle entrée `apiApprentissage.serverIps` (prod 54.38.65.110, recette 162.19.79.129)
- `server/src/http/server.ts` : ces IPs ajoutées à l'`allowList` de `@fastify/rate-limit` (Netmask /32)
- `server/src/http/controllers/v3/jobs/jobs.controller.v3.ts` : `config: { rateLimit }` retiré sur POST `/v3/jobs`, PUT `/v3/jobs/:id`, POST `/v3/jobs/multi-partner`, POST `/v4/jobs/multi-partner`, POST `/v4/jobs/multi-partner/bulk`, GET `/v3/jobs/export`
- `server/src/http/controllers/v2/application.controller.v2.ts` : rate-limit retiré sur POST `/v2/application`

## Ce qui reste rate-limité

- POST `/v3/jobs/:id/stats/:eventType` et POST `/v3/jobs/stats/search_view` (appelées par le front LBA)
- POST `/v2/_private/application` (appelée par le front LBA)
- Toutes les autres routes du controller (v1, v2 publiques, etc.)

## Plan de test

- [ ] `yarn typecheck` passe (vérifié localement)
- [ ] CI verte
- [ ] PR jumelle api-apprentissage#493 mergée et déployée en prod avant ce merge
- [ ] Une fois en prod : observer 24h via Sentry, vérifier absence de régression
- [ ] Vérifier qu'un appel depuis l'IP api-apprentissage n'est plus rate-limité côté LBA