### PR TITLE
fix: correctifs moteur de recherche

### DIFF
--- a/server/src/common/utils/stringUtils.test.ts
+++ b/server/src/common/utils/stringUtils.test.ts
@@ -1,6 +1,36 @@
 import { describe, expect, it } from "vitest"
 
-import { isNormalizedStringInSetOrArray, removeLineBreaks, sanitizeTextField } from "./stringUtils"
+import { isNormalizedStringInSetOrArray, removeLineBreaks, sanitizeTextField, sanitizeToPlainText } from "./stringUtils"
+
+describe("sanitizeToPlainText — texte brut (rendu children React, jamais innerHTML)", () => {
+  it("décode les entités HTML résiduelles", () => {
+    expect(sanitizeToPlainText("Boulanger &amp; pâtissier")).toBe("Boulanger & pâtissier")
+  })
+
+  it("laisse intact un texte déjà brut", () => {
+    expect(sanitizeToPlainText("H&M vendeur")).toBe("H&M vendeur")
+    expect(sanitizeToPlainText("Mécanicien H/F")).toBe("Mécanicien H/F")
+  })
+
+  it("supprime les tags exécutables (offer_title_custom non restreint par le schéma Zod)", () => {
+    expect(sanitizeToPlainText("<img src=x onerror=alert(1)>Serveur")).toBe("Serveur")
+    expect(sanitizeToPlainText("<script>alert(1)</script>Cuisinier")).toBe("Cuisinier")
+  })
+
+  it("neutralise un payload double-encodé", () => {
+    expect(sanitizeToPlainText("&lt;script&gt;alert(1)&lt;/script&gt;Cuisinier")).toBe("Cuisinier")
+  })
+
+  it("aplatit les tags de mise en forme sur une seule ligne", () => {
+    expect(sanitizeToPlainText("Commercial<br>terrain")).toBe("Commercial terrain")
+    expect(sanitizeToPlainText("<p>Vendeur</p><p>conseil</p>")).toBe("Vendeur conseil")
+  })
+
+  it("retourne une chaîne vide pour null/undefined", () => {
+    expect(sanitizeToPlainText(null)).toBe("")
+    expect(sanitizeToPlainText(undefined)).toBe("")
+  })
+})
 
 describe("sanitizeTextField", () => {
   describe("Edge cases and null handling", () => {

--- a/server/src/common/utils/stringUtils.ts
+++ b/server/src/common/utils/stringUtils.ts
@@ -14,6 +14,19 @@ export const sanitizeTextField = (text: string | null | undefined, keepFormat: b
 }
 
 /**
+ * Texte brut sur une seule ligne, sûr à rendre en children React (jamais en innerHTML) :
+ * strip des tags puis décodage final des entités — sanitizeTextField seul ne suffit pas,
+ * il ré-encode & < > en sortie et ces entités (« &amp; ») s'affichent telles quelles hors
+ * innerHTML. Fins de blocs et <br> deviennent des espaces. Pour les intitulés : titres
+ * d'offres (dont offer_title_custom saisi librement par les recruteurs), search_items.title.
+ */
+export const sanitizeToPlainText = (text: string | null | undefined): string => {
+  if (!text) return ""
+  const withSpaces = text.replace(/<\/(p|li|ul|ol|div|h[1-6])>|<br\s*\/?>/gi, " ")
+  return he.decode(sanitizeTextField(withSpaces)).replace(/\s+/g, " ").trim()
+}
+
+/**
  * Aplatit un texte sur une seule ligne : supprime sauts de ligne, tabulations et caractères de
  * contrôle, puis normalise les espaces. À utiliser pour les champs exportés en CSV / flux à plat
  * (ex: France Travail) afin que des retours à la ligne dans `description` / `description_entreprise`

--- a/server/src/jobs/search/generateSearchItemsCollection.ts
+++ b/server/src/jobs/search/generateSearchItemsCollection.ts
@@ -115,6 +115,7 @@ export const fillSearchItemsCollection = async () => {
     {
       $match: {
         partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+        offer_status: JOB_STATUS_ENGLISH.ACTIVE,
       },
     },
     {

--- a/server/src/migrations/20260728110908-remove-inactive-recruteurs-from-search-items.ts
+++ b/server/src/migrations/20260728110908-remove-inactive-recruteurs-from-search-items.ts
@@ -1,0 +1,51 @@
+import type { ObjectId } from "mongodb"
+import { JOB_STATUS_ENGLISH } from "shared"
+import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
+
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+
+/**
+ * La sync des recruteurs_lba vers search_items ne prend désormais que les actifs
+ * (offer_status ACTIVE dans le $match de fillSearchItemsCollection). Purge les docs déjà
+ * synchronisés qui ne satisfont plus cette règle : recruteurs inactifs, ainsi que les
+ * orphelins dont le doc jobs_partners source a disparu (même règle — plus jamais re-syncés).
+ */
+export const up = async () => {
+  const searchItems = getDbCollection("search_items")
+  const cursor = searchItems.find({ sub_type: LBA_ITEM_TYPE.RECRUTEURS_LBA }, { projection: { _id: 1 } })
+
+  let scanned = 0
+  let deleted = 0
+  let batch: ObjectId[] = []
+
+  const flushBatch = async () => {
+    if (!batch.length) return
+    const activeIds = new Set(
+      (
+        await getDbCollection("jobs_partners")
+          .find({ _id: { $in: batch }, partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA, offer_status: JOB_STATUS_ENGLISH.ACTIVE }, { projection: { _id: 1 } })
+          .toArray()
+      ).map((doc) => doc._id.toString())
+    )
+    const toDelete = batch.filter((id) => !activeIds.has(id.toString()))
+    if (toDelete.length) {
+      const result = await searchItems.deleteMany({ _id: { $in: toDelete } })
+      deleted += result.deletedCount
+    }
+    batch = []
+  }
+
+  for await (const doc of cursor) {
+    scanned++
+    batch.push(doc._id)
+    if (batch.length >= 1000) await flushBatch()
+  }
+  await flushBatch()
+
+  logger.info(`remove-inactive-recruteurs-from-search-items: ${deleted} supprimés sur ${scanned} recruteurs scannés`)
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/server/src/migrations/20260728150000-sanitize-offer-titles.ts
+++ b/server/src/migrations/20260728150000-sanitize-offer-titles.ts
@@ -1,0 +1,86 @@
+import type { AnyBulkWriteOperation } from "mongodb"
+import type { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
+import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
+import type { ISearchItem } from "shared/models/searchItems.model"
+
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { sanitizeToPlainText } from "@/common/utils/stringUtils"
+
+/**
+ * Les titres d'offres sont désormais stockés en texte brut (tags strippés, entités décodées —
+ * cf. `sanitizeToPlainText`) : côté `search_items` pour le rendu en children React du nouveau
+ * moteur, et côté `jobs_partners` pour les offres LBA dont `offer_title_custom` (saisie libre
+ * recruteur) n'était pas sanitizé à la source alors que la page détail et les cartes SEO
+ * rendent le titre en innerHTML. Les flux partenaires et l'API passent déjà par
+ * `formatTextFieldsJobsPartners` — seuls les titres `offres_emploi_lba` sont réécrits ici.
+ * L'index Atlas Search se resynchronise automatiquement sur les documents modifiés.
+ */
+
+// Seuls les titres contenant & < ou > peuvent changer après strip + décodage.
+const DIRTY_TITLE = /[&<>]/
+
+const sanitizeSearchItemsTitles = async (): Promise<string> => {
+  const collection = getDbCollection("search_items")
+  const cursor = collection.find({ title: DIRTY_TITLE }, { projection: { _id: 1, title: 1 } })
+
+  let scanned = 0
+  let updated = 0
+  let batch: AnyBulkWriteOperation<ISearchItem>[] = []
+
+  const flushBatch = async () => {
+    if (!batch.length) return
+    const result = await collection.bulkWrite(batch, { ordered: false })
+    updated += result.modifiedCount
+    batch = []
+  }
+
+  for await (const doc of cursor) {
+    scanned++
+    const plainTitle = sanitizeToPlainText(doc.title ?? "")
+    if (plainTitle !== doc.title) {
+      batch.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { title: plainTitle } } } })
+    }
+    if (batch.length >= 1000) await flushBatch()
+  }
+  await flushBatch()
+
+  return `search_items ${updated}/${scanned} réécrits`
+}
+
+const sanitizeLbaOfferTitles = async (): Promise<string> => {
+  const collection = getDbCollection("jobs_partners")
+  const cursor = collection.find({ partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, offer_title: DIRTY_TITLE }, { projection: { _id: 1, offer_title: 1 } })
+
+  let scanned = 0
+  let updated = 0
+  let batch: AnyBulkWriteOperation<IJobsPartnersOfferPrivate>[] = []
+
+  const flushBatch = async () => {
+    if (!batch.length) return
+    const result = await collection.bulkWrite(batch, { ordered: false })
+    updated += result.modifiedCount
+    batch = []
+  }
+
+  for await (const doc of cursor) {
+    scanned++
+    const plainTitle = sanitizeToPlainText(doc.offer_title ?? "")
+    if (plainTitle !== doc.offer_title) {
+      batch.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { offer_title: plainTitle } } } })
+    }
+    if (batch.length >= 1000) await flushBatch()
+  }
+  await flushBatch()
+
+  return `jobs_partners (offres LBA) ${updated}/${scanned} réécrits`
+}
+
+export const up = async () => {
+  const searchItemsReport = await sanitizeSearchItemsTitles()
+  const jobsPartnersReport = await sanitizeLbaOfferTitles()
+  logger.info(`sanitize-offer-titles: ${searchItemsReport}, ${jobsPartnersReport}`)
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -36,7 +36,7 @@ import { getStaticFilePath } from "@/common/utils/getStaticFilePath"
 import { isEmailFromPrivateCompany, isEmailSameDomain } from "@/common/utils/mailUtils"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { sentryCaptureException } from "@/common/utils/sentryUtils"
-import { sanitizeTextField } from "@/common/utils/stringUtils"
+import { sanitizeTextField, sanitizeToPlainText } from "@/common/utils/stringUtils"
 import config from "@/config"
 import { createViewDelegationLink } from "./appLinks.service"
 import { getUserManagingOffer } from "./application.service"
@@ -626,7 +626,9 @@ export const patchOffre = async (id: ObjectId, payload: PatchOffreBody): Promise
     offer_description: romeDetails?.definition,
     contract_duration: job.job_duration ?? null,
     offer_target_diploma: getDiplomaLevel(job.job_level_label) ?? null,
-    offer_title: job.offer_title_custom ?? job.rome_appellation_label ?? existingJob.offer_title,
+    // offer_title_custom = saisie libre recruteur (le schéma Zod n'interdit pas les tags HTML) →
+    // texte brut avant stockage ; si le nettoyage vide le titre, fallback comme s'il était absent.
+    offer_title: sanitizeToPlainText(job.offer_title_custom) || job.rome_appellation_label || existingJob.offer_title,
     offer_rome_appellation: job.rome_appellation_label,
     workplace_description: job.job_employer_description !== undefined ? sanitizeTextField(job.job_employer_description, true) || null : existingJob.workplace_description,
     to_applicant_questions: job.to_applicant_questions,
@@ -1183,7 +1185,9 @@ async function jobCreateToJobsPartner({
 
   const { definition, acces_metier } = romeDetails ?? {}
 
-  const offer_title = job.offer_title_custom ?? job.rome_appellation_label ?? job.rome_label ?? "Offre"
+  // offer_title_custom = saisie libre recruteur (le schéma Zod n'interdit pas les tags HTML) →
+  // texte brut avant stockage ; si le nettoyage vide le titre, fallback comme s'il était absent.
+  const offer_title = sanitizeToPlainText(job.offer_title_custom) || job.rome_appellation_label || job.rome_label || "Offre"
   const newId = new ObjectId()
   const lbaUrl = buildLbaUrl(LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, newId, siret, offer_title)
   const contractStartDate = resolveContractStartFromJob(job, now)

--- a/server/src/services/search/searchItems.service.test.ts
+++ b/server/src/services/search/searchItems.service.test.ts
@@ -8,7 +8,27 @@ import { beforeEach, describe, expect, it } from "vitest"
 
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 
-import { removeJobPartnersFromSearchItems, resetSearchItemBuildContextCache, syncSearchItemsDelta, upsertJobPartnersToSearchItems } from "./searchItems.service"
+import {
+  dedupeRepeatedTitle,
+  removeJobPartnersFromSearchItems,
+  resetSearchItemBuildContextCache,
+  syncSearchItemsDelta,
+  upsertJobPartnersToSearchItems,
+} from "./searchItems.service"
+
+describe("dedupeRepeatedTitle", () => {
+  it("supprime la duplication d'intitulé", () => {
+    expect(dedupeRepeatedTitle("BTS bâtiment BTS bâtiment")).toBe("BTS bâtiment")
+  })
+
+  it("détecte la duplication malgré des entités HTML", () => {
+    expect(dedupeRepeatedTitle("Achat &amp; vente Achat & vente")).toBe("Achat & vente")
+  })
+
+  it("laisse intact un titre non dupliqué", () => {
+    expect(dedupeRepeatedTitle("Conseiller de vente en alternance")).toBe("Conseiller de vente en alternance")
+  })
+})
 
 describe("searchItems.service — synchronisation jobs_partners → search_items", () => {
   useMongo()

--- a/server/src/services/search/searchItems.service.test.ts
+++ b/server/src/services/search/searchItems.service.test.ts
@@ -139,6 +139,19 @@ describe("searchItems.service — synchronisation jobs_partners → search_items
       })
       expect(doc?.title).toBe("Boulangerie du Marché")
     })
+
+    it("retire un recruteur passé inactif (même règle que le batch nightly)", async () => {
+      const recruteur = generateJobsPartnersOfferPrivate({ partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA })
+      await getDbCollection("jobs_partners").insertOne(recruteur)
+      await upsertJobPartnersToSearchItems([recruteur._id])
+      expect(await getDbCollection("search_items").countDocuments({ _id: recruteur._id })).toBe(1)
+
+      await getDbCollection("jobs_partners").updateOne({ _id: recruteur._id }, { $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE } })
+      const result = await upsertJobPartnersToSearchItems([recruteur._id])
+
+      expect(result.removed).toBe(1)
+      expect(await getDbCollection("search_items").countDocuments({ _id: recruteur._id })).toBe(0)
+    })
   })
 
   describe("removeJobPartnersFromSearchItems", () => {

--- a/server/src/services/search/searchItems.service.ts
+++ b/server/src/services/search/searchItems.service.ts
@@ -11,7 +11,7 @@ import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { sentryCaptureException } from "@/common/utils/sentryUtils"
 import { notifyToSlack } from "@/common/utils/slackUtils"
 
-import { sanitizeTextField } from "@/common/utils/stringUtils"
+import { sanitizeTextField, sanitizeToPlainText } from "@/common/utils/stringUtils"
 
 /**
  * Construction et synchronisation des documents `search_items` (index MongoDB Search).
@@ -230,9 +230,10 @@ export const getTypeFilterLabel = (partner_label: string, fromCfa?: boolean | nu
 
 // Certains intitulés sources arrivent dupliqués (« BTS bâtiment BTS bâtiment » — formations
 // catalogue comme offres partenaires) : on ne garde qu'une occurrence, sinon le doublon
-// pollue les suggestions d'autocomplétion et les titres affichés.
+// pollue les suggestions d'autocomplétion et les titres affichés. Titres passés en texte
+// brut (sanitizeToPlainText) : rendus en children React côté UI, jamais en innerHTML.
 export const dedupeRepeatedTitle = (title: string): string => {
-  const trimmed = title.trim()
+  const trimmed = sanitizeToPlainText(title)
   if (trimmed.length <= 6) return trimmed
   const half = Math.floor(trimmed.length / 2)
   const first = trimmed.slice(0, half).trim()

--- a/server/src/services/search/searchItems.service.ts
+++ b/server/src/services/search/searchItems.service.ts
@@ -456,9 +456,10 @@ export const upsertSearchItem = async (doc: ISearchItem) => {
 
 /**
  * Synchronise des jobs_partners identifiés vers search_items :
- * - offre ACTIVE → upsert (keywords Mistral préservés) ;
- * - offre non-ACTIVE ou _id disparu de jobs_partners → retrait de l'index ;
- * - recruteurs_lba → upsert inconditionnel (le batch nightly n'a jamais filtré leur statut).
+ * - offre ou recruteur ACTIVE → upsert (keywords Mistral préservés) ;
+ * - non-ACTIVE ou _id disparu de jobs_partners → retrait de l'index (même règle que le
+ *   $match du batch nightly — sinon un recruteur inactif purgé réapparaîtrait via le cron
+ *   delta entre deux nightly).
  * Ne touche JAMAIS les documents `type: "formation"`.
  */
 export const upsertJobPartnersToSearchItems = async (ids: ObjectId[], sharedCtx?: SearchItemBuildContext): Promise<{ upserted: number; removed: number }> => {
@@ -480,6 +481,10 @@ export const upsertJobPartnersToSearchItems = async (ids: ObjectId[], sharedCtx?
   }
 
   for (const recruteur of recruteurs) {
+    if (recruteur.offer_status !== JOB_STATUS_ENGLISH.ACTIVE) {
+      toRemove.push(recruteur._id)
+      continue
+    }
     await upsertSearchItem(buildRecruteurSearchItem(recruteur, ctx))
     upserted++
   }

--- a/ui/app/beta/_components/SearchHitCard.tsx
+++ b/ui/app/beta/_components/SearchHitCard.tsx
@@ -135,9 +135,12 @@ export function SearchHitCard({ hit, currentParams, position }: SearchHitCardPro
           linkProps={{ href: detailUrl, prefetch: false, onClick: trackClick }}
           start={<HitTags hit={hit} />}
           title={
-            <Typography component="span" className={fr.cx("fr-text--bold", "fr-text--md")} sx={{ color: fr.colors.decisions.text.actionHigh.grey.default }}>
-              {hit.title ?? ""}
-            </Typography>
+            <Typography
+              component="span"
+              dangerouslySetInnerHTML={{ __html: hit.title ?? "" }}
+              className={fr.cx("fr-text--bold", "fr-text--md")}
+              sx={{ color: fr.colors.decisions.text.actionHigh.grey.default }}
+            />
           }
           desc={
             <Box component="span" sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("3v") }}>

--- a/ui/app/beta/_components/SearchHitCard.tsx
+++ b/ui/app/beta/_components/SearchHitCard.tsx
@@ -135,12 +135,9 @@ export function SearchHitCard({ hit, currentParams, position }: SearchHitCardPro
           linkProps={{ href: detailUrl, prefetch: false, onClick: trackClick }}
           start={<HitTags hit={hit} />}
           title={
-            <Typography
-              component="span"
-              dangerouslySetInnerHTML={{ __html: hit.title ?? "" }}
-              className={fr.cx("fr-text--bold", "fr-text--md")}
-              sx={{ color: fr.colors.decisions.text.actionHigh.grey.default }}
-            />
+            <Typography component="span" className={fr.cx("fr-text--bold", "fr-text--md")} sx={{ color: fr.colors.decisions.text.actionHigh.grey.default }}>
+              {hit.title ?? ""}
+            </Typography>
           }
           desc={
             <Box component="span" sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("3v") }}>


### PR DESCRIPTION
PR collective des correctifs du nouveau moteur de recherche.

## Changements

- **Sync recruteurs** : seuls les recruteurs LBA `offer_status: Active` sont synchronisés vers `search_items` (ajout du statut dans le `$match` de `fillSearchItemsCollection`).
- **Migration** `20260728110908-remove-inactive-recruteurs-from-search-items` : purge de `search_items` les recruteurs inactifs déjà synchronisés, ainsi que les orphelins dont le doc `jobs_partners` source a disparu (batches de 1000, pas de shutdown requis). Testée en local : 288 995 recruteurs scannés.
- **Affichage des titres** (`SearchHitCard`) : décodage des entités HTML (`&amp;`…) dans le titre des cartes de résultats.

## Plan de test

- [ ] `yarn cli migrations:up` en recette, puis vérifier `db.search_items.countDocuments({ sub_type: "recruteurs_lba" })` = nombre de recruteurs actifs dans `jobs_partners`
- [ ] Relancer `fillSearchItemsCollection` : les inactifs ne réapparaissent pas
- [ ] Cartes de résultats : un titre contenant `&amp;` s'affiche avec `&`