### PR TITLE
feat: ajoute le mode de rédaction libre au dépôt d'offre

### DIFF
--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -623,7 +623,7 @@ export const patchOffre = async (id: ObjectId, payload: PatchOffreBody): Promise
     offer_to_be_acquired_skills: getSkillsFromRome(job.competences_rome?.savoir_faire, romeDetails?.competences?.savoir_faire),
     offer_to_be_acquired_knowledge: getSkillsFromRome(job.competences_rome?.savoirs, romeDetails?.competences?.savoirs),
     offer_access_conditions: romeDetails?.acces_metier ? [romeDetails.acces_metier] : [],
-    offer_description: romeDetails?.definition,
+    offer_description: sanitizeTextField(job.job_description, true) || romeDetails?.definition || "",
     contract_duration: job.job_duration ?? null,
     offer_target_diploma: getDiplomaLevel(job.job_level_label) ?? null,
     // offer_title_custom = saisie libre recruteur (le schéma Zod n'interdit pas les tags HTML) →
@@ -1244,7 +1244,7 @@ async function jobCreateToJobsPartner({
     offer_access_conditions: acces_metier ? [acces_metier] : [],
     offer_title,
     offer_rome_codes: job.rome_code ?? null,
-    offer_description: job.job_description ?? definition ?? "",
+    offer_description: sanitizeTextField(job.job_description, true) || definition || "",
     offer_creation: now,
     offer_expiration: addExpirationPeriod(now).toDate(),
     offer_status: status,

--- a/shared/src/routes/formulaire.route.ts
+++ b/shared/src/routes/formulaire.route.ts
@@ -214,6 +214,7 @@ export const zFormulaireRoute = {
         job_duration: true,
         job_rythm: true,
         job_employer_description: true,
+        job_description: true,
         competences_rome: true,
         offer_title_custom: true,
         to_applicant_questions: true,

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffre.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffre.tsx
@@ -96,6 +96,7 @@ export const FormulaireEditionOffre = ({
                 step_name: "screening_questions",
                 has_screening_questions: finalValues.to_applicant_questions?.length > 0,
                 ft_eligible: isFtEligible,
+                description_mode: finalValues.job_description ? "custom" : "structured",
               })
               handleSave(finalValues)
             } else {
@@ -121,6 +122,7 @@ export const FormulaireEditionOffre = ({
               step_name: "ft_support",
               has_screening_questions: finalValues.to_applicant_questions?.length > 0,
               ft_eligible: isFtEligible,
+              description_mode: finalValues.job_description ? "custom" : "structured",
             })
             pushMatomoEvent({
               event: MATOMO_EVENTS.JOB_CREATION_FT_PARTNERSHIP_STEP,

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep1.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep1.tsx
@@ -2,6 +2,7 @@
 
 import { fr } from "@codegouvfr/react-dsfr"
 import Input from "@codegouvfr/react-dsfr/Input"
+import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons"
 import { Box, Typography } from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
 import dayjs from "dayjs"
@@ -14,6 +15,7 @@ import * as Yup from "yup"
 import { InfosDiffusionOffre } from "@/components/DepotOffre/InfosDiffusionOffre"
 import type { RomeCompetenceKey } from "@/components/DepotOffre/RomeDetail"
 import { RomeDetailWithQuery } from "@/components/DepotOffre/RomeDetailWithQuery"
+import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { getRomeDetail } from "@/utils/api"
 import { FormulaireEditionOffreButtons } from "./FormulaireEditionOffreButtons"
 import { FormulaireEditionOffreFields } from "./FormulaireEditionOffreFields"
@@ -21,6 +23,66 @@ import { FormulaireEditionOffreFields } from "./FormulaireEditionOffreFields"
 const ISO_DATE_FORMAT = "YYYY-MM-DD"
 const FR_DATE_FORMAT = "DD/MM/YYYY"
 const EMPLOYER_DESCRIPTION_MAX = 800
+const JOB_DESCRIPTION_MAX = 3000
+
+type DescriptionMode = "structured" | "custom"
+
+const DescriptionModeToggle = ({ mode, onChange }: { mode: DescriptionMode; onChange: (mode: DescriptionMode) => void }) => (
+  <RadioButtons
+    style={{ marginBottom: 0 }}
+    legend="Mode de rédaction"
+    name="description_mode"
+    options={[
+      {
+        label: "Utiliser la description du métier",
+        hintText: "Description générée à partir de la fiche métier, personnalisable via les compétences.",
+        nativeInputProps: {
+          checked: mode === "structured",
+          onChange: () => onChange("structured"),
+        },
+      },
+      {
+        label: "Personnaliser la description",
+        hintText: "Rédigez vous-même la description du poste.",
+        nativeInputProps: {
+          checked: mode === "custom",
+          onChange: () => onChange("custom"),
+        },
+      },
+    ]}
+  />
+)
+
+const JobDescriptionField = () => {
+  const { values, setFieldValue, errors } = useFormikContext<any>()
+  return (
+    <Box sx={{ mt: fr.spacing("4v") }}>
+      <Input
+        label="Description du poste"
+        hintText={
+          <>
+            Décrivez les missions et responsabilités du poste.{" "}
+            <DsfrLink href="/guide/rediger-son-offre-d-alternance?source=guide-recruteur">Découvrir la charte</DsfrLink>
+          </>
+        }
+        state={errors.job_description ? "error" : "info"}
+        stateRelatedMessage={
+          (errors.job_description as string) ??
+          "Notre équipe modère les contenus. Toute description non conforme à la réglementation pourra entrainer la suppression de l'offre, la désactivation du compte et faire l'objet d'un signalement aux autorités compétentes. La taille du champ est limitée à 3000 caractères."
+        }
+        textArea
+        nativeTextAreaProps={{
+          name: "job_description",
+          value: values.job_description,
+          maxLength: JOB_DESCRIPTION_MAX,
+          rows: 8,
+          style: { resize: "none" },
+          onChange: (e) => setFieldValue("job_description", e.target.value),
+        }}
+      />
+    </Box>
+  )
+}
 
 const EmployerDescriptionField = () => {
   const { values, setFieldValue, errors } = useFormikContext<any>()
@@ -77,6 +139,7 @@ export const FormulaireEditionOffreStep1 = ({
 
   const [selectedCompetences, setSelectedCompetences] = useState<IReferentielRomeForJob["competences"] | null>(offre?.competences_rome ?? formValues?.competences_rome ?? null)
   const [competencesDirty, setCompetencesDirty] = useState(Boolean(formValues))
+  const [descriptionMode, setDescriptionMode] = useState<DescriptionMode>(offre?.job_description || formValues?.job_description ? "custom" : "structured")
 
   const onRomeChange = (rome: string, appellation: string) => {
     setRomeAndAppellation({ rome, appellation })
@@ -124,6 +187,7 @@ export const FormulaireEditionOffreStep1 = ({
       competences_rome: finalSelectedCompetences,
       offer_title_custom: values.offer_title_custom || null,
       job_employer_description: values.job_employer_description || null,
+      job_description: descriptionMode === "custom" ? values.job_description?.trim() || null : null,
     }
     onSubmit?.(values)
   }
@@ -154,6 +218,7 @@ export const FormulaireEditionOffreStep1 = ({
     job_rythm: offre?.job_rythm ?? "",
     offer_title_custom: offre?.offer_title_custom ?? "",
     job_employer_description: offre?.job_employer_description ?? "",
+    job_description: offre?.job_description ?? "",
     ...formValues,
   }
   initialValues.offer_title_custom = initialValues.offer_title_custom ?? ""
@@ -185,6 +250,12 @@ export const FormulaireEditionOffreStep1 = ({
             .transform((v) => v || undefined)
             .min(30, "La présentation est trop courte (minimum 30 caractères).")
             .max(EMPLOYER_DESCRIPTION_MAX, `La présentation est trop longue (maximum ${EMPLOYER_DESCRIPTION_MAX} caractères).`),
+          job_description: Yup.string()
+            .trim()
+            .transform((v) => v || undefined)
+            .min(30, "La description est trop courte (minimum 30 caractères).")
+            .max(JOB_DESCRIPTION_MAX, `La description est trop longue (maximum ${JOB_DESCRIPTION_MAX} caractères).`)
+            .test("required-if-custom", "Champ obligatoire", (value) => descriptionMode !== "custom" || Boolean(value)),
         })}
         onSubmit={(values: any) => localOnSubmit(values)}
       >
@@ -262,6 +333,13 @@ export const FormulaireEditionOffreStep1 = ({
                   <Box sx={{ mt: fr.spacing("4v") }}>
                     <FormulaireEditionOffreFields section="offer" onRomeChange={onRomeChange} />
                   </Box>
+
+                  {romeAndAppellation && (
+                    <Box sx={{ mt: fr.spacing("6v") }}>
+                      <DescriptionModeToggle mode={descriptionMode} onChange={setDescriptionMode} />
+                      {descriptionMode === "custom" && <JobDescriptionField />}
+                    </Box>
+                  )}
 
                   <Box sx={{ mt: fr.spacing("4v") }}>
                     {romeAndAppellation ? (


### PR DESCRIPTION
Closes #4998

## Changements

- Ajoute un toggle "Mode de rédaction" dans l'étape 1 du dépôt d'offre : "Utiliser la description du métier" (comportement structuré ROME actuel, inchangé) vs "Personnaliser la description" (texte libre).
- Ajoute le champ libre "Description du poste" (texte brut, 3000 caractères max), branché sur le champ `job_description` déjà présent dans le schéma partagé mais jusqu'ici jamais exposé côté formulaire.
- Corrige une faille XSS stockée latente : `job_description` n'était sanitizé nulle part avant stockage (contrairement à `job_employer_description`), alors qu'il est rendu via `dangerouslySetInnerHTML` sur la fiche candidat. Comme ce champ n'était jamais alimenté avant ce PR, le risque était dormant ; il est désormais actif via l'UI donc corrigé à la création (`jobCreateToJobsPartner`) et à l'édition (`patchOffre`).
- Ajoute `job_description` à la route PUT d'édition d'offre (`/formulaire/offre/:jobId`), qui ne le supportait pas alors que la route de création si — l'édition d'une offre avec description libre échouait silencieusement (le champ était ignoré).
- Ajoute une dimension `description_mode` (structured/custom) aux événements Matomo `job_creation_completed` pour suivre le taux d'adoption du nouveau mode.
- La fiche candidat (emploi_LBA) n'a nécessité aucune modification : `JobDescription.tsx` et `LbaJobDetail.tsx` géraient déjà l'affichage de `job_description` avec fallback sur la description ROME.
- Lien "Découvrir la charte" pointant vers `/guide/rediger-son-offre-d-alternance?source=guide-recruteur` (page à livrer dans une PR suivante, #5010).

## Plan de test

- [x] `yarn typecheck`
- [x] `formulaire.service.test.ts` (15/15, y compris le test de snapshot sur `offer_description`)
- [x] `job.model.test.ts` (12/12)
- [ ] `yarn check:fix` — bloqué localement par un problème d'environnement sans rapport (config Biome imbriquée détectée dans des worktrees d'une autre session en cours), à relancer une fois résolu
- [ ] Test manuel en local du parcours recruteur (ancien formulaire inchangé + nouveau mode libre bout en bout) et de la fiche candidat correspondante — non exécuté dans cette session (nécessite un compte recruteur de test authentifié)