### PR TITLE
fix: filtre les recruteurs LBA actifs dans le contrôle de drift

### DIFF
--- a/server/src/services/search/searchItems.service.test.ts
+++ b/server/src/services/search/searchItems.service.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it } from "vitest"
 import { getDbCollection } from "@/common/utils/mongodbUtils"
 
 import {
+  controlSearchItemsDrift,
   dedupeRepeatedTitle,
   removeJobPartnersFromSearchItems,
   resetSearchItemBuildContextCache,
@@ -192,6 +193,25 @@ describe("searchItems.service — synchronisation jobs_partners → search_items
 
       expect(result.removed).toBe(1)
       expect(await getDbCollection("search_items").countDocuments({ _id: job._id })).toBe(0)
+    })
+  })
+
+  describe("controlSearchItemsDrift", () => {
+    it("ne compte que les recruteurs LBA actifs dans le volume attendu", async () => {
+      const recruteurActif = generateJobsPartnersOfferPrivate({ partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA })
+      const recruteurInactif = generateJobsPartnersOfferPrivate({
+        partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+        offer_status: JOB_STATUS_ENGLISH.ANNULEE,
+      })
+      await getDbCollection("jobs_partners").insertMany([recruteurActif, recruteurInactif])
+      // Seul le recruteur actif est indexé : le recruteur annulé n'a jamais été (ou plus) dans search_items.
+      await upsertJobPartnersToSearchItems([recruteurActif._id, recruteurInactif._id])
+
+      const result = await controlSearchItemsDrift()
+
+      expect(result.expectedRecruteurs).toBe(1)
+      expect(result.indexedRecruteurs).toBe(1)
+      expect(result.drift).toBe(false)
     })
   })
 })

--- a/server/src/services/search/searchItems.service.ts
+++ b/server/src/services/search/searchItems.service.ts
@@ -562,7 +562,7 @@ const DRIFT_RELATIVE_THRESHOLD = 0.01
 export const controlSearchItemsDrift = async () => {
   const [expectedOffers, expectedRecruteurs, indexedOffers, indexedRecruteurs] = await Promise.all([
     getDbCollection("jobs_partners").countDocuments({ partner_label: { $ne: JOBPARTNERS_LABEL.RECRUTEURS_LBA }, offer_status: JOB_STATUS_ENGLISH.ACTIVE }),
-    getDbCollection("jobs_partners").countDocuments({ partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA }),
+    getDbCollection("jobs_partners").countDocuments({ partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA, offer_status: JOB_STATUS_ENGLISH.ACTIVE }),
     getDbCollection("search_items").countDocuments({ type: "offre", sub_type: { $ne: LBA_ITEM_TYPE.RECRUTEURS_LBA } }),
     getDbCollection("search_items").countDocuments({ sub_type: LBA_ITEM_TYPE.RECRUTEURS_LBA }),
   ])


### PR DESCRIPTION
## Changements

- Le comptage des recruteurs LBA dans `controlSearchItemsDrift` incluait tous les recruteurs, actifs ou non, alors que le comptage des offres se limite aux offres actives. La comparaison de drift n'était donc pas homogène.
- Ajout du filtre `offer_status: JOB_STATUS_ENGLISH.ACTIVE` sur le comptage des recruteurs LBA pour aligner les deux comptages.

## Plan de test

- [ ] Vérifier que `controlSearchItemsDrift` ne remonte plus de faux positifs de drift liés aux recruteurs LBA inactifs