### PR TITLE
fix: corrige l'URL de base de l'API Notion

### DIFF
--- a/ui/services/fetchNotionPage.ts
+++ b/ui/services/fetchNotionPage.ts
@@ -1,5 +1,6 @@
 import { NotionAPI } from "notion-client"
 
-const notion = new NotionAPI()
+// https://github.com/NotionX/react-notion-x/issues/710
+const notion = new NotionAPI({ apiBaseUrl: "https://app.notion.com/api/v3" })
 
 export const fetchNotionPage = async (pageId: string) => await notion.getPage(pageId)


### PR DESCRIPTION
## Changements

- Corrige `fetchNotionPage.ts` pour cibler explicitement `https://app.notion.com/api/v3` comme base URL de l'API Notion (voir [react-notion-x#710](https://github.com/NotionX/react-notion-x/issues/710))

## Plan de test

- [ ] Vérifier qu'une page Notion (ex: aide/FAQ) se charge correctement côté UI