### PR TITLE
fix: restaurer les offres offres_emploi_lba désactivées par erreur

### DIFF
--- a/server/src/migrations/20260611143504-restore-jobs-partners-offres-emploi-lba.ts
+++ b/server/src/migrations/20260611143504-restore-jobs-partners-offres-emploi-lba.ts
@@ -1,0 +1,48 @@
+import type { Filter } from "mongodb"
+import { JOB_STATUS_ENGLISH } from "shared"
+import { type IJobsPartnersOfferPrivate, JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
+
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+
+const GRANTED_BY = "20260611143504-restore-jobs-partners-offres-emploi-lba"
+
+/**
+ * Restaure les offres OFFRES_EMPLOI_LBA désactivées par erreur.
+ *
+ * Cible : les jobs_partners qui ont été annulés par cancelRemovedJobsPartners
+ * (offer_status = Cancelled, historique avec reason "supprimée du flux source")
+ * mais dont l'offre n'est PAS encore expirée.
+ *
+ * Action : repasse offer_status à Active et trace la réactivation dans
+ * offer_status_history.
+ */
+export const up = async () => {
+  const now = new Date()
+
+  const filter: Filter<IJobsPartnersOfferPrivate> = {
+    partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA,
+    offer_status: JOB_STATUS_ENGLISH.ANNULEE, // "Cancelled"
+    "offer_status_history.reason": "supprimée du flux source",
+    // offer_expiration non dépassée. Les offres sans date d'expiration (null)
+    // ne sont volontairement PAS réactivées par cette correction.
+    offer_expiration: { $gt: now },
+  }
+
+  const { matchedCount } = await getDbCollection("jobs_partners").updateMany(filter, {
+    $set: { offer_status: JOB_STATUS_ENGLISH.ACTIVE },
+    $push: {
+      offer_status_history: {
+        date: now,
+        status: JOB_STATUS_ENGLISH.ACTIVE,
+        reason: "réactivation suite à désactivation erronée du flux source",
+        granted_by: GRANTED_BY,
+      },
+    },
+  })
+
+  logger.info(`restore offres_emploi_lba : ${matchedCount} offres réactivées`)
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/server/src/migrations/20260611143504-restore-jobs-partners-offres-emploi-lba.ts
+++ b/server/src/migrations/20260611143504-restore-jobs-partners-offres-emploi-lba.ts
@@ -29,7 +29,7 @@ export const up = async () => {
     offer_expiration: { $gt: now },
   }
 
-  const { matchedCount } = await getDbCollection("jobs_partners").updateMany(filter, {
+  const { matchedCount, modifiedCount } = await getDbCollection("jobs_partners").updateMany(filter, {
     $set: { offer_status: JOB_STATUS_ENGLISH.ACTIVE },
     $push: {
       offer_status_history: {
@@ -41,8 +41,7 @@ export const up = async () => {
     },
   })
 
-  logger.info(`restore offres_emploi_lba : ${matchedCount} offres réactivées`)
-}
+  logger.info(`restore offres_emploi_lba : ${modifiedCount}/${matchedCount} offres réactivées`)
 
 // set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
 export const requireShutdown: boolean = false

--- a/server/src/migrations/20260611143504-restore-jobs-partners-offres-emploi-lba.ts
+++ b/server/src/migrations/20260611143504-restore-jobs-partners-offres-emploi-lba.ts
@@ -42,6 +42,7 @@ export const up = async () => {
   })
 
   logger.info(`restore offres_emploi_lba : ${modifiedCount}/${matchedCount} offres réactivées`)
+}
 
 // set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
 export const requireShutdown: boolean = false


### PR DESCRIPTION
Closes #4812

## Changements

- Ajout d'une migration MongoDB qui réactive les `jobs_partners` `offres_emploi_lba` annulés par erreur.
- Cible : `offer_status = Cancelled`, historique avec `reason: "supprimée du flux source"`, et `offer_expiration` non dépassée (`$gt: now`).
- Action : `offer_status` repassé à `Active` + entrée ajoutée dans `offer_status_history` (`reason: "réactivation suite à désactivation erronée du flux source"`).
- Les offres sans date d'expiration (`offer_expiration: null`) sont volontairement exclues.

## Plan de test

- [ ] Vérifier le `count` des offres matchées avant migration : `offres_emploi_lba` + `Cancelled` + `offer_status_history.reason = "supprimée du flux source"` + `offer_expiration > now`.
- [ ] Lancer la migration et confirmer que `matchedCount` (log) correspond.
- [ ] Vérifier qu'un échantillon est bien repassé en `Active` avec la nouvelle entrée d'historique.
- [ ] Vérifier que les offres déjà expirées et celles avec `offer_expiration: null` ne sont pas touchées.