### PR TITLE
chore: ajoute la config de preview server au launch.json

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,25 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "ui-dev",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [
+        "workspace",
+        "ui",
+        "dev"
+      ],
+      "port": 3000
+    },
+    {
+      "name": "server-dev",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [
+        "workspace",
+        "server",
+        "dev"
+      ],
+      "port": 5001
+    }
+  ]
+}


### PR DESCRIPTION
Ajoute l'entrée `server-dev` (`yarn workspace server dev`, port 5001) au launch.json, en complément de `ui-dev`, pour pouvoir tester de bout en bout (UI + API) depuis le Browser pane.

## Test plan

- [x] Démarrage vérifié : le server se connecte à MongoDB et répond sur `/api/healthcheck` sans erreur