### PR TITLE
fix: gère les erreurs 502/503/504 de l'API entreprise (#5007)

### DIFF
--- a/server/src/common/apis/apiEntreprise/apiEntreprise.client.test.ts
+++ b/server/src/common/apis/apiEntreprise/apiEntreprise.client.test.ts
@@ -1,23 +1,40 @@
 import nock from "nock"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+
+import { sentryCaptureException } from "@/common/utils/sentryUtils"
 
 import { getEtablissementFromGouvSafe } from "./apiEntreprise.client"
 import { apiEntrepriseEtablissementFixture } from "./apiEntreprise.client.fixture"
 
+vi.mock("@/common/utils/sentryUtils")
+
+const siret = apiEntrepriseEtablissementFixture.dinum.data.siret
+
+const nockApiEntreprise = (status: number, body: unknown = {}) =>
+  nock("https://entreprise.api.gouv.fr/v3/insee/")
+    .get(`/sirene/etablissements/diffusibles/${encodeURIComponent(siret)}`)
+    .query({
+      token: "LBA_ENTREPRISE_API_KEY",
+      context: "mission-apprentissage",
+      recipient: "12000101100010",
+      object: "consolidation",
+    })
+    .reply(status, body)
+
 describe("getEtablissementFromGouvSafe", () => {
   it("should return data from API entreprise", async () => {
     const result = apiEntrepriseEtablissementFixture.dinum
-    nock("https://entreprise.api.gouv.fr/v3/insee/")
-      .get(`/sirene/etablissements/diffusibles/${encodeURIComponent(result.data.siret)}`)
-      .query({
-        token: "LBA_ENTREPRISE_API_KEY",
-        context: "mission-apprentissage",
-        recipient: "12000101100010",
-        object: "consolidation",
-      })
-      .reply(200, result)
+    nockApiEntreprise(200, result)
 
-    await expect(getEtablissementFromGouvSafe(result.data.siret)).resolves.toEqual(result)
+    await expect(getEtablissementFromGouvSafe(siret)).resolves.toEqual(result)
     expect(nock.isDone()).toBe(true)
+  })
+
+  it.each([502, 503, 504])("should return null and capture in Sentry on %i response", async (status) => {
+    nockApiEntreprise(status)
+
+    await expect(getEtablissementFromGouvSafe(siret)).resolves.toBeNull()
+    expect(nock.isDone()).toBe(true)
+    expect(sentryCaptureException).toHaveBeenCalledTimes(1)
   })
 })

--- a/server/src/common/apis/apiEntreprise/apiEntreprise.client.ts
+++ b/server/src/common/apis/apiEntreprise/apiEntreprise.client.ts
@@ -41,6 +41,9 @@ export async function getEtablissementFromGouvSafe(siret: string): Promise<IEtab
       return null
     }
     sentryCaptureException(error)
+    if ([502, 503, 504].includes(status)) {
+      return null
+    }
     throw error
   }
 }


### PR DESCRIPTION
## Changements

- Dans `getEtablissementFromGouvSafe`, les codes 502/503/504 retournés par l'API Entreprise (ex: INSEE hors-délai) retournent désormais `null` au lieu de propager l'exception
- L'erreur est toujours capturée dans Sentry pour garder la visibilité
- Résultat : la création d'offre échoue avec un message d'erreur métier au lieu d'un crash HTTP 500

## Plan de test

- [ ] Tester la création d'offre en simulant une erreur API Entreprise (variable `simulateError` ou en coupant l'accès réseau)
- [ ] Vérifier que Sentry reçoit bien l'erreur
- [ ] Vérifier que la création d'offre retourne une erreur lisible côté UI plutôt qu'une 500