### PR TITLE
fix: rend le CTA Continuer du dépôt d'offre accessible RGAA

### DIFF
--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreButtons.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreButtons.tsx
@@ -5,14 +5,42 @@ import { Box } from "@mui/material"
 import { useFormikContext } from "formik"
 import type { IJob } from "shared"
 
-export const FormulaireEditionOffreButtons = ({ offre, competencesDirty }: { offre?: IJob; competencesDirty: boolean }) => {
-  const { isValid, isSubmitting, dirty, submitForm } = useFormikContext<any>()
+// Focus le premier champ en erreur dans l'ordre visuel (DOM), pas dans l'ordre des clés de errors
+// (non garanti). Fonctionne aussi sur mobile : scrollIntoView + focus sont supportés nativement.
+const focusFirstInvalidField = (errorFieldNames: string[]) => {
+  const candidates = errorFieldNames
+    .map((name) => document.querySelector<HTMLElement>(`[name="${name}"]`))
+    .filter((el): el is HTMLElement => Boolean(el))
+    .sort((a, b) => (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1))
 
-  const finalDirty = dirty || competencesDirty
+  const target = candidates[0]
+  if (target) {
+    target.scrollIntoView({ behavior: "smooth", block: "center" })
+    target.focus({ preventScroll: true })
+  }
+}
+
+export const FormulaireEditionOffreButtons = ({ offre }: { offre?: IJob }) => {
+  const { isSubmitting, submitForm, validateForm, setTouched } = useFormikContext<any>()
+
+  const handleClick = async () => {
+    const validationErrors = await validateForm()
+    const errorFieldNames = Object.keys(validationErrors)
+
+    if (errorFieldNames.length > 0) {
+      // affiche les messages d'erreur sur tous les champs concernés (state="error" des composants
+      // DSFR est conditionné par touched pour la plupart des champs du formulaire).
+      await setTouched(Object.fromEntries(errorFieldNames.map((name) => [name, true])), false)
+      focusFirstInvalidField(errorFieldNames)
+      return
+    }
+
+    submitForm()
+  }
 
   return (
     <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-      <Button disabled={!(isValid && finalDirty) || isSubmitting} onClick={submitForm} data-testid="creer-offre">
+      <Button disabled={isSubmitting} onClick={handleClick} data-testid="creer-offre">
         Continuer
       </Button>
     </Box>

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep1.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/FormulaireEditionOffreStep1.tsx
@@ -184,13 +184,11 @@ export const FormulaireEditionOffreStep1 = ({
   })
 
   const [selectedCompetences, setSelectedCompetences] = useState<IReferentielRomeForJob["competences"] | null>(offre?.competences_rome ?? formValues?.competences_rome ?? null)
-  const [competencesDirty, setCompetencesDirty] = useState(Boolean(formValues))
   const [descriptionMode, setDescriptionMode] = useState<DescriptionMode>(offre?.job_description || formValues?.job_description ? "custom" : "structured")
 
   const onRomeChange = (rome: string, appellation: string) => {
     setRomeAndAppellation({ rome, appellation })
     setSelectedCompetences(null)
-    setCompetencesDirty(true)
   }
 
   const onSelectedCompetencesChange = (selectedCompetences: Record<RomeCompetenceKey, Set<string>>) => {
@@ -218,7 +216,6 @@ export const FormulaireEditionOffreStep1 = ({
       }),
     }
     setSelectedCompetences(savedCompetences)
-    setCompetencesDirty(true)
   }
 
   if (!establishment_id) return <></>
@@ -408,7 +405,7 @@ export const FormulaireEditionOffreStep1 = ({
                 </Box>
               </Box>
               <Box sx={{ borderTop: `1px solid ${fr.colors.decisions.border.default.grey.default}`, pt: fr.spacing("8v") }}>
-                <FormulaireEditionOffreButtons offre={offre} competencesDirty={competencesDirty} />
+                <FormulaireEditionOffreButtons offre={offre} />
               </Box>
             </div>
           )


### PR DESCRIPTION
Closes #5007

Empilée sur la PR #5006 (dépendance explicite du ticket) — base = feat/issue-5006, à retargeter sur main une fois les PR précédentes mergées.

## Changements

- `FormulaireEditionOffreButtons.tsx` : le CTA "Continuer" n'est plus désactivé selon `isValid`/`dirty`/`competencesDirty` — reste actif en permanence (seul `isSubmitting` le désactive, pour éviter un double submit).
- Au clic : `validateForm()` calcule les erreurs, `setTouched` les marque toutes comme touchées (déclenche l'affichage des messages d'erreur DSFR déjà conditionnés par `touched` sur la plupart des champs), puis le focus clavier est positionné sur le premier champ en erreur dans l'ordre visuel du DOM (et non l'ordre des clés de l'objet errors, non garanti) — fonctionne aussi sur mobile (`scrollIntoView` + `focus` natifs).
- Si aucune erreur, `submitForm()` s'exécute normalement.
- Nettoyage en passant : suppression de l'état `competencesDirty` (dans `FormulaireEditionOffreStep1.tsx`) devenu mort puisqu'il ne servait qu'à cette désactivation.

## Point en suspens / hors périmètre

- `offer_title_custom` (champ facultatif) n'a pas d'affichage d'erreur inline câblé du tout dans `FormulaireEditionOffreFields.tsx` (ni avant ni après ce correctif) — pré-existant, hors périmètre de ce ticket puisqu'il ne s'agit pas d'un champ obligatoire.
- Les composants complexes (sélecteur de métier `DropdownCombobox`, cases à cocher de compétences ROME) n'ont pas été vérifiés visuellement pour confirmer que le focus atterrit correctement dessus — le ciblage par attribut `name` devrait fonctionner mais mérite une QA visuelle.

## Plan de test

- [x] `yarn typecheck`
- [ ] `yarn check:fix` — bloqué localement par un problème d'environnement sans rapport (config Biome imbriquée détectée dans des worktrees d'une autre session en cours)
- [ ] Test manuel : clic sur "Continuer" avec des champs obligatoires vides → erreurs affichées + focus sur le premier champ, y compris au clavier et sur mobile — non exécuté dans cette session (pas de compte recruteur de test authentifié)
- [ ] Vérification lecteur d'écran (restitution des messages d'erreur) — non exécutée dans cette session