### PR TITLE
fix: raccourcit le title et retire le salaire codé en dur des meta des pages villes

### DIFF
--- a/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
+++ b/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
@@ -26,9 +26,12 @@ export async function generateMetadata({ params }: { params: Promise<{ ville: st
     }
   }
 
+  const totalOffres = (data.job_count + data.recruteur_count).toLocaleString("fr-FR")
+  const totalRecruteurs = data.recruteur_count.toLocaleString("fr-FR")
+
   return {
-    title: `Alternance ${data.ville} : ${data.job_count + data.recruteur_count} Offres | Salaires & Formations ${new Date().getFullYear()}`,
-    description: `${data.job_count + data.recruteur_count} offres d'alternance à ${data.ville}. Salaire moyen 1050€. BTS, Licence Pro, Master. Trouvez votre contrat d'apprentissage en ${data.region}.`,
+    title: `Alternance à ${data.ville} : ${totalOffres} offres | La bonne alternance`,
+    description: `${totalOffres} offres d'alternance à ${data.ville}, dont ${totalRecruteurs} entreprises qui recrutent sans publier d'annonce. Service public gratuit. Infos salaire, logement, transports.`,
   }
 }
 

--- a/ui/components/ItemDetail/AideApprentissage.tsx
+++ b/ui/components/ItemDetail/AideApprentissage.tsx
@@ -10,7 +10,9 @@ const AideApprentissage = () => {
         Futur alternant ? Découvrez les aides auxquelles vous avez droit et parlez-en avec vos proches
       </Typography>
 
-      <Typography>Avec 1jeune1solution, évaluez les aides financières auxquelles vous avez droit en matière de logement, transport, santé, formation, emploi, culture, sport et alimentation.</Typography>
+      <Typography>
+        Avec 1jeune1solution, évaluez les aides financières auxquelles vous avez droit en matière de logement, transport, santé, formation, emploi, culture, sport et alimentation.
+      </Typography>
 
       <Typography sx={{ mt: fr.spacing("4v") }}>
         Accéder à{" "}


### PR DESCRIPTION
Closes #4496

## Pour les non-développeurs

Sur Google, les pages villes (ex. « alternance marseille ») s'affichaient avec un titre trop long — coupé par Google (« Salaires & Formations ... ») — et une description contenant « Salaire moyen 1050€ », un chiffre identique pour toutes les villes, codé en dur, qui se périmera et ne correspond à la situation de presque aucun candidat (la grille réelle va de ~504€ à ~1 867€ selon l'âge et l'année).

Cette PR remplace ces deux textes par :

- **Title** (≈ 59 caractères, plus de troncature) : `Alternance à Marseille : 8 273 offres | La bonne alternance`
- **Description** : `8 273 offres d'alternance à Marseille, dont 4 500 entreprises qui recrutent sans publier d'annonce. Service public gratuit. Infos salaire, logement, transports.`

Le nombre d'offres passe en premier (c'est notre meilleur argument face à Indeed et Hellowork, et Google le met en gras), le « marché caché » des candidatures spontanées devient l'accroche différenciante, et « Service public gratuit » installe la confiance. Les pages villes rankent déjà top 2-3 (données Search Console) : l'objectif est d'améliorer le taux de clic, pas la position.

Note de scope : le « double H1 » mentionné dans le ticket d'origine est déjà corrigé dans le code actuel (un seul `<h1>`, le bloc interne est un `span`) — aucune modification HTML dans cette PR.

## Pour les développeurs

`ui/app/(editorial)/alternance/ville/[ville]/page.tsx` — uniquement `generateMetadata` :

- Title : suppression de `Salaires & Formations ${new Date().getFullYear()}`, ajout du suffixe `| La bonne alternance` (pattern des autres pages)
- Description : suppression du « Salaire moyen 1050€ » codé en dur et de `${data.region}`, mise en avant de `recruteur_count` (candidatures spontanées)
- Les compteurs sont formatés via `toLocaleString("fr-FR")` (« 8 273 » au lieu de « 8273 »)
- Aucun changement sur le fallback sans data, le JSON-LD, le breadcrumb ou le rendu de la page

## Plan de test

- [ ] Ouvrir une page ville en preview (ex. `/alternance/ville/marseille`) et vérifier `<title>` et `<meta name="description">` dans le code source
- [ ] Vérifier le formatage français des nombres (espace insécable : « 8 273 »)
- [ ] Vérifier qu'une ville inexistante affiche toujours le fallback (`/alternance/ville/xxx` → 404)