### PR TITLE
fix: active le bouton de recherche mobile à la modification des filtres

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheSubmitButton.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheSubmitButton.tsx
@@ -13,17 +13,40 @@ import type { IRechercheForm } from "@/app/_components/RechercheForm/RechercheFo
 // doit pas être considérée comme une modification.
 const metierKey = (metier: IRechercheForm["metier"]) => (metier ? JSON.stringify({ type: metier.type, label: metier.label, romes: metier.romes }) : null)
 const lieuKey = (lieu: IRechercheForm["lieu"]) => (lieu ? JSON.stringify({ label: lieu.label, latitude: lieu.latitude, longitude: lieu.longitude }) : null)
+// Champs normalisés (null/undefined/"" confondus, tableaux triés) : les initialValues sont
+// reconstruits depuis l'URL et ne portent pas exactement les mêmes valeurs vides que le formulaire.
+const filtresKey = (values: IRechercheForm) =>
+  JSON.stringify({
+    displayedItemTypes: [...(values.displayedItemTypes ?? [])].sort(),
+    radius: values.radius || null,
+    diploma: values.diploma ?? null,
+    typesEmploi: [...(values.typesEmploi ?? [])].sort(),
+    elligibleHandicapFilter: values.elligibleHandicapFilter ?? false,
+  })
 
-export function RechercheSubmitButton({ children, style, forceMobileStyle = false }: { children?: React.ReactNode; style?: CSSProperties; forceMobileStyle?: boolean }) {
+export function RechercheSubmitButton({
+  children,
+  style,
+  forceMobileStyle = false,
+  compareAllFields = false,
+}: {
+  children?: React.ReactNode
+  style?: CSSProperties
+  forceMobileStyle?: boolean
+  compareAllFields?: boolean
+}) {
   const { isSubmitting, errors, touched, values, initialValues } = useFormikContext<IRechercheForm>()
 
   const hasError = (Object.keys(errors) as (keyof IRechercheForm)[]).some((key) => Boolean(errors[key]) && Boolean(touched[key]))
 
-  // Seuls le métier et le lieu déclenchent une nouvelle recherche via le bouton.
-  // Les autres champs (rayon, diplôme, types d'emploi, handicap, catégories) filtrent
-  // la vue / relancent l'API directement. On garde donc le bouton désactivé tant que
-  // ni le métier ni le lieu n'ont été modifiés par rapport à la recherche courante.
-  const isModified = metierKey(values.metier) !== metierKey(initialValues.metier) || lieuKey(values.lieu) !== lieuKey(initialValues.lieu)
+  // En desktop, seuls le métier et le lieu déclenchent une nouvelle recherche via le bouton :
+  // les autres champs (rayon, diplôme, types d'emploi, handicap, catégories) filtrent la vue /
+  // relancent l'API directement. Dans le formulaire mobile plein écran (compareAllFields),
+  // AUCUN champ ne s'applique avant la soumission : toute modification doit activer le bouton.
+  const isModified =
+    metierKey(values.metier) !== metierKey(initialValues.metier) ||
+    lieuKey(values.lieu) !== lieuKey(initialValues.lieu) ||
+    (compareAllFields && filtresKey(values) !== filtresKey(initialValues))
 
   return (
     <Box

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheMobileForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheMobileForm.tsx
@@ -44,7 +44,11 @@ export function RechercheMobileForm({ rechercheParams }: { rechercheParams: IRec
         niveauSelect={<RechercheNiveauSelectFormik />}
         typesOffresEmploiSelect={<RechercheTypesEmploiSelectFormik rechercheResults={rechercheResults} />}
         handicapCheckbox={<RechercheElligibleHandicapCheckboxFormik rechercheParams={rechercheParams} />}
-        submitButton={<RechercheSubmitButton forceMobileStyle={true}>Rechercher</RechercheSubmitButton>}
+        submitButton={
+          <RechercheSubmitButton forceMobileStyle={true} compareAllFields={true}>
+            Rechercher
+          </RechercheSubmitButton>
+        }
       />
     </RechercheForm>
   )


### PR DESCRIPTION
## Changements

- Nouvelle prop `compareAllFields` sur `RechercheSubmitButton` : compare aussi rayon, diplôme, types d'emploi, handicap et catégories (avec normalisation des valeurs vides et tri des tableaux).
- Activée uniquement dans `RechercheMobileForm` (formulaire mobile plein écran, où aucun champ ne s'applique avant la soumission). En desktop, le comportement reste inchangé : métier/lieu via le bouton, les autres filtres agissent directement sur les résultats.

## Plan de test

- [ ] Mobile, page résultats : ouvrir le formulaire, modifier uniquement le rayon ou le diplôme → le bouton « Rechercher » s'active
- [ ] Soumettre applique le filtre et re-désactive le bouton
- [ ] Desktop : le bouton reste désactivé tant que métier/lieu ne changent pas