### PR TITLE
feat: optimisation SEO de la page salaire (guide rémunération + FAQPage + maillage)

### DIFF
--- a/ui/app/(editorial)/guide-alternant/comprendre-la-remuneration/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/comprendre-la-remuneration/page.tsx
@@ -11,9 +11,25 @@ import { TableArticle } from "@/app/(editorial)/_components/TableArticle"
 import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { SchemaOrg } from "@/components/SchemaOrg"
 import { PAGES } from "@/utils/routes.utils"
 
-export const metadata: Metadata = PAGES.static.guideAlternantComprendreLaRemuneration.getMetadata()
+const remunerationPage = PAGES.static.guideAlternantComprendreLaRemuneration
+
+export const metadata: Metadata = remunerationPage.getMetadata()
+
+// Miroir texte brut de la FAQ visible ci-dessous, pour le JSON-LD FAQPage (aide à obtenir les rich results / PAA).
+const FAQ_ITEMS = [
+  {
+    question: "L'alternant est-il payé pendant ses périodes de formation ?",
+    answer:
+      "Oui, l'alternant perçoit son salaire à la fois pendant les périodes en entreprise et pendant les périodes de formation en CFA ou organisme de formation. C'est l'employeur qui verse l'intégralité du salaire.",
+  },
+  {
+    question: "Le salaire est-il versé pendant les congés payés ?",
+    answer: "Oui, comme tout salarié, l'alternant bénéficie de congés payés rémunérés (5 semaines par an minimum) et son salaire est maintenu pendant les congés.",
+  },
+]
 
 const BlocSalaire = () => (
   <Grid container spacing={fr.spacing("4v")} mb={fr.spacing("4v")}>
@@ -245,6 +261,15 @@ const ComprendreLaRemunerationPage = () => {
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantComprendreLaRemuneration}
     >
+      <SchemaOrg
+        type="FAQPage"
+        title={remunerationPage.title}
+        description={remunerationPage.getMetadata().description ?? ""}
+        url={remunerationPage.getPath()}
+        breadcrumbs={[]}
+        omitBreadcrumb
+        faqItems={FAQ_ITEMS}
+      />
       <Section title="Comprendre la rémunération en alternance">
         <Paragraph>La rémunération minimale en alternance diffère selon le contrat choisi. Deux types de contrats existent :</Paragraph>
         <ParagraphList

--- a/ui/app/(landing-pages)/salaire-alternant/_components/AllerPlusLoin.tsx
+++ b/ui/app/(landing-pages)/salaire-alternant/_components/AllerPlusLoin.tsx
@@ -30,6 +30,11 @@ export const AllerPlusLoin = () => (
     <Divider sx={{ width: fr.spacing("16v"), height: 0, background: "none", borderBottom: `${fr.spacing("1v")} solid ${fr.colors.decisions.border.default.blueFrance.default}` }} />
     <Grid container spacing={2} mt={2}>
       <CardItem
+        title="Comprendre la rémunération en alternance"
+        description="Grille de salaire par âge et année de contrat, calcul brut/net et exonérations en 2026"
+        href={PAGES.static.guideAlternantComprendreLaRemuneration.getPath()}
+      />
+      <CardItem
         title="Découvrir les aides auxquelles j'ai droit"
         description="Avant de démarrer la simulation de vos aides, pensez à vous munir de vos ressources et de celles de votre entreprise"
         href="https://mes-aides.1jeune1solution.beta.gouv.fr/"

--- a/ui/utils/routes.utils.ts
+++ b/ui/utils/routes.utils.ts
@@ -228,8 +228,9 @@ export const PAGES = {
       title: "Comprendre la rémunération en alternance",
       index: true,
       getMetadata: () => ({
-        title: "Salaire alternant 2026 | Grilles et barèmes officiels",
-        description: "Barèmes de salaire en apprentissage et professionnalisation 2026. Grilles par âge, diplôme, calcul brut/net et exonérations fiscales.",
+        title: "Salaire en alternance 2026 : grille et barèmes officiels",
+        description:
+          "Grille de salaire en alternance 2026 : de 27 % à 100 % du SMIC selon l'âge et l'année de contrat. Apprentissage et professionnalisation, calcul brut/net et exonérations.",
       }),
     },
     guideAlternantCommentSignerUnContratEnAlternance: {


### PR DESCRIPTION
Refs #5035 — **Lot 1 (mécanique SEO)**. Le Lot 2 (contenu/barèmes) est un brief à valider par l'équipe contenu, non inclus ici.

## 🧩 En clair (non technique)

**Le problème** — Sur « salaire alternance 2026 » (~70 000 impressions/an), **deux de nos pages se concurrençaient** : le simulateur `/salaire-alternant` et le guide `/comprendre-la-remuneration`. Résultat : Google était partagé, aucune ne passait le top 3 (plafond position 5-7).

**Le gain recherché** — Clarifier les rôles : le **guide** devient la référence « grille et barèmes » (informationnel), le **simulateur** reste l'outil de calcul. On les relie l'un à l'autre et on donne à Google les données structurées de la FAQ. Objectif : faire décoller le guide sur le gros volume informationnel, **sans casser le simulateur** (qui gagne déjà ses requêtes « calcul / simulateur »).

## 🔧 Détail technique

- **Metas du guide** (`routes.utils.ts`) : title/description recentrés sur « salaire **en alternance** 2026 : grille et barèmes » (au lieu de « salaire altern**ant** »), avec la fourchette 27 %–100 % du SMIC.
- **Données structurées `FAQPage` (JSON-LD)** sur `comprendre-la-remuneration`, via le composant existant `SchemaOrg` (miroir texte de la FAQ visible) → surface SERP / rich results.
- **Lien réciproque** : le guide liait déjà vers le simulateur ; on ajoute **simulateur → guide** (carte « Comprendre la rémunération » dans `AllerPlusLoin`). Hiérarchie claire = fin de la cannibalisation.
- Simulateur : **metas inchangées** (on protège ses positions 1-3 sur « simulateur / calcul salaire alternance »).

## 🚫 Hors scope — Lot 2 (brief contenu séparé, à valider par l'équipe contenu)
Mise à jour du **SMIC 1 823,03 € → 1 867,02 €** (revalorisation 1er juin 2026) + montants € dans les grilles + FAQ étendue (People Also Ask) + section « baisse du net depuis mars 2025 ». → **données légales**, à valider par les propriétaires du contenu (même cycle de validation que les autres pages guide).

## ✅ Plan de test
- [ ] `yarn typecheck` OK (validé en local)
- [ ] Preview *(à déclencher après merge de `main` post-mongot, pas maintenant)* : `view-source` du guide → title/description à jour + **1 seul** bloc JSON-LD `FAQPage` valide (Rich Results Test)
- [ ] Vérifier le lien réciproque simulateur ↔ guide dans les deux sens
