### PR TITLE
fix: permet de mentionner des membres de l'équipe dans les notifications slack

### DIFF
--- a/server/src/common/utils/slackUtils.ts
+++ b/server/src/common/utils/slackUtils.ts
@@ -2,12 +2,26 @@ import axios from "axios"
 
 import config from "@/config"
 
-export const notifyToSlack = async ({ subject, message, error }: { subject: string; message: string; error?: boolean }) => {
-  const text = `[${config.env.toUpperCase()} — LBA ${subject && `- ${subject}`}] ${error ? "— :warning:" : "— :white_check_mark:"} — ${message}`
+type SlackWebhookPayload = {
+  text: string
+}
+
+export const SLACK_CHANNEL_MENTION = "<!channel>"
+export const SLACK_HERE_MENTION = "<!here>"
+
+// résout un pseudo vers une mention notifiante <@memberId> via config.slackTeamMemberIds ;
+// sans ID connu, retombe sur un @pseudo purement visuel (aucune notification)
+export const slackMention = (memberName: string): string => {
+  const memberId = config.slackTeamMemberIds[memberName]
+  return memberId ? `<@${memberId}>` : `@${memberName}`
+}
+
+export const notifyToSlack = async ({ subject, message, error, mentions }: { subject: string; message: string; error?: boolean; mentions?: string[] }) => {
+  const mentionText = mentions?.length ? ` — cc ${mentions.map(slackMention).join(" ")}` : ""
+  const text = `[${config.env.toUpperCase()} — LBA ${subject && `- ${subject}`}] ${error ? "— :warning:" : "— :white_check_mark:"} — ${message}${mentionText}`
   if (config.jobSlackWebhook) {
-    await axios.post(config.jobSlackWebhook, {
-      text,
-    })
+    const payload: SlackWebhookPayload = { text }
+    await axios.post(config.jobSlackWebhook, payload)
   } else {
     console.info(text)
   }

--- a/server/src/common/utils/slackUtils.ts
+++ b/server/src/common/utils/slackUtils.ts
@@ -12,6 +12,7 @@ export const SLACK_HERE_MENTION = "<!here>"
 // résout un pseudo vers une mention notifiante <@memberId> via config.slackTeamMemberIds ;
 // sans ID connu, retombe sur un @pseudo purement visuel (aucune notification)
 export const slackMention = (memberName: string): string => {
+  if ((memberName.startsWith("<") && memberName.endsWith(">")) || memberName.startsWith("@")) return memberName
   const memberId = config.slackTeamMemberIds[memberName]
   return memberId ? `<@${memberId}>` : `@${memberName}`
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -20,6 +20,8 @@ const config = {
   },
   slackWebhookUrl: env.get("LBA_SLACK_WEBHOOK_URL").asString(),
   jobSlackWebhook: env.get("LBA_JOB_SLACK_WEBHOOK").asString(),
+  // map pseudo -> member ID Slack (ex: {"kevin":"U04XXXXXXXX"}), utilisée par slackMention
+  slackTeamMemberIds: env.get("LBA_SLACK_TEAM_MEMBER_IDS").default("{}").asJsonObject() as Record<string, string>,
   mongodb: {
     uri: env.get("LBA_MONGODB_URI").required().asString(),
   },


### PR DESCRIPTION
Closes #4966

## Changements

- Nouveau helper `slackMention(memberName)` : résout un pseudo vers une mention notifiante `<@memberId>` via la config `slackTeamMemberIds`, avec fallback en `@pseudo` visuel si l'ID est inconnu
- Nouvelle config `slackTeamMemberIds` lue depuis la variable d'env optionnelle `LBA_SLACK_TEAM_MEMBER_IDS` (JSON `{"pseudo":"U…"}`, `{}` par défaut)
- `notifyToSlack` accepte un paramètre optionnel `mentions?: string[]` qui ajoute un `— cc @…` en fin de message, sans impact sur les appels existants
- Constantes `SLACK_CHANNEL_MENTION` / `SLACK_HERE_MENTION` et typage du payload webhook (`SlackWebhookPayload`)

## Plan de test

- [ ] `yarn typecheck` passe
- [ ] Sans `LBA_SLACK_TEAM_MEMBER_IDS` définie : `notifyToSlack` fonctionne comme avant (aucune régression sur les ~30 appels existants)
- [ ] Avec `LBA_SLACK_TEAM_MEMBER_IDS={"pseudo":"U…"}` et `mentions: ["pseudo"]` : le message Slack notifie bien la personne
- [ ] Avec un pseudo absent de la map : le message affiche `@pseudo` sans erreur