### PR TITLE
fix: ajoute la dimension search_engine=production aux événements matomo du moteur legacy

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/CandidatRechercheForm.tsx
@@ -8,7 +8,7 @@ import { useNavigateToRecherchePage } from "@/app/(candidat)/(recherche)/recherc
 import { useRechercheResults } from "@/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults"
 import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { apiGet } from "@/utils/api.utils"
-import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
+import { MATOMO_EVENTS, pushMatomoEvent, SEARCH_ENGINES } from "@/utils/matomoUtils"
 import { RechercheInputsLayout } from "./RechercheInputs/RechercheInputsLayout"
 import { RechercheLieuAutocomplete } from "./RechercheInputs/RechercheLieuAutocomplete"
 import { RechercheMetierAutocomplete } from "./RechercheInputs/RechercheMetierAutocomplete"
@@ -39,6 +39,7 @@ export function CandidatRechercheForm({ rechercheParams }: { rechercheParams: IR
         search_radius: rechercheForm.radius ? parseInt(rechercheForm.radius, 10) : 30,
         search_diploma: rechercheForm.diploma ?? "indifferent",
         search_origin: "page_resultat",
+        search_engine: SEARCH_ENGINES.PRODUCTION,
       })
       navigateToRecherchePage({ ...rechercheFormToRechercheParams(rechercheForm), scrollToRecruteursLba: false })
     },
@@ -70,6 +71,7 @@ export function CandidatRechercheForm({ rechercheParams }: { rechercheParams: IR
       search_job_name: rechercheParams.job_name || "non_renseigné",
       search_address: rechercheParams.geo?.address || "non_renseigné",
       search_diploma: rechercheParams.diploma ?? "indifferent",
+      search_engine: SEARCH_ENGINES.PRODUCTION,
     })
   }, [rechercheResults.status, rechercheResults.displayedItems.length, rechercheResults.displayedJobs.length, rechercheResults.displayedFormations.length, rechercheParams])
 

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheMobileForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/RechercheMobileForm.tsx
@@ -13,7 +13,7 @@ import { RechercheTypesEmploiSelectFormik } from "@/app/(candidat)/(recherche)/r
 import { useNavigateToRecherchePage } from "@/app/(candidat)/(recherche)/recherche/_hooks/useNavigateToRecherchePage"
 import { useRechercheResults } from "@/app/(candidat)/(recherche)/recherche/_hooks/useRechercheResults"
 import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
-import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
+import { MATOMO_EVENTS, pushMatomoEvent, SEARCH_ENGINES } from "@/utils/matomoUtils"
 
 export function RechercheMobileForm({ rechercheParams }: { rechercheParams: IRecherchePageParams }) {
   const navigateToRecherchePage = useNavigateToRecherchePage(rechercheParams)
@@ -29,6 +29,7 @@ export function RechercheMobileForm({ rechercheParams }: { rechercheParams: IRec
           search_radius: formValues.radius ? parseInt(formValues.radius, 10) : 30,
           search_diploma: formValues.diploma ?? "indifferent",
           search_origin: "page_resultat",
+          search_engine: SEARCH_ENGINES.PRODUCTION,
         })
         navigateToRecherchePage({ ...rechercheFormToRechercheParams(formValues), displayMobileForm: false, scrollToRecruteursLba: false })
       }}

--- a/ui/app/(editorial)/alternance/_components/JobsCtaTracked.tsx
+++ b/ui/app/(editorial)/alternance/_components/JobsCtaTracked.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Button from "@codegouvfr/react-dsfr/Button"
-import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
+import { MATOMO_EVENTS, pushMatomoEvent, SEARCH_ENGINES } from "@/utils/matomoUtils"
 
 type SearchOrigin = "page_ville" | "page_metier"
 
@@ -25,6 +25,8 @@ export function JobsCtaTracked({ href, searchOrigin, searchJobName, searchAddres
       search_radius: 30,
       search_diploma: "indifferent",
       search_origin: searchOrigin,
+      // Les CTA éditoriaux pointent vers les parcours du moteur legacy.
+      search_engine: SEARCH_ENGINES.PRODUCTION,
     })
   }
 

--- a/ui/app/(home)/_components/HomeRechercheForm.tsx
+++ b/ui/app/(home)/_components/HomeRechercheForm.tsx
@@ -13,7 +13,7 @@ import { RechercheResultTypeCheckboxFormik } from "@/app/(candidat)/(recherche)/
 import { RechercheSubmitButton } from "@/app/(candidat)/(recherche)/recherche/_components/RechercheInputs/RechercheSubmitButton"
 import { useNavigateToRecherchePage } from "@/app/(candidat)/(recherche)/recherche/_hooks/useNavigateToRecherchePage"
 import type { WithRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
-import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
+import { MATOMO_EVENTS, pushMatomoEvent, SEARCH_ENGINES } from "@/utils/matomoUtils"
 
 function HomeRechercheFormUI(props: { onSubmit: (values: IRechercheForm) => void; footer?: React.ReactNode }) {
   return (
@@ -66,6 +66,7 @@ function HomeRechercheFormComponent(props: WithRecherchePageParams & { footer?: 
           search_radius: rechercheForm.radius ? parseInt(rechercheForm.radius, 10) : 30,
           search_diploma: rechercheForm.diploma ?? "indifferent",
           search_origin: "page_accueil",
+          search_engine: SEARCH_ENGINES.PRODUCTION,
         })
         onSubmit(rechercheFormToRechercheParams(rechercheForm))
       }}


### PR DESCRIPTION
## Contexte

Retour monitoring : la dimension `search_engine` n'apparaît que sur les événements du moteur beta (`beta-v1`) — impossible de comparer les volumes entre moteurs dans Matomo. Vérifié dans l'historique : elle n'a jamais été câblée côté legacy (seul `new_search_optout` portait `production`), ce n'est pas une régression.

## Changements

`search_engine: "production"` (constante `SEARCH_ENGINES.PRODUCTION` existante) ajouté aux 4 sites d'émission du moteur legacy :

- `CandidatRechercheForm` : `search_launched` (formulaire page résultats) + `search_results_displayed`
- `RechercheMobileForm` : `search_launched`
- `HomeRechercheForm` : `search_launched` (formulaire home legacy — affiché uniquement hors opt-in)
- `JobsCtaTracked` : `search_launched` (CTA éditoriaux, qui pointent vers les parcours legacy)

## Plan de test

- [ ] Sur `/recherche` (legacy), lancer une recherche → `window._mtm` contient `search_launched` et `search_results_displayed` avec `search_engine: "production"`
- [ ] Sur `/beta/recherche`, inchangé : les événements portent `search_engine: "beta-v1"`