### PR TITLE
feat: fil d'ariane et maillage interne entre les pages landing

### DIFF
--- a/ui/app/(editorial)/alternance/_components/landing_links.ts
+++ b/ui/app/(editorial)/alternance/_components/landing_links.ts
@@ -1,26 +1,16 @@
+import { stringNormaliser } from "shared"
 import { metierData } from "@/app/(editorial)/alternance/_components/metier_data"
 import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 
-// Normalise un libellé (ville ou métier) en slug comparable : minuscules, sans accents, séparateurs -> "-".
-// Sert à savoir si une page landing sœur existe pour tisser le maillage interne, avec repli /recherche sinon.
-function normalize(value: string): string {
-  return value
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/\p{Diacritic}/gu, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
-}
-
-const villeSlugByLabel = new Map(villeData.map((ville) => [normalize(ville.ville), ville.slug]))
-const metierSlugByLabel = new Map(metierData.map((metier) => [normalize(metier.metier), metier.slug]))
+const villeSlugByLabel = new Map(villeData.map((ville) => [stringNormaliser(ville.ville), ville.slug]))
+const metierSlugByLabel = new Map(metierData.map((metier) => [stringNormaliser(metier.metier), metier.slug]))
 
 // Renvoie le slug de la page ville correspondante si elle existe, sinon null.
 export function findVilleLandingSlug(nom: string): string | null {
-  return villeSlugByLabel.get(normalize(nom)) ?? null
+  return villeSlugByLabel.get(stringNormaliser(nom)) ?? null
 }
 
 // Renvoie le slug de la page métier correspondante si elle existe, sinon null.
 export function findMetierLandingSlug(nom: string): string | null {
-  return metierSlugByLabel.get(normalize(nom)) ?? null
+  return metierSlugByLabel.get(stringNormaliser(nom)) ?? null
 }

--- a/ui/app/(editorial)/alternance/_components/landing_links.ts
+++ b/ui/app/(editorial)/alternance/_components/landing_links.ts
@@ -1,0 +1,26 @@
+import { metierData } from "@/app/(editorial)/alternance/_components/metier_data"
+import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
+
+// Normalise un libellé (ville ou métier) en slug comparable : minuscules, sans accents, séparateurs -> "-".
+// Sert à savoir si une page landing sœur existe pour tisser le maillage interne, avec repli /recherche sinon.
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+}
+
+const villeSlugByLabel = new Map(villeData.map((ville) => [normalize(ville.ville), ville.slug]))
+const metierSlugByLabel = new Map(metierData.map((metier) => [normalize(metier.metier), metier.slug]))
+
+// Renvoie le slug de la page ville correspondante si elle existe, sinon null.
+export function findVilleLandingSlug(nom: string): string | null {
+  return villeSlugByLabel.get(normalize(nom)) ?? null
+}
+
+// Renvoie le slug de la page métier correspondante si elle existe, sinon null.
+export function findMetierLandingSlug(nom: string): string | null {
+  return metierSlugByLabel.get(normalize(nom)) ?? null
+}

--- a/ui/app/(editorial)/alternance/diplome/[slug]/_components/MetiersSection.tsx
+++ b/ui/app/(editorial)/alternance/diplome/[slug]/_components/MetiersSection.tsx
@@ -2,6 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Typography } from "@mui/material"
 import Link from "next/link"
 import type { IDiplomeMetier } from "shared/models/seoDiplome.model"
+import { findMetierLandingSlug } from "@/app/(editorial)/alternance/_components/landing_links"
 import { SectionTitle } from "@/app/(editorial)/alternance/_components/SectionTitle"
 import { UTM_PARAMS } from "../_data/constants"
 
@@ -12,40 +13,45 @@ export function MetiersSection({ titre, text, liste, romes }: { titre: string; t
       <SectionTitle title={title} description={text} />
 
       <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" }, gap: fr.spacing("6v"), alignItems: "start" }}>
-        {liste.map((metier) => (
-          <Box
-            key={metier.title}
-            sx={{
-              p: fr.spacing("6v"),
-              borderRadius: "5px",
-              border: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
-              boxShadow: "0 2px 6px 0 rgba(0, 0, 18, 0.16)",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              textAlign: "center",
-              gap: fr.spacing("6v"),
-            }}
-          >
-            <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
-              <span className={fr.cx("fr-icon-briefcase-line" as any)} aria-hidden="true" style={{ color: "#417DC4", fontSize: "24px" }} />
-              <Typography sx={{ fontWeight: 700, fontSize: "24px", lineHeight: "32px", color: "#417DC4", textAlign: "center" }}>{metier.title}</Typography>
+        {liste.map((metier) => {
+          const metierSlug = findMetierLandingSlug(metier.title)
+          // Maillage interne : on pointe vers la page métier sœur si elle existe, sinon repli vers la recherche.
+          const href = metierSlug ? `/alternance/metier/${metierSlug}?${UTM_PARAMS}` : `/recherche-emploi?romes=${romes.join(",")}&${UTM_PARAMS}`
+          return (
+            <Box
+              key={metier.title}
+              sx={{
+                p: fr.spacing("6v"),
+                borderRadius: "5px",
+                border: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
+                boxShadow: "0 2px 6px 0 rgba(0, 0, 18, 0.16)",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                textAlign: "center",
+                gap: fr.spacing("6v"),
+              }}
+            >
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+                <span className={fr.cx("fr-icon-briefcase-line" as any)} aria-hidden="true" style={{ color: "#417DC4", fontSize: "24px" }} />
+                <Typography sx={{ fontWeight: 700, fontSize: "24px", lineHeight: "32px", color: "#417DC4", textAlign: "center" }}>{metier.title}</Typography>
+              </Box>
+              <Typography sx={{ fontWeight: 700, fontSize: "22px", lineHeight: "28px", color: fr.colors.decisions.text.title.grey.default, textAlign: "center" }}>
+                {metier.offres} offres en alternance sur toute la France
+              </Typography>
+              <Box sx={{ mt: "auto" }}>
+                <Link
+                  href={href}
+                  title={`Voir les offres d'emploi en alternance pour le diplôme de ${titre}`}
+                  className={fr.cx("fr-link" as any, "fr-icon-arrow-right-line" as any, "fr-link--icon-right" as any)}
+                  style={{ fontSize: "16px" }}
+                >
+                  Voir les offres
+                </Link>
+              </Box>
             </Box>
-            <Typography sx={{ fontWeight: 700, fontSize: "22px", lineHeight: "28px", color: fr.colors.decisions.text.title.grey.default, textAlign: "center" }}>
-              {metier.offres} offres en alternance sur toute la France
-            </Typography>
-            <Box sx={{ mt: "auto" }}>
-              <Link
-                href={`/recherche-emploi?romes=${romes.join(",")}&${UTM_PARAMS}`}
-                title={`Voir les offres d'emploi en alternance pour le diplôme de ${titre}`}
-                className={fr.cx("fr-link" as any, "fr-icon-arrow-right-line" as any, "fr-link--icon-right" as any)}
-                style={{ fontSize: "16px" }}
-              >
-                Voir les offres
-              </Link>
-            </Box>
-          </Box>
-        ))}
+          )
+        })}
       </Box>
     </Box>
   )

--- a/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
+++ b/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { diplomeData } from "@/app/(editorial)/alternance/_components/diplome_data"
 import { UTM_PARAMS } from "@/app/(editorial)/alternance/diplome/[slug]/_data/constants"
+import { SchemaOrg } from "@/components/SchemaOrg"
 import { apiGet } from "@/utils/api.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { DescriptionDiplome } from "./_components/DescriptionDiplome"
@@ -46,9 +47,23 @@ export default async function DiplomePage({ params }: { params: Promise<{ slug: 
 
   const data = rawData as unknown as ISeoDiplome
 
+  const diplomePage = PAGES.dynamic.seoDiplome(slug, data.titre)
+  const breadcrumbs = [
+    { name: "Accueil", url: PAGES.static.home.getPath() },
+    { name: PAGES.static.alternanceDiplomes.title, url: PAGES.static.alternanceDiplomes.getPath() },
+    { name: data.titre, url: diplomePage.getPath() },
+  ]
+
   return (
     <Box>
-      <Breadcrumb pages={[PAGES.static.home]} />
+      <SchemaOrg
+        type="WebPage"
+        title={`${data.titre} en alternance`}
+        description={`Découvrez le ${data.titre} en alternance : programme, prérequis, salaire, entreprises qui recrutent et débouchés.`}
+        url={diplomePage.getPath()}
+        breadcrumbs={breadcrumbs}
+      />
+      <Breadcrumb pages={[PAGES.static.alternanceDiplomes, diplomePage]} />
 
       <DefaultContainer sx={{ px: 0 }}>
         <HeroDiplome titre={data.titre} sousTitre={data.sousTitre} kpis={data.kpis} romes={data.romes} />

--- a/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
+++ b/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
@@ -4,13 +4,17 @@ import { Box, Typography } from "@mui/material"
 import Image from "next/image"
 import Link from "next/link"
 import { redirect } from "next/navigation"
+import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import CarteOffre from "@/app/(editorial)/alternance/_components/CarteOffre"
 import { JobsCtaTracked } from "@/app/(editorial)/alternance/_components/JobsCtaTracked"
+import { findVilleLandingSlug } from "@/app/(editorial)/alternance/_components/landing_links"
 import { SalaireSection } from "@/app/(editorial)/alternance/diplome/[slug]/_components/SalaireSection"
 import { HomeCircleImageDecoration } from "@/app/(home)/_components/HomeCircleImageDecoration"
+import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { apiGet } from "@/utils/api.utils"
+import { PAGES } from "@/utils/routes.utils"
 
 const UTM_PARAMS = "utm_source=lba&utm_medium=website&utm_campaign=lba_seo-prog-metiers"
 
@@ -104,6 +108,13 @@ export default async function Metier({ params }: { params: Promise<{ metier: str
   const jobsSearchUrl = `/recherche?romes=${romesParam}&radius=30&displayFormations=false&job_name=${encodeURIComponent(data.metier)}&${UTM_PARAMS}`
   const formationsSearchUrl = `/recherche?romes=${romesParam}&radius=30&displayEntreprises=false&job_name=${encodeURIComponent(data.metier)}&${UTM_PARAMS}`
 
+  const metierPage = PAGES.dynamic.seoMetier(metier, data.metier)
+  const breadcrumbs = [
+    { name: "Accueil", url: PAGES.static.home.getPath() },
+    { name: PAGES.static.alternanceMetiers.title, url: PAGES.static.alternanceMetiers.getPath() },
+    { name: data.metier, url: metierPage.getPath() },
+  ]
+
   const statItems = [
     { icon: "/images/seo/malette.svg", value: data.job_count, label: "Offres d'emploi en alternance disponibles" },
     { icon: "/images/seo/metier/ecosystem.svg", value: data.applicant_count, label: "candidats sur les 3 derniers mois" },
@@ -113,6 +124,15 @@ export default async function Metier({ params }: { params: Promise<{ metier: str
 
   return (
     <Box>
+      <SchemaOrg
+        type="WebPage"
+        title={`Alternance ${data.metier}`}
+        description={`Offres, salaire moyen, entreprises et formations en alternance ${data.metier}.`}
+        url={metierPage.getPath()}
+        breadcrumbs={breadcrumbs}
+      />
+      <Breadcrumb pages={[PAGES.static.alternanceMetiers, metierPage]} />
+
       <DefaultContainer sx={{ px: 0 }}>
         <Box
           sx={{
@@ -308,48 +328,50 @@ export default async function Metier({ params }: { params: Promise<{ metier: str
               mt: fr.spacing("4v"),
             }}
           >
-            {(data.villes as { nom: string; job_count: number; geopoint: { lat: number; long: number } }[]).map((ville) => (
-              <Link
-                key={ville.nom}
-                href={`/recherche?romes=${romesParam}&lat=${ville.geopoint.lat}&lon=${ville.geopoint.long}&address=${ville.nom}&job_name=${encodeURIComponent(data.metier)}&displayFormations=false&${UTM_PARAMS}`}
-                style={{ background: "transparent" }}
-                aria-label={`Afficher les offres en alternance de ${data.metier} à ${ville.nom}`}
-              >
-                <Box
-                  sx={{
-                    ...boxCss,
-                    minWidth: "220px",
-                    width: "100%",
-                    maxWidth: "100%",
-                    paddingY: fr.spacing("8v"),
-                    paddingX: fr.spacing("6v"),
-                    ":hover": {
-                      backgroundColor: fr.colors.decisions.background.alt.blueFrance.default,
-                      cursor: "pointer",
-                    },
-                  }}
-                >
-                  <Box sx={{ width: "100%", textAlign: "center" }}>
-                    <Image alt="" aria-hidden="true" src="/images/seo/metier/france.svg" width={60} height={60} />
-                  </Box>
-                  <Box sx={{ width: "100%", textAlign: "left" }}>
-                    <Typography
-                      sx={{ mt: fr.spacing("1v"), fontSize: "2rem", fontWeight: "bold", lineHeight: 1.2, color: fr.colors.decisions.background.actionHigh.blueFrance.default }}
-                    >
-                      {ville.nom}
-                    </Typography>
-                    <Box sx={{ width: "100%", display: "flex", alignItems: "center", flexDirection: "row" }}>
-                      <Typography sx={{ flex: 1, mt: fr.spacing("2v"), fontSize: "1.375rem", fontWeight: "bold", lineHeight: 1.1, color: "#161616" }}>
-                        {ville.job_count} offres
+            {(data.villes as { nom: string; job_count: number; geopoint: { lat: number; long: number } }[]).map((ville) => {
+              const villeSlug = findVilleLandingSlug(ville.nom)
+              // Maillage interne : lien vers la page ville sœur si elle existe, sinon repli vers la recherche.
+              const href = villeSlug
+                ? `/alternance/ville/${villeSlug}?${UTM_PARAMS}`
+                : `/recherche?romes=${romesParam}&lat=${ville.geopoint.lat}&lon=${ville.geopoint.long}&address=${ville.nom}&job_name=${encodeURIComponent(data.metier)}&displayFormations=false&${UTM_PARAMS}`
+              return (
+                <Link key={ville.nom} href={href} style={{ background: "transparent" }} aria-label={`Afficher les offres en alternance de ${data.metier} à ${ville.nom}`}>
+                  <Box
+                    sx={{
+                      ...boxCss,
+                      minWidth: "220px",
+                      width: "100%",
+                      maxWidth: "100%",
+                      paddingY: fr.spacing("8v"),
+                      paddingX: fr.spacing("6v"),
+                      ":hover": {
+                        backgroundColor: fr.colors.decisions.background.alt.blueFrance.default,
+                        cursor: "pointer",
+                      },
+                    }}
+                  >
+                    <Box sx={{ width: "100%", textAlign: "center" }}>
+                      <Image alt="" aria-hidden="true" src="/images/seo/metier/france.svg" width={60} height={60} />
+                    </Box>
+                    <Box sx={{ width: "100%", textAlign: "left" }}>
+                      <Typography
+                        sx={{ mt: fr.spacing("1v"), fontSize: "2rem", fontWeight: "bold", lineHeight: 1.2, color: fr.colors.decisions.background.actionHigh.blueFrance.default }}
+                      >
+                        {ville.nom}
                       </Typography>
-                      <ArrowRightLine
-                        sx={{ color: fr.colors.decisions.background.actionHigh.blueFrance.default, mt: fr.spacing("1v"), ml: fr.spacing("3v"), width: 16, height: 16 }}
-                      />
+                      <Box sx={{ width: "100%", display: "flex", alignItems: "center", flexDirection: "row" }}>
+                        <Typography sx={{ flex: 1, mt: fr.spacing("2v"), fontSize: "1.375rem", fontWeight: "bold", lineHeight: 1.1, color: "#161616" }}>
+                          {ville.job_count} offres
+                        </Typography>
+                        <ArrowRightLine
+                          sx={{ color: fr.colors.decisions.background.actionHigh.blueFrance.default, mt: fr.spacing("1v"), ml: fr.spacing("3v"), width: 16, height: 16 }}
+                        />
+                      </Box>
                     </Box>
                   </Box>
-                </Box>
-              </Link>
-            ))}
+                </Link>
+              )
+            })}
           </Box>
         </Box>
 

--- a/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
+++ b/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
@@ -333,7 +333,7 @@ export default async function Metier({ params }: { params: Promise<{ metier: str
               // Maillage interne : lien vers la page ville sœur si elle existe, sinon repli vers la recherche.
               const href = villeSlug
                 ? `/alternance/ville/${villeSlug}?${UTM_PARAMS}`
-                : `/recherche?romes=${romesParam}&lat=${ville.geopoint.lat}&lon=${ville.geopoint.long}&address=${ville.nom}&job_name=${encodeURIComponent(data.metier)}&displayFormations=false&${UTM_PARAMS}`
+                : `/recherche?romes=${romesParam}&lat=${ville.geopoint.lat}&lon=${ville.geopoint.long}&address=${encodeURIComponent(ville.nom)}&job_name=${encodeURIComponent(data.metier)}&displayFormations=false&${UTM_PARAMS}`
               return (
                 <Link key={ville.nom} href={href} style={{ background: "transparent" }} aria-label={`Afficher les offres en alternance de ${data.metier} à ${ville.nom}`}>
                   <Box

--- a/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
+++ b/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
@@ -2,6 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Typography } from "@mui/material"
 import Image from "next/image"
 import { redirect } from "next/navigation"
+import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import CarteOffre from "@/app/(editorial)/alternance/_components/CarteOffre"
 import { JobsCtaTracked } from "@/app/(editorial)/alternance/_components/JobsCtaTracked"
@@ -9,8 +10,10 @@ import { appartements, loisirs, transports } from "@/app/(editorial)/alternance/
 import { HomeCircleImageDecoration } from "@/app/(home)/_components/HomeCircleImageDecoration"
 import { TagCandidatureSpontanee } from "@/components/ItemDetail/TagCandidatureSpontanee"
 import { TagOffreEmploi } from "@/components/ItemDetail/TagOffreEmploi"
+import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { apiGet } from "@/utils/api.utils"
+import { PAGES } from "@/utils/routes.utils"
 
 export async function generateMetadata({ params }: { params: Promise<{ ville: string }> }) {
   const { ville } = await params
@@ -39,8 +42,24 @@ export default async function Ville({ params }: { params: Promise<{ ville: strin
     redirect("/404")
   }
 
+  const villePage = PAGES.dynamic.seoVille(ville, data.ville)
+  const breadcrumbs = [
+    { name: "Accueil", url: PAGES.static.home.getPath() },
+    { name: PAGES.static.alternanceVilles.title, url: PAGES.static.alternanceVilles.getPath() },
+    { name: data.ville, url: villePage.getPath() },
+  ]
+
   return (
     <Box>
+      <SchemaOrg
+        type="WebPage"
+        title={`Alternance à ${data.ville}`}
+        description={`Offres d'alternance, entreprises qui recrutent, logement et vie d'alternant à ${data.ville}.`}
+        url={villePage.getPath()}
+        breadcrumbs={breadcrumbs}
+      />
+      <Breadcrumb pages={[PAGES.static.alternanceVilles, villePage]} />
+
       <DefaultContainer sx={{ px: 0 }}>
         <Box
           sx={{

--- a/ui/components/SchemaOrg.tsx
+++ b/ui/components/SchemaOrg.tsx
@@ -186,7 +186,8 @@ export const SchemaOrg = ({
   return (
     <>
       {schemas.map((schema, index) => (
-        <script key={index} type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+        // On échappe le caractère inférieur en séquence unicode pour qu'un libellé contenant une balise fermante de script ne puisse pas casser le script (XSS script-breakout).
+        <script key={index} type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema).replace(/</g, "\\u003c") }} />
       ))}
     </>
   )

--- a/ui/utils/routes.utils.ts
+++ b/ui/utils/routes.utils.ts
@@ -958,17 +958,17 @@ export const PAGES = {
         title: `Tâche CRON ${props.id} - La bonne alternance`,
       }),
     }),
-    seoVille: (villeSlug: string): IPage => ({
+    seoVille: (villeSlug: string, villeLabel?: string): IPage => ({
       getPath: () => `/alternance/ville/${villeSlug}`,
-      title: `Trouver une alternance à ${villeSlug}`,
+      title: villeLabel ?? `Trouver une alternance à ${villeSlug}`,
     }),
-    seoMetier: (metierSlug: string): IPage => ({
+    seoMetier: (metierSlug: string, metierLabel?: string): IPage => ({
       getPath: () => `/alternance/metier/${metierSlug}`,
-      title: `Trouver une alternance en ${metierSlug}`,
+      title: metierLabel ?? `Trouver une alternance en ${metierSlug}`,
     }),
-    seoDiplome: (diplomeSlug: string): IPage => ({
+    seoDiplome: (diplomeSlug: string, diplomeLabel?: string): IPage => ({
       getPath: () => `/alternance/diplome/${diplomeSlug}`,
-      title: `${diplomeSlug} en alternance`,
+      title: diplomeLabel ?? `${diplomeSlug} en alternance`,
     }),
   },
   notion: {},


### PR DESCRIPTION
Closes #5037

## 🧩 En clair (non technique)

**Le problème** — Sur nos pages SEO (métier, ville, diplôme), deux choses affaiblissaient le référencement :
1. Le **fil d'Ariane** (le petit chemin « Accueil › … › page ») était **cassé sur les pages diplôme** (il n'affichait que « Accueil ») et **absent** sur les pages ville et métier. Google s'en sert pour comprendre la hiérarchie du site.
2. Le **maillage interne** fuyait : le bloc « villes » d'une page métier et le bloc « métiers » d'une page diplôme renvoyaient vers l'**outil de recherche** (que Google lit mal) au lieu de renvoyer vers nos **autres pages SEO** indexables. Le « jus » SEO se perdait au lieu de nourrir le réseau de pages.

**Le gain** — Chaque page landing renvoie désormais vers ses pages sœurs quand elles existent, et expose un fil d'Ariane propre (+ données structurées `BreadcrumbList` pour Google). On renforce le maillage thématique et on réduit la dépendance à la page de recherche.

## 🔧 Détails techniques

- **Fil d'Ariane + `BreadcrumbList` JSON-LD** (via le composant existant `SchemaOrg`) sur les 3 pages : `metier/[metier]`, `ville/[ville]`, `diplome/[slug]`. La page diplôme passait `pages={[PAGES.static.home]}` → corrigée en `[hub diplômes, page courante]`.
- **Recâblage du maillage interne** :
  - bloc « villes » (page métier) → `/alternance/ville/[slug]` si la landing existe, sinon repli `/recherche` ;
  - bloc « métiers » (page diplôme, `MetiersSection`) → `/alternance/metier/[slug]` si la landing existe, sinon repli `/recherche-emploi`.
- **Nouveau helper `_components/landing_links.ts`** : centralise la résolution « une landing sœur existe-t-elle ? » (normalisation sans accents des libellés → slug connu dans `metierData` / `villeData`).
- **`PAGES.dynamic.seoVille/seoMetier/seoDiplome`** : ajout d'un libellé optionnel (rétro-compatible) pour un fil d'Ariane lisible (le nom du métier/ville/diplôme au lieu du slug).

`yarn typecheck` ✅ · `yarn check` ✅ (sur les fichiers concernés).

## ✅ Plan de test

- [ ] Page métier (ex. `/alternance/metier/developpeur-web`) : fil d'Ariane `Accueil › Métiers en alternance › Développeur web` ; le bloc villes pointe vers `/alternance/ville/[slug]` pour les villes couvertes, vers `/recherche` sinon.
- [ ] Page ville (ex. `/alternance/ville/bordeaux`) : fil d'Ariane `Accueil › Alternance dans les grandes villes › Bordeaux`.
- [ ] Page diplôme (ex. un slug existant) : fil d'Ariane réparé ; le bloc métiers pointe vers `/alternance/metier/[slug]` quand la landing existe.
- [ ] Données structurées : présence d'un `BreadcrumbList` JSON-LD valide sur les 3 pages (test Rich Results Google).