### PR TITLE
fix: exclure les offres GEIQ du rendu PartnerJobDetail

### DIFF
--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
@@ -349,7 +349,9 @@ function JobDetail({
             {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && !isMandataire && !isCfaEntreprise && <LbaJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}
             {kind === LBA_ITEM_TYPE.RECRUTEURS_LBA && <RecruteurLbaDetail recruteurLba={selectedItem as ILbaItemLbaCompanyJson} />}
             {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES && (isCfaEntreprise || isGeiq) && <GeiqJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}
-            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES && !isCfaEntreprise && <PartnerJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}
+            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES && !isCfaEntreprise && !isGeiq && (
+              <PartnerJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />
+            )}
 
             <AideApprentissage />
 


### PR DESCRIPTION
Closes #4923

## Changements

- Ajout de la condition `!isGeiq` dans le rendu `PartnerJobDetail` pour éviter le double rendu avec `GeiqJobDetail` sur les offres de type GEIQ

## Plan de test

- [ ] Ouvrir le détail d'une offre GEIQ → seul `GeiqJobDetail` s'affiche, pas `PartnerJobDetail`
- [ ] Ouvrir le détail d'une offre partenaire non-GEIQ → `PartnerJobDetail` s'affiche normalement
- [ ] Vérifier qu'une offre CFA entreprise ne régresse pas