### PR TITLE
feat: rate limiting nginx sur les routes front anti-scraping (#5075)

### DIFF
--- a/.infra/files/configs/reverse_proxy/extra-conf.d/rate-limit.conf.template
+++ b/.infra/files/configs/reverse_proxy/extra-conf.d/rate-limit.conf.template
@@ -1,0 +1,27 @@
+# Limitation de débit par IP sur les routes réservées au front (anti-scraping).
+# Un usage humain fait des rafales courtes ; un scraper tient un débit soutenu.
+# Les zones limitent donc le débit continu avec un burst généreux.
+# Les dépassements sont logués dans error.log et alimentent le jail fail2ban
+# nginx-req-limit (ban iptables 1h au-delà de 50 dépassements sur 1h).
+
+# Les IPs internes (healthchecks, réseau docker) ne sont pas limitées.
+geo $lba_limited {
+    default        1;
+    127.0.0.1      0;
+    10.0.0.0/8     0;
+    172.16.0.0/12  0;
+    192.168.0.0/16 0;
+}
+
+map $lba_limited $lba_limit_key {
+    0 "";
+    1 $binary_remote_addr;
+}
+
+# Recherche d'offres du front (/api/v1/_private/, /api/_private/).
+limit_req_zone $lba_limit_key zone=lba_search:10m rate=30r/m;
+
+# Autocomplétion métiers (/api/rome) : 1 appel par frappe, rafales tolérées.
+limit_req_zone $lba_limit_key zone=lba_autocomplete:10m rate=2r/s;
+
+limit_req_status 429;

--- a/.infra/files/configs/reverse_proxy/locations/10_api.conf.template
+++ b/.infra/files/configs/reverse_proxy/locations/10_api.conf.template
@@ -4,6 +4,31 @@ location /api {
     include includes/proxy.conf;
 }
 
+# Routes réservées au front : rate limiting nginx (zones dans extra-conf.d/rate-limit.conf)
+location /api/rome {
+    limit_req zone=lba_autocomplete burst=40 nodelay;
+
+    set $upstream http://server:5000;
+    include includes/error_page_json.conf;
+    include includes/proxy.conf;
+}
+
+location /api/_private/ {
+    limit_req zone=lba_search burst=60 nodelay;
+
+    set $upstream http://server:5000;
+    include includes/error_page_json.conf;
+    include includes/proxy.conf;
+}
+
+location /api/v1/_private/ {
+    limit_req zone=lba_search burst=60 nodelay;
+
+    set $upstream http://server:5000;
+    include includes/error_page_json.conf;
+    include includes/proxy.conf;
+}
+
 location ~* ^/api/v1/application$ {
     client_max_body_size    5M;
 

--- a/.infra/files/configs/reverse_proxy/locations/10_api.conf.template
+++ b/.infra/files/configs/reverse_proxy/locations/10_api.conf.template
@@ -4,7 +4,7 @@ location /api {
     include includes/proxy.conf;
 }
 
-# Routes réservées au front : rate limiting nginx (zones dans extra-conf.d/rate-limit.conf)
+# Routes réservées au front : rate limiting nginx (zones dans extra-conf.d/rate-limit.conf.template)
 location /api/rome {
     limit_req zone=lba_autocomplete burst=40 nodelay;
 


### PR DESCRIPTION
Closes #5075

## Changements

- Nouveau fichier `extra-conf.d/rate-limit.conf.template` (inclus au niveau `http` du nginx) : deux zones `limit_req` par IP, avec exclusion des IPs internes (healthchecks, réseau docker) via `geo`/`map`.
- `locations/10_api.conf.template` : application des limites sur les routes réservées au front :
  - `/api/v1/_private/` et `/api/_private/` (recherche d'offres) : **30 req/min soutenu, burst 60** (`nodelay`)
  - `/api/rome` (autocomplétion métiers, 1 appel par frappe) : **2 req/s soutenu, burst 40** (`nodelay`)
- Réponse `429` au-delà de la limite.

## Pourquoi ces seuils

Un humain fait des rafales courtes (chargement d'une page de recherche = quelques appels, frappe dans l'autocomplétion) puis s'arrête : le burst les absorbe intégralement. Un scraper tient un débit continu : c'est le débit soutenu qui le rejette. Le scraper du 3 août (~0,9 req/s en continu sur la recherche, ~8 req/s sur `/api/rome`) passait sous le rate limit applicatif (5 req/s) mais serait bloqué par ces règles.

Les dépassements sont logués dans `error.log`, déjà surveillé par le jail fail2ban `nginx-req-limit` (repo infra) : au-delà de 50 dépassements en 1h, ban iptables automatique d'1h. L'escalade est donc gratuite.

Les API partenaires publiques (v1/v2/v3 hors `_private`) ne sont volontairement pas limitées ici : consommateurs légitimes à fort débit, rate limit applicatif en place.

## Plan de test

- [ ] Déployer en recette et vérifier que le nginx démarre (`nginx -t` via le healthcheck du conteneur)
- [ ] Navigation normale : recherche + autocomplétion → aucun 429
- [ ] `for i in $(seq 1 100); do curl -s -o /dev/null -w '%{http_code}\n' 'https://labonnealternance-recette.apprentissage.beta.gouv.fr/api/v1/_private/jobs/min?romes=M1805&latitude=48.85&longitude=2.35&radius=30'; sleep 0.5; done` → 429 après épuisement du burst
- [ ] Vérifier l'apparition des lignes `limiting requests` dans `/opt/app/system/nginx/error.log`