### PR TITLE
fix: correction de l'utilisation de Sentry (type options et format extra)

### DIFF
--- a/server/src/common/utils/sentryUtils.ts
+++ b/server/src/common/utils/sentryUtils.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/node"
 
-export const sentryCaptureException = (error: any, options?: object): void => {
+export const sentryCaptureException = (error: any, options?: Parameters<typeof Sentry.captureException>[1]): void => {
   Sentry.captureException(error, options)
 }
 

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -1441,19 +1441,12 @@ export const processScheduledRecruiterIntentions = async () => {
         callback(null)
       },
     })
-
     await pipeline(stream, transform)
-
-    await notifyToSlack({
-      subject: "Envoi des intentions des recruteurs",
-      message: `${counters.total} intentions traitrées. ${counters.total - counters.error} intentions envoyées. ${counters.entretien} proposition(s) d'entretien. ${counters.error} erreurs.`,
-      error: false,
-    })
   } catch (err) {
-    await notifyToSlack({
-      subject: "Envoi des intentions des recruteurs",
-      message: "Erreur technique dans le traitement des intentions des recruteurs",
-      error: true,
+    sentryCaptureException(err, {
+      extra: {
+        message: "Erreur technique dans le traitement des intentions des recruteurs",
+      },
     })
     throw err
   }

--- a/server/src/services/external/api-alternance/certification.service.ts
+++ b/server/src/services/external/api-alternance/certification.service.ts
@@ -16,7 +16,7 @@ const getFirstCertificationFromAPIApprentissage = async (rncp: string, throwOnEr
 
     return data[0]
   } catch (error: any) {
-    sentryCaptureException(error, { responseData: error.response?.data })
+    sentryCaptureException(error, { extra: { responseData: error.response?.data } })
 
     if (throwOnError) {
       const err = internal("Erreur lors de la récupération des informations de certification", {


### PR DESCRIPTION
Closes #4936

## Changements

- `sentryUtils.ts` : type `options` remplacé par `Parameters<typeof Sentry.captureException>[1]` pour correspondre à l'API réelle
- `certification.service.ts` : données extra correctement encapsulées dans `{ extra: {} }`
- `application.service.ts` : erreurs capturées via `sentryCaptureException` avec le bon format `{ extra: {} }` ; suppression des notifications Slack de succès/erreur

## Plan de test

- [ ] Vérifier que les erreurs Sentry apparaissent bien avec les données `extra` dans le dashboard Sentry
- [ ] Vérifier que `processScheduledRecruiterIntentions` capture bien les erreurs sans planter