### PR TITLE
fix: restreint la validation des noms aux schémas de saisie

### DIFF
--- a/shared/src/models/usersRecruteur.model.ts
+++ b/shared/src/models/usersRecruteur.model.ts
@@ -26,17 +26,24 @@ export const ZUserStatusValidation = z
   })
   .strict()
 
+// Validation de saisie des noms (2 lettres minimum) : à n'appliquer qu'aux BODIES des routes
+// de création/édition. Portée par le modèle, elle fuiterait dans les schémas de RÉPONSE dérivés
+// (ZUserRecruteurPublic, ZUserForOpco…) et bloquerait la connexion des comptes existants dont
+// le nom stocké ne la satisfait pas (nom vide, une lettre…).
+export const ZPersonNameInput = z
+  .string()
+  .transform((value) => removeUrlsFromText(value))
+  .refine(validatePersonName, PERSON_NAME_VALIDATION_MESSAGE)
+
 export const ZUserRecruteurWritable = z
   .object({
     last_name: z
       .string()
       .transform((value) => removeUrlsFromText(value))
-      .refine(validatePersonName, PERSON_NAME_VALIDATION_MESSAGE)
       .describe("Nom de l'utilisateur"),
     first_name: z
       .string()
       .transform((value) => removeUrlsFromText(value))
-      .refine(validatePersonName, PERSON_NAME_VALIDATION_MESSAGE)
       .describe("Prénom de l'utilisateur"),
     opco: extensions.buildEnum(OPCOS_LABEL).nullable().describe("Information sur l'opco de l'entreprise"),
     idcc: z.number().nullable().describe("Identifiant convention collective de l'entreprise"),

--- a/shared/src/routes/formulaire.route.ts
+++ b/shared/src/routes/formulaire.route.ts
@@ -3,7 +3,7 @@ import { extensions } from "../helpers/zodHelpers/zodPrimitives.js"
 import { z } from "../helpers/zodWithOpenApi.js"
 import { JOB_START_TYPE, JOB_STATUS, ZJob, ZJobCreate } from "../models/job.model.js"
 import { ZRecruiter, ZRecruiterWithRomeDetailAndApplicationCount } from "../models/recruiter.model.js"
-import { ZUserRecruteurWritable } from "../models/usersRecruteur.model.js"
+import { ZPersonNameInput } from "../models/usersRecruteur.model.js"
 import { ZUserWithAccountFields } from "../models/userWithAccount.model.js"
 import type { IRoutesDef } from "./common.routes.js"
 
@@ -78,8 +78,8 @@ export const zFormulaireRoute = {
         .object({
           establishment_siret: z.string(),
           email: z.string(),
-          last_name: ZUserRecruteurWritable.shape.last_name,
-          first_name: ZUserRecruteurWritable.shape.first_name,
+          last_name: ZPersonNameInput,
+          first_name: ZPersonNameInput,
           phone: z.string(),
           isDeclarationExact: z.boolean().optional(),
         })

--- a/shared/src/routes/recruiters.routes.ts
+++ b/shared/src/routes/recruiters.routes.ts
@@ -10,7 +10,7 @@ import { ZEntreprise } from "../models/entreprise.model.js"
 import { ZEntrepriseManagedByCfa } from "../models/entreprisesManagedByCfa.model.js"
 import { ZRecruiter } from "../models/recruiter.model.js"
 import { EntrepriseEngagementSources } from "../models/referentielEngagementEntreprise.model.js"
-import { ZUserRecruteurPublic, ZUserRecruteurWritable } from "../models/usersRecruteur.model.js"
+import { ZPersonNameInput, ZUserRecruteurPublic, ZUserRecruteurWritable } from "../models/usersRecruteur.model.js"
 import { ZUserWithAccount } from "../models/userWithAccount.model.js"
 import type { IRoutesDef } from "./common.routes.js"
 
@@ -156,17 +156,17 @@ export const zRecruiterRoutes = {
             type: z.literal("CFA"),
           })
           .strict()
-          .extend(
-            ZUserRecruteurWritable.pick({
-              last_name: true,
-              first_name: true,
+          .extend({
+            last_name: ZPersonNameInput,
+            first_name: ZPersonNameInput,
+            ...ZUserRecruteurWritable.pick({
               phone: true,
               email: true,
               origin: true,
               establishment_siret: true,
               opco: true,
-            }).shape
-          ),
+            }).shape,
+          }),
         z
           .object({
             type: z.literal("ENTREPRISE"),
@@ -174,16 +174,16 @@ export const zRecruiterRoutes = {
             idcc: z.string().optional(),
           })
           .strict()
-          .extend(
-            ZUserRecruteurWritable.pick({
-              last_name: true,
-              first_name: true,
+          .extend({
+            last_name: ZPersonNameInput,
+            first_name: ZPersonNameInput,
+            ...ZUserRecruteurWritable.pick({
               phone: true,
               email: true,
               origin: true,
               establishment_siret: true,
-            }).shape
-          ),
+            }).shape,
+          }),
       ]),
       response: {
         "200": z


### PR DESCRIPTION
Corrige une régression introduite par la PR 5025 (validation « 2 lettres minimum » des noms).

## Problème

La validation était portée par le modèle `ZUserRecruteurWritable`, dont dérivent les schémas de **réponse** (`ZUserRecruteurPublic`, `ZUserForOpco`, détail utilisateur). Tout compte existant dont le nom stocké ne respecte pas la règle (nom vide, une lettre…) provoquait un `ResponseSerializationError` 500 sur `POST /api/login/verification` et `GET /api/auth/session` → connexion impossible, y compris pour les admins.

## Changements

- Nouveau schéma `ZPersonNameInput` (strip d'URLs + validation 2 lettres), appliqué uniquement aux **bodies** : `/etablissement/creation` (branches CFA et ENTREPRISE) et `/user/:userId/formulaire`.
- `ZUserRecruteurWritable.last_name/first_name` reviennent à leur forme d'avant (string + strip d'URLs) → les schémas de réponse acceptent à nouveau les données existantes.

## Plan de test

- [ ] `yarn test server/src/http/controllers/etablissementRecruteur.controller.test.ts` (19 tests, dont les rejets de noms invalides ajoutés par la PR 5025)
- [ ] Connexion admin avec un compte au nom vide/une lettre : plus de 500
- [ ] Création de compte avec un nom invalide : toujours rejetée en 400