### PR TITLE
fix: corrige le type du champ handiengagee (booléen au lieu de string)

### DIFF
--- a/shared/src/models/rawRecruteursLba.model.ts
+++ b/shared/src/models/rawRecruteursLba.model.ts
@@ -24,7 +24,7 @@ export const ZRecruteursLbaRaw = z.object({
   coordonneeLambertAbscisseEtablissement: z.number().nullable(),
   coordonneeLambertOrdonneeEtablissement: z.number().nullable(),
   rome_codes: z.array(z.object({ rome_code: z.string(), normalized_score: z.number() })),
-  handiengagee: z.string().nullish(),
+  handiengagee: z.boolean().nullish(), // TODO: mapper vers computed_jobs_partners
   site_web: z.string().nullish(),
 })
 


### PR DESCRIPTION
Closes #4959

Suite au point de synchro Alexis × Kevin.

## Changements

- Corrige le type Zod du champ `handiengagee` (`string` → `boolean`) dans `shared/src/models/rawRecruteursLba.model.ts` — vérifié ensemble, c'est bien un booléen.
- Ajoute une note `TODO` pour le mapping vers `computed_jobs_partners` (voir plus bas).

## À suivre (hors périmètre de cette PR)

Le mapping de `handiengagee` dans `recruteursLbaToJobPartners` n'est pas fait : pas de champ cible clair aujourd'hui. `contract_is_disabled_elligible` a une sémantique différente (éligibilité de l'offre ≠ engagement entreprise), et l'engagement entreprise est déjà géré via `referentiel_engagement_entreprise`. À arbitrer avec Alexis.

## Plan de test

- [ ] `yarn typecheck` passe
- [ ] L'import `raw_recruteurslba` valide les entrées où `handiengagee` est un booléen (et rejette proprement les anciennes valeurs string)