### PR TITLE
feat: enquête tally branchée sur le nouveau moteur de recherche

### DIFF
--- a/ui/app/beta/_components/EnqueteTally.tsx
+++ b/ui/app/beta/_components/EnqueteTally.tsx
@@ -1,9 +1,16 @@
+"use client"
+
 import { captureException } from "@sentry/browser"
 import { useEffect } from "react"
-import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
+
+import { parseSearchPageParams } from "../_utils/search.params.utils"
+import { SEARCH_MODE_OPTIONS } from "./SearchTypeRechercheSelect"
+
+// https://tally.so/forms/LZq2l1 — « Donnez votre avis » (nouveau moteur de recherche)
+const TALLY_FORM_ID = "LZq2l1"
 
 let triggered = false
-const PERCENTAGE_TRIGGER = 0.1 // 10%
+const PERCENTAGE_TRIGGER = 0.2 // 20%
 const TIME_ELAPSED_TRIGGER = 15_000 // 15 secondes
 let scriptInitialized = false
 
@@ -28,22 +35,13 @@ const openPopup = () => {
     }
     triggered = true
 
-    const rechercheParams = parseRecherchePageParams(new URL(window.location.href).searchParams, IRechercheMode.DEFAULT)
+    const params = parseSearchPageParams(new URL(window.location.href).searchParams)
 
-    const itemTypes: string[] = []
-    if (rechercheParams.displayEntreprises) {
-      itemTypes.push("métier")
-    }
-    if (rechercheParams.displayFormations) {
-      itemTypes.push("formation")
-    }
-
-    const hiddenFields: { checkbox?: string; libelle?: string; lieu?: string; niveau?: string; handi?: string } = {
-      libelle: rechercheParams.job_name,
-      lieu: rechercheParams.geo?.address,
-      niveau: rechercheParams.diploma,
-      handi: `${rechercheParams.elligibleHandicapFilter}`,
-      checkbox: itemTypes.join(" & "),
+    // Clés = hidden fields configurés dans le formulaire Tally (keywords / lieu / type).
+    const hiddenFields: { keywords?: string; lieu?: string; type?: string } = {
+      keywords: params.q,
+      lieu: params.lieu_label,
+      type: SEARCH_MODE_OPTIONS.find((option) => option.value === params.mode)?.label ?? params.mode,
     }
 
     const options: TallyOptions = {
@@ -58,7 +56,7 @@ const openPopup = () => {
       hiddenFields,
     }
     // @ts-expect-error
-    window.Tally.openPopup("b5xXxZ", options)
+    window.Tally.openPopup(TALLY_FORM_ID, options)
   } catch (err) {
     captureException(err)
   }

--- a/ui/app/beta/_components/SearchPageClient.tsx
+++ b/ui/app/beta/_components/SearchPageClient.tsx
@@ -18,6 +18,7 @@ import type { ISearchPageParams, SearchMode } from "../_utils/search.params.util
 import { buildSearchUrl, parseSearchPageParams } from "../_utils/search.params.utils"
 import type { FilterChange, SortChange } from "../_utils/search.tracking.utils"
 import { diffFilterChanges, diffSortChange, searchTypeOf } from "../_utils/search.tracking.utils"
+import { EnqueteTally } from "./EnqueteTally"
 import { ExitNewSearchLink } from "./ExitNewSearchLink"
 import { SearchBar } from "./SearchBar"
 import { clearedFilters, SearchFilters } from "./SearchFilters"
@@ -215,6 +216,7 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
 
   return (
     <>
+      <EnqueteTally />
       <Box component="main" sx={{ display: "flex", flexDirection: "column", backgroundColor: fr.colors.decisions.background.alt.grey.default, minHeight: "100dvh" }}>
         <PublicHeader />
 


### PR DESCRIPTION
## Changements

- Déplace `EnqueteTally` (code mort depuis le redesign) vers `ui/app/beta/_components/` et le monte sur la page résultats du nouveau moteur (`/beta/recherche`).
- Nouveau formulaire Tally `LZq2l1` (« Donnez votre avis ») avec les hidden fields configurés côté Tally : `keywords` (métier recherché), `lieu`, `type` (libellé du mode de recherche).
- Déclencheurs : 20 % de scroll ou 15 s, une seule fois, pas de réaffichage après soumission.

## Plan de test

- [ ] Sur `/beta/recherche?q=boulanger&lieu_label=Paris`, attendre 15 s : la popup Tally s'ouvre
- [ ] L'iframe Tally contient `keywords=boulanger&lieu=Paris&type=Emplois+uniquement`
- [ ] La popup ne se réaffiche pas après fermeture ou soumission