### PR TITLE
fix: émet new_search_optout avant la navigation (sortie du nouveau moteur en SPA)

### DIFF
--- a/ui/app/beta/_components/ExitNewSearchLink.tsx
+++ b/ui/app/beta/_components/ExitNewSearchLink.tsx
@@ -2,6 +2,7 @@
 
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box } from "@mui/material"
+import { useRouter } from "next/navigation"
 
 import { useNewSearchOptIn } from "../_hooks/useNewSearchOptIn"
 
@@ -12,6 +13,7 @@ import { useNewSearchOptIn } from "../_hooks/useNewSearchOptIn"
  * formulaire legacy se réaffiche sur place.
  */
 export function ExitNewSearchLink({ navigateToLegacy = true }: { navigateToLegacy?: boolean }) {
+  const router = useRouter()
   const { optOut } = useNewSearchOptIn()
   const className = fr.cx("fr-link", "fr-link--sm", "fr-icon-arrow-go-back-line", "fr-link--icon-left")
 
@@ -23,8 +25,18 @@ export function ExitNewSearchLink({ navigateToLegacy = true }: { navigateToLegac
     )
   }
 
+  // Navigation SPA (router.push) et non suivi du <a> plein rechargement : new_search_optout
+  // est poussé dans le dataLayer au clic, et le déchargement de page gagnait la course contre
+  // l'émission du beacon par le container MTM (événement systématiquement perdu). Le href est
+  // conservé pour la sémantique lien (survol, ouverture dans un nouvel onglet).
+  const handleExit = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault()
+    optOut()
+    router.push("/recherche")
+  }
+
   return (
-    <Box component="a" href="/recherche" onClick={optOut} className={className} sx={{ whiteSpace: "nowrap" }}>
+    <Box component="a" href="/recherche" onClick={handleExit} className={className} sx={{ whiteSpace: "nowrap" }}>
       Revenir au moteur de recherche principal
     </Box>
   )


### PR DESCRIPTION
## Contexte

Vérification end-to-end du tracking Matomo du nouveau moteur en production : tous les événements émettent correctement leur beacon vers Matomo (`results_displayed`, `filter_applied`, `filter_opened`, `optin`)… sauf `new_search_optout`, systématiquement perdu (reproduit 2×).

Cause : le lien « Revenir au moteur de recherche principal » était un `<a href="/recherche">` en rechargement complet — l'événement est bien poussé dans le dataLayer au clic, mais le déchargement de la page gagne la course contre l'émission du beacon par le container MTM. Le bandeau opt-in navigue en SPA (`router.push`), d'où son bon fonctionnement.

Conséquence actuelle : les opt-out ne sont pas comptés dans Matomo, le ratio opt-in/opt-out est faussé.

## Changements

- `ExitNewSearchLink` : `preventDefault()` + `router.push("/recherche")` (navigation SPA, comme l'opt-in) — le `href` est conservé pour la sémantique lien (survol, ouverture nouvel onglet).

## Plan de test

- [ ] Depuis `/beta/recherche`, cliquer « Revenir au moteur de recherche principal » → arrivée sur `/recherche` legacy vierge, flag opt-in désactivé
- [ ] Vérifier dans l'onglet réseau qu'une requête `matomo.php` avec `e_a` optout part au clic
- [ ] Post-deploy : les événements optout apparaissent dans Matomo (idsite 7)