### PR TITLE
feat: metas SEO dynamiques des pages de recherche

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.test.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.test.ts
@@ -52,4 +52,14 @@ describe("buildRechercheMetadata", () => {
       )
     })
   })
+
+  describe("recherche géo-restreinte sans libellé d'adresse (lat/lon sans address)", () => {
+    const geoSansAdresse = { job_name: "Data analyst", geo: { address: null, latitude: 45.75, longitude: 4.85 } }
+
+    it("n'ajoute pas de lieu au title et n'écrit pas « en France » dans la description", () => {
+      const { title, description } = buildRechercheMetadata(geoSansAdresse, "default")
+      expect(title).toBe("Alternance Data analyst : offres et formations | La bonne alternance")
+      expect(description).toBe("Toutes les offres et formations en alternance Data analyst. Postulez gratuitement sur le service public de l'alternance.")
+    })
+  })
 })

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.test.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { buildRechercheMetadata } from "./recherche.metadata.utils"
+
+const withJobAndCity = { job_name: "Data analyst", geo: { address: "Lyon", latitude: 45.75, longitude: 4.85 } }
+const withJobOnly = { job_name: "Data analyst", geo: null }
+const empty = { job_name: null, geo: null }
+
+describe("buildRechercheMetadata", () => {
+  describe("default (offres + formations)", () => {
+    it("met le métier et la ville en tête du title", () => {
+      const { title } = buildRechercheMetadata(withJobAndCity, "default")
+      expect(title).toBe("Alternance Data analyst à Lyon : offres et formations | La bonne alternance")
+    })
+
+    it("gère le métier seul (France entière) dans la description", () => {
+      const { title, description } = buildRechercheMetadata(withJobOnly, "default")
+      expect(title).toBe("Alternance Data analyst : offres et formations | La bonne alternance")
+      expect(description).toBe("Toutes les offres et formations en alternance Data analyst en France. Postulez gratuitement sur le service public de l'alternance.")
+    })
+
+    it("retombe sur un title générique sans métier", () => {
+      const { title } = buildRechercheMetadata(empty, "default")
+      expect(title).toBe("Offres et formations en alternance | La bonne alternance")
+    })
+
+    it("traite un job_name vide comme une absence de métier", () => {
+      const { title } = buildRechercheMetadata({ job_name: "  ", geo: null }, "default")
+      expect(title).toBe("Offres et formations en alternance | La bonne alternance")
+    })
+
+    it("gère des params null", () => {
+      const { title } = buildRechercheMetadata(null, "default")
+      expect(title).toBe("Offres et formations en alternance | La bonne alternance")
+    })
+  })
+
+  describe("emploi (offres d'emploi uniquement)", () => {
+    it("cible les offres d'emploi avec un CTA dans la description", () => {
+      const { title, description } = buildRechercheMetadata(withJobAndCity, "emploi")
+      expect(title).toBe("Alternance Data analyst à Lyon : offres d'emploi | La bonne alternance")
+      expect(description).toBe("Toutes les offres d'emploi en alternance Data analyst à Lyon. Postulez gratuitement sur le service public de l'alternance.")
+    })
+  })
+
+  describe("formation (formations uniquement)", () => {
+    it("cible les formations", () => {
+      const { title, description } = buildRechercheMetadata(withJobAndCity, "formation")
+      expect(title).toBe("Formations en alternance Data analyst à Lyon | La bonne alternance")
+      expect(description).toBe(
+        "Toutes les formations en apprentissage Data analyst à Lyon. Comparez les programmes et postulez gratuitement sur le service public de l'alternance."
+      )
+    })
+  })
+})

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.ts
@@ -12,8 +12,11 @@ const SUFFIX = " | La bonne alternance"
 export function buildRechercheMetadata(rechercheParams: Partial<IRecherchePageParams> | null, kind: IRechercheMetaKind): { title: string; description: string } {
   const jobName = rechercheParams?.job_name?.trim() || null
   const address = rechercheParams?.geo?.address?.trim() || null
+  // Distingue 3 cas de géo : adresse libellée (" à Lyon") · géo sans libellé (recherche
+  // par rayon lat/lon sans param `address` → aucun lieu ajouté) · aucune géo (" en France").
+  const hasGeo = rechercheParams?.geo != null
   const lieuTitle = address ? ` à ${address}` : ""
-  const lieuDesc = address ? ` à ${address}` : " en France"
+  const lieuDesc = address ? ` à ${address}` : hasGeo ? "" : " en France"
 
   if (kind === "formation") {
     if (jobName) {

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.ts
@@ -1,0 +1,48 @@
+import type { IRecherchePageParams } from "./recherche.route.utils"
+
+export type IRechercheMetaKind = "default" | "emploi" | "formation"
+
+const SUFFIX = " | La bonne alternance"
+
+/**
+ * Construit le title + meta description SEO d'une page de recherche.
+ * Met le métier (et la ville) en tête du title et ajoute un CTA dans la description.
+ * `kind` : "default" (offres + formations), "emploi" (offres d'emploi), "formation" (formations).
+ */
+export function buildRechercheMetadata(rechercheParams: Partial<IRecherchePageParams> | null, kind: IRechercheMetaKind): { title: string; description: string } {
+  const jobName = rechercheParams?.job_name?.trim() || null
+  const address = rechercheParams?.geo?.address?.trim() || null
+  const lieuTitle = address ? ` à ${address}` : ""
+  const lieuDesc = address ? ` à ${address}` : " en France"
+
+  if (kind === "formation") {
+    if (jobName) {
+      return {
+        title: `Formations en alternance ${jobName}${lieuTitle}${SUFFIX}`,
+        description: `Toutes les formations en apprentissage ${jobName}${lieuDesc}. Comparez les programmes et postulez gratuitement sur le service public de l'alternance.`,
+      }
+    }
+    return {
+      title: `Formations en alternance${SUFFIX}`,
+      description: "Trouvez votre formation en apprentissage près de chez vous. Comparez les programmes par métier et par ville, postulez gratuitement.",
+    }
+  }
+
+  const isEmploi = kind === "emploi"
+  const offreLabel = isEmploi ? "offres d'emploi" : "offres et formations"
+  const descOffreLabel = isEmploi ? "offres d'emploi en alternance" : "offres et formations en alternance"
+
+  if (jobName) {
+    return {
+      title: `Alternance ${jobName}${lieuTitle} : ${offreLabel}${SUFFIX}`,
+      description: `Toutes les ${descOffreLabel} ${jobName}${lieuDesc}. Postulez gratuitement sur le service public de l'alternance.`,
+    }
+  }
+
+  return {
+    title: `${isEmploi ? "Offres d'emploi en alternance" : "Offres et formations en alternance"}${SUFFIX}`,
+    description: isEmploi
+      ? "Trouvez votre alternance parmi des milliers d'offres d'emploi près de chez vous. Filtrez par métier, ville et type de contrat, postulez gratuitement."
+      : "Trouvez votre alternance parmi des milliers d'offres et de formations près de chez vous. Filtrez par métier, ville et type de contrat.",
+  }
+}

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
@@ -184,19 +184,6 @@ export function buildRecherchePageParams(rechercheParams: Partial<IRecherchePage
   return query.toString()
 }
 
-export function buildSearchTitle(rechercheParams: Partial<IRecherchePageParams> | null) {
-  let searchTitleContext = ""
-  if (rechercheParams?.job_name) {
-    searchTitleContext += ` - ${rechercheParams.job_name}`
-    if (rechercheParams?.geo?.address) {
-      searchTitleContext += ` à ${rechercheParams.geo.address}`
-    } else if (rechercheParams?.geo == null) {
-      searchTitleContext += ` sur la France entière `
-    }
-  }
-  return searchTitleContext
-}
-
 export function parseRecherchePageParams(search: ReadonlyURLSearchParams | URLSearchParams | null, mode: IRechercheMode): IRecherchePageParams | null {
   if (search === null) {
     return null

--- a/ui/utils/routes.utils.ts
+++ b/ui/utils/routes.utils.ts
@@ -4,9 +4,9 @@ import type { ETAT_UTILISATEUR, OPCOS_LABEL } from "shared/constants/index"
 import { ADMIN, CFA, ENTREPRISE, OPCO } from "shared/constants/index"
 import type { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import { generateUri } from "shared/helpers/generateUri"
-
+import { buildRechercheMetadata } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils"
 import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
-import { buildRecherchePageParams, buildSearchTitle, IRechercheMode } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
+import { buildRecherchePageParams, IRechercheMode } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 
 export interface IPage {
   getPath: (args?: any) => string
@@ -753,49 +753,31 @@ export const PAGES = {
     },
     recherche: (rechercheParams: Partial<IRecherchePageParams> | null): IPage => {
       const search = buildRecherchePageParams(rechercheParams, IRechercheMode.DEFAULT)
-      const searchTitleContext = buildSearchTitle(rechercheParams)
 
       return {
         getPath: () => `/recherche${search ? `?${search}` : ""}` as string,
         index: false,
-        getMetadata: () => ({
-          title: `Offres en alternance${searchTitleContext} | La bonne alternance`,
-          description: searchTitleContext
-            ? `Trouvez des offres d'emploi en alternance et des formations en apprentissage${searchTitleContext}. Postulez directement en ligne.`
-            : "Trouvez des offres d'emploi en alternance et des formations en apprentissage près de chez vous. Filtrez par métier, ville et type de contrat.",
-        }),
+        getMetadata: () => buildRechercheMetadata(rechercheParams, "default"),
         title: "Offres en alternance",
       }
     },
     rechercheFormation: (rechercheParams: Partial<IRecherchePageParams> | null): IPage => {
       const search = buildRecherchePageParams(rechercheParams, IRechercheMode.FORMATIONS_ONLY)
-      const searchTitleContext = buildSearchTitle(rechercheParams)
 
       return {
         getPath: () => `/recherche-formation${search ? `?${search}` : ""}` as string,
         index: false,
-        getMetadata: () => ({
-          title: `Formations en alternance${searchTitleContext} | La bonne alternance`,
-          description: searchTitleContext
-            ? `Trouvez des formations en apprentissage${searchTitleContext}. Comparez les programmes et postulez en ligne.`
-            : "Trouvez des formations en apprentissage près de chez vous. Comparez les programmes par métier et par ville, postulez directement en ligne.",
-        }),
+        getMetadata: () => buildRechercheMetadata(rechercheParams, "formation"),
         title: "Formations en alternance",
       }
     },
     rechercheEmploi: (rechercheParams: Partial<IRecherchePageParams> | null): IPage => {
       const search = buildRecherchePageParams(rechercheParams, IRechercheMode.JOBS_ONLY)
-      const searchTitleContext = buildSearchTitle(rechercheParams)
 
       return {
         getPath: () => `/recherche-emploi${search ? `?${search}` : ""}` as string,
         index: false,
-        getMetadata: () => ({
-          title: `Offres en alternance${searchTitleContext} | La bonne alternance`,
-          description: searchTitleContext
-            ? `Trouvez des offres d'emploi en alternance${searchTitleContext}. Postulez directement en ligne.`
-            : "Trouvez des offres d'emploi en alternance près de chez vous. Filtrez par métier, ville et type de contrat, postulez directement en ligne.",
-        }),
+        getMetadata: () => buildRechercheMetadata(rechercheParams, "emploi"),
         title: "Offres en alternance",
       }
     },


### PR DESCRIPTION
Closes #4497

## 🧩 En clair (non technique)

**Le problème** — Sur Google, nos pages de résultats de recherche affichaient un titre générique (« Offres en alternance - Data analyst sur la France entière | La bonne alternance ») : le mot-clé important est noyé au milieu et aucune phrase ne donne envie de cliquer. Ces pages sont pourtant notre **2ᵉ source de visites** (~213 000 clics/an).

**Le gain recherché** — Des titres et descriptions plus efficaces : le **métier (et la ville) en tête**, et une phrase d'incitation (« Postulez gratuitement… »). Objectif : **plus de clics** sur des pages déjà bien positionnées, sans rien créer de nouveau.

## 🔧 Détail technique

- Nouveau helper `buildRechercheMetadata(params, kind)` (`recherche.metadata.utils.ts`) : title métier-en-tête + ville, description avec CTA ; 3 variantes (`default`, `emploi`, `formation`).
- Branché dans les 3 fonctions `recherche*` de `routes.utils.ts` ; suppression de `buildSearchTitle` (devenu inutile).
- Distinction géo restaurée : `" à {ville}"` si adresse, **rien** si recherche par rayon sans libellé, `" en France"` si aucune géo.
- Test unitaire (8 cas) : 3 variantes + sans métier / job_name vide / params null / géo sans libellé.

Exemples : `Alternance Data analyst à Lyon : offres et formations | La bonne alternance` · `Alternance Data analyst : offres d'emploi | La bonne alternance`

## 🚫 Hors scope
Le `noindex` des pages sans métier n'est pas inclus (nécessite la fondation robots #5032, puis le nettoyage chirurgical #5034). Les `index: false` existants sont inchangés.

## ✅ Plan de test
- [ ] `yarn typecheck` + `yarn test` OK (8/8 en local)
- [ ] Preview : `view-source` d'une page `/recherche?job_name=…&address=…` → le `<title>` et la `<meta description>` reflètent le métier + la ville + le CTA
