### PR TITLE
fix: garder le CTA de recherche désactivé tant que métier ou lieu n'est pas modifié

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheSubmitButton.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheSubmitButton.tsx
@@ -6,11 +6,19 @@ import { useFormikContext } from "formik"
 import type React from "react"
 import type { CSSProperties } from "react"
 
-export function RechercheSubmitButton({ children, style, forceMobileStyle = false }: { children?: React.ReactNode; style?: CSSProperties; forceMobileStyle?: boolean }) {
-  const formikContext = useFormikContext()
-  const { isSubmitting, errors, touched } = formikContext
+import type { IRechercheForm } from "@/app/_components/RechercheForm/RechercheForm"
 
-  const hasError = Object.values(errors as object).some(([key, value]) => Boolean(value) && touched[key])
+export function RechercheSubmitButton({ children, style, forceMobileStyle = false }: { children?: React.ReactNode; style?: CSSProperties; forceMobileStyle?: boolean }) {
+  const { isSubmitting, errors, touched, values, initialValues } = useFormikContext<IRechercheForm>()
+
+  const hasError = (Object.keys(errors) as (keyof IRechercheForm)[]).some((key) => Boolean(errors[key]) && Boolean(touched[key]))
+
+  // Seuls le métier et le lieu déclenchent une nouvelle recherche via le bouton.
+  // Les autres champs (rayon, diplôme, types d'emploi, handicap, catégories) filtrent
+  // la vue / relancent l'API directement. On garde donc le bouton désactivé tant que
+  // ni le métier ni le lieu n'ont été modifiés par rapport à la recherche courante.
+  const isModified =
+    JSON.stringify(values.metier ?? null) !== JSON.stringify(initialValues.metier ?? null) || JSON.stringify(values.lieu ?? null) !== JSON.stringify(initialValues.lieu ?? null)
 
   return (
     <Box
@@ -29,7 +37,7 @@ export function RechercheSubmitButton({ children, style, forceMobileStyle = fals
       }}
     >
       <Button
-        disabled={isSubmitting || hasError}
+        disabled={isSubmitting || hasError || !isModified}
         iconPosition="left"
         type="submit"
         iconId="fr-icon-search-line"

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheSubmitButton.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheSubmitButton.tsx
@@ -8,6 +8,12 @@ import type { CSSProperties } from "react"
 
 import type { IRechercheForm } from "@/app/_components/RechercheForm/RechercheForm"
 
+// On ne compare que les champs fonctionnels : l'option de métier issue de l'autocomplete
+// porte une propriété `group` absente des initialValues reconstruits depuis l'URL, qui ne
+// doit pas être considérée comme une modification.
+const metierKey = (metier: IRechercheForm["metier"]) => (metier ? JSON.stringify({ type: metier.type, label: metier.label, romes: metier.romes }) : null)
+const lieuKey = (lieu: IRechercheForm["lieu"]) => (lieu ? JSON.stringify({ label: lieu.label, latitude: lieu.latitude, longitude: lieu.longitude }) : null)
+
 export function RechercheSubmitButton({ children, style, forceMobileStyle = false }: { children?: React.ReactNode; style?: CSSProperties; forceMobileStyle?: boolean }) {
   const { isSubmitting, errors, touched, values, initialValues } = useFormikContext<IRechercheForm>()
 
@@ -17,8 +23,7 @@ export function RechercheSubmitButton({ children, style, forceMobileStyle = fals
   // Les autres champs (rayon, diplôme, types d'emploi, handicap, catégories) filtrent
   // la vue / relancent l'API directement. On garde donc le bouton désactivé tant que
   // ni le métier ni le lieu n'ont été modifiés par rapport à la recherche courante.
-  const isModified =
-    JSON.stringify(values.metier ?? null) !== JSON.stringify(initialValues.metier ?? null) || JSON.stringify(values.lieu ?? null) !== JSON.stringify(initialValues.lieu ?? null)
+  const isModified = metierKey(values.metier) !== metierKey(initialValues.metier) || lieuKey(values.lieu) !== lieuKey(initialValues.lieu)
 
   return (
     <Box


### PR DESCRIPTION
Closes #4795

## Changements

- Le bouton de recherche (`RechercheSubmitButton`) ne se réactive désormais que si le **métier** ou le **lieu** a été modifié par rapport à la recherche courante (`values` vs `initialValues`). Les autres champs (rayon, diplôme, types d'emploi, handicap, catégories) filtrent la vue / relancent l'API directement et n'affectent plus l'état du bouton.
- Correction du calcul `hasError` qui était bugué : `Object.values(errors).some(([key, value]) => …)` déstructurait des chaînes de caractères et ne détectait jamais correctement une erreur touchée. Remplacé par une itération typée sur les clés.
- Suppression d'un `console.log` de debug.
- Typage du contexte Formik via `useFormikContext<IRechercheForm>()`.

Grâce à `enableReinitialize` du Formik, `initialValues` se resynchronise sur les params d'URL après chaque recherche : le CTA se redésactive automatiquement tant que métier/lieu ne changent pas.

## Plan de test

- [ ] Sur la page résultats, charger une recherche existante : le CTA est grisé au chargement
- [ ] Modifier le métier ou le lieu : le CTA se réactive
- [ ] Modifier uniquement un filtre (rayon, diplôme, type d'emploi, handicap, catégories) : le CTA reste grisé et le filtre s'applique directement
- [ ] Lancer la recherche puis ne rien toucher : le CTA redevient grisé
- [ ] Vérifier sur Chrome, Firefox, Safari