### PR TITLE
fix: timezone flaky test extend offre

### DIFF
--- a/server/tests/sdk/entrepriseSdk.ts
+++ b/server/tests/sdk/entrepriseSdk.ts
@@ -146,7 +146,7 @@ export const entrepriseSdk = (httpClient: TestHttpClient) => ({
       path: `/api/formulaire/offre/${jobId}/extend`,
       cookies,
       body: {
-        job_start_date: dayjs().format("YYYY-MM-DD"),
+        job_start_date: dayjs().tz().format("YYYY-MM-DD"),
         job_start_type: JOB_START_TYPE.PRECISE_DATE,
         job_start_date_flexible: false,
       },


### PR DESCRIPTION
## Changements

- Le helper de test `entrepriseSdk.extendOffer` construisait `job_start_date` avec `dayjs().format("YYYY-MM-DD")`, calé sur le fuseau système du process (UTC en CI GitHub Actions).
- La validation Zod côté serveur (`ZJobStartDateCreate`) calcule "aujourd'hui" explicitement en Europe/Paris.
- Pendant la fenêtre quotidienne où Paris a déjà basculé au jour suivant mais l'UTC non (~22h-minuit UTC en été, ~23h-minuit en hiver), la date envoyée était en retard d'un jour, ce qui faisait échouer le refine `job_start_date must be greater or equal to today's date` → 400 au lieu de 200, `job_prolongation_count` resté à 0.
- Fix : ancrer le helper sur le fuseau Paris (`dayjs().tz()`) comme le fait le serveur.
- Explique les 2 échecs identiques observés en CI sur la PR #5109 (le test passe systématiquement en local car la machine est déjà en TZ Europe/Paris).

## Plan de test

- [x] Suite `PUT /formulaire/offre/:jobId/extend` relancée localement (2 passed)
- [x] Simulation isolée à un instant proche de minuit UTC en été confirmant que l'ancien code échoue la validation et que le nouveau la passe