### PR TITLE
fix: optimise les meta du hub metiers et corrige son double h1

### DIFF
--- a/ui/app/(editorial)/metiers/page.tsx
+++ b/ui/app/(editorial)/metiers/page.tsx
@@ -25,7 +25,7 @@ export default async function Metiers() {
         <Box sx={{ p: fr.spacing("10v"), marginBottom: fr.spacing("10v"), borderRadius: "10px", backgroundColor: fr.colors.decisions.background.default.grey.hover }}>
           <Typography id="editorial-content-container" component="h1" variant="h1" sx={{ mb: fr.spacing("4v") }}>
             Tous les emplois
-            <Typography component="h1" variant="h1" sx={{ display: "block", color: fr.colors.decisions.text.default.info.default }}>
+            <Typography component="span" variant="h1" sx={{ display: "block", color: fr.colors.decisions.text.default.info.default }}>
               et formations en alternance
             </Typography>
           </Typography>

--- a/ui/components/ItemDetail/AideApprentissage.tsx
+++ b/ui/components/ItemDetail/AideApprentissage.tsx
@@ -10,7 +10,9 @@ const AideApprentissage = () => {
         Futur alternant ? Découvrez les aides auxquelles vous avez droit et parlez-en avec vos proches
       </Typography>
 
-      <Typography>Avec 1jeune1solution, évaluez les aides financières auxquelles vous avez droit en matière de logement, transport, santé, formation, emploi, culture, sport et alimentation.</Typography>
+      <Typography>
+        Avec 1jeune1solution, évaluez les aides financières auxquelles vous avez droit en matière de logement, transport, santé, formation, emploi, culture, sport et alimentation.
+      </Typography>
 
       <Typography sx={{ mt: fr.spacing("4v") }}>
         Accéder à{" "}

--- a/ui/utils/routes.utils.ts
+++ b/ui/utils/routes.utils.ts
@@ -96,9 +96,10 @@ export const PAGES = {
       getPath: () => `/metiers` as string,
       title: "Métiers",
       index: false,
+      // Le « 77 » correspond au nombre de secteurs listés dans ui/config/metiers.txt (compteur en dur, cf. note ci-dessous).
       getMetadata: () => ({
-        title: "Métiers en alternance - Découvrez les opportunités sur La bonne alternance",
-        description: "Découvrez plus de 200 métiers accessibles en alternance : commerce, informatique, santé, BTP et bien d'autres. Trouvez la voie qui vous correspond.",
+        title: "Métiers en alternance : 77 secteurs | La bonne alternance",
+        description: "La liste des 77 secteurs qui recrutent en alternance : RH, communication, vente, BTP, santé, informatique… Offres d'emploi et formations du CAP au Master.",
       }),
     },
     // Note : les compteurs des meta ci-dessous sont en dur volontairement.


### PR DESCRIPTION
Closes #4574

## Pour les non-développeurs

Le hub `/metiers` (la page qui liste tous les secteurs en alternance) s'affichait sur Google avec un titre de 74 caractères — tronqué — et sans promesse concrète : « Métiers en alternance - Découvrez les opportunités sur La bonne alternance ». Sa description annonçait « plus de 200 métiers » alors que la page liste en réalité 77 secteurs.

Nouvelles meta :

- **Title** (57 caractères) : `Métiers en alternance : 77 secteurs | La bonne alternance`
- **Description** : `La liste des 77 secteurs qui recrutent en alternance : RH, communication, vente, BTP, santé, informatique… Offres d'emploi et formations du CAP au Master.`

Le mot « liste » est choisi délibérément : c'est le terme qui revient dans les requêtes réelles des utilisateurs sur cette page dans Search Console (« liste des métiers en alternance », « liste des métiers pour apprentissage »). Le chiffre 77 correspond au nombre exact de secteurs listés. Le title reste distinct de celui du hub `/alternance/metiers` (« 30 métiers en alternance qui recrutent ») pour éviter toute concurrence entre les deux pages dans Google.

Contexte honnête sur l'impact attendu : le CTR de 0,4 % mentionné dans le ticket est en grande partie un artefact de mesure — ~77 % des impressions de cette page viennent de la requête de marque « la bonne alternance », où elle apparaît en sitelink (compté comme impression, rarement cliqué). Sur ses vraies requêtes cibles, la page performe déjà correctement ; cette PR est une optimisation d'hygiène à faible coût, pas un chantier de trafic.

En bonus, la page avait un double `<h1>` imbriqué (le même défaut que celui corrigé sur les pages villes) : corrigé ici, sans aucun changement visuel.

## Pour les développeurs

- `ui/utils/routes.utils.ts` — bloc `PAGES.static.metiers` : nouveau title + description, avec un commentaire indiquant que le « 77 » correspond au contenu de `ui/config/metiers.txt` (compteur en dur, pattern déjà documenté dans le fichier pour les hubs voisins)
- `ui/app/(editorial)/metiers/page.tsx` — le `Typography component="h1"` imbriqué passe en `component="span"` (variant `h1` conservé, rendu identique) : un seul `<h1>` dans le DOM
- `ui/components/ItemDetail/AideApprentissage.tsx` — correctif de formatage Biome hérité de `main` (commit séparé), nécessaire pour que `yarn check:ci` passe ; également présent dans la PR des pages villes, il deviendra un no-op au merge de la première des deux

## Plan de test

- [ ] Ouvrir `/metiers` en preview et vérifier `<title>` et `<meta name="description">` dans le code source
- [ ] Vérifier qu'il n'y a qu'un seul `<h1>` dans le DOM et que le rendu du bandeau titre est inchangé (« et formations en alternance » toujours en bleu, à la ligne)
- [ ] Vérifier que la page liste bien 77 secteurs (cohérence avec le chiffre annoncé)