### PR TITLE
feat: bloque la réactivation d'un compte ayant déjà un accès actif sur une autre organisation

### DIFF
--- a/server/src/services/roleManagement.service.ts
+++ b/server/src/services/roleManagement.service.ts
@@ -18,7 +18,7 @@ import { archiveDelegatedFormulaire, archiveFormulaire, checkForJobActivations }
 import { sendEngagementHandicapEmailIfNeeded } from "./handiEngagement.service"
 import mailer from "./mailer.service"
 import { sendWelcomeEmailToUserRecruteur } from "./userRecruteur.service"
-import { activateUser } from "./userWithAccount.service"
+import { activateUser, hasActiveRoleOnAnotherOrganization } from "./userWithAccount.service"
 
 export const modifyPermissionToUser = async (
   props: Pick<IRoleManagement, "authorized_id" | "authorized_type" | "user_id" | "origin">,
@@ -358,6 +358,10 @@ export const deactivateUserRole = async ({
 export const activateUserRole = async ({ userId, organizationId, requestedBy }: { userId: ObjectId; organizationId: string; requestedBy: IUserWithAccount }) => {
   const user = await getDbCollection("userswithaccounts").findOne({ _id: userId })
   if (!user) throw badRequest()
+
+  if (await hasActiveRoleOnAnotherOrganization(userId, organizationId)) {
+    throw badRequest("Cet utilisateur a déjà un accès actif sur une autre organisation. La réactivation est impossible.")
+  }
 
   const updatedRole = await adminOrOpcoUpdatePermissionToUser({
     reason: "",

--- a/server/src/services/roleManagement.service.ts
+++ b/server/src/services/roleManagement.service.ts
@@ -360,7 +360,7 @@ export const activateUserRole = async ({ userId, organizationId, requestedBy }: 
   if (!user) throw badRequest()
 
   if (await hasActiveRoleOnAnotherOrganization(userId, organizationId)) {
-    throw badRequest("Cet utilisateur a déjà un accès actif sur une autre organisation. La réactivation est impossible.")
+    throw badRequest("Cet utilisateur a déjà un accès actif sur une autre organisation. L'activation est impossible.")
   }
 
   const updatedRole = await adminOrOpcoUpdatePermissionToUser({

--- a/server/src/services/userWithAccount.service.test.ts
+++ b/server/src/services/userWithAccount.service.test.ts
@@ -1,0 +1,79 @@
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { ObjectId } from "mongodb"
+import { VALIDATION_UTILISATEUR } from "shared/constants/recruteur"
+import { generateRoleManagementFixture, generateRoleManagementStatusEventFixture } from "shared/fixtures/roleManagement.fixture"
+import { AccessStatus } from "shared/models/roleManagement.model"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+
+import { hasActiveRoleOnAnotherOrganization } from "./userWithAccount.service"
+
+useMongo()
+
+describe("userWithAccount.service", () => {
+  describe("hasActiveRoleOnAnotherOrganization", () => {
+    const userId = new ObjectId()
+    const organizationId = "org-A"
+
+    beforeEach(async () => {
+      await getDbCollection("rolemanagements").deleteMany({})
+    })
+
+    const seedRole = async (props: Parameters<typeof generateRoleManagementFixture>[0]) => {
+      await getDbCollection("rolemanagements").insertOne(generateRoleManagementFixture(props))
+    }
+
+    it("retourne true si un rôle GRANTED existe sur une autre organisation", async () => {
+      await seedRole({
+        user_id: userId,
+        authorized_id: "org-B",
+        status: [generateRoleManagementStatusEventFixture({ status: AccessStatus.GRANTED })],
+      })
+      expect(await hasActiveRoleOnAnotherOrganization(userId, organizationId)).toBe(true)
+    })
+
+    it("retourne false si le seul rôle GRANTED est sur la même organisation", async () => {
+      await seedRole({
+        user_id: userId,
+        authorized_id: organizationId,
+        status: [generateRoleManagementStatusEventFixture({ status: AccessStatus.GRANTED })],
+      })
+      expect(await hasActiveRoleOnAnotherOrganization(userId, organizationId)).toBe(false)
+    })
+
+    it("retourne false si le rôle sur une autre organisation est DENIED", async () => {
+      await seedRole({
+        user_id: userId,
+        authorized_id: "org-B",
+        status: [
+          generateRoleManagementStatusEventFixture({ status: AccessStatus.GRANTED }),
+          generateRoleManagementStatusEventFixture({ status: AccessStatus.DENIED, validation_type: VALIDATION_UTILISATEUR.MANUAL, date: new Date(Date.now() + 1000) }),
+        ],
+      })
+      expect(await hasActiveRoleOnAnotherOrganization(userId, organizationId)).toBe(false)
+    })
+
+    it("retourne false si le rôle sur une autre organisation est AWAITING_VALIDATION", async () => {
+      await seedRole({
+        user_id: userId,
+        authorized_id: "org-B",
+        status: [generateRoleManagementStatusEventFixture({ status: AccessStatus.AWAITING_VALIDATION })],
+      })
+      expect(await hasActiveRoleOnAnotherOrganization(userId, organizationId)).toBe(false)
+    })
+
+    it("retourne false si l'utilisateur n'a aucun rôle", async () => {
+      expect(await hasActiveRoleOnAnotherOrganization(userId, organizationId)).toBe(false)
+    })
+
+    it("ignore les rôles GRANTED appartenant à un autre utilisateur", async () => {
+      await seedRole({
+        user_id: new ObjectId(),
+        authorized_id: "org-B",
+        status: [generateRoleManagementStatusEventFixture({ status: AccessStatus.GRANTED })],
+      })
+      expect(await hasActiveRoleOnAnotherOrganization(userId, organizationId)).toBe(false)
+    })
+  })
+})

--- a/server/src/services/userWithAccount.service.ts
+++ b/server/src/services/userWithAccount.service.ts
@@ -127,6 +127,14 @@ export const emailHasActiveRole = async (email: string): Promise<boolean> => {
   return Boolean(activeRoles.length)
 }
 
+export const hasActiveRoleOnAnotherOrganization = async (userId: ObjectId, organizationId: string): Promise<boolean> => {
+  const roles = await getDbCollection("rolemanagements").find({ user_id: userId }).toArray()
+  return roles.some((role) => {
+    const roleStatus = getLastStatusEvent(role.status)?.status
+    return roleStatus === AccessStatus.GRANTED && role.authorized_id !== organizationId
+  })
+}
+
 export const isUserEmailChecked = (user: IUserWithAccount): boolean => user.status.some((event) => event.status === UserEventType.VALIDATION_EMAIL)
 
 const activationStatus = [UserEventType.ACTIF, UserEventType.DESACTIVE]

--- a/ui/common/hooks/useUserHistoryUpdate.ts
+++ b/ui/common/hooks/useUserHistoryUpdate.ts
@@ -11,20 +11,20 @@ export default function useUserHistoryUpdate() {
 
   return useCallback(
     async (status: AccessStatus, apiCall: () => Promise<unknown>) => {
-      await apiCall()
-        .then(() =>
-          ["user-list-opco", "user-list"].map(async (x) =>
-            client.invalidateQueries({
-              queryKey: [x],
-            })
-          )
-        )
-        .then(() => {
-          toast({
-            description: `Utilisateur ${getDescription(status)}`,
-            autoHideDuration: 4000,
-          })
+      try {
+        await apiCall()
+        await Promise.all(["user-list-opco", "user-list"].map((x) => client.invalidateQueries({ queryKey: [x] })))
+        toast({
+          description: `Utilisateur ${getDescription(status)}`,
+          autoHideDuration: 4000,
         })
+      } catch (error) {
+        toast({
+          variant: "error",
+          description: error instanceof Error ? error.message : "Une erreur est survenue",
+          autoHideDuration: 5000,
+        })
+      }
     },
     [client, toast]
   )

--- a/ui/utils/api.ts
+++ b/ui/utils/api.ts
@@ -102,13 +102,13 @@ export const getUserStatusByToken = async (userId: string, token: string) =>
   apiGet("/user/status/:userId/by-token", { params: { userId }, headers: { authorization: `Bearer ${token}` } })
 
 export const activateUserRole = async (userId: string, organizationId: string) =>
-  apiPost("/user/:userId/organization/:organizationId/activate", { params: { userId, organizationId } }).catch(errorHandler)
+  apiPost("/user/:userId/organization/:organizationId/activate", { params: { userId, organizationId } })
 
 export const deactivateUserRole = async (userId: string, organizationId: string, reason: string) =>
-  apiPost("/user/:userId/organization/:organizationId/deactivate", { params: { userId, organizationId }, body: { reason } }).catch(errorHandler)
+  apiPost("/user/:userId/organization/:organizationId/deactivate", { params: { userId, organizationId }, body: { reason } })
 
 export const notifyNotMyOpcoUserRole = async (userId: string, organizationId: string, reason: string) =>
-  apiPost("/user/:userId/organization/:organizationId/not-my-opco", { params: { userId, organizationId }, body: { reason } }).catch(errorHandler)
+  apiPost("/user/:userId/organization/:organizationId/not-my-opco", { params: { userId, organizationId }, body: { reason } })
 
 export const createSuperUser = async (user: INewSuperUser) => apiPost("/admin/users", { body: user })
 


### PR DESCRIPTION
Closes #4508

## Contexte

Un email pouvait se retrouver avec deux rôles `GRANTED` actifs simultanés : quand un compte désactivé était réactivé par un admin alors qu'un autre rôle actif existait déjà sur un autre SIRET. À la connexion, l'utilisateur n'accédait qu'au dernier SIRET validé et perdait l'autre accès.

## Changements

### Backend — blocage de la réactivation
- Nouveau helper `hasActiveRoleOnAnotherOrganization(userId, organizationId)` dans `userWithAccount.service.ts` : détecte un rôle `GRANTED` sur un `authorized_id` différent (tous types d'accès).
- Garde dans `activateUserRole` : lève un `badRequest` explicite si un accès actif existe déjà sur une autre organisation.
- 6 tests unitaires (avec MongoDB) sur le helper.

### Frontend — remontée du message d'erreur
- Retrait du `.catch(errorHandler)` silencieux sur `activateUserRole` / `deactivateUserRole` / `notifyNotMyOpcoUserRole` (elles rejettent désormais).
- `useUserHistoryUpdate` : `try/catch` affichant un toast d'erreur avec le message serveur, au lieu d'un faux toast de succès « Utilisateur validé ».

## Plan de test

- [ ] Créer un user avec 2 rôles (1 `GRANTED` org A, 1 `DENIED` org B)
- [ ] Tenter de réactiver le rôle org B depuis l'admin → l'action est bloquée et un toast d'erreur s'affiche avec le message
- [ ] Désactiver org A puis réactiver org B → succès, toast « Utilisateur validé »
- [ ] Vérifier que désactivation et not-my-opco affichent aussi leurs erreurs éventuelles