### PR TITLE
feat: unifie la modale de clôture de recrutement sur les 5 points d'entrée (#5046)

### DIFF
--- a/server/src/http/controllers/formulaire.controller.ts
+++ b/server/src/http/controllers/formulaire.controller.ts
@@ -413,20 +413,20 @@ export default (server: Server) => {
       if (!exists) {
         return res.status(400).send({ status: "INVALID_RESSOURCE", message: "L'offre n'existe pas" })
       }
-      const { job_status, job_status_comment, job_status_comment_precision, job_relation_channel } = req.body
+      const { job_status, job_status_comment, job_status_comment_precision, job_recruitment_channel } = req.body
       const statusMapping: Record<typeof job_status, JOB_STATUS_ENGLISH> = {
         [JOB_STATUS.POURVUE]: JOB_STATUS_ENGLISH.POURVUE,
         [JOB_STATUS.ANNULEE]: JOB_STATUS_ENGLISH.ANNULEE,
       }
-      await closeOffreWithMotif({
+      const { alreadyClosed } = await closeOffreWithMotif({
         id: jobId,
         offer_status: statusMapping[job_status],
         job_status_comment,
         job_status_comment_precision,
-        job_relation_channel,
+        job_recruitment_channel,
       })
       await validateUserEmailFromJobId(jobId)
-      return res.status(200).send({})
+      return res.status(200).send({ alreadyClosed })
     }
   )
 
@@ -444,19 +444,19 @@ export default (server: Server) => {
       if (!exists) {
         return res.status(400).send({ status: "INVALID_RESSOURCE", message: "L'offre n'existe pas" })
       }
-      const { job_status, job_status_comment, job_status_comment_precision, job_relation_channel } = req.body
+      const { job_status, job_status_comment, job_status_comment_precision, job_recruitment_channel } = req.body
       const statusMapping: Record<typeof job_status, JOB_STATUS_ENGLISH> = {
         [JOB_STATUS.POURVUE]: JOB_STATUS_ENGLISH.POURVUE,
         [JOB_STATUS.ANNULEE]: JOB_STATUS_ENGLISH.ANNULEE,
       }
-      await closeOffreWithMotif({
+      const { alreadyClosed } = await closeOffreWithMotif({
         job_status_comment,
         job_status_comment_precision,
-        job_relation_channel,
+        job_recruitment_channel,
         offer_status: statusMapping[job_status],
         id: req.params.jobId,
       })
-      return res.status(200).send({})
+      return res.status(200).send({ alreadyClosed })
     }
   )
 

--- a/server/src/http/controllers/formulaire.controller.ts
+++ b/server/src/http/controllers/formulaire.controller.ts
@@ -9,9 +9,8 @@ import { generateOffreToken } from "@/services/appLinks.service"
 import { buildEstablishmentId, entrepriseOnboardingWorkflow, establishmentIdToUserIdAndSiret } from "@/services/etablissement.service"
 import {
   archiveFormulaireByEstablishmentId,
-  cancelOffre,
-  cancelOffreFromAdminInterface,
   checkOffreExists,
+  closeOffreWithMotif,
   createJob,
   createJobDelegations,
   extendOffre,
@@ -414,7 +413,18 @@ export default (server: Server) => {
       if (!exists) {
         return res.status(400).send({ status: "INVALID_RESSOURCE", message: "L'offre n'existe pas" })
       }
-      await cancelOffre(jobId)
+      const { job_status, job_status_comment, job_status_comment_precision, job_relation_channel } = req.body
+      const statusMapping: Record<typeof job_status, JOB_STATUS_ENGLISH> = {
+        [JOB_STATUS.POURVUE]: JOB_STATUS_ENGLISH.POURVUE,
+        [JOB_STATUS.ANNULEE]: JOB_STATUS_ENGLISH.ANNULEE,
+      }
+      await closeOffreWithMotif({
+        id: jobId,
+        offer_status: statusMapping[job_status],
+        job_status_comment,
+        job_status_comment_precision,
+        job_relation_channel,
+      })
       await validateUserEmailFromJobId(jobId)
       return res.status(200).send({})
     }
@@ -434,13 +444,15 @@ export default (server: Server) => {
       if (!exists) {
         return res.status(400).send({ status: "INVALID_RESSOURCE", message: "L'offre n'existe pas" })
       }
-      const { job_status, job_status_comment } = req.body
+      const { job_status, job_status_comment, job_status_comment_precision, job_relation_channel } = req.body
       const statusMapping: Record<typeof job_status, JOB_STATUS_ENGLISH> = {
         [JOB_STATUS.POURVUE]: JOB_STATUS_ENGLISH.POURVUE,
         [JOB_STATUS.ANNULEE]: JOB_STATUS_ENGLISH.ANNULEE,
       }
-      await cancelOffreFromAdminInterface({
+      await closeOffreWithMotif({
         job_status_comment,
+        job_status_comment_precision,
+        job_relation_channel,
         offer_status: statusMapping[job_status],
         id: req.params.jobId,
       })

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -105,7 +105,7 @@ export async function setupJobProcessor() {
           },
           "Clôture des offres jobs_partners au seuil de candidatures": {
             cron_string: "*/30 * * * *",
-            handler: closeJobsPartnersOnApplicationThreshold,
+            handler: async () => closeJobsPartnersOnApplicationThreshold(),
             tag: "main",
           },
           "Mise à jour des adresses emails bloquées": {

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -34,6 +34,7 @@ import { generateFranceTravailAccess } from "./franceTravail/generateFranceTrava
 import { createRoleManagement360 } from "./metabase/metabaseRoleManagement360"
 import { create as createMigration, status as statusMigration, up as upMigration } from "./migrations/migrations"
 import { sendMiseEnRelation } from "./miseEnRelation/sendMiseEnRelation"
+import { closeJobsPartnersOnApplicationThreshold } from "./offrePartenaire/closeJobsPartnersOnApplicationThreshold"
 import { expireJobsPartners } from "./offrePartenaire/expireJobsPartners"
 import { importers } from "./offrePartenaire/jobsPartners.importer"
 import { processJobPartnersForApi } from "./offrePartenaire/processJobPartnersForApi"
@@ -100,6 +101,11 @@ export async function setupJobProcessor() {
           "Expiration des offres jobs_partners": {
             cron_string: "*/30 * * * *",
             handler: expireJobsPartners,
+            tag: "main",
+          },
+          "Clôture des offres jobs_partners au seuil de candidatures": {
+            cron_string: "*/30 * * * *",
+            handler: closeJobsPartnersOnApplicationThreshold,
             tag: "main",
           },
           "Mise à jour des adresses emails bloquées": {

--- a/server/src/jobs/offrePartenaire/closeJobsPartnersOnApplicationThreshold.ts
+++ b/server/src/jobs/offrePartenaire/closeJobsPartnersOnApplicationThreshold.ts
@@ -83,7 +83,11 @@ const sendThresholdEmails = async (closedJobs: IJobsPartnersOfferPrivate[]) => {
  * (seuil au-delà duquel on considère que le recruteur n'a plus besoin de nouvelles candidatures),
  * et notifie le recruteur par mail avec un lien vers le formulaire de clôture de recrutement.
  */
-export const closeJobsPartnersOnApplicationThreshold = async () => {
+export const closeJobsPartnersOnApplicationThreshold = async (payload?: { threshold?: string | number }) => {
+  // threshold configurable (CLI --threshold, défaut 80) : permet de tester en preview sans avoir
+  // à créer 80 candidatures réelles sur une offre.
+  const threshold = payload?.threshold !== undefined ? Number(payload.threshold) : APPLICATION_COUNT_THRESHOLD
+
   const activeJobs = await getDbCollection("jobs_partners").find({ partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, offer_status: JOB_STATUS_ENGLISH.ACTIVE }).toArray()
 
   if (!activeJobs.length) {
@@ -94,10 +98,10 @@ export const closeJobsPartnersOnApplicationThreshold = async () => {
   const applicationCounts = await getApplicationByJobCount(activeJobs.map((job) => job._id))
   const countByJobId = new Map(applicationCounts.map((appCount) => [appCount._id, appCount.count]))
 
-  const jobsToClose = activeJobs.filter((job) => (countByJobId.get(job._id.toString()) ?? 0) >= APPLICATION_COUNT_THRESHOLD)
+  const jobsToClose = activeJobs.filter((job) => (countByJobId.get(job._id.toString()) ?? 0) >= threshold)
 
   if (!jobsToClose.length) {
-    logger.info("closeJobsPartnersOnApplicationThreshold: aucune offre n'a atteint le seuil de candidatures.")
+    logger.info(`closeJobsPartnersOnApplicationThreshold: aucune offre n'a atteint le seuil de ${threshold} candidatures.`)
     return
   }
 
@@ -113,7 +117,7 @@ export const closeJobsPartnersOnApplicationThreshold = async () => {
           offer_status_history: {
             date: now,
             status: JOB_STATUS_ENGLISH.ANNULEE,
-            reason: "seuil de 80 candidatures atteint",
+            reason: `seuil de ${threshold} candidatures atteint`,
             granted_by: "closeJobsPartnersOnApplicationThreshold",
           },
         },
@@ -125,7 +129,7 @@ export const closeJobsPartnersOnApplicationThreshold = async () => {
     }
   })
 
-  logger.info(`closeJobsPartnersOnApplicationThreshold: ${closedJobs.length} offres clôturées (seuil de ${APPLICATION_COUNT_THRESHOLD} candidatures atteint)`)
+  logger.info(`closeJobsPartnersOnApplicationThreshold: ${closedJobs.length} offres clôturées (seuil de ${threshold} candidatures atteint)`)
 
   await sendThresholdEmails(closedJobs)
 }

--- a/server/src/jobs/offrePartenaire/closeJobsPartnersOnApplicationThreshold.ts
+++ b/server/src/jobs/offrePartenaire/closeJobsPartnersOnApplicationThreshold.ts
@@ -1,0 +1,131 @@
+import { groupBy } from "lodash-es"
+import { ObjectId } from "mongodb"
+import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import { JOB_STATUS_ENGLISH } from "shared/models/index"
+import type { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
+import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
+
+import { logger } from "@/common/logger"
+import { asyncForEach } from "@/common/utils/asyncUtils"
+import { getStaticFilePath } from "@/common/utils/getStaticFilePath"
+import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { sentryCaptureException } from "@/common/utils/sentryUtils"
+import { sanitizeTextField } from "@/common/utils/stringUtils"
+import config from "@/config"
+import { userWithAccountToUserForToken } from "@/security/accessTokenService"
+import { createCancelJobLink } from "@/services/appLinks.service"
+import { getApplicationByJobCount } from "@/services/application.service"
+import mailer from "@/services/mailer.service"
+
+const APPLICATION_COUNT_THRESHOLD = 80
+
+const getReminderCompanyName = ({
+  workplace_name,
+  workplace_brand,
+  workplace_legal_name,
+}: Pick<IJobsPartnersOfferPrivate, "workplace_name" | "workplace_brand" | "workplace_legal_name">) => {
+  return workplace_name ?? workplace_brand ?? workplace_legal_name ?? ""
+}
+
+const sendThresholdEmails = async (closedJobs: IJobsPartnersOfferPrivate[]) => {
+  const managedClosedJobs = closedJobs.filter((job) => job.managed_by)
+  if (!managedClosedJobs.length) {
+    return
+  }
+
+  const groupByUserOffres = groupBy(managedClosedJobs, (job) => job.managed_by?.toString())
+
+  await asyncForEach(Object.values(groupByUserOffres), async (jobsGroup) => {
+    const firstJob = jobsGroup.at(0)
+    try {
+      if (!firstJob) {
+        throw new Error("inattendu: groupe vide")
+      }
+      const { managed_by } = firstJob
+      if (!managed_by) {
+        throw new Error(`managed_by vide pour l'offre avec id=${firstJob._id}`)
+      }
+      const contactUser = await getDbCollection("userswithaccounts").findOne({ _id: new ObjectId(managed_by) })
+      if (!contactUser) {
+        throw new Error(`impossible de trouver l'utilisateur gérant l'offre avec id=${firstJob._id}`)
+      }
+
+      await mailer.sendEmail({
+        to: contactUser.email,
+        subject: "Votre offre d'alternance a été dépubliée",
+        template: getStaticFilePath("./templates/mail-offre-seuil-candidatures.mjml.ejs"),
+        data: {
+          images: {
+            logoLba: `${config.publicUrl}/images/emails/logo_LBA.png?raw=true`,
+            logoRf: `${config.publicUrl}/images/emails/logo_rf.png?raw=true`,
+            logoFooter: `${config.publicUrl}/assets/logo-republique-francaise.webp?raw=true`,
+          },
+          last_name: sanitizeTextField(contactUser.last_name),
+          first_name: sanitizeTextField(contactUser.first_name),
+          establishment_raison_sociale: getReminderCompanyName(firstJob),
+          offres: jobsGroup.map((job) => ({
+            job_title: job.offer_title,
+            cloturer: createCancelJobLink(userWithAccountToUserForToken(contactUser), job._id.toString(), LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA),
+          })),
+          publicEmail: config.publicEmail,
+        },
+      })
+    } catch (err) {
+      logger.error(err)
+      logger.error(`closeJobsPartnersOnApplicationThreshold: envoi du mail de seuil, offre id=${firstJob?._id}, erreur`)
+      sentryCaptureException(err)
+    }
+  })
+}
+
+/**
+ * @description Clôture automatiquement les offres LBA actives ayant atteint un nombre élevé de candidatures
+ * (seuil au-delà duquel on considère que le recruteur n'a plus besoin de nouvelles candidatures),
+ * et notifie le recruteur par mail avec un lien vers le formulaire de clôture de recrutement.
+ */
+export const closeJobsPartnersOnApplicationThreshold = async () => {
+  const activeJobs = await getDbCollection("jobs_partners").find({ partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, offer_status: JOB_STATUS_ENGLISH.ACTIVE }).toArray()
+
+  if (!activeJobs.length) {
+    logger.info("closeJobsPartnersOnApplicationThreshold: aucune offre active à vérifier.")
+    return
+  }
+
+  const applicationCounts = await getApplicationByJobCount(activeJobs.map((job) => job._id))
+  const countByJobId = new Map(applicationCounts.map((appCount) => [appCount._id, appCount.count]))
+
+  const jobsToClose = activeJobs.filter((job) => (countByJobId.get(job._id.toString()) ?? 0) >= APPLICATION_COUNT_THRESHOLD)
+
+  if (!jobsToClose.length) {
+    logger.info("closeJobsPartnersOnApplicationThreshold: aucune offre n'a atteint le seuil de candidatures.")
+    return
+  }
+
+  const now = new Date()
+  const closedJobs: IJobsPartnersOfferPrivate[] = []
+
+  await asyncForEach(jobsToClose, async (job) => {
+    const found = await getDbCollection("jobs_partners").findOneAndUpdate(
+      { _id: job._id },
+      {
+        $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: now },
+        $push: {
+          offer_status_history: {
+            date: now,
+            status: JOB_STATUS_ENGLISH.ANNULEE,
+            reason: "seuil de 80 candidatures atteint",
+            granted_by: "closeJobsPartnersOnApplicationThreshold",
+          },
+        },
+      },
+      { returnDocument: "after" }
+    )
+    if (found) {
+      closedJobs.push(found)
+    }
+  })
+
+  logger.info(`closeJobsPartnersOnApplicationThreshold: ${closedJobs.length} offres clôturées (seuil de ${APPLICATION_COUNT_THRESHOLD} candidatures atteint)`)
+
+  await sendThresholdEmails(closedJobs)
+}

--- a/server/src/jobs/offrePartenaire/expireJobsPartners.ts
+++ b/server/src/jobs/offrePartenaire/expireJobsPartners.ts
@@ -1,23 +1,101 @@
+import { groupBy } from "lodash-es"
+import { ObjectId } from "mongodb"
+import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import { JOB_STATUS_ENGLISH } from "shared/models/index"
+import type { IJobsPartnersOfferPrivate } from "shared/models/jobsPartners.model"
 
 import { logger } from "@/common/logger"
+import { asyncForEach } from "@/common/utils/asyncUtils"
+import { getStaticFilePath } from "@/common/utils/getStaticFilePath"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
+import { sentryCaptureException } from "@/common/utils/sentryUtils"
+import { sanitizeTextField } from "@/common/utils/stringUtils"
+import config from "@/config"
+import { userWithAccountToUserForToken } from "@/security/accessTokenService"
+import { createCancelJobLink } from "@/services/appLinks.service"
+import mailer from "@/services/mailer.service"
+
+const getReminderCompanyName = ({
+  workplace_name,
+  workplace_brand,
+  workplace_legal_name,
+}: Pick<IJobsPartnersOfferPrivate, "workplace_name" | "workplace_brand" | "workplace_legal_name">) => {
+  return workplace_name ?? workplace_brand ?? workplace_legal_name ?? ""
+}
+
+const sendExpirationEmails = async (expiredJobs: IJobsPartnersOfferPrivate[]) => {
+  // Seules les offres gérées par LBA (managed_by renseigné) reçoivent le mail de clôture automatique.
+  const managedExpiredJobs = expiredJobs.filter((job) => job.managed_by)
+  if (!managedExpiredJobs.length) {
+    return
+  }
+
+  const groupByUserOffres = groupBy(managedExpiredJobs, (job) => job.managed_by?.toString())
+
+  await asyncForEach(Object.values(groupByUserOffres), async (jobsGroup) => {
+    const firstJob = jobsGroup.at(0)
+    try {
+      if (!firstJob) {
+        throw new Error("inattendu: groupe vide")
+      }
+      const { managed_by } = firstJob
+      if (!managed_by) {
+        throw new Error(`managed_by vide pour l'offre avec id=${firstJob._id}`)
+      }
+      const contactUser = await getDbCollection("userswithaccounts").findOne({ _id: new ObjectId(managed_by) })
+      if (!contactUser) {
+        throw new Error(`impossible de trouver l'utilisateur gérant l'offre avec id=${firstJob._id}`)
+      }
+
+      await mailer.sendEmail({
+        to: contactUser.email,
+        subject: "Votre offre d'alternance a expiré",
+        template: getStaticFilePath("./templates/mail-offre-expiree-auto.mjml.ejs"),
+        data: {
+          images: {
+            logoLba: `${config.publicUrl}/images/emails/logo_LBA.png?raw=true`,
+            logoRf: `${config.publicUrl}/images/emails/logo_rf.png?raw=true`,
+            logoFooter: `${config.publicUrl}/assets/logo-republique-francaise.webp?raw=true`,
+          },
+          last_name: sanitizeTextField(contactUser.last_name),
+          first_name: sanitizeTextField(contactUser.first_name),
+          establishment_raison_sociale: getReminderCompanyName(firstJob),
+          offres: jobsGroup.map((job) => ({
+            job_title: job.offer_title,
+            cloturer: createCancelJobLink(userWithAccountToUserForToken(contactUser), job._id.toString(), LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA),
+          })),
+          publicEmail: config.publicEmail,
+        },
+      })
+    } catch (err) {
+      logger.error(err)
+      logger.error(`expireJobsPartners: envoi du mail d'expiration, offre id=${firstJob?._id}, erreur`)
+      sentryCaptureException(err)
+    }
+  })
+}
 
 export const expireJobsPartners = async () => {
-  const result = await getDbCollection("jobs_partners").updateMany(
-    { offer_status: JOB_STATUS_ENGLISH.ACTIVE, offer_expiration: { $lt: new Date() } },
-    {
-      // updated_at : requis par le cron delta search_items (syncSearchItemsDelta).
-      $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: new Date() },
-      $push: {
-        offer_status_history: {
-          date: new Date(),
-          status: JOB_STATUS_ENGLISH.ANNULEE,
-          reason: "offre expirée (date dépassée)",
-          granted_by: "expireJobsPartners",
-        },
+  const now = new Date()
+  const filter = { offer_status: JOB_STATUS_ENGLISH.ACTIVE, offer_expiration: { $lt: now } }
+
+  // On récupère les offres AVANT le flip de statut pour pouvoir envoyer le mail de clôture automatique
+  // aux recruteurs gérés par LBA (managed_by renseigné), sans changer le filtre du updateMany ci-dessous.
+  const expiringJobs = await getDbCollection("jobs_partners").find(filter).toArray()
+
+  const result = await getDbCollection("jobs_partners").updateMany(filter, {
+    // updated_at : requis par le cron delta search_items (syncSearchItemsDelta).
+    $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: now },
+    $push: {
+      offer_status_history: {
+        date: now,
+        status: JOB_STATUS_ENGLISH.ANNULEE,
+        reason: "offre expirée (date dépassée)",
+        granted_by: "expireJobsPartners",
       },
-    }
-  )
+    },
+  })
   logger.info(`expireJobsPartners: ${result.modifiedCount} offres expirées`)
+
+  await sendExpirationEmails(expiringJobs)
 }

--- a/server/src/jobs/recruiters/recruiterOfferExpirationReminderJob.ts
+++ b/server/src/jobs/recruiters/recruiterOfferExpirationReminderJob.ts
@@ -17,7 +17,7 @@ import { notifyToSlack } from "@/common/utils/slackUtils"
 import { sanitizeTextField } from "@/common/utils/stringUtils"
 import config from "@/config"
 import { userWithAccountToUserForToken } from "@/security/accessTokenService"
-import { createAuthMagicLink, createCancelJobLink, createProlongerOffreLink, createProvidedJobLink } from "@/services/appLinks.service"
+import { createAuthMagicLink, createCloturerOffreMagicLink, createProlongerOffreLink, createProvidedJobLink } from "@/services/appLinks.service"
 import { buildEstablishmentId } from "@/services/etablissement.service"
 import mailer from "@/services/mailer.service"
 
@@ -105,7 +105,13 @@ export const recruiterOfferExpirationReminderJob = async (numberOfDaysToExpirati
             job_type: job.contract_type.join(", "),
             job_level_label: job.offer_target_diploma?.label ?? "Indifférent",
             job_start_date: dayjs(job.contract_start).format("DD/MM/YYYY"),
-            supprimer: createCancelJobLink(userWithAccountToUserForToken(contactUser), job._id.toString(), LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA),
+            supprimer: job.workplace_siret
+              ? createCloturerOffreMagicLink(userWithAccountToUserForToken(contactUser), {
+                  jobId: job._id.toString(),
+                  establishment_id: buildEstablishmentId(contactUser._id, job.workplace_siret),
+                  userType: is_delegated ? CFA : ENTREPRISE,
+                })
+              : createAuthMagicLink(userWithAccountToUserForToken(contactUser)),
             pourvue: createProvidedJobLink(userWithAccountToUserForToken(contactUser), job._id.toString(), LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA),
             prolonger: job.workplace_siret
               ? createProlongerOffreLink(userWithAccountToUserForToken(contactUser), {

--- a/server/src/jobs/simpleJobDefinitions.ts
+++ b/server/src/jobs/simpleJobDefinitions.ts
@@ -345,6 +345,7 @@ export const simpleJobDefinitions: SimpleJobDefinition[] = [
   {
     fct: closeJobsPartnersOnApplicationThreshold,
     description: "Clôture les offres jobs_partners ayant atteint le seuil de 80 candidatures",
+    cliOptions: [{ flags: "--threshold <n>", description: "Seuil de candidatures à utiliser pour ce run (défaut 80, utile pour tester en preview)" }],
   },
   {
     fct: classifyRomesForDomainesMetiers,

--- a/server/src/jobs/simpleJobDefinitions.ts
+++ b/server/src/jobs/simpleJobDefinitions.ts
@@ -37,6 +37,7 @@ import { createRoleManagement360 } from "./metabase/metabaseRoleManagement360"
 import { sendMiseEnRelation } from "./miseEnRelation/sendMiseEnRelation"
 import { processApec } from "./offrePartenaire/apec/processApec"
 import { processAtlas, processMeteojob, processNosTalentsNosEmplois, processToulouseMetropole, processViteUnEmploi } from "./offrePartenaire/clever-connect/processCleverConnect"
+import { closeJobsPartnersOnApplicationThreshold } from "./offrePartenaire/closeJobsPartnersOnApplicationThreshold"
 import { processDecathlon } from "./offrePartenaire/decathlon/importDecathlon"
 import { detectClassificationJobsPartners } from "./offrePartenaire/detectClassificationJobsPartners"
 import { processEmploiInclusion } from "./offrePartenaire/emploi-inclusion/importEmploiInclusion"
@@ -340,6 +341,10 @@ export const simpleJobDefinitions: SimpleJobDefinition[] = [
   {
     fct: expireJobsPartners,
     description: "Change le status des offres dont la date d'expiration est dépassée",
+  },
+  {
+    fct: closeJobsPartnersOnApplicationThreshold,
+    description: "Clôture les offres jobs_partners ayant atteint le seuil de 80 candidatures",
   },
   {
     fct: classifyRomesForDomainesMetiers,

--- a/server/src/services/appLinks.service.ts
+++ b/server/src/services/appLinks.service.ts
@@ -55,6 +55,34 @@ export const createProlongerOffreLink = (
   return `${config.publicUrl}/espace-pro/authentification?token=${encodeURIComponent(token)}&redirect=${encodeURIComponent(redirectPath)}`
 }
 
+/**
+ * Lien magique connectant le recruteur puis le redirigeant vers son tableau de bord avec la modale
+ * "Clôturer votre recrutement" ouverte sur l'offre concernée (au lieu d'exécuter l'action côté serveur
+ * sans passer par la saisie d'un motif).
+ */
+export const createCloturerOffreMagicLink = (
+  user: UserForAccessToken,
+  { establishment_id, jobId, userType }: { establishment_id: string; jobId: string; userType: typeof CFA | typeof ENTREPRISE }
+) => {
+  const token = generateAccessToken(
+    user,
+    [
+      generateScope({
+        schema: zRoutes.post["/login/verification"],
+        options: {
+          params: undefined,
+          querystring: undefined,
+        },
+      }),
+    ],
+    {
+      expiresIn: "30d",
+    }
+  )
+  const redirectPath = userType === CFA ? `/espace-pro/cfa/entreprise/${establishment_id}?action=cloturer&jobId=${jobId}` : `/espace-pro/entreprise?action=cloturer&jobId=${jobId}`
+  return `${config.publicUrl}/espace-pro/authentification?token=${encodeURIComponent(token)}&redirect=${encodeURIComponent(redirectPath)}`
+}
+
 export function createValidationMagicLink(user: IUserWithAccountForAccessToken) {
   const token = generateAccessToken(
     user,

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -33,10 +33,11 @@ import { sanitizeTextField } from "@/common/utils/stringUtils"
 import config from "@/config"
 import type { UserForAccessToken } from "@/security/accessTokenService"
 import { userWithAccountToUserForToken } from "@/security/accessTokenService"
-import { createCancelJobLink, createProvidedJobLink, generateApplicationReplyToken } from "./appLinks.service"
+import { createCancelJobLink, createCloturerOffreMagicLink, createProvidedJobLink, generateApplicationReplyToken } from "./appLinks.service"
 import { getApplicantFromDB, getOrCreateApplicant } from "./applicant.service"
 import type { BrevoEventStatus } from "./brevo.service"
 import { isInfected } from "./clamav.service"
+import { buildEstablishmentId } from "./etablissement.service"
 import { buildLbaUrl } from "./jobs/jobOpportunity/jobOpportunity.service"
 import mailer from "./mailer.service"
 import { syncJobPartnersToSearchItemsInBackground } from "./search/searchItems.service"
@@ -405,12 +406,14 @@ const buildRecruiterEmailUrlsAndParameters = async (application: IApplication) =
 
   let user: IUserWithAccount | undefined
   let jobPartnerLabel = ""
+  let lbaJob: IJobsPartnersOfferPrivate | undefined
   if (application.job_origin === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA) {
     const jobOrCompany = await getJobOrCompany(application)
     if (jobOrCompany.type !== LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA) {
       throw internal(`inattendu : type !== ${LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA}`)
     }
     const { job } = jobOrCompany
+    lbaJob = job
     const { managed_by } = job
     if (managed_by) {
       user = await getUserManagingOffer({ _id: job._id, managed_by })
@@ -437,7 +440,18 @@ const buildRecruiterEmailUrlsAndParameters = async (application: IApplication) =
   if (application.job_id) {
     urls.jobUrl = `${config.publicUrl}${buildJobUrlPath(application.job_origin, application.job_id.toString())}${utmRecruiterData}`
     urls.jobProvidedUrl = createProvidedJobLink(userForToken, application.job_id.toString(), application.job_origin, utmRecruiterData)
-    urls.cancelJobUrl = createCancelJobLink(userForToken, application.job_id.toString(), application.job_origin, utmRecruiterData)
+    // Pour une offre LBA gérée par un recruteur identifié, on privilégie le lien qui connecte le recruteur
+    // et ouvre la modale "Clôturer votre recrutement" sur son tableau de bord (motif obligatoire).
+    // Sinon (offre partenaire, ou offre LBA sans gestionnaire identifié) on garde l'ancien lien par jeton,
+    // qui exécute l'action directement sur une page autonome.
+    urls.cancelJobUrl =
+      user && lbaJob?.workplace_siret
+        ? createCloturerOffreMagicLink(userWithAccountToUserForToken(user), {
+            jobId: application.job_id.toString(),
+            establishment_id: buildEstablishmentId(user._id, lbaJob.workplace_siret),
+            userType: lbaJob.is_delegated ? CFA : ENTREPRISE,
+          })
+        : createCancelJobLink(userForToken, application.job_id.toString(), application.job_origin, utmRecruiterData)
   }
 
   return urls

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -675,15 +675,18 @@ export const closeOffreWithMotif = async ({
   offer_status,
   job_status_comment,
   job_status_comment_precision,
-  job_relation_channel,
+  job_recruitment_channel,
 }: {
   id: ObjectId
   offer_status: JOB_STATUS_ENGLISH
   job_status_comment: string
   job_status_comment_precision?: string
-  job_relation_channel?: string
-}): Promise<void> => {
+  job_recruitment_channel?: string
+}): Promise<{ alreadyClosed: boolean }> => {
   const now = new Date()
+  // returnDocument: "before" pour savoir si l'offre était déjà clôturée avant cette requête
+  // (ex: lien de clôture cliqué deux fois) — la mise à jour est appliquée dans tous les cas,
+  // le motif reste une donnée utile même sur une offre déjà close.
   const found = await getDbCollection("jobs_partners").findOneAndUpdate(
     { partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, _id: id },
     {
@@ -693,17 +696,18 @@ export const closeOffreWithMotif = async ({
         offer_expiration: now,
         job_status_comment,
         job_status_comment_precision,
-        job_relation_channel,
+        job_recruitment_channel,
       },
     },
     {
-      returnDocument: "after",
+      returnDocument: "before",
     }
   )
   if (!found) {
     throw new Error(`could not find lba offer with id=${id}`)
   }
   syncJobPartnersToSearchItemsInBackground([id])
+  return { alreadyClosed: found.offer_status !== JOB_STATUS_ENGLISH.ACTIVE }
 }
 
 /**

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -667,33 +667,35 @@ export const provideOffre = async (id: ObjectId): Promise<void> => {
 }
 
 /**
- * @description Cancel job from transaction email
+ * @description Clôture une offre (POURVUE ou ANNULEE) avec un motif de clôture, quelle que soit l'origine
+ * (mail transactionnel via magic-link, ou interface d'admin/dashboard)
  */
-export const cancelOffre = async (id: ObjectId): Promise<void> => {
-  const now = new Date()
-  const found = await getDbCollection("jobs_partners").findOneAndUpdate(
-    { partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, _id: id },
-    { $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: now, offer_expiration: now } }
-  )
-  if (!found) {
-    throw new Error(`could not find lba offer with id=${id}`)
-  }
-  syncJobPartnersToSearchItemsInBackground([id])
-}
-
-export const cancelOffreFromAdminInterface = async ({
+export const closeOffreWithMotif = async ({
   id,
   offer_status,
   job_status_comment,
+  job_status_comment_precision,
+  job_relation_channel,
 }: {
   id: ObjectId
   offer_status: JOB_STATUS_ENGLISH
   job_status_comment: string
+  job_status_comment_precision?: string
+  job_relation_channel?: string
 }): Promise<void> => {
   const now = new Date()
   const found = await getDbCollection("jobs_partners").findOneAndUpdate(
     { partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, _id: id },
-    { $set: { offer_status, updated_at: now, offer_expiration: now, job_status_comment } },
+    {
+      $set: {
+        offer_status,
+        updated_at: now,
+        offer_expiration: now,
+        job_status_comment,
+        job_status_comment_precision,
+        job_relation_channel,
+      },
+    },
     {
       returnDocument: "after",
     }

--- a/server/static/templates/mail-expiration-offres.mjml.ejs
+++ b/server/static/templates/mail-expiration-offres.mjml.ejs
@@ -96,8 +96,12 @@
               Connectez-vous à votre espace afin de gérer vos offres :
               <br />
             </mj-text>
-              <mj-button href="<%= data.connectionUrl %>" align="center" background-color="#000091" border-radius="0px" border="1px solid #000091" color="#ffffff" css-class="button" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="14px" font-weight="700" inner-padding="4px 0px 4px 0px" line-height="24px" padding="0px 0px 0px 0px" width="123px">
-              Me connecter
+            <mj-button href="<%= offre.supprimer %>" align="center" background-color="#000091" border-radius="0px" border="1px solid #000091" color="#ffffff" css-class="button" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="14px" font-weight="700" inner-padding="4px 0px 4px 0px" line-height="24px" padding="0px" width="180px">
+              Dépublier mon offre
+            </mj-button>
+            <mj-spacer width="16px"></mj-spacer>
+            <mj-button href="<%= offre.prolonger %>" align="center" background-color="#000091" border-radius="0px" border="1px solid #000091" color="#ffffff" css-class="button" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="14px" font-weight="700" inner-padding="4px 0px 4px 0px" line-height="24px" padding="0px" width="180px">
+              Prolonger mon offre
             </mj-button>
           </mj-column>
         </mj-group>
@@ -131,16 +135,6 @@
               <br />
               <span style="font-weight: 700;"><%= offre.job_type %></span>
               <br /><br />
-
-              <a href="<%= offre.prolonger %>" style="text-decoration: underline; color: inherit;">
-                Prolonger mon offre
-              </a>
-              <br />
-              <br />
-              <a href="<%= offre.supprimer %>" style="text-decoration: underline; color: inherit;">
-                Dépublier mon offre
-              </a>
-              <br />
             </mj-text>
           </mj-column>
         </mj-group>

--- a/server/static/templates/mail-offre-expiree-auto.mjml.ejs
+++ b/server/static/templates/mail-offre-expiree-auto.mjml.ejs
@@ -1,4 +1,3 @@
-<% var dansXjours = data.threshold === 1 ? 'demain' : 'dans '+data.threshold+' jours' %>
 <% var offre = data.offres[0] %>
 <mjml>
   <mj-head>
@@ -61,7 +60,7 @@
       .column > table { border-collapse: separate; }
     </mj-style>
   </mj-head>
-  <mj-body background-color="#f5f5fe" name="Entreprise - Rappel " width="800px">
+  <mj-body background-color="#f5f5fe" name="Entreprise - Offre expirée" width="800px">
     <mj-column border-radius="0px" css-class="wrapper" padding="32px 100px 32px 100px">
       <mj-section border-radius="0px" css-class="section">
         <mj-group>
@@ -90,58 +89,15 @@
               Bonjour <%= data.first_name %> <%= data.last_name %>,
               <br />
               <br />
-              L’offre d’alternance que vous avez publiée pour <span style="font-weight: 700;"><%= data.establishment_raison_sociale %></span><% if (offre.workplace_siret) { %>, SIRET <span style="font-weight: 700;"><%= offre.workplace_siret %></span><% } %> expire <%= dansXjours %>.
+              Votre offre d'alternance <span style="font-weight: 700;"><%= offre.job_title %></span> pour l'établissement <span style="font-weight: 700;"><%= data.establishment_raison_sociale %></span> a expiré et n'est plus visible sur le site La bonne alternance.
               <br />
               <br />
-              Connectez-vous à votre espace afin de gérer vos offres :
+              Afin de mesurer l'utilité de notre service, pouvez-vous nous indiquer où en est votre recrutement ?
               <br />
             </mj-text>
-              <mj-button href="<%= data.connectionUrl %>" align="center" background-color="#000091" border-radius="0px" border="1px solid #000091" color="#ffffff" css-class="button" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="14px" font-weight="700" inner-padding="4px 0px 4px 0px" line-height="24px" padding="0px 0px 0px 0px" width="123px">
-              Me connecter
+              <mj-button href="<%= offre.cloturer %>" align="center" background-color="#000091" border-radius="0px" border="1px solid #000091" color="#ffffff" css-class="button" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="14px" font-weight="700" inner-padding="4px 0px 4px 0px" line-height="24px" padding="0px 0px 0px 0px" width="200px">
+              Clôturer mon recrutement
             </mj-button>
-          </mj-column>
-        </mj-group>
-      </mj-section>
-      <mj-spacer height="24px">
-
-      </mj-spacer>
-      <mj-section background-color="#ffffff" border-radius="4px" border="1px solid #e3e3fd" css-class="section">
-        <mj-group>
-          <mj-column border-radius="0px" css-class="column" padding="11px 23px" vertical-align="middle" width="100%">
-            <mj-text align="left" color="#000091" css-class="text" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="20px" font-weight="700" line-height="22px" padding="10px 0px 10px 0px">
-              Rappel de l’offre
-              <br />
-            </mj-text>
-
-            <mj-text align="left" color="#161616" css-class="text" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="16px" font-weight="400" line-height="24px" padding="10px 0px 0px 0px">
-
-              <% if (offre.job_title) { %>
-              Titre :
-              <br />
-              <span style="font-weight: 700;"><%= offre.job_title %></span>
-              <br /><br />
-              <% } %>
-
-              Métier :
-              <br />
-              <span style="font-weight: 700;"><%= offre.rome_appellation_label %></span>
-              <br /><br />
-
-              Type :
-              <br />
-              <span style="font-weight: 700;"><%= offre.job_type %></span>
-              <br /><br />
-
-              <a href="<%= offre.prolonger %>" style="text-decoration: underline; color: inherit;">
-                Prolonger mon offre
-              </a>
-              <br />
-              <br />
-              <a href="<%= offre.supprimer %>" style="text-decoration: underline; color: inherit;">
-                Dépublier mon offre
-              </a>
-              <br />
-            </mj-text>
           </mj-column>
         </mj-group>
       </mj-section>

--- a/server/static/templates/mail-offre-expiree-auto.mjml.ejs
+++ b/server/static/templates/mail-offre-expiree-auto.mjml.ejs
@@ -84,7 +84,7 @@
       </mj-spacer>
       <mj-section background-color="#ffffff" border-radius="4px" border="1px solid #e3e3fd" css-class="section">
         <mj-group>
-          <mj-column border-radius="0px" css-class="column" padding="23px"vertical-align="middle" width="100%">
+          <mj-column border-radius="0px" css-class="column" padding="23px" vertical-align="middle" width="100%">
             <mj-text align="left" color="#161616" css-class="text" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="16px" font-weight="400" line-height="24px" padding="0px 0px 16px 0px">
               Bonjour <%= data.first_name %> <%= data.last_name %>,
               <br />

--- a/server/static/templates/mail-offre-seuil-candidatures.mjml.ejs
+++ b/server/static/templates/mail-offre-seuil-candidatures.mjml.ejs
@@ -84,7 +84,7 @@
       </mj-spacer>
       <mj-section background-color="#ffffff" border-radius="4px" border="1px solid #e3e3fd" css-class="section">
         <mj-group>
-          <mj-column border-radius="0px" css-class="column" padding="23px"vertical-align="middle" width="100%">
+          <mj-column border-radius="0px" css-class="column" padding="23px" vertical-align="middle" width="100%">
             <mj-text align="left" color="#161616" css-class="text" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="16px" font-weight="400" line-height="24px" padding="0px 0px 16px 0px">
               Bonjour <%= data.first_name %> <%= data.last_name %>,
               <br />

--- a/server/static/templates/mail-offre-seuil-candidatures.mjml.ejs
+++ b/server/static/templates/mail-offre-seuil-candidatures.mjml.ejs
@@ -1,4 +1,3 @@
-<% var dansXjours = data.threshold === 1 ? 'demain' : 'dans '+data.threshold+' jours' %>
 <% var offre = data.offres[0] %>
 <mjml>
   <mj-head>
@@ -61,7 +60,7 @@
       .column > table { border-collapse: separate; }
     </mj-style>
   </mj-head>
-  <mj-body background-color="#f5f5fe" name="Entreprise - Rappel " width="800px">
+  <mj-body background-color="#f5f5fe" name="Entreprise - Seuil de candidatures atteint" width="800px">
     <mj-column border-radius="0px" css-class="wrapper" padding="32px 100px 32px 100px">
       <mj-section border-radius="0px" css-class="section">
         <mj-group>
@@ -90,58 +89,15 @@
               Bonjour <%= data.first_name %> <%= data.last_name %>,
               <br />
               <br />
-              L’offre d’alternance que vous avez publiée pour <span style="font-weight: 700;"><%= data.establishment_raison_sociale %></span><% if (offre.workplace_siret) { %>, SIRET <span style="font-weight: 700;"><%= offre.workplace_siret %></span><% } %> expire <%= dansXjours %>.
+              Votre offre d'alternance <span style="font-weight: 700;"><%= offre.job_title %></span> a suscité un grand intérêt auprès des candidats. La bonne alternance a automatiquement dépublié votre offre.
               <br />
               <br />
-              Connectez-vous à votre espace afin de gérer vos offres :
+              Afin de mesurer l'utilité de notre service, pouvez-vous nous indiquer où en est votre recrutement ?
               <br />
             </mj-text>
-              <mj-button href="<%= data.connectionUrl %>" align="center" background-color="#000091" border-radius="0px" border="1px solid #000091" color="#ffffff" css-class="button" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="14px" font-weight="700" inner-padding="4px 0px 4px 0px" line-height="24px" padding="0px 0px 0px 0px" width="123px">
-              Me connecter
+              <mj-button href="<%= offre.cloturer %>" align="center" background-color="#000091" border-radius="0px" border="1px solid #000091" color="#ffffff" css-class="button" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="14px" font-weight="700" inner-padding="4px 0px 4px 0px" line-height="24px" padding="0px 0px 0px 0px" width="200px">
+              Clôturer mon recrutement
             </mj-button>
-          </mj-column>
-        </mj-group>
-      </mj-section>
-      <mj-spacer height="24px">
-
-      </mj-spacer>
-      <mj-section background-color="#ffffff" border-radius="4px" border="1px solid #e3e3fd" css-class="section">
-        <mj-group>
-          <mj-column border-radius="0px" css-class="column" padding="11px 23px" vertical-align="middle" width="100%">
-            <mj-text align="left" color="#000091" css-class="text" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="20px" font-weight="700" line-height="22px" padding="10px 0px 10px 0px">
-              Rappel de l’offre
-              <br />
-            </mj-text>
-
-            <mj-text align="left" color="#161616" css-class="text" font-family="Arial, Helvetica, Verdana, sans-serif" font-size="16px" font-weight="400" line-height="24px" padding="10px 0px 0px 0px">
-
-              <% if (offre.job_title) { %>
-              Titre :
-              <br />
-              <span style="font-weight: 700;"><%= offre.job_title %></span>
-              <br /><br />
-              <% } %>
-
-              Métier :
-              <br />
-              <span style="font-weight: 700;"><%= offre.rome_appellation_label %></span>
-              <br /><br />
-
-              Type :
-              <br />
-              <span style="font-weight: 700;"><%= offre.job_type %></span>
-              <br /><br />
-
-              <a href="<%= offre.prolonger %>" style="text-decoration: underline; color: inherit;">
-                Prolonger mon offre
-              </a>
-              <br />
-              <br />
-              <a href="<%= offre.supprimer %>" style="text-decoration: underline; color: inherit;">
-                Dépublier mon offre
-              </a>
-              <br />
-            </mj-text>
           </mj-column>
         </mj-group>
       </mj-section>

--- a/server/tests/sdk/entrepriseSdk.ts
+++ b/server/tests/sdk/entrepriseSdk.ts
@@ -3,7 +3,7 @@ import { mockApiBal } from "@tests/mocks/mockApiBal"
 import { mockApiEntreprise } from "@tests/mocks/mockApiEntreprise"
 import { mockGeolocalisation } from "@tests/mocks/mockGeolocalisation"
 import type { TestHttpClient } from "@tests/utils/server.test.utils"
-import { type IJobCreate, type IUserWithAccount, JOB_START_TYPE } from "shared"
+import { type IJobCreate, type IUserWithAccount, JOB_START_TYPE, JOB_STATUS } from "shared"
 import { ENTREPRISE } from "shared/constants/index"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import { OPCOS_LABEL } from "shared/constants/recruteur"
@@ -105,7 +105,15 @@ export const entrepriseSdk = (httpClient: TestHttpClient) => ({
     })
     return response
   },
-  async cancelOffer({ jobId, user }: { jobId: string; user: IUserWithAccount }) {
+  async cancelOffer({
+    jobId,
+    user,
+    body = { job_status: JOB_STATUS.ANNULEE, job_status_comment: "Je ne suis plus en recherche" },
+  }: {
+    jobId: string
+    user: IUserWithAccount
+    body?: z.input<(typeof zRoutes)["put"]["/formulaire/offre/:jobId/cancel"]["body"]>
+  }) {
     const url = createCancelJobLink(userWithAccountToUserForToken(user), jobId, LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA)
     const token = new URL(url).searchParams.get("token")
 
@@ -115,6 +123,7 @@ export const entrepriseSdk = (httpClient: TestHttpClient) => ({
       headers: {
         Authorization: `Bearer ${token}`,
       },
+      body,
     })
     return response
   },

--- a/shared/src/models/jobsPartners.model.ts
+++ b/shared/src/models/jobsPartners.model.ts
@@ -168,6 +168,11 @@ const ZJobsPartnersRecruiterPrivateFields = z.object({
   cfa_address_label: z.string().nullish().describe("Adresse du CFA si offre déléguée"),
   ft_support: z.boolean().nullish().describe("Indique si le créateur de l'offre a demandé un accompagnement par France Travail"),
   job_status_comment: z.string().nullish().describe("Raison de la suppression de l'offre"),
+  job_status_comment_precision: z.string().nullish().describe('Précision libre quand job_status_comment = "Autre"'),
+  job_relation_channel: z
+    .string()
+    .nullish()
+    .describe("Canal de mise en relation quand l'offre a été pourvue sans l'aide de LBA (ex: via un site internet, école/CFA, ...), ou texte libre si \"Autre\""),
   job_delegation_count: z.number().nullish().describe("Nombre de délégations"),
   delegations: z.array(ZDelegation).nullish().describe("Liste des délégations"),
 

--- a/shared/src/models/jobsPartners.model.ts
+++ b/shared/src/models/jobsPartners.model.ts
@@ -169,7 +169,7 @@ const ZJobsPartnersRecruiterPrivateFields = z.object({
   ft_support: z.boolean().nullish().describe("Indique si le créateur de l'offre a demandé un accompagnement par France Travail"),
   job_status_comment: z.string().nullish().describe("Raison de la suppression de l'offre"),
   job_status_comment_precision: z.string().nullish().describe('Précision libre quand job_status_comment = "Autre"'),
-  job_relation_channel: z
+  job_recruitment_channel: z
     .string()
     .nullish()
     .describe("Canal de mise en relation quand l'offre a été pourvue sans l'aide de LBA (ex: via un site internet, école/CFA, ...), ou texte libre si \"Autre\""),

--- a/shared/src/routes/formulaire.route.ts
+++ b/shared/src/routes/formulaire.route.ts
@@ -12,9 +12,14 @@ const zJobClosingBody = z
     job_status: z.enum([JOB_STATUS.POURVUE, JOB_STATUS.ANNULEE]),
     job_status_comment: z.string(),
     job_status_comment_precision: z.string().optional(),
-    job_relation_channel: z.string().optional(),
+    job_recruitment_channel: z.string().optional(),
   })
   .strict()
+
+// alreadyClosed : l'offre n'était déjà plus ACTIVE au moment de la requête (ex: lien de clôture utilisé
+// deux fois) — la mise à jour du motif est appliquée quand même, mais le front peut adapter son message.
+const zJobClosingResponse = z.object({ alreadyClosed: z.boolean() }).strict()
+const zInvalidRessourceError = z.object({ status: z.literal("INVALID_RESSOURCE"), message: z.string() }).strict()
 
 export const zFormulaireRoute = {
   get: {
@@ -250,7 +255,8 @@ export const zFormulaireRoute = {
       params: z.object({ jobId: zObjectId }).strict(),
       body: zJobClosingBody,
       response: {
-        "200": z.object({}).strict(),
+        "200": zJobClosingResponse,
+        "400": zInvalidRessourceError,
       },
       securityScheme: {
         auth: "access-token",
@@ -266,7 +272,8 @@ export const zFormulaireRoute = {
       params: z.object({ jobId: zObjectId }).strict(),
       body: zJobClosingBody,
       response: {
-        "200": z.object({}).strict(),
+        "200": zJobClosingResponse,
+        "400": zInvalidRessourceError,
       },
       securityScheme: {
         auth: "cookie-session",

--- a/shared/src/routes/formulaire.route.ts
+++ b/shared/src/routes/formulaire.route.ts
@@ -7,6 +7,15 @@ import { ZPersonNameInput } from "../models/usersRecruteur.model.js"
 import { ZUserWithAccountFields } from "../models/userWithAccount.model.js"
 import type { IRoutesDef } from "./common.routes.js"
 
+const zJobClosingBody = z
+  .object({
+    job_status: z.enum([JOB_STATUS.POURVUE, JOB_STATUS.ANNULEE]),
+    job_status_comment: z.string(),
+    job_status_comment_precision: z.string().optional(),
+    job_relation_channel: z.string().optional(),
+  })
+  .strict()
+
 export const zFormulaireRoute = {
   get: {
     "/formulaire/:establishment_id": {
@@ -239,6 +248,7 @@ export const zFormulaireRoute = {
       method: "put",
       path: "/formulaire/offre/:jobId/cancel",
       params: z.object({ jobId: zObjectId }).strict(),
+      body: zJobClosingBody,
       response: {
         "200": z.object({}).strict(),
       },
@@ -254,12 +264,7 @@ export const zFormulaireRoute = {
       method: "put",
       path: "/formulaire/offre/f/:jobId/cancel",
       params: z.object({ jobId: zObjectId }).strict(),
-      body: z
-        .object({
-          job_status: z.enum([JOB_STATUS.POURVUE, JOB_STATUS.ANNULEE]),
-          job_status_comment: z.string(),
-        })
-        .strict(),
+      body: zJobClosingBody,
       response: {
         "200": z.object({}).strict(),
       },

--- a/shared/src/routes/formulaire.route.ts
+++ b/shared/src/routes/formulaire.route.ts
@@ -6,6 +6,7 @@ import { ZRecruiter, ZRecruiterWithRomeDetailAndApplicationCount } from "../mode
 import { ZPersonNameInput } from "../models/usersRecruteur.model.js"
 import { ZUserWithAccountFields } from "../models/userWithAccount.model.js"
 import type { IRoutesDef } from "./common.routes.js"
+import { ZResError } from "./common.routes.js"
 
 const zJobClosingBody = z
   .object({
@@ -256,7 +257,7 @@ export const zFormulaireRoute = {
       body: zJobClosingBody,
       response: {
         "200": zJobClosingResponse,
-        "400": zInvalidRessourceError,
+        "400": z.union([ZResError, zInvalidRessourceError]),
       },
       securityScheme: {
         auth: "access-token",
@@ -273,7 +274,7 @@ export const zFormulaireRoute = {
       body: zJobClosingBody,
       response: {
         "200": zJobClosingResponse,
-        "400": zInvalidRessourceError,
+        "400": z.union([ZResError, zInvalidRessourceError]),
       },
       securityScheme: {
         auth: "cookie-session",

--- a/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
+++ b/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
@@ -1,0 +1,155 @@
+import { fr } from "@codegouvfr/react-dsfr"
+import Button from "@codegouvfr/react-dsfr/Button"
+import Select from "@codegouvfr/react-dsfr/Select"
+import { Box, Typography } from "@mui/material"
+import { FormikProvider, useFormik } from "formik"
+import { JOB_STATUS } from "shared"
+import { z } from "zod"
+import { toFormikValidationSchema } from "zod-formik-adapter"
+
+import CustomInput from "@/app/_components/CustomInput"
+
+export const motifsPourvus = ["J'ai pourvu l'offre avec La bonne alternance", "J'ai pourvu l'offre sans l'aide de La bonne alternance"]
+const motifSansAideLba = motifsPourvus[1]
+const motifAutre = "Autre"
+export const autreMotifs = ["Je ne suis plus en recherche", "Je ne reçois pas de candidature", "Les candidatures reçues ne sont pas assez qualifiées", motifAutre]
+
+export const motifs = [...motifsPourvus, ...autreMotifs]
+
+const canalAutre = "Autre"
+export const canaux = [
+  "Via un site internet",
+  "Via une école, un CFA",
+  "Via un organisme de recrutement (France Travail, Mission locale, ...)",
+  "Via mon réseau personnel",
+  "Le candidat m'a contacté de façon autonome",
+  "Via les réseaux sociaux",
+  canalAutre,
+]
+
+const zodSchema = z.object({
+  motif: z.string().nonempty(),
+  motifPrecision: z.string().optional(),
+  canal: z.string().optional(),
+  canalPrecision: z.string().optional(),
+})
+
+export type IClotureRecrutementFormValues = z.output<typeof zodSchema>
+
+export interface IClotureRecrutementPayload {
+  job_status: JOB_STATUS.POURVUE | JOB_STATUS.ANNULEE
+  job_status_comment: string
+  job_status_comment_precision?: string
+  job_relation_channel?: string
+}
+
+export interface ClotureRecrutementFormProps {
+  offreId: string
+  onSuccess: () => void
+  onCancel: () => void
+  submit: (offreId: string, payload: IClotureRecrutementPayload) => Promise<unknown>
+}
+
+export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, submit }: ClotureRecrutementFormProps) {
+  const onSubmit = async (values: IClotureRecrutementFormValues) => {
+    const { motif, motifPrecision, canal, canalPrecision } = values
+    const estPourvueSansAideLba = motif === motifSansAideLba
+    const jobStatus = motifsPourvus.includes(motif) ? JOB_STATUS.POURVUE : JOB_STATUS.ANNULEE
+
+    const job_relation_channel = estPourvueSansAideLba ? (canal === canalAutre ? canalPrecision || canal : canal) || undefined : undefined
+    const job_status_comment_precision = motif === motifAutre ? motifPrecision || undefined : undefined
+
+    await submit(offreId, {
+      job_status: jobStatus,
+      job_status_comment: motif,
+      job_status_comment_precision,
+      job_relation_channel,
+    })
+    onSuccess()
+  }
+
+  const formik = useFormik({
+    initialValues: {
+      motif: "",
+      motifPrecision: "",
+      canal: "",
+      canalPrecision: "",
+    },
+    validationSchema: toFormikValidationSchema(zodSchema),
+    enableReinitialize: true,
+    onSubmit,
+  })
+
+  const { motif, canal } = formik.values
+
+  return (
+    <Box>
+      <Typography className={fr.cx("fr-text--xl", "fr-text--bold")} sx={{ mb: fr.spacing("2v") }} component="h2">
+        Clôturer votre recrutement
+      </Typography>
+
+      <Box sx={{ pb: fr.spacing("4v") }}>
+        <Typography sx={{ mb: 1, color: "#3A3A3A", lineHeight: "24px" }}>Vous ne recevrez plus de candidatures.</Typography>
+        <FormikProvider value={formik}>
+          <form onSubmit={formik.handleSubmit}>
+            <Select
+              label="Motif de la clôture (obligatoire) *"
+              nativeSelectProps={{
+                onChange: async (event) => formik.setFieldValue("motif", event.target.value, true),
+                name: "motif",
+                required: true,
+              }}
+            >
+              <option disabled hidden selected value="">
+                Sélectionnez une valeur...
+              </option>
+              {motifs.map((reason) => (
+                <option key={reason} value={reason}>
+                  {reason}
+                </option>
+              ))}
+            </Select>
+
+            {motif === motifSansAideLba && (
+              <Select
+                label="Comment avez-vous pourvu votre offre ? (Facultatif)"
+                nativeSelectProps={{
+                  onChange: async (event) => formik.setFieldValue("canal", event.target.value, true),
+                  name: "canal",
+                }}
+              >
+                <option disabled hidden selected value="">
+                  Sélectionnez une valeur...
+                </option>
+                {canaux.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </Select>
+            )}
+
+            {motif === motifSansAideLba && canal === canalAutre && (
+              <CustomInput label="Par quel autre moyen avez-vous pourvu l'offre ? (Facultatif)" name="canalPrecision" required={false} />
+            )}
+
+            {motif === motifAutre && <CustomInput label="Précisez votre motif (Facultatif)" name="motifPrecision" required={false} />}
+
+            <Box sx={{ display: "flex", justifyContent: "flex-end", mt: fr.spacing("6v") }}>
+              <Box sx={{ ml: fr.spacing("3v") }}>
+                <Button type="button" priority="secondary" onClick={() => onCancel()}>
+                  Annuler
+                </Button>
+              </Box>
+              <Box sx={{ ml: fr.spacing("3v") }}>
+                <Button type="submit" disabled={!formik.dirty || !formik.isValid}>
+                  Confirmer
+                </Button>
+              </Box>
+            </Box>
+          </form>
+        </FormikProvider>
+      </Box>
+    </Box>
+  )
+}

--- a/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
+++ b/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
@@ -56,7 +56,7 @@ export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, s
     const estPourvueSansAideLba = motif === motifSansAideLba
     const jobStatus = motifsPourvus.includes(motif) ? JOB_STATUS.POURVUE : JOB_STATUS.ANNULEE
 
-    const job_relation_channel = estPourvueSansAideLba ? (canal === canalAutre ? canalPrecision || canal : canal) || undefined : undefined
+    const job_relation_channel = estPourvueSansAideLba ? (canal === canalAutre ? canalPrecision || undefined : canal) || undefined : undefined
     const job_status_comment_precision = motif === motifAutre ? motifPrecision || undefined : undefined
 
     await submit(offreId, {

--- a/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
+++ b/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
@@ -40,14 +40,14 @@ export interface IClotureRecrutementPayload {
   job_status: JOB_STATUS.POURVUE | JOB_STATUS.ANNULEE
   job_status_comment: string
   job_status_comment_precision?: string
-  job_relation_channel?: string
+  job_recruitment_channel?: string
 }
 
 export interface ClotureRecrutementFormProps {
   offreId: string
-  onSuccess: () => void
+  onSuccess: (result?: { alreadyClosed?: boolean }) => void
   onCancel: () => void
-  submit: (offreId: string, payload: IClotureRecrutementPayload) => Promise<unknown>
+  submit: (offreId: string, payload: IClotureRecrutementPayload) => Promise<{ alreadyClosed?: boolean } | unknown>
 }
 
 export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, submit }: ClotureRecrutementFormProps) {
@@ -56,16 +56,16 @@ export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, s
     const estPourvueSansAideLba = motif === motifSansAideLba
     const jobStatus = motifsPourvus.includes(motif) ? JOB_STATUS.POURVUE : JOB_STATUS.ANNULEE
 
-    const job_relation_channel = estPourvueSansAideLba ? (canal === canalAutre ? canalPrecision || undefined : canal) || undefined : undefined
+    const job_recruitment_channel = estPourvueSansAideLba ? (canal === canalAutre ? canalPrecision || undefined : canal) || undefined : undefined
     const job_status_comment_precision = motif === motifAutre ? motifPrecision || undefined : undefined
 
-    await submit(offreId, {
+    const result = await submit(offreId, {
       job_status: jobStatus,
       job_status_comment: motif,
       job_status_comment_precision,
-      job_relation_channel,
+      job_recruitment_channel,
     })
-    onSuccess()
+    onSuccess(result as { alreadyClosed?: boolean } | undefined)
   }
 
   const formik = useFormik({
@@ -93,7 +93,7 @@ export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, s
         <FormikProvider value={formik}>
           <form onSubmit={formik.handleSubmit}>
             <Select
-              label="Motif de la clôture (obligatoire) *"
+              label="Motif (obligatoire)"
               nativeSelectProps={{
                 onChange: async (event) => formik.setFieldValue("motif", event.target.value, true),
                 name: "motif",
@@ -101,7 +101,7 @@ export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, s
               }}
             >
               <option disabled hidden selected value="">
-                Sélectionnez une valeur...
+                Sélectionner un motif
               </option>
               {motifs.map((reason) => (
                 <option key={reason} value={reason}>
@@ -119,7 +119,7 @@ export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, s
                 }}
               >
                 <option disabled hidden selected value="">
-                  Sélectionnez une valeur...
+                  Sélectionner une option
                 </option>
                 {canaux.map((c) => (
                   <option key={c} value={c}>

--- a/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
+++ b/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
@@ -122,7 +122,7 @@ export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, s
 
         {motif === motifSansAideLba && (
           <Select
-            label="Comment avez-vous pourvu votre offre ? (Facultatif)"
+            label="Comment avez-vous pourvu votre offre ? (facultatif)"
             nativeSelectProps={{
               onChange: async (event) => formik.setFieldValue("canal", event.target.value, true),
               name: "canal",
@@ -140,10 +140,10 @@ export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, s
         )}
 
         {motif === motifSansAideLba && canal === canalAutre && (
-          <CustomInput label="Par quel autre moyen avez-vous pourvu l'offre ? (Facultatif)" name="canalPrecision" required={false} pb={0} />
+          <CustomInput label="Par quel autre moyen avez-vous pourvu l'offre ? (facultatif)" name="canalPrecision" required={false} pb={0} />
         )}
 
-        {motif === motifAutre && <CustomInput label="Précisez votre motif (Facultatif)" name="motifPrecision" required={false} pb={0} />}
+        {motif === motifAutre && <CustomInput label="Précisez votre motif (facultatif)" name="motifPrecision" required={false} pb={0} />}
 
         <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
           <Box sx={{ ml: fr.spacing("3v") }}>

--- a/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
+++ b/ui/app/(espace-pro)/_components/ClotureRecrutementForm.tsx
@@ -83,73 +83,81 @@ export default function ClotureRecrutementForm({ offreId, onSuccess, onCancel, s
   const { motif, canal } = formik.values
 
   return (
-    <Box>
-      <Typography className={fr.cx("fr-text--xl", "fr-text--bold")} sx={{ mb: fr.spacing("2v") }} component="h2">
-        Clôturer votre recrutement
-      </Typography>
+    <FormikProvider value={formik}>
+      {/* Figma (mode dev) : la modale empile ses éléments dans un flex column avec un gap fixe de 16px (fr.spacing("4v")),
+          au lieu des marges par défaut de DSFR (24px entre deux .fr-select-group / .fr-input-group consécutifs). */}
+      <Box
+        component="form"
+        onSubmit={formik.handleSubmit}
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: fr.spacing("4v"),
+          "& .fr-select-group, & .fr-input-group": { marginBottom: "0 !important" },
+        }}
+      >
+        <Typography className={fr.cx("fr-text--xl", "fr-text--bold")} component="h2" sx={{ mb: 0 }}>
+          Clôturer votre recrutement
+        </Typography>
 
-      <Box sx={{ pb: fr.spacing("4v") }}>
-        <Typography sx={{ mb: 1, color: "#3A3A3A", lineHeight: "24px" }}>Vous ne recevrez plus de candidatures.</Typography>
-        <FormikProvider value={formik}>
-          <form onSubmit={formik.handleSubmit}>
-            <Select
-              label="Motif (obligatoire)"
-              nativeSelectProps={{
-                onChange: async (event) => formik.setFieldValue("motif", event.target.value, true),
-                name: "motif",
-                required: true,
-              }}
-            >
-              <option disabled hidden selected value="">
-                Sélectionner un motif
+        <Typography sx={{ color: "#3A3A3A", lineHeight: "24px" }}>Vous ne recevrez plus de candidatures.</Typography>
+
+        <Select
+          label="Motif (obligatoire)"
+          nativeSelectProps={{
+            onChange: async (event) => formik.setFieldValue("motif", event.target.value, true),
+            name: "motif",
+            required: true,
+          }}
+        >
+          <option disabled hidden selected value="">
+            Sélectionner un motif
+          </option>
+          {motifs.map((reason) => (
+            <option key={reason} value={reason}>
+              {reason}
+            </option>
+          ))}
+        </Select>
+
+        {motif === motifSansAideLba && (
+          <Select
+            label="Comment avez-vous pourvu votre offre ? (Facultatif)"
+            nativeSelectProps={{
+              onChange: async (event) => formik.setFieldValue("canal", event.target.value, true),
+              name: "canal",
+            }}
+          >
+            <option disabled hidden selected value="">
+              Sélectionner une option
+            </option>
+            {canaux.map((c) => (
+              <option key={c} value={c}>
+                {c}
               </option>
-              {motifs.map((reason) => (
-                <option key={reason} value={reason}>
-                  {reason}
-                </option>
-              ))}
-            </Select>
+            ))}
+          </Select>
+        )}
 
-            {motif === motifSansAideLba && (
-              <Select
-                label="Comment avez-vous pourvu votre offre ? (Facultatif)"
-                nativeSelectProps={{
-                  onChange: async (event) => formik.setFieldValue("canal", event.target.value, true),
-                  name: "canal",
-                }}
-              >
-                <option disabled hidden selected value="">
-                  Sélectionner une option
-                </option>
-                {canaux.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
-                  </option>
-                ))}
-              </Select>
-            )}
+        {motif === motifSansAideLba && canal === canalAutre && (
+          <CustomInput label="Par quel autre moyen avez-vous pourvu l'offre ? (Facultatif)" name="canalPrecision" required={false} pb={0} />
+        )}
 
-            {motif === motifSansAideLba && canal === canalAutre && (
-              <CustomInput label="Par quel autre moyen avez-vous pourvu l'offre ? (Facultatif)" name="canalPrecision" required={false} />
-            )}
+        {motif === motifAutre && <CustomInput label="Précisez votre motif (Facultatif)" name="motifPrecision" required={false} pb={0} />}
 
-            {motif === motifAutre && <CustomInput label="Précisez votre motif (Facultatif)" name="motifPrecision" required={false} />}
-
-            <Box sx={{ display: "flex", justifyContent: "flex-end", mt: fr.spacing("6v") }}>
-              <Box sx={{ ml: fr.spacing("3v") }}>
-                <Button type="button" priority="secondary" onClick={() => onCancel()}>
-                  Annuler
-                </Button>
-              </Box>
-              <Box sx={{ ml: fr.spacing("3v") }}>
-                <Button type="submit" disabled={!formik.dirty || !formik.isValid}>
-                  Confirmer
-                </Button>
-              </Box>
-            </Box>
-          </form>
-        </FormikProvider>
+        <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+          <Box sx={{ ml: fr.spacing("3v") }}>
+            <Button type="button" priority="secondary" onClick={() => onCancel()}>
+              Annuler
+            </Button>
+          </Box>
+          <Box sx={{ ml: fr.spacing("3v") }}>
+            <Button type="submit" disabled={!formik.dirty || !formik.isValid}>
+              Confirmer
+            </Button>
+          </Box>
+        </Box>
       </Box>
-    </Box>
+    </FormikProvider>
   )
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/ConfirmationSuppressionOffre.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/ConfirmationSuppressionOffre.tsx
@@ -1,35 +1,12 @@
 import { fr } from "@codegouvfr/react-dsfr"
-import Button from "@codegouvfr/react-dsfr/Button"
-import Select from "@codegouvfr/react-dsfr/Select"
-import { Box, Typography } from "@mui/material"
+import { Box } from "@mui/material"
 import { useQueryClient } from "@tanstack/react-query"
-import { FormikProvider, useFormik } from "formik"
-import { JOB_STATUS } from "shared"
-import { z } from "zod"
-import { toFormikValidationSchema } from "zod-formik-adapter"
 
-import CustomInput from "@/app/_components/CustomInput"
+import ClotureRecrutementForm, { type IClotureRecrutementPayload } from "@/app/(espace-pro)/_components/ClotureRecrutementForm"
 import { useToast } from "@/app/hooks/useToast"
 import { ModalReadOnly } from "@/components/ModalReadOnly"
 import { cancelOffreFromAdmin } from "@/utils/api"
 import { MATOMO_EVENTS, pushMatomoEvent } from "@/utils/matomoUtils"
-
-const zodSchema = z.object({
-  motif: z.string().nonempty(),
-  autreMotif: z.string().optional(),
-})
-
-const motifsPourvus = ["J'ai pourvu l'offre avec La bonne alternance", "J'ai pourvu l'offre sans l'aide de La bonne alternance"]
-const motifAutre = "Autre"
-const autreMotifs = [
-  "Je ne suis plus en recherche",
-  "Je ne reçois pas de candidature",
-  "Je n’ai pas pu personnaliser mon offre",
-  "Les candidatures reçues ne sont pas assez qualifiées",
-  motifAutre,
-]
-
-const motifs = [...motifsPourvus, ...autreMotifs]
 
 export interface ConfirmationSuppressionOffreProps {
   isOpen: boolean
@@ -40,92 +17,24 @@ export interface ConfirmationSuppressionOffreProps {
 export default function ConfirmationSuppressionOffre(props: ConfirmationSuppressionOffreProps) {
   const toast = useToast()
   const client = useQueryClient()
-
-  const resetState = () => {
-    onClose()
-  }
-
-  const onSubmit = (values: z.output<typeof zodSchema>) => {
-    const { motif, autreMotif } = values
-    const estPouvue = motifsPourvus.includes(motif)
-    const jobStatus = estPouvue ? JOB_STATUS.POURVUE : JOB_STATUS.ANNULEE
-    const motifFinal = (motif === motifAutre ? autreMotif || motif : motif) || undefined
-    cancelOffreFromAdmin(offre._id, { job_status: jobStatus, job_status_comment: motifFinal })
-      .then(() => {
-        pushMatomoEvent({ event: MATOMO_EVENTS.OFFER_DELETE_CONFIRMED })
-        toast({
-          title: `Offre supprimée.`,
-          description: "Votre offre a bien été mise à jour.",
-        })
-      })
-      .then(() => resetState())
-      .finally(async () =>
-        client.invalidateQueries({
-          queryKey: ["offre-liste"],
-        })
-      )
-  }
-
-  const formik = useFormik({
-    initialValues: {
-      motif: "",
-      autreMotif: "",
-    },
-    validationSchema: toFormikValidationSchema(zodSchema),
-    enableReinitialize: true,
-    onSubmit,
-  })
-
   const { isOpen, onClose, offre } = props
+
+  const submit = async (offreId: string, payload: IClotureRecrutementPayload) => {
+    await cancelOffreFromAdmin(offreId, payload)
+    pushMatomoEvent({ event: MATOMO_EVENTS.OFFER_DELETE_CONFIRMED })
+    toast({
+      title: `Offre supprimée.`,
+      description: "Votre offre a bien été mise à jour.",
+    })
+    await client.invalidateQueries({
+      queryKey: ["offre-liste"],
+    })
+  }
 
   return (
     <ModalReadOnly isOpen={isOpen} onClose={onClose}>
       <Box sx={{ pb: fr.spacing("4v"), px: fr.spacing("4v") }}>
-        <Typography className={fr.cx("fr-text--xl", "fr-text--bold")} sx={{ mb: fr.spacing("2v") }} component="h2">
-          Êtes-vous certain de vouloir supprimer votre offre ?
-        </Typography>
-
-        <Box
-          sx={{
-            pb: fr.spacing("4v"),
-          }}
-        >
-          <Typography sx={{ mb: 1, color: "#3A3A3A", lineHeight: "24px" }}>Celle-ci sera définitivement supprimée. Vous ne recevrez plus de candidatures.</Typography>
-          <FormikProvider value={formik}>
-            <form onSubmit={formik.handleSubmit}>
-              <Select
-                label="Motif de la suppression (obligatoire) *"
-                nativeSelectProps={{
-                  onChange: async (event) => formik.setFieldValue("motif", event.target.value, true),
-                  name: "motif",
-                  required: true,
-                }}
-              >
-                <option disabled hidden selected value="">
-                  Sélectionnez une valeur...
-                </option>
-                {motifs.map((reason) => (
-                  <option key={reason} value={reason}>
-                    {reason}
-                  </option>
-                ))}
-              </Select>
-              {formik.values.motif === motifAutre && <CustomInput label="Précisez votre motif (facultatif)" name="autreMotif" required={false} />}
-              <Box sx={{ display: "flex", justifyContent: "flex-end", mt: fr.spacing("6v") }}>
-                <Box sx={{ ml: fr.spacing("3v") }}>
-                  <Button type="button" priority="secondary" onClick={() => resetState()}>
-                    Annuler
-                  </Button>
-                </Box>
-                <Box sx={{ ml: fr.spacing("3v") }}>
-                  <Button type="submit" disabled={!formik.dirty || !formik.isValid}>
-                    Confirmer la suppression
-                  </Button>
-                </Box>
-              </Box>
-            </form>
-          </FormikProvider>
-        </Box>
+        <ClotureRecrutementForm offreId={offre._id} onSuccess={onClose} onCancel={onClose} submit={submit} />
       </Box>
     </ModalReadOnly>
   )

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabs.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabs.tsx
@@ -247,7 +247,7 @@ export const OffresTabs = ({
   return (
     <>
       <OffreProlongationModal modalControls={offreProlongationModalControls} onOffreProlongationSubmit={onOffreProlongationSubmit} />
-      <ConfirmationSuppressionOffre {...confirmationSuppression} offre={currentOffre} />
+      {currentOffre && <ConfirmationSuppressionOffre {...confirmationSuppression} offre={currentOffre} />}
       <Table caption={caption} columns={columns} data={jobsWithGeoCoords} />
     </>
   )

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabs.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabs.tsx
@@ -89,7 +89,7 @@ export const OffresTabs = ({
 
   const currentOffre = jobs.find((job) => job._id === currentOfferId)
 
-  const confirmationSuppression = useDisclosure()
+  const confirmationSuppression = useDisclosure(Boolean(searchParams.get("action") === "cloturer" && currentOffre))
   const offreProlongationModalControls = useDisclosure(Boolean(searchParams.get("action") === "prolonger" && currentOffre))
   const toast = useToast()
   const client = useQueryClient()

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/OffreActionPage.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/OffreActionPage.tsx
@@ -3,16 +3,19 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Typography } from "@mui/material"
 import Image from "next/image"
+import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 
+import ClotureRecrutementForm, { type IClotureRecrutementPayload } from "@/app/(espace-pro)/_components/ClotureRecrutementForm"
 import LoadingEmptySpace from "@/app/(espace-pro)/_components/LoadingEmptySpace"
 import { cancelOffre, cancelPartnerJob, fillOffre, providedPartnerJob } from "@/utils/api"
 import { PAGES } from "@/utils/routes.utils"
 
+// Note: l'action "cancel" pour les offres LBA (OFFRES_EMPLOI_LBA) n'est plus déclenchée automatiquement ici,
+// elle passe désormais par le formulaire ClotureRecrutementForm (voir plus bas) qui recueille un motif obligatoire.
 const jobActions = {
   [LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA]: {
-    cancel: cancelOffre,
     provided: fillOffre,
   },
   [LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES]: {
@@ -46,8 +49,16 @@ export function OffreActionPage({
   jobType: Exclude<LBA_ITEM_TYPE, LBA_ITEM_TYPE.FORMATION>
 }) {
   const [result, setResult] = useState("")
+  const router = useRouter()
+
+  // Pour les offres LBA, l'annulation passe par le formulaire "Clôturer votre recrutement" (motif obligatoire),
+  // au lieu d'annuler silencieusement l'offre au chargement de la page.
+  const isClotureForm = actionName === "cancel" && jobType === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA
 
   useEffect(() => {
+    if (isClotureForm) {
+      return
+    }
     if (!jobId || !actionName || !jobType) return
 
     const action = jobActions[jobType]?.[actionName]
@@ -62,7 +73,11 @@ export function OffreActionPage({
     } else {
       setResult("Unsupported action.")
     }
-  }, [jobId, actionName, jobType, token])
+  }, [jobId, actionName, jobType, token, isClotureForm])
+
+  const submitCloture = async (id: string, payload: IClotureRecrutementPayload) => {
+    await cancelOffre(id, token, payload)
+  }
 
   const cssParameters = {
     background: "#fff1e5",
@@ -79,7 +94,7 @@ export function OffreActionPage({
         margin: "auto",
       }}
     >
-      {actionName === "cancel" && (
+      {actionName === "cancel" && !isClotureForm && (
         <Typography component="h1" sx={homeEditorialH1}>
           Annulation de l'offre déposée sur La bonne alternance
         </Typography>
@@ -89,18 +104,32 @@ export function OffreActionPage({
           Modification de l'offre déposée sur La bonne alternance
         </Typography>
       )}
-      {!result && <LoadingEmptySpace label="Chargement en cours..." />}
-      {result && result !== "ok" && (
-        <Box sx={{ display: "flex", alignItems: "center", color: "#4a4a4a", ...cssParameters }}>
-          <Image width="32" style={{ marginRight: fr.spacing("2v") }} src="/images/icons/errorAlert.svg" alt="" />
-          {result}
-        </Box>
+
+      {isClotureForm ? (
+        result === "ok" ? (
+          <Typography component="h2" sx={homeEditorialH2}>
+            Votre offre a été modifiée
+          </Typography>
+        ) : (
+          <ClotureRecrutementForm offreId={jobId} onSuccess={() => setResult("ok")} onCancel={() => router.push(PAGES.static.home.getPath())} submit={submitCloture} />
+        )
+      ) : (
+        <>
+          {!result && <LoadingEmptySpace label="Chargement en cours..." />}
+          {result && result !== "ok" && (
+            <Box sx={{ display: "flex", alignItems: "center", color: "#4a4a4a", ...cssParameters }}>
+              <Image width="32" style={{ marginRight: fr.spacing("2v") }} src="/images/icons/errorAlert.svg" alt="" />
+              {result}
+            </Box>
+          )}
+          {result && result === "ok" && (
+            <Typography component="h2" sx={homeEditorialH2}>
+              Votre offre a été modifiée
+            </Typography>
+          )}
+        </>
       )}
-      {result && result === "ok" && (
-        <Typography component="h2" sx={homeEditorialH2}>
-          Votre offre a été modifiée
-        </Typography>
-      )}
+
       <Box sx={{ mt: fr.spacing("8v") }}>
         Aller sur le site{" "}
         <Link

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/OffreActionPage.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/OffreActionPage.tsx
@@ -75,9 +75,7 @@ export function OffreActionPage({
     }
   }, [jobId, actionName, jobType, token, isClotureForm])
 
-  const submitCloture = async (id: string, payload: IClotureRecrutementPayload) => {
-    await cancelOffre(id, token, payload)
-  }
+  const submitCloture = async (id: string, payload: IClotureRecrutementPayload) => cancelOffre(id, token, payload)
 
   const cssParameters = {
     background: "#fff1e5",
@@ -106,12 +104,17 @@ export function OffreActionPage({
       )}
 
       {isClotureForm ? (
-        result === "ok" ? (
+        result === "ok" || result === "already-closed" ? (
           <Typography component="h2" sx={homeEditorialH2}>
-            Votre offre a été modifiée
+            {result === "already-closed" ? "Cette offre était déjà clôturée. Votre réponse a bien été enregistrée." : "Votre offre a été modifiée"}
           </Typography>
         ) : (
-          <ClotureRecrutementForm offreId={jobId} onSuccess={() => setResult("ok")} onCancel={() => router.push(PAGES.static.home.getPath())} submit={submitCloture} />
+          <ClotureRecrutementForm
+            offreId={jobId}
+            onSuccess={(cloturationResult) => setResult(cloturationResult?.alreadyClosed ? "already-closed" : "ok")}
+            onCancel={() => router.push(PAGES.static.home.getPath())}
+            submit={submitCloture}
+          />
         )
       ) : (
         <>

--- a/ui/components/ItemDetail/AideApprentissage.tsx
+++ b/ui/components/ItemDetail/AideApprentissage.tsx
@@ -10,7 +10,9 @@ const AideApprentissage = () => {
         Futur alternant ? Découvrez les aides auxquelles vous avez droit et parlez-en avec vos proches
       </Typography>
 
-      <Typography>Avec 1jeune1solution, évaluez les aides financières auxquelles vous avez droit en matière de logement, transport, santé, formation, emploi, culture, sport et alimentation.</Typography>
+      <Typography>
+        Avec 1jeune1solution, évaluez les aides financières auxquelles vous avez droit en matière de logement, transport, santé, formation, emploi, culture, sport et alimentation.
+      </Typography>
 
       <Typography sx={{ mt: fr.spacing("4v") }}>
         Accéder à{" "}

--- a/ui/utils/api.ts
+++ b/ui/utils/api.ts
@@ -54,7 +54,8 @@ export const viewOffreDelegation = async (jobId: string, siret: string, token: s
 export const cancelPartnerJob = async (id: string, token: string) => apiPost("/v2/_private/jobs/canceled/:id", { params: { id }, headers: { authorization: `Bearer ${token}` } })
 export const providedPartnerJob = async (id: string, token: string) => apiPost("/v2/_private/jobs/provided/:id", { params: { id }, headers: { authorization: `Bearer ${token}` } })
 // once offres_emploi_lba are definitly stored in jobs partners, we can move this call to /jobs/:jobId/cancel
-export const cancelOffre = async (jobId: string, token: string) => apiPut(`/formulaire/offre/:jobId/cancel`, { params: { jobId }, headers: { authorization: `Bearer ${token}` } })
+export const cancelOffre = async (jobId: string, token: string, data: IRoutes["put"]["/formulaire/offre/:jobId/cancel"]["body"]["_input"]) =>
+  apiPut(`/formulaire/offre/:jobId/cancel`, { params: { jobId }, body: data, headers: { authorization: `Bearer ${token}` } })
 export const cancelOffreFromAdmin = async (jobId: string, data: IRoutes["put"]["/formulaire/offre/f/:jobId/cancel"]["body"]["_input"]) =>
   apiPut("/formulaire/offre/f/:jobId/cancel", { params: { jobId }, body: data })
 export const extendOffre = async (jobId: string, jobFields: Jsonify<IBody<IRoutes["put"]["/formulaire/offre/:jobId/extend"]>>) => {


### PR DESCRIPTION
Closes #5046

## Changements

- Modale "Clôturer votre recrutement" unifiée dans un composant partagé (`ClotureRecrutementForm`), réutilisé en modale sur le dashboard et en page autonome pour les liens magiques.
- Nouveaux champs `job_status_comment_precision` et `job_relation_channel` sur `jobs_partners` — le motif choisi (`job_status_comment`) n'est plus écrasé par le texte libre.
- Question complémentaire "Comment avez-vous pourvu votre offre ?" affichée quand le motif est "sans l'aide de La bonne alternance", avec précision libre facultative si "Autre".
- Précision libre facultative quand le motif principal est "Autre".
- Le lien "Supprimer mon offre" de l'email de candidature ouvre désormais la modale (motif obligatoire) au lieu d'annuler l'offre silencieusement.
- Ajout du bouton "Dépublier mon offre" dans l'email de rappel J-7 (le lien existait déjà côté données, jamais affiché).
- Deux nouveaux emails transactionnels + jobs : dépublication automatique par expiration (extension du job existant) et par seuil de 80 candidatures (nouveau job), chacun avec CTA "Clôturer mon recrutement" vers la modale.
- Fusion des fonctions serveur `cancelOffre`/`cancelOffreFromAdminInterface` en une seule `closeOffreWithMotif`, et harmonisation du schéma de body entre les deux routes de clôture.

## Plan de test

- [ ] `yarn typecheck` et `yarn check:ci` passent
- [ ] Dashboard : action "Supprimer l'offre" → tester motif "sans l'aide de LBA" (canal affiché) et motif "Autre" (précision affichée), vérifier les 3 champs en base
- [ ] Lien magique email de candidature ("Supprimer mon offre") → ouvre la modale, motif obligatoire
- [ ] Lien magique email J-7 ("Dépublier mon offre") → bouton présent et fonctionnel
- [ ] Déclencher manuellement les 2 nouveaux jobs (expiration, seuil 80 candidatures) → email reçu, CTA fonctionnel
- [ ] Relecture du copywriting des 2 nouveaux templates mjml (adaptation du ticket, pas de maquette Figma dédiée)