### PR TITLE
feat: ajoute le lien salaire en alternance au footer et salaire-alternant au sitemap

### DIFF
--- a/ui/app/_components/Footer.tsx
+++ b/ui/app/_components/Footer.tsx
@@ -43,6 +43,12 @@ const linkListContent: LinkCategory[] = [
       },
       {
         linkProps: {
+          href: PAGES.static.guideAlternantComprendreLaRemuneration.getPath(),
+        },
+        text: "Salaire en alternance",
+      },
+      {
+        linkProps: {
           href: PAGES.static.guideRecruteur.getPath(),
         },
         text: "Guide recruteur",

--- a/ui/components/ItemDetail/AideApprentissage.tsx
+++ b/ui/components/ItemDetail/AideApprentissage.tsx
@@ -10,7 +10,9 @@ const AideApprentissage = () => {
         Futur alternant ? Découvrez les aides auxquelles vous avez droit et parlez-en avec vos proches
       </Typography>
 
-      <Typography>Avec 1jeune1solution, évaluez les aides financières auxquelles vous avez droit en matière de logement, transport, santé, formation, emploi, culture, sport et alimentation.</Typography>
+      <Typography>
+        Avec 1jeune1solution, évaluez les aides financières auxquelles vous avez droit en matière de logement, transport, santé, formation, emploi, culture, sport et alimentation.
+      </Typography>
 
       <Typography sx={{ mt: fr.spacing("4v") }}>
         Accéder à{" "}

--- a/ui/services/generateMainSitemap.ts
+++ b/ui/services/generateMainSitemap.ts
@@ -221,7 +221,7 @@ export function getMainSitemapPageGroups(): SitemapPageGroup[] {
         {
           path: "/salaire-alternant",
           label: "Simulateur de salaire en alternance",
-          description: "Simulateur de salaire en alternance : calcul de la rémunération mensuelle brut et net selon l'âge, le contrat et l'année de formation.",
+          description: "Simulateur de salaire en alternance : calcul de la rémunération mensuelle brute et nette selon l'âge, le contrat et l'année de formation.",
         },
       ],
     },

--- a/ui/services/generateMainSitemap.ts
+++ b/ui/services/generateMainSitemap.ts
@@ -10,7 +10,7 @@ import { getStaticMetiers } from "@/utils/getStaticData"
 import { getHostFromHeader } from "@/utils/requestUtils"
 
 // Attention ! Il faut mettre à jour cette date lorsque le sitemap généré par ce fichier change
-export const mainSitemapLastModificationDate = new Date("2026-06-03T00:00:00.000Z")
+export const mainSitemapLastModificationDate = new Date("2026-08-06T00:00:00.000Z")
 
 // Une page référencée à la fois dans le sitemap et dans le llms.txt.
 // `label` et `description` ne servent qu'au llms.txt (le sitemap n'utilise que le path).
@@ -213,6 +213,17 @@ export function getMainSitemapPageGroups(): SitemapPageGroup[] {
         label: job.name,
         description: `Fiche métier ${job.name} : missions, formations et offres en alternance.`,
       })),
+    },
+    {
+      title: "Salaire en alternance",
+      priority: 0.9,
+      pages: [
+        {
+          path: "/salaire-alternant",
+          label: "Simulateur de salaire en alternance",
+          description: "Simulateur de salaire en alternance : calcul de la rémunération mensuelle brut et net selon l'âge, le contrat et l'année de formation.",
+        },
+      ],
     },
   ]
 }


### PR DESCRIPTION
Closes #5087

## Pour les non-développeurs

Sur la recherche Google « la bonne alternance » (notre vitrine : ~201 000 impressions en 3 mois), les 5 liens affichés sous notre résultat principal (« sitelinks ») donnent une image dégradée : l'un d'eux est le bouton d'interface « Modifier la recherche », et nos contenus salaire — parmi les plus recherchés par les jeunes — n'y figurent pas.

Google compose ces liens automatiquement à partir de ce que notre propre site met en avant (documentation officielle : aucun réglage direct n'existe). Or aucun lien interne ne pointait vers nos pages salaire, et le simulateur `/salaire-alternant` était absent du sitemap. Google ne peut pas mettre en avant ce que nous-mêmes n'affichons nulle part.

Cette PR corrige la cause racine :

- Un lien « **Salaire en alternance** » apparaît dans le footer de toutes les pages, vers le guide rémunération (qui ranke déjà sur « salaire alternance 2026 »). Il basculera vers le simulateur quand son contenu sera livré.
- Le simulateur `/salaire-alternant` entre dans le **sitemap** et le llms.txt — décision actée : on référence dès maintenant, le contenu suit.

Bénéfices attendus : éligibilité des pages salaire aux sitelinks de la marque, signal interne qui soutient leur positionnement hors marque, et accès en 1 clic au sujet salaire depuis tout le site. Effet à vérifier sur la SERP de marque sous ~6 semaines.

## Pour les développeurs

- `ui/app/_components/Footer.tsx` : nouvelle entrée « Salaire en alternance » dans la catégorie « Aide & Ressources », via `PAGES.static.guideAlternantComprendreLaRemuneration.getPath()` (pattern identique aux entrées voisines)
- `ui/services/generateMainSitemap.ts` : nouveau groupe « Salaire en alternance » (priorité 0.9) avec `/salaire-alternant`, ajouté en fin de liste pour ne pas réordonner les URLs existantes ; `mainSitemapLastModificationDate` mise à jour au 2026-08-06 comme demandé par le commentaire du fichier. Le groupe alimente automatiquement sitemap-main.xml et llms.txt
- `ui/components/ItemDetail/AideApprentissage.tsx` : correctif de formatage Biome hérité de `main` (commit séparé, également présent dans les deux autres PRs SEO ouvertes ; deviendra un no-op au premier merge)

## Plan de test

- [ ] Vérifier dans le footer de n'importe quelle page la présence de « Salaire en alternance » (catégorie Aide & Ressources) pointant vers `/guide-alternant/comprendre-la-remuneration`
- [ ] Ouvrir `/sitemap-main.xml` et vérifier la présence de `/salaire-alternant` et la nouvelle date de modification
- [ ] Ouvrir `/llms.txt` et vérifier la section « Salaire en alternance »