### PR TITLE
fix: sécurise l'annulation des offres absentes du flux via des sous-jobs dédiés

### DIFF
--- a/server/src/jobs/offrePartenaire/cancelRemovedJobsPartners.ts
+++ b/server/src/jobs/offrePartenaire/cancelRemovedJobsPartners.ts
@@ -16,6 +16,10 @@ import { getDbCollection } from "@/common/utils/mongodbUtils"
 export const cancelRemovedJobsPartners = async (matchFilter: Filter<IComputedJobsPartners>) => {
   logger.info("début de cancelRemovedJobsPartners")
 
+  if (!matchFilter || Object.keys(matchFilter).length === 0) {
+    throw new Error("cancelRemovedJobsPartners: matchFilter is required and must not be empty")
+  }
+
   const matchStage = {
     $match: {
       $and: [matchFilter, { offer_status: JOB_STATUS_ENGLISH.ACTIVE }],

--- a/server/src/jobs/offrePartenaire/cancelRemovedJobsPartners.ts
+++ b/server/src/jobs/offrePartenaire/cancelRemovedJobsPartners.ts
@@ -5,7 +5,15 @@ import type { IComputedJobsPartners } from "shared/models/jobsPartnersComputed.m
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 
-export const cancelRemovedJobsPartners = async (matchFilter: Filter<IComputedJobsPartners> = {}) => {
+/**
+ * Annule les offres jobs_partners absentes (ou expirées) du flux source correspondant.
+ *
+ * IMPORTANT : `matchFilter` est obligatoire et ne doit jamais être vide. Un filtre vide
+ * annulerait toutes les offres actives tous partenaires confondus. Cette fonction n'est donc
+ * pas exposée en CLI : passer par les sous-jobs dédiés (cancelRemovedJobsPartnersFlux,
+ * cancelRemovedJobsPartnersRecruteursLba) qui encapsulent leur filtre respectif.
+ */
+export const cancelRemovedJobsPartners = async (matchFilter: Filter<IComputedJobsPartners>) => {
   logger.info("début de cancelRemovedJobsPartners")
 
   const matchStage = {

--- a/server/src/jobs/offrePartenaire/processJobPartners.ts
+++ b/server/src/jobs/offrePartenaire/processJobPartners.ts
@@ -7,12 +7,20 @@ import { importFromComputedToJobsPartners } from "./importFromComputedToJobsPart
 
 export const jobPartnersByFlux = Object.values(JOBPARTNERS_LABEL).filter((jobPartner) => !jobPartnersExcludedFromFlux.includes(jobPartner))
 
+/**
+ * Annule les offres des partenaires traités par flux qui ne sont plus présentes dans le flux source.
+ * Sous-job CLI-safe : le filtre est encapsulé ici, jamais vide.
+ */
+export const cancelRemovedJobsPartnersFlux = async () => {
+  await cancelRemovedJobsPartners({ partner_label: { $in: jobPartnersByFlux } })
+}
+
 export const processComputedAndImportToJobPartners = async () => {
   logger.info("début de processComputedAndImportToJobPartners")
   const filter = { partner_label: { $in: jobPartnersByFlux } }
   await fillComputedJobsPartners({ addedMatchFilter: filter })
   await importFromComputedToJobsPartners(filter)
-  await cancelRemovedJobsPartners(filter)
+  await cancelRemovedJobsPartnersFlux()
   await fillLbaUrl()
   logger.info("fin de processComputedAndImportToJobPartners")
 }

--- a/server/src/jobs/offrePartenaire/recruteur-lba/processRecruteursLba.ts
+++ b/server/src/jobs/offrePartenaire/recruteur-lba/processRecruteursLba.ts
@@ -31,14 +31,23 @@ export const processRecruteursLba = async ({ sourceFileReadStream, skipCheckFile
   logger.info("fin de processRecruteursLba")
 }
 
+const recruteursLbaFilter: Filter<IComputedJobsPartners> = {
+  partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+}
+
+/**
+ * Annule les offres recruteurs LBA qui ne sont plus présentes dans le flux source.
+ * Sous-job CLI-safe : le filtre est encapsulé ici, jamais vide.
+ */
+export const cancelRemovedJobsPartnersRecruteursLba = async () => {
+  await cancelRemovedJobsPartners(recruteursLbaFilter)
+}
+
 export async function processRecruteursLbaRawToEnd() {
   await importRecruteurLbaToComputed()
   await fillComputedRecruteursLba()
 
-  const filter: Filter<IComputedJobsPartners> = {
-    partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
-  }
-  await importFromComputedToJobsPartners(filter)
+  await importFromComputedToJobsPartners(recruteursLbaFilter)
   await fillLbaUrl()
-  await cancelRemovedJobsPartners(filter)
+  await cancelRemovedJobsPartnersRecruteursLba()
 }

--- a/server/src/jobs/simpleJobDefinitions.ts
+++ b/server/src/jobs/simpleJobDefinitions.ts
@@ -33,7 +33,6 @@ import { generateFranceTravailAccess } from "./franceTravail/generateFranceTrava
 import { createRoleManagement360 } from "./metabase/metabaseRoleManagement360"
 import { sendMiseEnRelation } from "./miseEnRelation/sendMiseEnRelation"
 import { processApec } from "./offrePartenaire/apec/processApec"
-import { cancelRemovedJobsPartners } from "./offrePartenaire/cancelRemovedJobsPartners"
 import { processAtlas, processMeteojob, processNosTalentsNosEmplois, processToulouseMetropole, processViteUnEmploi } from "./offrePartenaire/clever-connect/processCleverConnect"
 import { processDecathlon } from "./offrePartenaire/decathlon/importDecathlon"
 import { detectClassificationJobsPartners } from "./offrePartenaire/detectClassificationJobsPartners"
@@ -56,10 +55,10 @@ import { processLaposte } from "./offrePartenaire/laposte/processLaposte"
 import { processLeboncoin } from "./offrePartenaire/leboncoin/processLeboncoin"
 import { processPass } from "./offrePartenaire/pass/processPass"
 import { processFillRomeStandalone } from "./offrePartenaire/processFillRomeStandalone"
-import { processComputedAndImportToJobPartners } from "./offrePartenaire/processJobPartners"
+import { cancelRemovedJobsPartnersFlux, processComputedAndImportToJobPartners } from "./offrePartenaire/processJobPartners"
 import { processJobPartnersForApi } from "./offrePartenaire/processJobPartnersForApi"
 import { removeMissingRecruteursLbaFromComputedJobPartners } from "./offrePartenaire/recruteur-lba/importRecruteursLbaRaw"
-import { processRecruteursLba, processRecruteursLbaRawToEnd } from "./offrePartenaire/recruteur-lba/processRecruteursLba"
+import { cancelRemovedJobsPartnersRecruteursLba, processRecruteursLba, processRecruteursLbaRawToEnd } from "./offrePartenaire/recruteur-lba/processRecruteursLba"
 import { processRhAlternance } from "./offrePartenaire/rh-alternance/processRhAlternance"
 import { analyzeClosedCompanies } from "./oneTimeJob/analyzeClosedCompanies"
 import { cleanClosedCompanies } from "./oneTimeJob/cleanClosedCompanies"
@@ -407,8 +406,12 @@ export const simpleJobDefinitions: SimpleJobDefinition[] = [
     description: "Renouvelle le champ lba_url dans la collection jobs_partners",
   },
   {
-    fct: cancelRemovedJobsPartners,
-    description: "Annule les offres présentes dans jobs_partners qui ne sont plus présentes dans le flux source (ex: recruteurs LBA)",
+    fct: cancelRemovedJobsPartnersFlux,
+    description: "Annule les offres des partenaires traités par flux absentes du flux source",
+  },
+  {
+    fct: cancelRemovedJobsPartnersRecruteursLba,
+    description: "Annule les offres recruteurs LBA absentes du flux source",
   },
   {
     fct: processRecruteursLbaRawToEnd,


### PR DESCRIPTION
Closes #4809

## Contexte

Le job `cancelRemovedJobsPartners` était exposé en CLI. La CLI invoque chaque job **sans payload**, donc le job tournait avec `matchFilter = {}` : un filtre vide annule **toutes** les offres actives absentes du computed, tous partenaires confondus. C'est ce qui a désactivé en masse des offres `offres_emploi_lba` (voir restauration en #4812 / PR #4813).

## Changements

- `cancelRemovedJobsPartners` : `matchFilter` devient **obligatoire** (suppression du défaut `= {}`). Appeler la fonction sans filtre est désormais une erreur de compilation.
- Retrait de `cancelRemovedJobsPartners` de la CLI (`simpleJobDefinitions`).
- Ajout de deux sous-jobs CLI-safe qui encapsulent chacun leur filtre :
  - `cancelRemovedJobsPartnersFlux` (partenaires traités par flux) — dans `processJobPartners.ts`
  - `cancelRemovedJobsPartnersRecruteursLba` (recruteurs LBA) — dans `processRecruteursLba.ts`
- Mise à jour des appelants de prod (`processComputedAndImportToJobPartners`, `processRecruteursLbaRawToEnd`) pour passer par les sous-jobs.

## Plan de test

- [ ] `yarn typecheck` OK (vérifié en local).
- [ ] `vitest cancelRemovedJobsPartners` + `processRecruteursLba` verts (vérifié en local).
- [ ] Vérifier que les commandes CLI exposées sont bien `cancelRemovedJobsPartnersFlux` et `cancelRemovedJobsPartnersRecruteursLba`, et que `cancelRemovedJobsPartners` n'est plus listée.
- [ ] Confirmer qu'aucune commande CLI ne peut lancer une annulation sans filtre.