### PR TITLE
feat: ajoute la modération IA des descriptions libres

### DIFF
--- a/server/src/common/utils/maskPersonalData.test.ts
+++ b/server/src/common/utils/maskPersonalData.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+
+import { maskPersonalData } from "./maskPersonalData"
+
+describe("maskPersonalData", () => {
+  describe("null/undefined/empty handling", () => {
+    it("should return the input unchanged for null", () => {
+      expect(maskPersonalData(null as unknown as string)).toBe(null)
+    })
+    it("should return the input unchanged for undefined", () => {
+      expect(maskPersonalData(undefined as unknown as string)).toBe(undefined)
+    })
+    it("should return an empty string unchanged", () => {
+      expect(maskPersonalData("")).toBe("")
+    })
+  })
+
+  describe("phone numbers", () => {
+    it("should mask a mobile number with spaces", () => {
+      expect(maskPersonalData("Contactez-moi au 06 12 34 56 78 pour plus d'infos.")).toBe("Contactez-moi au 06xxxxxxxx pour plus d'infos.")
+    })
+    it("should mask a number with dots", () => {
+      expect(maskPersonalData("Tel: 06.12.34.56.78")).toBe("Tel: 06xxxxxxxx")
+    })
+    it("should mask a number with no separators", () => {
+      expect(maskPersonalData("Appelez le 0612345678 svp")).toBe("Appelez le 06xxxxxxxx svp")
+    })
+    it("should mask a landline number", () => {
+      expect(maskPersonalData("Standard : 01 23 45 67 89")).toBe("Standard : 06xxxxxxxx")
+    })
+    it("should mask a number with the +33 prefix", () => {
+      expect(maskPersonalData("+33 6 12 34 56 78 pour me joindre")).toBe("06xxxxxxxx pour me joindre")
+    })
+    it("should leave text without a phone number unchanged", () => {
+      expect(maskPersonalData("Poste à pourvoir dès que possible.")).toBe("Poste à pourvoir dès que possible.")
+    })
+  })
+
+  describe("emails", () => {
+    it("should mask an email address", () => {
+      expect(maskPersonalData("Envoyez votre CV à recrutement@entreprise.fr")).toBe("Envoyez votre CV à emxxx@xxx.fr")
+    })
+    it("should mask multiple emails", () => {
+      expect(maskPersonalData("Contact : a@test.com ou b@test.fr")).toBe("Contact : emxxx@xxx.fr ou emxxx@xxx.fr")
+    })
+  })
+
+  describe("urls", () => {
+    it("should mask a plain url", () => {
+      expect(maskPersonalData("Plus d'infos sur www.entreprise.fr")).toBe("Plus d'infos sur www.lien_non_disponible.com")
+    })
+    it("should mask a url with protocol", () => {
+      expect(maskPersonalData("Voir https://entreprise.fr/carrieres pour postuler")).toBe("Voir www.lien_non_disponible.com pour postuler")
+    })
+  })
+
+  describe("mixed content", () => {
+    it("should mask phone, email and url together, keeping the rest of the text intact", () => {
+      const input = "Rejoignez-nous ! Contact : rh@entreprise.fr, tel 06 12 34 56 78, site www.entreprise.fr. Mission passionnante."
+      const expected = "Rejoignez-nous ! Contact : emxxx@xxx.fr, tel 06xxxxxxxx, site www.lien_non_disponible.com. Mission passionnante."
+      expect(maskPersonalData(input)).toBe(expected)
+    })
+
+    it("should not alter text with no personal data", () => {
+      const input = "Nous recherchons un(e) alternant(e) motivé(e) pour rejoindre notre équipe commerciale de 5 personnes."
+      expect(maskPersonalData(input)).toBe(input)
+    })
+  })
+})

--- a/server/src/common/utils/maskPersonalData.ts
+++ b/server/src/common/utils/maskPersonalData.ts
@@ -1,0 +1,47 @@
+const PHONE_REGEX = /(?:\+33[\s.-]?|0)[1-9](?:[\s.-]?\d{2}){4}\b/g
+const EMAIL_REGEX = /[a-zA-Z0-9][a-zA-Z0-9._%+-]*@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}/g
+// url avec protocole ou préfixe www : bornée par les espaces/ponctuation (pas de sur-capture de la ponctuation de fin de phrase)
+const URL_WITH_PREFIX_REGEX = /\b(?:https?:\/\/|www\.)[^\s,;:!?()<>"'«»]+/gi
+// domaine nu sans www/protocole (ex: "voir entreprise.fr") : bornée par \b, insensible à la ponctuation adjacente
+const BARE_DOMAIN_REGEX = /\b[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.(?:gouv\.fr|asso\.fr|co\.uk|fr|com|net|org|io|co|eu|info|biz)\b/gi
+
+const PHONE_MASK = "06xxxxxxxx"
+const EMAIL_MASK = "emxxx@xxx.fr"
+const URL_MASK = "www.lien_non_disponible.com"
+
+// ponctuation de fin de phrase pouvant suivre un match sans espace (à ne jamais inclure dans le masque)
+const TRAILING_PUNCTUATION_REGEX = /[.,;:!?)\]}>"'»]+$/
+
+const maskMatches = (text: string, regex: RegExp, mask: string, skip?: (index: number) => boolean): string => {
+  const matches = [...text.matchAll(regex)].filter((m) => !skip?.(m.index))
+  if (matches.length === 0) return text
+
+  let result = text
+  for (const match of [...matches].reverse()) {
+    const index = match.index
+    const length = match[0].length - (match[0].match(TRAILING_PUNCTUATION_REGEX)?.[0].length ?? 0)
+    result = result.substring(0, index) + mask + result.substring(index + length)
+  }
+  return result
+}
+
+/**
+ * Masque les coordonnées personnelles (téléphone, email, url) détectées dans un texte libre,
+ * pour la modération des descriptions d'offre saisies librement par les recruteurs (cf #5006).
+ * Remplace par des formats prédéfinis plutôt que de supprimer, pour ne pas casser la lisibilité
+ * du texte autour. Regex dédiées (plutôt que shared/utils/detectUrlAndEmails) : ce dernier perd
+ * les matches dont le domaine est directement suivi d'une ponctuation sans espace (ex: "fr,"),
+ * un cas trop fréquent en prose libre pour une fonctionnalité de modération.
+ */
+export const maskPersonalData = (text: string): string => {
+  if (!text) return text
+
+  let masked = text.replace(PHONE_REGEX, PHONE_MASK)
+  // url avant email : évite qu'une adresse email déjà masquée en "emxxx@xxx.fr" ne soit re-capturée
+  // par la détection de domaine nu ("xxx.fr") lors d'un passage ultérieur.
+  masked = maskMatches(masked, URL_WITH_PREFIX_REGEX, URL_MASK)
+  masked = maskMatches(masked, BARE_DOMAIN_REGEX, URL_MASK, (index) => masked[index - 1] === "@")
+  masked = maskMatches(masked, EMAIL_REGEX, EMAIL_MASK)
+
+  return masked
+}

--- a/server/src/http/controllers/formulaire.controller.ts
+++ b/server/src/http/controllers/formulaire.controller.ts
@@ -25,6 +25,7 @@ import {
   validateDelegatedCompanyPhoneAndEmail,
   validateUserEmailFromJobId,
 } from "@/services/formulaire.service"
+import { moderateFreeText } from "@/services/offreModeration.service"
 import { getUserRecruteurById } from "@/services/userRecruteur.service"
 import { getUserWithAccountByEmail } from "@/services/userWithAccount.service"
 
@@ -284,6 +285,22 @@ export default (server: Server) => {
       })
       const token = generateOffreToken(user, createdOffer)
       return res.status(200).send({ job_id: createdOffer._id.toString(), token })
+    }
+  )
+
+  /**
+   * Améliore (orthographe, structure, modération) un texte libre saisi par le recruteur, sans le sauvegarder.
+   */
+  server.post(
+    "/formulaire/:establishment_id/offre/ameliorer-texte",
+    {
+      schema: zRoutes.post["/formulaire/:establishment_id/offre/ameliorer-texte"],
+      onRequest: [server.auth(zRoutes.post["/formulaire/:establishment_id/offre/ameliorer-texte"])],
+    },
+    async (req, res) => {
+      const { text } = req.body
+      const improvedText = await moderateFreeText(text)
+      return res.status(200).send({ text: improvedText ?? text })
     }
   )
 

--- a/server/src/services/formulaire.service.test.ts
+++ b/server/src/services/formulaire.service.test.ts
@@ -15,9 +15,15 @@ import type { ICFA } from "shared/models/cfa.model"
 import type { IEntreprise, IJobCreate, IReferentielRome, IUserWithAccount } from "shared/models/index"
 import { JOB_START_TYPE } from "shared/models/job.model"
 import { JOBPARTNERS_LABEL } from "shared/models/jobsPartners.model"
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 import { createJob, getCompetencesRomeFromPartnerJob, getFormulairesForCfaManagedEnterprises } from "./formulaire.service"
+
+// createJob/patchOffre appellent Mistral pour modérer job_description/job_employer_description (cf #5006) :
+// on mocke pour ne jamais dépendre du réseau/d'une clé API dans les tests, quel que soit le contenu des fixtures.
+vi.mock("@/services/mistralai/mistralai.service", () => ({
+  sendMistralMessages: vi.fn().mockResolvedValue(null),
+}))
 
 useMongo()
 

--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -44,6 +44,7 @@ import { getCatalogueFormations } from "./catalogue.service"
 import { buildEstablishmentId, establishmentIdToUserIdAndSiret, getEntrepriseDataFromSiret } from "./etablissement.service"
 import { buildLbaUrl } from "./jobs/jobOpportunity/jobOpportunity.service"
 import mailer from "./mailer.service"
+import { moderateFreeText } from "./offreModeration.service"
 import { anonymizeLbaJobsPartners } from "./partnerJob.service"
 import { getEntrepriseEngagementFranceTravail } from "./referentielEngagementEntreprise.service"
 import { getComputedUserAccess, getGrantedRoles, getMainRoleManagement } from "./roleManagement.service"
@@ -86,6 +87,14 @@ export const createJob = async ({
   origin?: string
 }): Promise<IJobsPartnersOfferPrivate> => {
   await validateFieldsFromReferentielRome(job)
+
+  // Modération systématique des champs de description libre (correction + PII, cf #5006),
+  // indépendamment du nombre d'utilisations restantes du CTA "Améliorer via l'IA" côté UI.
+  const [moderatedDescription, moderatedEmployerDescription] = await Promise.all([
+    moderateFreeText(job.job_description),
+    moderateFreeText(job.job_employer_description),
+  ])
+  const moderatedJob: IJobCreate = { ...job, job_description: moderatedDescription, job_employer_description: moderatedEmployerDescription }
 
   const entreprise = await getDbCollection("entreprises").findOne({ siret })
   if (!entreprise) {
@@ -134,7 +143,7 @@ export const createJob = async ({
   }
 
   const newJobPartner: IJobsPartnersOfferPrivate = await jobCreateToJobsPartner({
-    job,
+    job: moderatedJob,
     cfa: cfa ?? undefined,
     entreprise,
     user,
@@ -604,6 +613,13 @@ export const patchOffre = async (id: ObjectId, payload: PatchOffreBody): Promise
   const job = payload
   const now = new Date()
 
+  // Modération systématique des champs de description libre (correction + PII, cf #5006),
+  // indépendamment du nombre d'utilisations restantes du CTA "Améliorer via l'IA" côté UI.
+  const [moderatedDescription, moderatedEmployerDescription] = await Promise.all([
+    moderateFreeText(job.job_description),
+    job.job_employer_description !== undefined ? moderateFreeText(job.job_employer_description) : undefined,
+  ])
+
   const romeDetails = await getRomeDetailsFromDB(job.rome_code[0])
 
   const jobPartnerUpdate: Partial<IJobsPartnersOfferPrivate> = {
@@ -623,14 +639,14 @@ export const patchOffre = async (id: ObjectId, payload: PatchOffreBody): Promise
     offer_to_be_acquired_skills: getSkillsFromRome(job.competences_rome?.savoir_faire, romeDetails?.competences?.savoir_faire),
     offer_to_be_acquired_knowledge: getSkillsFromRome(job.competences_rome?.savoirs, romeDetails?.competences?.savoirs),
     offer_access_conditions: romeDetails?.acces_metier ? [romeDetails.acces_metier] : [],
-    offer_description: sanitizeTextField(job.job_description, true) || romeDetails?.definition || "",
+    offer_description: moderatedDescription || romeDetails?.definition || "",
     contract_duration: job.job_duration ?? null,
     offer_target_diploma: getDiplomaLevel(job.job_level_label) ?? null,
     // offer_title_custom = saisie libre recruteur (le schéma Zod n'interdit pas les tags HTML) →
     // texte brut avant stockage ; si le nettoyage vide le titre, fallback comme s'il était absent.
     offer_title: sanitizeToPlainText(job.offer_title_custom) || job.rome_appellation_label || existingJob.offer_title,
     offer_rome_appellation: job.rome_appellation_label,
-    workplace_description: job.job_employer_description !== undefined ? sanitizeTextField(job.job_employer_description, true) || null : existingJob.workplace_description,
+    workplace_description: job.job_employer_description !== undefined ? moderatedEmployerDescription || null : existingJob.workplace_description,
     to_applicant_questions: job.to_applicant_questions,
     contract_rythm: job.job_rythm,
     ...(job.ft_support !== undefined && { ft_support: job.ft_support }),
@@ -1244,7 +1260,8 @@ async function jobCreateToJobsPartner({
     offer_access_conditions: acces_metier ? [acces_metier] : [],
     offer_title,
     offer_rome_codes: job.rome_code ?? null,
-    offer_description: sanitizeTextField(job.job_description, true) || definition || "",
+    // job.job_description est déjà modéré (correction IA + masquage PII + sanitization HTML) par createJob.
+    offer_description: job.job_description || definition || "",
     offer_creation: now,
     offer_expiration: addExpirationPeriod(now).toDate(),
     offer_status: status,
@@ -1254,7 +1271,8 @@ async function jobCreateToJobsPartner({
     contract_remote: null,
     offer_status_history: [],
     workplace_address_street_label: null,
-    workplace_description: sanitizeTextField(job.job_employer_description, true) || null,
+    // job.job_employer_description est déjà modéré (correction IA + masquage PII + sanitization HTML) par createJob.
+    workplace_description: job.job_employer_description || null,
     workplace_name: null,
     workplace_website: null,
 

--- a/server/src/services/offreModeration.service.test.ts
+++ b/server/src/services/offreModeration.service.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { sendMistralMessages } from "@/services/mistralai/mistralai.service"
+
+import { moderateFreeText } from "./offreModeration.service"
+
+vi.mock("@/services/mistralai/mistralai.service", () => ({
+  sendMistralMessages: vi.fn(),
+}))
+
+describe("moderateFreeText", () => {
+  beforeEach(() => {
+    vi.mocked(sendMistralMessages).mockReset()
+  })
+
+  it("should return null for empty/null/undefined input without calling Mistral", async () => {
+    expect(await moderateFreeText(null)).toBe(null)
+    expect(await moderateFreeText(undefined)).toBe(null)
+    expect(await moderateFreeText("   ")).toBe(null)
+    expect(sendMistralMessages).not.toHaveBeenCalled()
+  })
+
+  it("should mask personal data before sending the text to Mistral", async () => {
+    vi.mocked(sendMistralMessages).mockResolvedValue(null)
+    await moderateFreeText("Contactez-moi au 06 12 34 56 78")
+
+    const [{ messages }] = vi.mocked(sendMistralMessages).mock.calls[0]
+    const userMessage = messages.find((m) => m.role === "user")
+    expect(userMessage?.content).toContain("06xxxxxxxx")
+    expect(userMessage?.content).not.toContain("06 12 34 56 78")
+  })
+
+  it("should return the masked input, unmodified by AI, when the Mistral call fails", async () => {
+    vi.mocked(sendMistralMessages).mockResolvedValue(null)
+    const result = await moderateFreeText("Rejoignez une equipe dynamique, tel 06 12 34 56 78.")
+    expect(result).toBe("Rejoignez une equipe dynamique, tel 06xxxxxxxx.")
+  })
+
+  it("should return the AI-corrected text when Mistral responds with valid JSON", async () => {
+    vi.mocked(sendMistralMessages).mockResolvedValue('{"text": "Rejoignez une équipe dynamique et bienveillante."}')
+    const result = await moderateFreeText("rejoint une equipe dynamik")
+    expect(result).toBe("Rejoignez une équipe dynamique et bienveillante.")
+  })
+
+  it("should fall back to the masked input when Mistral responds with malformed JSON", async () => {
+    vi.mocked(sendMistralMessages).mockResolvedValue("not json at all")
+    const result = await moderateFreeText("Poste ouvert aux candidats motives.")
+    expect(result).toBe("Poste ouvert aux candidats motives.")
+  })
+
+  it("should re-mask any personal data the AI might have reintroduced in its response", async () => {
+    vi.mocked(sendMistralMessages).mockResolvedValue('{"text": "Contactez le recrutement au 07 98 76 54 32."}')
+    const result = await moderateFreeText("un texte quelconque")
+    expect(result).toBe("Contactez le recrutement au 06xxxxxxxx.")
+  })
+
+  it("should strip executable HTML from the AI response before returning it", async () => {
+    vi.mocked(sendMistralMessages).mockResolvedValue('{"text": "<script>alert(1)</script>Rejoignez-nous"}')
+    const result = await moderateFreeText("un texte quelconque")
+    expect(result).not.toContain("<script")
+    expect(result).toContain("Rejoignez-nous")
+  })
+})

--- a/server/src/services/offreModeration.service.ts
+++ b/server/src/services/offreModeration.service.ts
@@ -1,0 +1,50 @@
+import { maskPersonalData } from "@/common/utils/maskPersonalData"
+import { sanitizeTextField } from "@/common/utils/stringUtils"
+import { sendMistralMessages } from "@/services/mistralai/mistralai.service"
+
+const MODERATION_SYSTEM_PROMPT = `Tu es un assistant de modération et de correction pour des offres d'alternance publiées sur La bonne alternance, un service public français.
+Tu reçois un texte rédigé librement par un recruteur (présentation de l'entreprise ou description du poste). Réponds uniquement avec un objet JSON de la forme {"text": "..."}, sans commentaire ni texte hors du JSON.
+
+Règles à appliquer strictement :
+1. Corrige l'orthographe, la grammaire et la ponctuation.
+2. Améliore la structure et la clarté de la formulation, sans changer le sens ni le fond du texte.
+3. Conserve toutes les informations factuelles présentes : responsabilités liées au poste, avantages, compétences, salaire, informations légales de l'entreprise.
+4. Supprime ou reformule tout propos discriminant (sexe, origine, apparence physique, situation de famille, grossesse, état de santé, handicap, orientation sexuelle, opinions politiques ou religieuses, âge), haineux, offensant, ou à caractère sexuel.
+5. Le texte fourni a déjà ses coordonnées personnelles (téléphone, email, url) masquées : ne tente jamais de les deviner ou de les réintroduire.
+6. Si le texte fourni est déjà correct et conforme, renvoie-le tel quel.`
+
+/**
+ * Corrige et modère un texte libre saisi par un recruteur (cf #5006) : masquage déterministe des
+ * coordonnées personnelles (avant tout envoi à l'API tierce Mistral, et en filet de sécurité après),
+ * puis correction orthographe/structure et retraitement des propos discriminants via l'IA.
+ * Ne bloque jamais l'appelant : en cas d'échec de l'appel IA, retourne le texte masqué non retravaillé.
+ */
+export const moderateFreeText = async (rawText: string | null | undefined): Promise<string | null> => {
+  const trimmed = rawText?.trim()
+  if (!trimmed) return null
+
+  const maskedInput = maskPersonalData(trimmed)
+
+  const response = await sendMistralMessages({
+    messages: [
+      { role: "system", content: MODERATION_SYSTEM_PROMPT },
+      { role: "user", content: maskedInput },
+    ],
+  })
+
+  if (!response) {
+    // échec de l'appel IA (timeout, erreur API) : on ne bloque pas le recruteur, le texte reste
+    // masqué mais non retravaillé — la sanitization HTML reste appliquée dans tous les cas.
+    return sanitizeTextField(maskedInput, true) || null
+  }
+
+  try {
+    const parsed = JSON.parse(response)
+    const improvedText = typeof parsed?.text === "string" && parsed.text.trim() ? parsed.text.trim() : maskedInput
+    // re-masquage + sanitization HTML en filet de sécurité : l'IA ne doit jamais pouvoir réintroduire
+    // des coordonnées ou du HTML exécutable dans le texte stocké et rendu via dangerouslySetInnerHTML.
+    return sanitizeTextField(maskPersonalData(improvedText), true) || null
+  } catch {
+    return sanitizeTextField(maskedInput, true) || null
+  }
+}

--- a/shared/src/routes/formulaire.route.ts
+++ b/shared/src/routes/formulaire.route.ts
@@ -156,6 +156,27 @@ export const zFormulaireRoute = {
         },
       },
     },
+    "/formulaire/:establishment_id/offre/ameliorer-texte": {
+      method: "post",
+      path: "/formulaire/:establishment_id/offre/ameliorer-texte",
+      params: z.object({ establishment_id: z.string() }).strict(),
+      body: z
+        .object({
+          field: z.enum(["job_description", "job_employer_description"]),
+          text: z.string().trim().min(1).max(3000),
+        })
+        .strict(),
+      response: {
+        "200": z.object({ text: z.string() }).strict(),
+      },
+      securityScheme: {
+        auth: "cookie-session",
+        access: "recruiter:add_job",
+        resources: {
+          job: [{ establishment_id: { type: "params", key: "establishment_id" } }],
+        },
+      },
+    },
     "/formulaire/offre/:jobId/delegation": {
       method: "post",
       path: "/formulaire/offre/:jobId/delegation",

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep1.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep1.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import { fr } from "@codegouvfr/react-dsfr"
+import Button from "@codegouvfr/react-dsfr/Button"
 import Input from "@codegouvfr/react-dsfr/Input"
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons"
-import { Box, Typography } from "@mui/material"
+import { Box, CircularProgress, Typography } from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
 import dayjs from "dayjs"
 import { Formik, useFormikContext } from "formik"
@@ -16,7 +17,7 @@ import { InfosDiffusionOffre } from "@/components/DepotOffre/InfosDiffusionOffre
 import type { RomeCompetenceKey } from "@/components/DepotOffre/RomeDetail"
 import { RomeDetailWithQuery } from "@/components/DepotOffre/RomeDetailWithQuery"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
-import { getRomeDetail } from "@/utils/api"
+import { ameliorerTexteOffre, getRomeDetail } from "@/utils/api"
 import { FormulaireEditionOffreButtons } from "./FormulaireEditionOffreButtons"
 import { FormulaireEditionOffreFields } from "./FormulaireEditionOffreFields"
 
@@ -24,6 +25,45 @@ const ISO_DATE_FORMAT = "YYYY-MM-DD"
 const FR_DATE_FORMAT = "DD/MM/YYYY"
 const EMPLOYER_DESCRIPTION_MAX = 800
 const JOB_DESCRIPTION_MAX = 3000
+const AMELIORER_IA_MAX_USAGES = 2
+
+type FreeTextFieldName = "job_description" | "job_employer_description"
+
+const AmeliorerIaButton = ({ fieldName, establishmentId }: { fieldName: FreeTextFieldName; establishmentId?: string }) => {
+  const { values, setFieldValue } = useFormikContext<any>()
+  const [remaining, setRemaining] = useState(AMELIORER_IA_MAX_USAGES)
+  const [loading, setLoading] = useState(false)
+  const text: string = values[fieldName] ?? ""
+
+  const handleClick = async () => {
+    if (!establishmentId || loading || remaining <= 0 || !text.trim()) return
+    setLoading(true)
+    try {
+      const result = await ameliorerTexteOffre(establishmentId, fieldName, text)
+      if (result && "text" in result && result.text) {
+        setFieldValue(fieldName, result.text)
+        setRemaining((r) => r - 1)
+      }
+    } catch {
+      // Échec de l'appel IA (timeout, erreur API) : le recruteur peut poursuivre son dépôt sans blocage.
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Button type="button" priority="tertiary" size="small" disabled={!establishmentId || loading || remaining <= 0 || !text.trim()} onClick={handleClick}>
+      {loading ? (
+        <>
+          <CircularProgress size={14} sx={{ mr: fr.spacing("2v"), verticalAlign: "middle" }} />
+          Amélioration en cours…
+        </>
+      ) : (
+        `Améliorer via l'IA (${remaining}/${AMELIORER_IA_MAX_USAGES})`
+      )}
+    </Button>
+  )
+}
 
 type DescriptionMode = "structured" | "custom"
 
@@ -53,7 +93,7 @@ const DescriptionModeToggle = ({ mode, onChange }: { mode: DescriptionMode; onCh
   />
 )
 
-const JobDescriptionField = () => {
+const JobDescriptionField = ({ establishmentId }: { establishmentId?: string }) => {
   const { values, setFieldValue, errors } = useFormikContext<any>()
   return (
     <Box sx={{ mt: fr.spacing("4v") }}>
@@ -80,11 +120,14 @@ const JobDescriptionField = () => {
           onChange: (e) => setFieldValue("job_description", e.target.value),
         }}
       />
+      <Box sx={{ mt: fr.spacing("2v"), display: "flex", justifyContent: "flex-end" }}>
+        <AmeliorerIaButton fieldName="job_description" establishmentId={establishmentId} />
+      </Box>
     </Box>
   )
 }
 
-const EmployerDescriptionField = () => {
+const EmployerDescriptionField = ({ establishmentId }: { establishmentId?: string }) => {
   const { values, setFieldValue, errors } = useFormikContext<any>()
   return (
     <Box>
@@ -106,6 +149,9 @@ const EmployerDescriptionField = () => {
           onChange: (e) => setFieldValue("job_employer_description", e.target.value),
         }}
       />
+      <Box sx={{ mt: fr.spacing("2v"), display: "flex", justifyContent: "flex-end" }}>
+        <AmeliorerIaButton fieldName="job_employer_description" establishmentId={establishmentId} />
+      </Box>
     </Box>
   )
 }
@@ -324,7 +370,7 @@ export const FormulaireEditionOffreStep1 = ({
                     La présentation de l'entreprise
                   </Typography>
                   <Box sx={{ mt: fr.spacing("4v") }}>
-                    <EmployerDescriptionField />
+                    <EmployerDescriptionField establishmentId={establishment_id} />
                   </Box>
 
                   <Typography variant="h4" sx={{ color: fr.colors.decisions.artwork.major.blueFrance.default, mt: fr.spacing("8v") }}>
@@ -337,7 +383,7 @@ export const FormulaireEditionOffreStep1 = ({
                   {romeAndAppellation && (
                     <Box sx={{ mt: fr.spacing("6v") }}>
                       <DescriptionModeToggle mode={descriptionMode} onChange={setDescriptionMode} />
-                      {descriptionMode === "custom" && <JobDescriptionField />}
+                      {descriptionMode === "custom" && <JobDescriptionField establishmentId={establishment_id} />}
                     </Box>
                   )}
 

--- a/ui/utils/api.ts
+++ b/ui/utils/api.ts
@@ -48,6 +48,8 @@ export const createOffre = async (establishment_id: string, newOffre: IJobCreate
   apiPost("/formulaire/:establishment_id/offre", { params: { establishment_id }, body: newOffre })
 export const createOffreByToken = async (establishment_id: string, newOffre: IJobCreate, token: string) =>
   apiPost("/formulaire/:establishment_id/offre/by-token", { params: { establishment_id }, body: newOffre, headers: { authorization: `Bearer ${token}` } })
+export const ameliorerTexteOffre = async (establishment_id: string, field: "job_description" | "job_employer_description", text: string) =>
+  apiPost("/formulaire/:establishment_id/offre/ameliorer-texte", { params: { establishment_id }, body: { field, text } })
 export const viewOffreDelegation = async (jobId: string, siret: string, token: string) =>
   apiPatch(`/formulaire/offre/:jobId/delegation/view`, { params: { jobId }, querystring: { siret_formateur: siret }, headers: { authorization: `Bearer ${token}` } })
 // need a function to cancel partner jobs : add the job_origin from the application in the url - refactor ui/pages/espace-pro/offre/[jobId]/[option].tsx needed


### PR DESCRIPTION
Closes #5006

Empilée sur la PR #4998 (introduit les champs libres job_description/job_employer_description) — base = feat/issue-4998, à retargeter sur main une fois celle-ci mergée.

## Changements

- Nouvel utilitaire `server/src/common/utils/maskPersonalData.ts` : masque téléphone/email/url dans un texte libre (formats `06xxxxxxxx` / `emxxx@xxx.fr` / `www.lien_non_disponible.com`). Regex dédiées plutôt que réutilisation de `shared/utils/detectUrlAndEmails` : ce dernier perd silencieusement les matches dont le domaine est directement suivi d'une ponctuation sans espace (`"contact@x.fr,"`), un cas trop fréquent en prose libre pour une fonctionnalité de modération — testé et confirmé en écrivant les tests (voir `maskPersonalData.test.ts`).
- Nouveau `server/src/services/offreModeration.service.ts` (`moderateFreeText`) : masquage PII avant tout envoi à Mistral (on ne transmet jamais de coordonnées brutes à l'API tierce), appel Mistral pour correction orthographe/structure + retraitement des propos discriminants/haineux/offensants, puis re-masquage + sanitization HTML du résultat en filet de sécurité. Échec de l'appel IA (timeout, erreur) → ne bloque jamais, retourne le texte masqué non retravaillé.
- Nouvelle route `POST /formulaire/:establishment_id/offre/ameliorer-texte` (cookie-session, scope `recruiter:add_job`) pour le CTA à la demande, sans sauvegarde.
- **Modération systématique à la sauvegarde**, indépendamment du compteur IA restant côté UI : `createJob` et `patchOffre` appellent désormais `moderateFreeText` sur `job_description` et `job_employer_description` avant stockage.
- Correctif en passant : la route PUT d'édition d'offre n'acceptait pas `job_description` (contrairement à la route de création) — l'édition d'une offre en mode libre échouait silencieusement à persister ce champ.
- UI : bouton "Améliorer via l'IA" sur les deux champs libres, compteur (2 utilisations), spinner pendant l'appel, désactivé à 0, échec non bloquant.

## Tests

- `maskPersonalData.test.ts` (15 tests) — téléphone/email/url isolés et combinés en prose.
- `offreModeration.service.test.ts` (7 tests) — Mistral mocké : succès, échec, JSON malformé, re-masquage du résultat IA, sanitization HTML du résultat IA.
- `formulaire.service.test.ts` mis à jour pour mocker Mistral (sinon appel réseau réel dès qu'un test fournit un job_description/job_employer_description non vide).

## Plan de test

- [x] `yarn typecheck`
- [x] `maskPersonalData.test.ts`, `offreModeration.service.test.ts`, `formulaire.service.test.ts`, `stringUtils.test.ts`, `job.model.test.ts` (136/136)
- [ ] `yarn check:fix` — bloqué localement par un problème d'environnement sans rapport (config Biome imbriquée détectée dans des worktrees d'une autre session en cours)
- [ ] Test manuel du CTA "Améliorer via l'IA" en local (nominal + échec simulé) et de la modération au clic sur "Continuer" — non exécuté dans cette session (nécessite compte recruteur de test + clé API Mistral valide en local)

## Point en suspens

- Le prompt de modération est générique (règles listées dans le ticket + charte affichée sur #5010), pas encore la liste de mots interdits définitive évoquée en commentaire du ticket (viendra de la PM) — prompt structuré pour l'accueillir facilement.