### PR TITLE
fix: retire la directive limit_req_status dupliquée dans rate-limit.conf

### DIFF
--- a/.infra/files/configs/reverse_proxy/extra-conf.d/rate-limit.conf.template
+++ b/.infra/files/configs/reverse_proxy/extra-conf.d/rate-limit.conf.template
@@ -24,5 +24,6 @@ limit_req_zone $lba_limit_key zone=lba_search:10m rate=30r/m;
 # Autocomplétion métiers (/api/rome) : 1 appel par frappe, rafales tolérées.
 limit_req_zone $lba_limit_key zone=lba_autocomplete:10m rate=2r/s;
 
-# limit_req_status 429 déjà défini globalement par le reverse proxy (extra-conf.d/limit_req.conf),
+# limit_req_status 429 déjà défini globalement par l'image du reverse proxy
+# (/etc/nginx/extra-conf.d/limit_req.conf dans le conteneur, hors de ce repo) :
 # ne pas le redéclarer ici sous peine de "directive is duplicate" au reload nginx.

--- a/.infra/files/configs/reverse_proxy/extra-conf.d/rate-limit.conf.template
+++ b/.infra/files/configs/reverse_proxy/extra-conf.d/rate-limit.conf.template
@@ -24,4 +24,5 @@ limit_req_zone $lba_limit_key zone=lba_search:10m rate=30r/m;
 # Autocomplétion métiers (/api/rome) : 1 appel par frappe, rafales tolérées.
 limit_req_zone $lba_limit_key zone=lba_autocomplete:10m rate=2r/s;
 
-limit_req_status 429;
+# limit_req_status 429 déjà défini globalement par le reverse proxy (extra-conf.d/limit_req.conf),
+# ne pas le redéclarer ici sous peine de "directive is duplicate" au reload nginx.

--- a/server/src/common/apis/apiEntreprise/apiEntreprise.client.test.ts
+++ b/server/src/common/apis/apiEntreprise/apiEntreprise.client.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/common/utils/sentryUtils")
 
 const siret = apiEntrepriseEtablissementFixture.dinum.data.siret
 
-const nockApiEntreprise = (status: number, body: unknown = {}) =>
+const nockApiEntreprise = (status: number, body: nock.Body = {}) =>
   nock("https://entreprise.api.gouv.fr/v3/insee/")
     .get(`/sirene/etablissements/diffusibles/${encodeURIComponent(siret)}`)
     .query({


### PR DESCRIPTION
## Changements

- Suppression de `limit_req_status 429;` dans `extra-conf.d/rate-limit.conf.template` (ajouté par le PR sur le rate limiting anti-scraping)
- Cette directive est déjà déclarée globalement par le reverse proxy (template `limit_req.conf` déjà présent dans l'image, hors de ce repo), qui alimente le jail fail2ban `nginx-req-limit`
- Les deux déclarations tombaient dans le même contexte `http` de nginx, ce qui faisait échouer le reload avec `"limit_req_status" directive is duplicate in /etc/nginx/extra-conf.d/rate-limit.conf:27` et bloquait le déploiement en prod

## Plan de test

- [ ] Vérifier que le déploiement (task "Reload du Reverse Proxy") passe sans erreur nginx
- [ ] Vérifier que les zones `lba_search` et `lba_autocomplete` renvoient bien un 429 (et non 503) en cas de dépassement, confirmant l'héritage du statut global