### PR TITLE
fix: relègue les candidatures spontanées en fin du tri par date de début de contrat

### DIFF
--- a/server/src/services/search/search-result.test.ts
+++ b/server/src/services/search/search-result.test.ts
@@ -1032,6 +1032,10 @@ describe.runIf(RUN_RELEVANCE)("search-result — pertinence du moteur de recherc
       expect(rankOf(result, "recruteur-travaux")).toBeGreaterThan(rankOf(result, "offre-travaux-flexible"))
       // Une offre sans date de démarrage reste écartée (elle trierait en tête sinon).
       expect(ids(result)).not.toContain("offre-conducteur-travaux")
+      // Invariant du result set : une vraie date de démarrage, sauf candidatures spontanées.
+      for (const hit of result.hits) {
+        if (!hit.is_algo_company) expect(hit.start_date).not.toBeNull()
+      }
     })
 
     it("compteur handi : counts.is_disabled_elligible reflète le result set et reste stable filtre actif", async () => {

--- a/server/src/services/search/search-result.test.ts
+++ b/server/src/services/search/search-result.test.ts
@@ -1022,14 +1022,16 @@ describe.runIf(RUN_RELEVANCE)("search-result — pertinence du moteur de recherc
       expect(ids(result)).not.toContain("offre-conducteur-travaux")
     })
 
-    it("sort=start_date : démarrages les plus proches d'abord, docs sans date écartés", async () => {
-      const result = await search({ q: "conducteur de travaux", sort: "start_date" })
+    it("sort=start_date : démarrages les plus proches d'abord, candidatures spontanées en fin de liste, offres sans date écartées", async () => {
+      const result = await search({ q: "conduite de travaux", sort: "start_date" })
 
       // aout (01/08) < handi (01/09) < flexible (01/12)
       expect(rankOf(result, "offre-travaux-aout")).toBeLessThan(rankOf(result, "offre-travaux-handi"))
       expect(rankOf(result, "offre-travaux-handi")).toBeLessThan(rankOf(result, "offre-travaux-flexible"))
-      // Sans date, un doc trierait en tête (valeur manquante avant toute date) → exclu de ce tri.
-      for (const hit of result.hits) expect(hit.start_date).not.toBeNull()
+      // Candidature spontanée : pas de date de début par nature → visible mais reléguée en fin.
+      expect(rankOf(result, "recruteur-travaux")).toBeGreaterThan(rankOf(result, "offre-travaux-flexible"))
+      // Une offre sans date de démarrage reste écartée (elle trierait en tête sinon).
+      expect(ids(result)).not.toContain("offre-conducteur-travaux")
     })
 
     it("compteur handi : counts.is_disabled_elligible reflète le result set et reste stable filtre actif", async () => {

--- a/server/src/services/search/search.service.ts
+++ b/server/src/services/search/search.service.ts
@@ -263,6 +263,18 @@ const HAS_START_DATE = { range: { path: "start_date", gte: new Date("1900-01-01T
 const HAS_PUBLICATION_DATE = { range: { path: "publication_date", gte: new Date("1900-01-01T00:00:00.000Z") } }
 const HAS_APPLICATION_COUNT = { range: { path: "application_count", gte: 0 } }
 
+// Result set du tri par date de début : les docs à vraie date de démarrage + les candidatures
+// spontanées (jamais de date par nature — elles restent visibles et sont reléguées en fin de
+// liste par la clé de tri is_algo_company, cf. buildSortStage, comme au tri par date de
+// publication). Les autres docs sans date (formations, offres sans start_date) trieraient en
+// tête (valeur manquante avant toute date en ordre croissant) → écartés.
+const START_DATE_SORT_FILTER = {
+  compound: {
+    should: [HAS_START_DATE, { equals: { path: "is_algo_company", value: true } }],
+    minimumShouldMatch: 1,
+  },
+}
+
 const buildStartDateFilter = (start_date: Date) => ({
   compound: {
     should: [
@@ -441,10 +453,10 @@ function buildCompoundOperator(filters: ISearchFilters) {
   if (sort === "applications") {
     filter.push(HAS_APPLICATION_COUNT)
   }
-  // Tri par date de début de contrat : même logique — les docs sans start_date (candidatures
-  // spontanées, formations) trieraient en tête en ordre croissant → écartés du tri.
+  // Tri par date de début de contrat : docs sans start_date écartés, SAUF les candidatures
+  // spontanées, conservées et reléguées en fin de liste (cf. START_DATE_SORT_FILTER).
   if (sort === "start_date") {
-    filter.push(HAS_START_DATE)
+    filter.push(START_DATE_SORT_FILTER)
   }
 
   // Tri par proximité : la porte de pertinence devient un filtre, et le score provient
@@ -479,9 +491,10 @@ function buildSortStage(filters: ISearchFilters): Record<string, unknown> {
     return { is_algo_company: { order: 1 }, publication_date: { order: -1 } }
   }
   if (filters.sort === "start_date") {
-    // Démarrages les plus proches d'abord ; les docs sans date sont écartés en amont
-    // (filter HAS_START_DATE, cf. buildCompoundOperator).
-    return { start_date: { order: 1 }, score: { $meta: "searchScore", order: -1 } }
+    // Démarrages les plus proches d'abord ; candidatures spontanées (sans date de début par
+    // nature) en DERNIER via la clé is_algo_company — même mécanique que le tri par date de
+    // publication. Les autres docs sans date sont écartés en amont (START_DATE_SORT_FILTER).
+    return { is_algo_company: { order: 1 }, start_date: { order: 1 }, score: { $meta: "searchScore", order: -1 } }
   }
   if (filters.sort === "applications") {
     // Moins de candidatures d'abord : maximise les chances du candidat et répartit les
@@ -570,7 +583,7 @@ function buildFacetCompound(filters: ISearchFilters, exclude: FacetDimension | n
     filter.push(HAS_APPLICATION_COUNT)
   }
   if (filters.sort === "start_date") {
-    filter.push(HAS_START_DATE)
+    filter.push(START_DATE_SORT_FILTER)
   }
 
   if (!gate && !filter.length) filter.push({ exists: { path: "type" } })


### PR DESCRIPTION
## Changements

- Tri « Date de début de contrat » : les candidatures spontanées (recruteurs de l'algo, sans date de début par nature) ne sont plus exclues du result set — elles restent visibles et sont reléguées en fin de liste, après les offres datées dont le tri est inchangé.
- Nouveau filtre `START_DATE_SORT_FILTER` (docs à vraie date de démarrage OU `is_algo_company: true`), appliqué à la recherche et aux compteurs de facettes ; les autres documents sans date restent écartés (ils trieraient en tête, une valeur manquante passant avant toute date en ordre croissant).
- Clé de tri primaire `is_algo_company` puis `start_date` croissant puis score — même mécanique que le tri « offres les plus récentes » qui relègue déjà les recruteurs algo.
- Test de pertinence mis à jour : ordre des démarrages conservé, recruteur présent en fin de liste, offre sans date toujours exclue (59/59 tests contre mongot).

## Plan de test

- [ ] Sur /beta/recherche, lancer une recherche renvoyant offres et entreprises à contacter (ex. « conduite de travaux »)
- [ ] Choisir le tri « Date de début de contrat » : les offres datées apparaissent d'abord, triées par démarrage croissant
- [ ] Vérifier que les cartes « Entreprises à contacter » apparaissent en fin de liste (et non plus absentes)
- [ ] Vérifier que les compteurs de filtres incluent bien les candidatures spontanées avec ce tri actif