### PR TITLE
feat: activate xp ft job export

### DIFF
--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -205,7 +205,7 @@ export async function setupJobProcessor() {
           },
           "Envoi des offres à France Travail": {
             cron_string: "30 5 * * *",
-            handler: config.env === "production" ? async () => exportJobsToFranceTravailCsvOnly() : async () => Promise.resolve(0),
+            handler: config.env === "production" ? async () => exportJobsToFranceTravail() : async () => Promise.resolve(0),
             tag: "main",
           },
           "export des offres LBA sur S3": {

--- a/server/src/jobs/partenaireExport/__snapshots__/exportToFranceTravail.test.ts.snap
+++ b/server/src/jobs/partenaireExport/__snapshots__/exportToFranceTravail.test.ts.snap
@@ -7,7 +7,7 @@ exports[`offerToFTOffer > should convert a job to an exported offer for FT 1`] =
   "CON_cle": null,
   "CON_libelle": null,
   "CPO_cle": null,
-  "Civ_correspondant": null,
+  "Civ_correspondant": 0,
   "Code_OGR": 11235,
   "Code_commune_etab": "Montpellier",
   "Code_postal_etab": "34000",

--- a/server/src/services/__snapshots__/application.service.test.ts.snap
+++ b/server/src/services/__snapshots__/application.service.test.ts.snap
@@ -13,7 +13,7 @@ exports[`buildApplicationFromHelloworkAndSaveToDb > Should successfully create a
   "applicant_message_to_company": "I am very interested in this position",
   "applicant_rythm_description": "",
   "application_url": null,
-  "caller": "Hellowork",
+  "caller": "hellowork-api",
   "company_address": "126 RUE DE L'UNIVERSITE 75007 PARIS",
   "company_email": "employer@test.fr",
   "company_feedback": null,

--- a/server/src/services/application.service.test.ts
+++ b/server/src/services/application.service.test.ts
@@ -272,7 +272,7 @@ describe("buildApplicationFromHelloworkAndSaveToDb", () => {
     // Verify the application was created in the database
     const savedApplication = await getDbCollection("applications").findOne({ _id: new ObjectId(result.atsApplicationId) })
     expect(savedApplication).toBeTruthy()
-    expect(savedApplication?.caller).toBe("Hellowork")
+    expect(savedApplication?.caller).toBe("hellowork-api")
     expect(savedApplication?.foreign_application_id).toBe("hw_app_123")
     expect(savedApplication?.foreign_application_status_url).toBe("https://api.hellowork.com/status/hw_app_123")
     expect(omit(savedApplication, ["_id", "applicant_id", "created_at", "last_update_at"])).toMatchSnapshot()
@@ -527,7 +527,7 @@ describe("buildApplicationFromHelloworkAndSaveToDb", () => {
         applicant_id: new ObjectId(),
         job_id: new ObjectId(),
         company_siret: "98765432109876",
-        caller: "Hellowork",
+        caller: "hellowork-api",
         applicant_message_to_company: "Test application",
         created_at: new Date(),
         last_update_at: new Date(),


### PR DESCRIPTION
This pull request updates the job processor configuration to ensure the correct handler is used for exporting jobs to France Travail. The main change is to call the `exportJobsToFranceTravail` function instead of the previous CSV-only variant in production.

**Job export handler update:**

* Updated the handler for the "Envoi des offres à France Travail" scheduled job to use the `exportJobsToFranceTravail` function, ensuring the full export logic is executed in production instead of just exporting a CSV. (`server/src/jobs/jobs.ts`)