### PR TITLE
fix: réactive sentry après migration du serveur

### DIFF
--- a/server/src/common/sentry/sentry.ts
+++ b/server/src/common/sentry/sentry.ts
@@ -71,15 +71,8 @@ function getOptions(): Sentry.NodeOptions {
   }
 }
 
-// Sentry temporairement désactivé : migration du serveur Sentry en cours.
-// `enabled: false` force le SDK à ne créer aucun client actif : tous les appels
-// unitaires (captureException, startSpan, captureMessage, setUser…) deviennent des
-// no-op silencieux, sans appel réseau. Rien d'autre à toucher dans le code.
-// TODO: repasser à true (retirer ce flag) une fois la migration terminée.
-const SENTRY_ENABLED = false
-
 export function initSentry(): void {
-  Sentry.init({ ...getOptions(), enabled: SENTRY_ENABLED })
+  Sentry.init({ ...getOptions() })
 }
 
 export async function closeSentry(): Promise<void> {


### PR DESCRIPTION
## Changements

- Retrait du flag `SENTRY_ENABLED = false` posé temporairement pendant la migration du serveur Sentry
- `initSentry()` réactive le SDK Sentry (capture d'exceptions, spans, messages, setUser à nouveau opérationnels)

## Plan de test

- [ ] Vérifier au démarrage du serveur que le client Sentry est initialisé (pas de no-op)
- [ ] Déclencher une erreur et confirmer sa remontée dans le nouveau serveur Sentry