### PR TITLE
feat: expose la date de dernière action et de dernière offre dans l'export Brevo

### DIFF
--- a/server/src/jobs/partenaireExport/exportContactsToBrevo.test.ts
+++ b/server/src/jobs/partenaireExport/exportContactsToBrevo.test.ts
@@ -1,0 +1,109 @@
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { ObjectId } from "mongodb"
+import { generateJobsPartnersFull } from "shared/fixtures/jobPartners.fixture"
+import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
+import { AccessEntityType, AccessStatus } from "shared/models/roleManagement.model"
+import { UserEventType } from "shared/models/userWithAccount.model"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { uploadContactListToBrevo } from "@/services/brevo.service"
+
+import { sendContactsToBrevo } from "./exportContactsToBrevo"
+
+vi.mock("@/services/brevo.service", () => ({ uploadContactListToBrevo: vi.fn().mockResolvedValue(undefined) }))
+vi.mock("@/common/utils/slackUtils", () => ({ notifyToSlack: vi.fn().mockResolvedValue(undefined) }))
+
+const makeRoleManagement360 = (over: Record<string, unknown> = {}) => ({
+  _id: new ObjectId(),
+  role_last_status: AccessStatus.GRANTED,
+  user_last_status: UserEventType.ACTIF,
+  role_authorized_type: AccessEntityType.ENTREPRISE,
+  user__id: new ObjectId(),
+  user_origin: "lba",
+  user_first_name: "Jeanne",
+  user_last_name: "Martin",
+  user_email: `jeanne-${new ObjectId().toHexString()}@entreprise.fr`,
+  role_createdAt: new Date("2025-05-01"),
+  user_last_action_date: new Date("2025-06-15"),
+  entreprise_enseigne: "Enseigne",
+  entreprise_raison_sociale: "Raison Sociale",
+  entreprise_siret: "34268752200066",
+  cfa_enseigne: null,
+  cfa_raison_sociale: null,
+  cfa_siret: null,
+  ...over,
+})
+
+describe("sendContactsToBrevo", () => {
+  useMongo()
+
+  beforeEach(async () => {
+    vi.mocked(uploadContactListToBrevo).mockClear()
+    return async () => {
+      await getDbCollection("rolemanagement360").deleteMany({})
+      await getDbCollection("jobs_partners").deleteMany({})
+    }
+  })
+
+  it("pousse LAST_ACTION_DATE et DATE_DERNIERE_OFFRE (max des offer_creation) pour les entreprises", async () => {
+    const contact = makeRoleManagement360()
+    await getDbCollection("rolemanagement360").insertOne(contact)
+    await getDbCollection("jobs_partners").insertMany([
+      generateJobsPartnersFull({ partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, managed_by: contact.user__id, offer_creation: new Date("2025-03-10") }),
+      generateJobsPartnersFull({ partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, managed_by: contact.user__id, offer_creation: new Date("2025-06-01") }),
+    ])
+
+    await sendContactsToBrevo()
+
+    // 2 appels (TRANSACTIONAL + MARKETING) pour le batch ENTREPRISE
+    const entrepriseCalls = vi
+      .mocked(uploadContactListToBrevo)
+      .mock.calls.filter(([, rows]) => (rows as Record<string, unknown>[]).some((r) => r.role_authorized_type === AccessEntityType.ENTREPRISE))
+    expect(entrepriseCalls.length).toBe(2)
+
+    const [, rows] = entrepriseCalls[0]
+    const row = (rows as Record<string, unknown>[]).find((r) => r.user_email === contact.user_email)
+    expect(row).toBeDefined()
+    expect(row?.user_last_action_date).toEqual(new Date("2025-06-15"))
+    expect(row?.last_offer_date).toEqual(new Date("2025-06-01"))
+    expect(row?.job_count).toBe(2)
+  })
+
+  it("pousse LAST_ACTION_DATE pour les CFA (sans DATE_DERNIERE_OFFRE)", async () => {
+    const cfaContact = makeRoleManagement360({
+      role_authorized_type: AccessEntityType.CFA,
+      cfa_enseigne: "CFA Enseigne",
+      cfa_raison_sociale: "CFA RS",
+      cfa_siret: "34268752200066",
+      entreprise_enseigne: null,
+      entreprise_raison_sociale: null,
+      entreprise_siret: null,
+    })
+    await getDbCollection("rolemanagement360").insertOne(cfaContact)
+
+    await sendContactsToBrevo()
+
+    const cfaCalls = vi
+      .mocked(uploadContactListToBrevo)
+      .mock.calls.filter(([, rows]) => (rows as Record<string, unknown>[]).some((r) => r.role_authorized_type === AccessEntityType.CFA))
+    expect(cfaCalls.length).toBe(2)
+    const [, rows] = cfaCalls[0]
+    const row = (rows as Record<string, unknown>[]).find((r) => r.user_email === cfaContact.user_email)
+    expect(row?.user_last_action_date).toEqual(new Date("2025-06-15"))
+    expect(row?.last_offer_date).toBeUndefined()
+  })
+
+  it("exclut les contacts non actifs ou non autorisés", async () => {
+    await getDbCollection("rolemanagement360").insertMany([
+      makeRoleManagement360({ user_last_status: UserEventType.DESACTIVE }),
+      makeRoleManagement360({ role_last_status: AccessStatus.AWAITING_VALIDATION }),
+    ])
+
+    await sendContactsToBrevo()
+
+    // le pipeline peut émettre des lots vides : on vérifie qu'aucun contact n'est poussé
+    const pushedRows = vi.mocked(uploadContactListToBrevo).mock.calls.flatMap(([, rows]) => rows as Record<string, unknown>[])
+    expect(pushedRows).toHaveLength(0)
+  })
+})

--- a/server/src/jobs/partenaireExport/exportContactsToBrevo.ts
+++ b/server/src/jobs/partenaireExport/exportContactsToBrevo.ts
@@ -18,6 +18,8 @@ type IBrevoContact = {
   user_last_name: string
   user_email: string
   role_createdAt: Date
+  user_last_action_date?: Date | null
+  last_offer_date?: Date | null
   role_authorized_type: AccessEntityType.CFA | AccessEntityType.ENTREPRISE
   entreprise_enseigne: string | null
   entreprise_raison_sociale: string | null
@@ -49,6 +51,14 @@ const contactMapper: ColumnOption[] = [
   {
     key: "role_createdAt",
     header: "ROLE_CREATEDAT",
+  },
+  {
+    key: "user_last_action_date",
+    header: "LAST_ACTION_DATE",
+  },
+  {
+    key: "last_offer_date",
+    header: "DATE_DERNIERE_OFFRE",
   },
   {
     key: "entreprise_enseigne",
@@ -104,6 +114,7 @@ const getRoleManagement360Stream = async (type: AccessEntityType) => {
             user_last_name: 1,
             user_email: 1,
             role_createdAt: 1,
+            user_last_action_date: 1,
             role_authorized_type: 1,
             entreprise_enseigne: 1,
             entreprise_raison_sociale: 1,
@@ -142,6 +153,7 @@ const getRoleManagement360Stream = async (type: AccessEntityType) => {
               user_last_name: "$user_last_name",
               user_email: "$user_email",
               role_createdAt: "$role_createdAt",
+              user_last_action_date: "$user_last_action_date",
               role_authorized_type: "$role_authorized_type",
               entreprise_enseigne: "$entreprise_enseigne",
               entreprise_raison_sociale: "$entreprise_raison_sociale",
@@ -157,6 +169,11 @@ const getRoleManagement360Stream = async (type: AccessEntityType) => {
                 $size: "$jobs_partners",
               },
             },
+            last_offer_date: {
+              $max: {
+                $max: "$jobs_partners.offer_creation",
+              },
+            },
           },
         },
         {
@@ -166,6 +183,7 @@ const getRoleManagement360Stream = async (type: AccessEntityType) => {
             user_last_name: "$_id.user_last_name",
             user_email: "$_id.user_email",
             role_createdAt: "$_id.role_createdAt",
+            user_last_action_date: "$_id.user_last_action_date",
             role_authorized_type: "$_id.role_authorized_type",
             entreprise_enseigne: "$_id.entreprise_enseigne",
             entreprise_raison_sociale: "$_id.entreprise_raison_sociale",
@@ -174,6 +192,7 @@ const getRoleManagement360Stream = async (type: AccessEntityType) => {
             cfa_raison_sociale: "$_id.cfa_raison_sociale",
             cfa_siret: "$_id.cfa_siret",
             job_count: 1,
+            last_offer_date: 1,
             recruiter_establishment_size: "$_id.recruiter_establishment_size",
             _id: 0,
           },


### PR DESCRIPTION
Closes #4977

## Contexte

Growth doit pouvoir segmenter dans Brevo les recruteurs dormants (campagne de réactivation du stock : comptes sans activité depuis 12-24 mois). Seule `ROLE_CREATEDAT` est exportée aujourd'hui — aucune donnée d'activité.

## Changements

- Export quotidien `sendContactsToBrevo` : ajout de deux colonnes
  - `LAST_ACTION_DATE` ← `user_last_action_date` (entreprises **et** CFA) ;
  - `DATE_DERNIERE_OFFRE` ← max des `offer_creation` des `jobs_partners` du recruteur (entreprises — la jointure existait déjà pour `JOB_COUNT`).
- Ajout d'un fichier de test d'intégration pour ce job (il n'en avait aucun) : colonnes poussées, max des dates d'offres, exclusion des comptes non actifs/non autorisés.

Aucun changement de config ni de comportement d'envoi : mêmes listes, même cron (22h30).

## Plan de test

- [x] 3 tests d'intégration (MongoDB réelle, Brevo/Slack mockés) — verts.
- [x] `yarn typecheck` + `biome check` OK.
- [ ] Après déploiement : vérifier dans Brevo que les attributs `LAST_ACTION_DATE` / `DATE_DERNIERE_OFFRE` se remplissent à la prochaine sync (22h30).

## Note pour growth

La segmentation "dormants" recommandée : `LAST_ACTION_DATE` entre 12 et 24 mois (au-delà de 24 mois, les comptes sont anonymisés côté LBA — leurs contacts Brevo ont des attributs figés).