### PR TITLE
fix: désactiver temporairement sentry côté serveur pendant la migration

### DIFF
--- a/server/src/common/sentry/sentry.ts
+++ b/server/src/common/sentry/sentry.ts
@@ -71,8 +71,15 @@ function getOptions(): Sentry.NodeOptions {
   }
 }
 
+// Sentry temporairement désactivé : migration du serveur Sentry en cours.
+// `enabled: false` force le SDK à ne créer aucun client actif : tous les appels
+// unitaires (captureException, startSpan, captureMessage, setUser…) deviennent des
+// no-op silencieux, sans appel réseau. Rien d'autre à toucher dans le code.
+// TODO: repasser à true (retirer ce flag) une fois la migration terminée.
+const SENTRY_ENABLED = false
+
 export function initSentry(): void {
-  Sentry.init(getOptions())
+  Sentry.init({ ...getOptions(), enabled: SENTRY_ENABLED })
 }
 
 export async function closeSentry(): Promise<void> {


### PR DESCRIPTION
Closes #4870

## Changements

- Désactivation de Sentry côté serveur via un flag `SENTRY_ENABLED = false` passé à `Sentry.init`
- Sans client actif, tous les appels unitaires (`sentryCaptureException`, `startSentryPerfRecording`, `Sentry.captureMessage`, hooks de scope) deviennent des no-op silencieux — aucun appel réseau vers l'ancien DSN pendant la migration
- `getOptions` reste référencé (pas de code mort) ; réactivation = repasser le flag à `true`

## Plan de test

- [ ] `yarn typecheck` passe
- [ ] Démarrer le serveur : aucun appel réseau vers Sentry, aucune erreur liée à l'init
- [ ] Vérifier qu'une exception déclenchée volontairement n'est pas envoyée à Sentry