### PR TITLE
fix: clarifie les libellés des actions de partage d'offre

### DIFF
--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabsMenu.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabsMenu.tsx
@@ -80,7 +80,7 @@ export const OffresTabsMenu = ({
         }
       : null,
     {
-      label: copied ? <Box color={copied ? "#18753C" : undefined}>Lien copié</Box> : "Partager l'offre",
+      label: copied ? <Box color={copied ? "#18753C" : undefined}>Lien copié</Box> : "Copier le lien de l'offre",
       onClick: (e) => {
         e.preventDefault()
         e.stopPropagation()
@@ -98,7 +98,7 @@ export const OffresTabsMenu = ({
     },
     user.type !== AUTHTYPE.CFA
       ? ({
-          label: "Voir les centres de formation",
+          label: "Partager aux CFA à proximité",
           link: cfaOptionParams.link,
           type: cfaOptionParams.type,
           ariaLabel: cfaOptionParams.ariaLabel,

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabsMenu.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabsMenu.tsx
@@ -80,7 +80,7 @@ export const OffresTabsMenu = ({
         }
       : null,
     {
-      label: copied ? <Box color={copied ? "#18753C" : undefined}>Lien copié</Box> : "Copier le lien de l'offre",
+      label: copied ? <Box color={fr.colors.decisions.text.default.success.default}>Lien copié</Box> : "Copier le lien de l'offre",
       onClick: (e) => {
         e.preventDefault()
         e.stopPropagation()


### PR DESCRIPTION
Closes #4859

## Changements

- Renomme le libellé « Partager l'offre » en « Copier le lien de l'offre » (le bouton copie effectivement le lien dans le presse-papier)
- Renomme le libellé « Voir les centres de formation » en « Partager aux CFA à proximité »

## Plan de test

- [ ] Sur l'espace employeur/admin, ouvrir le menu d'actions d'une offre
- [ ] Vérifier le libellé « Copier le lien de l'offre » et l'état « Lien copié » après clic
- [ ] Vérifier le libellé « Partager aux CFA à proximité » (non-CFA)
- [ ] Vérifier l'absence de régression sur les actions déclenchées