### PR TITLE
fix: préserve l'ouverture en nouvel onglet sur le lien de sortie du moteur beta

### DIFF
--- a/ui/app/beta/_components/ExitNewSearchLink.tsx
+++ b/ui/app/beta/_components/ExitNewSearchLink.tsx
@@ -28,10 +28,13 @@ export function ExitNewSearchLink({ navigateToLegacy = true }: { navigateToLegac
   // Navigation SPA (router.push) et non suivi du <a> plein rechargement : new_search_optout
   // est poussé dans le dataLayer au clic, et le déchargement de page gagnait la course contre
   // l'émission du beacon par le container MTM (événement systématiquement perdu). Le href est
-  // conservé pour la sémantique lien (survol, ouverture dans un nouvel onglet).
+  // conservé pour la sémantique lien (survol, molette — auxclick ne passe pas par onClick).
   const handleExit = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    event.preventDefault()
     optOut()
+    // Clic modifié (Cmd/Ctrl/Shift/Alt) : laisser le comportement natif (nouvel onglet /
+    // fenêtre) — la page courante reste ouverte, le beacon optout part sans course.
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+    event.preventDefault()
     router.push("/recherche")
   }
 


### PR DESCRIPTION
Follow-up du fix new_search_optout (retour de review Copilot, PR mergée avant correction).

## Changements

- `ExitNewSearchLink` : les clics modifiés (Cmd/Ctrl/Shift/Alt) laissent le comportement natif du lien (ouverture nouvel onglet/fenêtre) au lieu d'être détournés par le `preventDefault` — l'événement `new_search_optout` est émis dans tous les cas, et la page courante restant ouverte, son beacon part sans course avec le déchargement.
- Le clic gauche simple garde la navigation SPA (`router.push`) introduite pour fiabiliser le beacon.
- Note : le clic molette passe par `auxclick` (jamais par `onClick`) — il gardait déjà son comportement natif.

## Plan de test

- [ ] Clic simple : arrivée sur `/recherche` en SPA, beacon optout émis
- [ ] Cmd/Ctrl+clic : `/recherche` s'ouvre dans un nouvel onglet, beacon optout émis depuis l'onglet d'origine