### PR TITLE
feat: pilote Cache Components pour des navigations instantanées (#5114)

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -7,6 +7,10 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache
 
 # next.js
 /.next/

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/ui/app/(1jeune1solution)/1jeune1solution/page.tsx
+++ b/ui/app/(1jeune1solution)/1jeune1solution/page.tsx
@@ -7,6 +7,10 @@ import { HomeRechercheForm } from "@/app/(home)/_components/HomeRechercheForm"
 import { TagCandidatureSpontanee } from "@/components/ItemDetail/TagCandidatureSpontanee"
 import { TagOffreEmploi } from "@/components/ItemDetail/TagOffreEmploi"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 const utmParams = "utm_source=lba&utm_medium=website&utm_campaign=landinglba1j1s"
 export default async function unJeune1Solution({ searchParams }: { searchParams: Promise<Record<string, string>> }) {
   const rechercheParams = parseRecherchePageParams(new URLSearchParams(await searchParams), IRechercheMode.DEFAULT)

--- a/ui/app/(1jeune1solution)/layout.tsx
+++ b/ui/app/(1jeune1solution)/layout.tsx
@@ -7,6 +7,10 @@ import { Footer } from "@/app/_components/Footer"
 import { DsfrHeaderProps1J1S } from "@/app/(1jeune1solution)/components/Header1J1S"
 import InfoBanner from "@/components/InfoBanner/InfoBanner"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function UnJeuneUneSolutionLayout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/(recherche)/layout.tsx
+++ b/ui/app/(candidat)/(recherche)/layout.tsx
@@ -5,6 +5,10 @@ import type { PropsWithChildren } from "react"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { RechercheLayoutClient } from "./RechercheLayoutClient"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function RechercheLayout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/(recherche)/recherche-emploi/page.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche-emploi/page.tsx
@@ -4,6 +4,10 @@ import { RecherchePageComponentServer } from "@/app/(candidat)/(recherche)/reche
 import { IRechercheMode, parseRecherchePageParams, RechercheViewType } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 type Props = {
   searchParams: Promise<Record<string, string>>
 }

--- a/ui/app/(candidat)/(recherche)/recherche-formation/page.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche-formation/page.tsx
@@ -4,6 +4,10 @@ import { RecherchePageComponentServer } from "@/app/(candidat)/(recherche)/reche
 import { IRechercheMode, parseRecherchePageParams, RechercheViewType } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 type Props = {
   searchParams: Promise<Record<string, string>>
 }

--- a/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/LbaItemCard.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/RechercheResultats/LbaItemCard.tsx
@@ -120,7 +120,6 @@ export function LbaItemCard({ item, active, rechercheParams, position }: ResultC
           horizontal
           linkProps={{
             href: itemUrl,
-            prefetch: false,
             onClick:
               item.ideaType === LBA_ITEM_TYPE_OLD.FORMATION
                 ? undefined

--- a/ui/app/(candidat)/(recherche)/recherche/page.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/page.tsx
@@ -5,6 +5,10 @@ import { PAGES } from "@/utils/routes.utils"
 import { RecherchePageComponentServer } from "./_components/RecherchePageComponentServer"
 import { IRechercheMode, parseRecherchePageParams } from "./_utils/recherche.route.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 type Props = {
   searchParams: Promise<Record<string, string>>
 }

--- a/ui/app/(candidat)/detail-rendez-vous/[id]/layout.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/layout.tsx
@@ -5,6 +5,10 @@ import type { PropsWithChildren } from "react"
 import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
@@ -4,6 +4,10 @@ import { apiGet } from "@/utils/api.utils"
 import { PAGES } from "@/utils/routes.utils"
 import DetailRendezVousRendererClient from "./DetailRendezVousRendererClient"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.detailRendezVousApprentissage.getMetadata().title,
 }

--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
@@ -1,5 +1,6 @@
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import type { Metadata } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 import { redirect } from "next/navigation"
 import type { ILbaItemLbaCompanyJson, /*ILbaItemLbaJobJson, */ ILbaItemPartnerJobJson } from "shared"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
@@ -8,13 +9,6 @@ import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(rech
 import InfoBanner from "@/components/InfoBanner/InfoBanner"
 import { ApiError, apiGet } from "@/utils/api.utils"
 import JobDetailRendererClient from "./JobDetailRendererClient"
-
-// Désactive le streaming SSR pour éviter l'erreur "transformAlgorithm is not a function"
-// avec Next.js 16 quand les connexions sont interrompues (healthchecks, timeouts, etc.)
-// Voir: https://github.com/vercel/next.js/discussions/75995
-// Context: PRs #2474-2479, Sentry issue https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/6/
-export const dynamic = "force-dynamic"
-export const revalidate = 300 // Cache ISR pendant 5 minutes
 
 export async function generateMetadata({ params }): Promise<Metadata> {
   const { type, id } = await params
@@ -64,7 +58,15 @@ export default async function JobOfferPage({ params, searchParams }: { params: P
 const acceptedTypes = [LBA_ITEM_TYPE.RECRUTEURS_LBA, LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA, LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES]
 
 async function getOffreOption(type: LBA_ITEM_TYPE, id: string) {
+  // `apiGet` lit toujours `headers()` en interne (pour transmettre le cookie de session),
+  // ce qui est interdit dans un `"use cache"` classique — seul `"use cache: private"` l'autorise
+  // (cache navigateur uniquement, jamais côté serveur).
+  "use cache: private"
   if (!type || !id || !acceptedTypes.includes(type)) return null
+
+  cacheTag(`offer:${type}:${id}`)
+  cacheLife({ revalidate: 300 }) // 5 minutes, aligné sur l'ancien `revalidate = 300`
+
   try {
     const offre = await apiGet("/_private/jobs/:source/:id", { params: { source: type, id } })
     return offre

--- a/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
+++ b/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
@@ -1,5 +1,6 @@
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import type { Metadata } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 import { redirect } from "next/navigation"
 import { WidgetAwareHeader } from "@/app/_components/WidgetAwareHeader"
 import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
@@ -7,6 +8,13 @@ import { ApiError, apiGet } from "@/utils/api.utils"
 import TrainingDetailRendererClient from "./TrainingDetailRendererClient"
 
 async function getFormationOption(id: string) {
+  // `apiGet` lit toujours `headers()` en interne (pour transmettre le cookie de session),
+  // ce qui est interdit dans un `"use cache"` classique — seul `"use cache: private"` l'autorise
+  // (cache navigateur uniquement, jamais côté serveur).
+  "use cache: private"
+  cacheTag(`formation:${id}`)
+  cacheLife("minutes")
+
   try {
     const formation = await apiGet("/_private/formations/:id", { params: { id } })
     return formation

--- a/ui/app/(candidat)/formulaire-intention/layout.tsx
+++ b/ui/app/(candidat)/formulaire-intention/layout.tsx
@@ -5,6 +5,10 @@ import type { PropsWithChildren } from "react"
 import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/formulaire-intention/page.tsx
+++ b/ui/app/(candidat)/formulaire-intention/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import FormulaireIntentionPage from "./FormulaireIntentionPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Formulaire d'intention de recrutement - La bonne alternance",
 }

--- a/ui/app/(candidat)/postuler/layout.tsx
+++ b/ui/app/(candidat)/postuler/layout.tsx
@@ -2,6 +2,10 @@ import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 import { Footer } from "@/app/_components/Footer"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/postuler/page.tsx
+++ b/ui/app/(candidat)/postuler/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import PostulerPage from "./PostulerPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.postuler.getMetadata().title,
 }

--- a/ui/app/(creation-compte-widget)/espace-pro/widget/[origin]/page.tsx
+++ b/ui/app/(creation-compte-widget)/espace-pro/widget/[origin]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - La bonne alternance",
 }

--- a/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/detail/page.tsx
+++ b/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/detail/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import DetailPage from "./DetailPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - Informations de compte - La bonne alternance",
 }

--- a/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/fin/page.tsx
+++ b/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/fin/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import FinPage from "./FinPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Fin de création d'offre - La bonne alternance",
 }

--- a/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/offre/page.tsx
+++ b/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/offre/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import { DepotSimplifieCreationOffre } from "@/app/(espace-pro-creation-compte)/_components/DepotSimplifieCreationOffre"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - Informations de l'offre - La bonne alternance",
 }

--- a/ui/app/(creation-compte-widget)/layout.tsx
+++ b/ui/app/(creation-compte-widget)/layout.tsx
@@ -2,6 +2,10 @@ import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 import { DepotSimplifieLayout } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <DepotSimplifieLayout>

--- a/ui/app/(editorial)/a-propos/page.tsx
+++ b/ui/app/(editorial)/a-propos/page.tsx
@@ -46,11 +46,6 @@ import toulouseMetropole from "@/public/images/logosPartenaires/partenaire-toulo
 import veritone from "@/public/images/logosPartenaires/partenaire-veritone.webp"
 
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.aPropos.getMetadata().title,
   description: PAGES.static.aPropos.getMetadata().description,

--- a/ui/app/(editorial)/a-propos/page.tsx
+++ b/ui/app/(editorial)/a-propos/page.tsx
@@ -47,6 +47,10 @@ import veritone from "@/public/images/logosPartenaires/partenaire-veritone.webp"
 
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.aPropos.getMetadata().title,
   description: PAGES.static.aPropos.getMetadata().description,

--- a/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
+++ b/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
@@ -20,6 +20,10 @@ import { PreparationSection } from "./_components/PreparationSection"
 import { ProgrammeDiplome } from "./_components/ProgrammeDiplome"
 import { SalaireSection } from "./_components/SalaireSection"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 function getDiplomeData(slug: string) {
   return apiGet("/_private/seo/diplome/:diplome", { params: { diplome: slug } })
 }

--- a/ui/app/(editorial)/alternance/diplomes/page.tsx
+++ b/ui/app/(editorial)/alternance/diplomes/page.tsx
@@ -15,11 +15,6 @@ import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.alternanceDiplomes.getMetadata().title,
   description: PAGES.static.alternanceDiplomes.getMetadata().description,

--- a/ui/app/(editorial)/alternance/diplomes/page.tsx
+++ b/ui/app/(editorial)/alternance/diplomes/page.tsx
@@ -16,6 +16,10 @@ import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.alternanceDiplomes.getMetadata().title,
   description: PAGES.static.alternanceDiplomes.getMetadata().description,

--- a/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
+++ b/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
@@ -16,6 +16,10 @@ import { ArrowRightLine } from "@/theme/components/icons"
 import { apiGet } from "@/utils/api.utils"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 const UTM_PARAMS = "utm_source=lba&utm_medium=website&utm_campaign=lba_seo-prog-metiers"
 
 // Shared style constants

--- a/ui/app/(editorial)/alternance/metiers/page.tsx
+++ b/ui/app/(editorial)/alternance/metiers/page.tsx
@@ -15,11 +15,6 @@ import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.alternanceMetiers.getMetadata().title,
   description: PAGES.static.alternanceMetiers.getMetadata().description,

--- a/ui/app/(editorial)/alternance/metiers/page.tsx
+++ b/ui/app/(editorial)/alternance/metiers/page.tsx
@@ -16,6 +16,10 @@ import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.alternanceMetiers.getMetadata().title,
   description: PAGES.static.alternanceMetiers.getMetadata().description,

--- a/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
+++ b/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
@@ -15,6 +15,10 @@ import { ArrowRightLine } from "@/theme/components/icons"
 import { apiGet } from "@/utils/api.utils"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ ville: string }> }) {
   const { ville } = await params
   const data = await apiGet("/_private/seo/ville/:ville", { params: { ville } })

--- a/ui/app/(editorial)/alternance/villes/page.tsx
+++ b/ui/app/(editorial)/alternance/villes/page.tsx
@@ -15,11 +15,6 @@ import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.alternanceVilles.getMetadata().title,
   description: PAGES.static.alternanceVilles.getMetadata().description,

--- a/ui/app/(editorial)/alternance/villes/page.tsx
+++ b/ui/app/(editorial)/alternance/villes/page.tsx
@@ -16,6 +16,10 @@ import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.alternanceVilles.getMetadata().title,
   description: PAGES.static.alternanceVilles.getMetadata().description,

--- a/ui/app/(editorial)/barometre/page.tsx
+++ b/ui/app/(editorial)/barometre/page.tsx
@@ -31,11 +31,6 @@ import {
   topSecteursRecruteurs,
   topSecteursSpontanees,
 } from "./_data/t1-2026"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   ...PAGES.static.barometre.getMetadata(),
   alternates: {

--- a/ui/app/(editorial)/barometre/page.tsx
+++ b/ui/app/(editorial)/barometre/page.tsx
@@ -32,6 +32,10 @@ import {
   topSecteursSpontanees,
 } from "./_data/t1-2026"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   ...PAGES.static.barometre.getMetadata(),
   alternates: {

--- a/ui/app/(editorial)/contact/page.tsx
+++ b/ui/app/(editorial)/contact/page.tsx
@@ -9,6 +9,10 @@ import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { publicConfig } from "@/config.public"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.contact.getMetadata().title,
   description: PAGES.static.contact.getMetadata().description,

--- a/ui/app/(editorial)/contact/page.tsx
+++ b/ui/app/(editorial)/contact/page.tsx
@@ -8,11 +8,6 @@ import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { publicConfig } from "@/config.public"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.contact.getMetadata().title,
   description: PAGES.static.contact.getMetadata().description,

--- a/ui/app/(editorial)/desinscription/page.tsx
+++ b/ui/app/(editorial)/desinscription/page.tsx
@@ -3,6 +3,10 @@ import { DepotSimplifieStyling } from "@/components/espace_pro/common/components
 import { PAGES } from "@/utils/routes.utils"
 import { DesinscriptionRecruteur } from "./Desinscription"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.desinscription.getMetadata().title,
   description: PAGES.static.desinscription.getMetadata().description,

--- a/ui/app/(editorial)/desinscription/page.tsx
+++ b/ui/app/(editorial)/desinscription/page.tsx
@@ -2,11 +2,6 @@ import type { Metadata } from "next"
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 import { PAGES } from "@/utils/routes.utils"
 import { DesinscriptionRecruteur } from "./Desinscription"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.desinscription.getMetadata().title,
   description: PAGES.static.desinscription.getMetadata().description,

--- a/ui/app/(editorial)/espace-developpeurs/page.tsx
+++ b/ui/app/(editorial)/espace-developpeurs/page.tsx
@@ -7,11 +7,6 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.EspaceDeveloppeurs.getMetadata().title,
   description: PAGES.static.EspaceDeveloppeurs.getMetadata().description,

--- a/ui/app/(editorial)/espace-developpeurs/page.tsx
+++ b/ui/app/(editorial)/espace-developpeurs/page.tsx
@@ -8,6 +8,10 @@ import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.EspaceDeveloppeurs.getMetadata().title,
   description: PAGES.static.EspaceDeveloppeurs.getMetadata().description,

--- a/ui/app/(editorial)/guide-alternant/a-propos-des-formations/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/a-propos-des-formations/page.tsx
@@ -13,11 +13,6 @@ import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideAlternantAProposDesFormations.getMetadata()
 
 const AProposDesFormationsPage = () => {

--- a/ui/app/(editorial)/guide-alternant/a-propos-des-formations/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/a-propos-des-formations/page.tsx
@@ -14,6 +14,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideAlternantAProposDesFormations.getMetadata()
 
 const AProposDesFormationsPage = () => {

--- a/ui/app/(editorial)/guide-alternant/comment-signer-un-contrat-en-alternance/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/comment-signer-un-contrat-en-alternance/page.tsx
@@ -12,11 +12,6 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideAlternantCommentSignerUnContratEnAlternance.getMetadata()
 
 const CommentSignerUnContratEnAlternancePage = () => {

--- a/ui/app/(editorial)/guide-alternant/comment-signer-un-contrat-en-alternance/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/comment-signer-un-contrat-en-alternance/page.tsx
@@ -13,6 +13,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideAlternantCommentSignerUnContratEnAlternance.getMetadata()
 
 const CommentSignerUnContratEnAlternancePage = () => {

--- a/ui/app/(editorial)/guide-alternant/comprendre-la-remuneration/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/comprendre-la-remuneration/page.tsx
@@ -14,6 +14,10 @@ import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 const remunerationPage = PAGES.static.guideAlternantComprendreLaRemuneration
 
 export const metadata: Metadata = remunerationPage.getMetadata()

--- a/ui/app/(editorial)/guide-alternant/comprendre-la-remuneration/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/comprendre-la-remuneration/page.tsx
@@ -14,10 +14,6 @@ import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { PAGES } from "@/utils/routes.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 const remunerationPage = PAGES.static.guideAlternantComprendreLaRemuneration
 
 export const metadata: Metadata = remunerationPage.getMetadata()

--- a/ui/app/(editorial)/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur/page.tsx
@@ -14,6 +14,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideAlternantConseilsEtAstucesPourTrouverUnEmployeur.getMetadata()
 
 const ConseilsEtAstucesPourTrouverUnEmployeurPage = () => {

--- a/ui/app/(editorial)/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur/page.tsx
@@ -13,11 +13,6 @@ import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideAlternantConseilsEtAstucesPourTrouverUnEmployeur.getMetadata()
 
 const ConseilsEtAstucesPourTrouverUnEmployeurPage = () => {

--- a/ui/app/(editorial)/guide-alternant/la-rupture-de-contrat/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/la-rupture-de-contrat/page.tsx
@@ -11,11 +11,6 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideAlternantLaRuptureDeContrat.getMetadata()
 
 const LaRuptureDeContratPage = () => {

--- a/ui/app/(editorial)/guide-alternant/la-rupture-de-contrat/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/la-rupture-de-contrat/page.tsx
@@ -12,6 +12,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideAlternantLaRuptureDeContrat.getMetadata()
 
 const LaRuptureDeContratPage = () => {

--- a/ui/app/(editorial)/guide-alternant/les-aides-financieres-et-materielles/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/les-aides-financieres-et-materielles/page.tsx
@@ -11,6 +11,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideAlternantLesAidesFinancieresEtMaterielles.getMetadata()
 
 const LesAidesFinancieresEtMateriellesPage = () => {

--- a/ui/app/(editorial)/guide-alternant/les-aides-financieres-et-materielles/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/les-aides-financieres-et-materielles/page.tsx
@@ -10,11 +10,6 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideAlternantLesAidesFinancieresEtMaterielles.getMetadata()
 
 const LesAidesFinancieresEtMateriellesPage = () => {

--- a/ui/app/(editorial)/guide-alternant/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/page.tsx
@@ -17,6 +17,10 @@ import { SchemaOrg } from "@/components/SchemaOrg"
 import { PAGES } from "@/utils/routes.utils"
 import { ARTICLES } from "./const"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideAlternant.getMetadata()
 
 const GuideAlternantPage = () => {

--- a/ui/app/(editorial)/guide-alternant/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/page.tsx
@@ -16,11 +16,6 @@ import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { PAGES } from "@/utils/routes.utils"
 import { ARTICLES } from "./const"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideAlternant.getMetadata()
 
 const GuideAlternantPage = () => {

--- a/ui/app/(editorial)/guide-alternant/preparer-son-projet-en-alternance/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/preparer-son-projet-en-alternance/page.tsx
@@ -13,6 +13,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideAlternantPreparerSonProjetEnAlternance.getMetadata()
 
 const PreparerSonProjetEnAlternancePage = () => {

--- a/ui/app/(editorial)/guide-alternant/preparer-son-projet-en-alternance/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/preparer-son-projet-en-alternance/page.tsx
@@ -12,11 +12,6 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideAlternantPreparerSonProjetEnAlternance.getMetadata()
 
 const PreparerSonProjetEnAlternancePage = () => {

--- a/ui/app/(editorial)/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur/page.tsx
@@ -10,11 +10,6 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur.getMetadata()
 
 const RoleEtMissionsDuMaitreDApprentissageOuTuteurPage = () => {

--- a/ui/app/(editorial)/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur/page.tsx
@@ -11,6 +11,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur.getMetadata()
 
 const RoleEtMissionsDuMaitreDApprentissageOuTuteurPage = () => {

--- a/ui/app/(editorial)/guide-alternant/se-faire-accompagner/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/se-faire-accompagner/page.tsx
@@ -12,6 +12,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideAlternantSeFaireAccompagner.getMetadata()
 
 const SeFaireAccompagnerPage = () => {

--- a/ui/app/(editorial)/guide-alternant/se-faire-accompagner/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/se-faire-accompagner/page.tsx
@@ -11,11 +11,6 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideAlternantSeFaireAccompagner.getMetadata()
 
 const SeFaireAccompagnerPage = () => {

--- a/ui/app/(editorial)/guide-cfa/accompagner-vos-alternants/page.tsx
+++ b/ui/app/(editorial)/guide-cfa/accompagner-vos-alternants/page.tsx
@@ -14,6 +14,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-cfa/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideCfaAccompagnerVosAlternants.getMetadata()
 
 const AccompagnerVosAlternantsPage = async () => {

--- a/ui/app/(editorial)/guide-cfa/accompagner-vos-alternants/page.tsx
+++ b/ui/app/(editorial)/guide-cfa/accompagner-vos-alternants/page.tsx
@@ -13,11 +13,6 @@ import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-cfa/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideCfaAccompagnerVosAlternants.getMetadata()
 
 const AccompagnerVosAlternantsPage = async () => {

--- a/ui/app/(editorial)/guide-cfa/la-carte-etudiant-des-metiers/page.tsx
+++ b/ui/app/(editorial)/guide-cfa/la-carte-etudiant-des-metiers/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { Suspense } from "react"
 import { AUTHTYPE } from "shared/constants/recruteur"
 import { LayoutArticle } from "@/app/(editorial)/_components/LayoutArticle"
 import { Paragraph } from "@/app/(editorial)/_components/Paragraph"
@@ -11,13 +12,19 @@ import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 import { BandeauAuthentificationCfa } from "../BandeauAuthentificationCfa"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideCfaLaCarteEtudiantDesMetiers.getMetadata()
 
-const LaCarteEtudiantDesMetiersPage = async () => {
+const LaCarteEtudiantDesMetiersPage = () => {
+  return (
+    <Suspense fallback={null}>
+      <LaCarteEtudiantDesMetiersContent />
+    </Suspense>
+  )
+}
+
+// La session gate à la fois le bandeau (prop top-level de LayoutArticle) et le lien inline
+// plus bas dans le contenu — un seul composant Suspense-wrappé lit la session une fois pour les deux.
+const LaCarteEtudiantDesMetiersContent = async () => {
   const { user } = await getSession()
   const isCfaConnected = user && user.type === AUTHTYPE.CFA
   const linkCarteEtudiantDesMetiers = isCfaConnected ? PAGES.static.espaceProCfaCarteDEtudiantDesMetiers.getPath() : PAGES.static.authentification.getPath()

--- a/ui/app/(editorial)/guide-cfa/la-carte-etudiant-des-metiers/page.tsx
+++ b/ui/app/(editorial)/guide-cfa/la-carte-etudiant-des-metiers/page.tsx
@@ -11,6 +11,10 @@ import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 import { BandeauAuthentificationCfa } from "../BandeauAuthentificationCfa"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideCfaLaCarteEtudiantDesMetiers.getMetadata()
 
 const LaCarteEtudiantDesMetiersPage = async () => {

--- a/ui/app/(editorial)/guide-cfa/page.tsx
+++ b/ui/app/(editorial)/guide-cfa/page.tsx
@@ -14,11 +14,6 @@ import { SchemaOrg } from "@/components/SchemaOrg"
 import { PAGES } from "@/utils/routes.utils"
 import { ARTICLES as ARTICLES_PARTAGES } from "../guide/const"
 import { ARTICLES } from "./const"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideCfa.getMetadata()
 
 const guideCfaPage = () => {

--- a/ui/app/(editorial)/guide-cfa/page.tsx
+++ b/ui/app/(editorial)/guide-cfa/page.tsx
@@ -15,6 +15,10 @@ import { PAGES } from "@/utils/routes.utils"
 import { ARTICLES as ARTICLES_PARTAGES } from "../guide/const"
 import { ARTICLES } from "./const"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideCfa.getMetadata()
 
 const guideCfaPage = () => {

--- a/ui/app/(editorial)/guide-recruteur/cerfa-apprentissage-et-professionnalisation/page.tsx
+++ b/ui/app/(editorial)/guide-recruteur/cerfa-apprentissage-et-professionnalisation/page.tsx
@@ -14,11 +14,6 @@ import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideRecruteurCerfaApprentissageEtProfessionnalisation.getMetadata()
 
 const CerfaApprentissageEtProfessionnalisationPage = () => {

--- a/ui/app/(editorial)/guide-recruteur/cerfa-apprentissage-et-professionnalisation/page.tsx
+++ b/ui/app/(editorial)/guide-recruteur/cerfa-apprentissage-et-professionnalisation/page.tsx
@@ -15,6 +15,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideRecruteurCerfaApprentissageEtProfessionnalisation.getMetadata()
 
 const CerfaApprentissageEtProfessionnalisationPage = () => {

--- a/ui/app/(editorial)/guide-recruteur/je-suis-employeur-public/page.tsx
+++ b/ui/app/(editorial)/guide-recruteur/je-suis-employeur-public/page.tsx
@@ -10,11 +10,6 @@ import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideRecruteurJeSuisEmployeurPublic.getMetadata()
 
 const JeSuisEmployeurPublicPage = () => {

--- a/ui/app/(editorial)/guide-recruteur/je-suis-employeur-public/page.tsx
+++ b/ui/app/(editorial)/guide-recruteur/je-suis-employeur-public/page.tsx
@@ -11,6 +11,10 @@ import { ARTICLES } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideRecruteurJeSuisEmployeurPublic.getMetadata()
 
 const JeSuisEmployeurPublicPage = () => {

--- a/ui/app/(editorial)/guide-recruteur/page.tsx
+++ b/ui/app/(editorial)/guide-recruteur/page.tsx
@@ -15,11 +15,6 @@ import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { PAGES } from "@/utils/routes.utils"
 import { ARTICLES } from "./const"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.guideRecruteur.getMetadata()
 
 const GuideRecruteurPage = () => {

--- a/ui/app/(editorial)/guide-recruteur/page.tsx
+++ b/ui/app/(editorial)/guide-recruteur/page.tsx
@@ -16,6 +16,10 @@ import { SchemaOrg } from "@/components/SchemaOrg"
 import { PAGES } from "@/utils/routes.utils"
 import { ARTICLES } from "./const"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.guideRecruteur.getMetadata()
 
 const GuideRecruteurPage = () => {

--- a/ui/app/(editorial)/guide/apprentissage-et-handicap/page.tsx
+++ b/ui/app/(editorial)/guide/apprentissage-et-handicap/page.tsx
@@ -17,6 +17,10 @@ import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteu
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   ...PAGES.static.guideApprentissageEtHandicap.getMetadata(),
   alternates: { canonical: PAGES.static.guideApprentissageEtHandicap.getPath() },

--- a/ui/app/(editorial)/guide/apprentissage-et-handicap/page.tsx
+++ b/ui/app/(editorial)/guide/apprentissage-et-handicap/page.tsx
@@ -16,11 +16,6 @@ import { ARTICLES as ARTICLES_CFA } from "@/app/(editorial)/guide-cfa/const"
 import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   ...PAGES.static.guideApprentissageEtHandicap.getMetadata(),
   alternates: { canonical: PAGES.static.guideApprentissageEtHandicap.getPath() },

--- a/ui/app/(editorial)/guide/decouvrir-l-alternance/page.tsx
+++ b/ui/app/(editorial)/guide/decouvrir-l-alternance/page.tsx
@@ -14,11 +14,6 @@ import { ARTICLES as ARTICLES_CFA } from "@/app/(editorial)/guide-cfa/const"
 import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   ...PAGES.static.guideDecouvrirLAlternance.getMetadata(),
   alternates: { canonical: PAGES.static.guideDecouvrirLAlternance.getPath() },

--- a/ui/app/(editorial)/guide/decouvrir-l-alternance/page.tsx
+++ b/ui/app/(editorial)/guide/decouvrir-l-alternance/page.tsx
@@ -15,6 +15,10 @@ import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteu
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   ...PAGES.static.guideDecouvrirLAlternance.getMetadata(),
   alternates: { canonical: PAGES.static.guideDecouvrirLAlternance.getPath() },

--- a/ui/app/(editorial)/guide/prevention-des-risques-professionnels-pour-les-apprentis/page.tsx
+++ b/ui/app/(editorial)/guide/prevention-des-risques-professionnels-pour-les-apprentis/page.tsx
@@ -11,11 +11,6 @@ import { ARTICLES as ARTICLES_ALTERNANT } from "@/app/(editorial)/guide-alternan
 import { ARTICLES as ARTICLES_CFA } from "@/app/(editorial)/guide-cfa/const"
 import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteur/const"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   ...PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getMetadata(),
   alternates: { canonical: PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getPath() },

--- a/ui/app/(editorial)/guide/prevention-des-risques-professionnels-pour-les-apprentis/page.tsx
+++ b/ui/app/(editorial)/guide/prevention-des-risques-professionnels-pour-les-apprentis/page.tsx
@@ -12,6 +12,10 @@ import { ARTICLES as ARTICLES_CFA } from "@/app/(editorial)/guide-cfa/const"
 import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteur/const"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   ...PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getMetadata(),
   alternates: { canonical: PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getPath() },

--- a/ui/app/(editorial)/layout.tsx
+++ b/ui/app/(editorial)/layout.tsx
@@ -1,17 +1,12 @@
 import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
+import { Suspense } from "react"
 import { Footer } from "@/app/_components/Footer"
-import { PublicHeader } from "@/app/_components/PublicHeader"
+import { PublicHeader, PublicHeaderStatic } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
-export default async function EditorialLayout({ children }: PropsWithChildren) {
-  const { user } = await getSession()
-
+export default function EditorialLayout({ children }: PropsWithChildren) {
   return (
     <>
       <SkipLinks
@@ -21,11 +16,18 @@ export default async function EditorialLayout({ children }: PropsWithChildren) {
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <PublicHeader user={user} hideConnectionButton={false} />
+      <Suspense fallback={<PublicHeaderStatic />}>
+        <EditorialHeaderWithUser />
+      </Suspense>
       <Box component="main" role="main">
         {children}
       </Box>
       <Footer />
     </>
   )
+}
+
+async function EditorialHeaderWithUser() {
+  const { user } = await getSession()
+  return <PublicHeader user={user} hideConnectionButton={false} />
 }

--- a/ui/app/(editorial)/layout.tsx
+++ b/ui/app/(editorial)/layout.tsx
@@ -5,6 +5,10 @@ import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function EditorialLayout({ children }: PropsWithChildren) {
   const { user } = await getSession()
 

--- a/ui/app/(editorial)/metiers/[slug]/page.tsx
+++ b/ui/app/(editorial)/metiers/[slug]/page.tsx
@@ -11,10 +11,6 @@ import type { IStaticMetiers, IStaticVilles } from "@/utils/get-static-data"
 import { getStaticMetiers, getStaticVilles } from "@/utils/get-static-data"
 import { PAGES } from "@/utils/routes.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 const getTowns = () => {
   const txtDirectory = path.join(process.cwd(), "config")
   const towns = getStaticVilles(txtDirectory)

--- a/ui/app/(editorial)/metiers/[slug]/page.tsx
+++ b/ui/app/(editorial)/metiers/[slug]/page.tsx
@@ -11,6 +11,10 @@ import type { IStaticMetiers, IStaticVilles } from "@/utils/get-static-data"
 import { getStaticMetiers, getStaticVilles } from "@/utils/get-static-data"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 const getTowns = () => {
   const txtDirectory = path.join(process.cwd(), "config")
   const towns = getStaticVilles(txtDirectory)

--- a/ui/app/(editorial)/metiers/page.tsx
+++ b/ui/app/(editorial)/metiers/page.tsx
@@ -8,11 +8,6 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { getStaticMetiers } from "@/utils/get-static-data"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.metiers.getMetadata().title,
   description: PAGES.static.metiers.getMetadata().description,

--- a/ui/app/(editorial)/metiers/page.tsx
+++ b/ui/app/(editorial)/metiers/page.tsx
@@ -9,6 +9,10 @@ import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { getStaticMetiers } from "@/utils/get-static-data"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.metiers.getMetadata().title,
   description: PAGES.static.metiers.getMetadata().description,

--- a/ui/app/(editorial)/plan-du-site/page.tsx
+++ b/ui/app/(editorial)/plan-du-site/page.tsx
@@ -11,6 +11,10 @@ import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { publicConfig } from "@/config.public"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.planDuSite.getMetadata().title,
   description: PAGES.static.planDuSite.getMetadata().description,

--- a/ui/app/(editorial)/plan-du-site/page.tsx
+++ b/ui/app/(editorial)/plan-du-site/page.tsx
@@ -10,11 +10,6 @@ import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { publicConfig } from "@/config.public"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.planDuSite.getMetadata().title,
   description: PAGES.static.planDuSite.getMetadata().description,

--- a/ui/app/(editorial)/statistiques/page.tsx
+++ b/ui/app/(editorial)/statistiques/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import StatistiquesClient from "./StatistiquesClient"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.statistiques.getMetadata().title,
   description: PAGES.static.statistiques.getMetadata().description,

--- a/ui/app/(editorial)/statistiques/page.tsx
+++ b/ui/app/(editorial)/statistiques/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import StatistiquesClient from "./StatistiquesClient"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.statistiques.getMetadata().title,
   description: PAGES.static.statistiques.getMetadata().description,

--- a/ui/app/(editorial-with-notion)/accessibilite/page.tsx
+++ b/ui/app/(editorial-with-notion)/accessibilite/page.tsx
@@ -15,5 +15,3 @@ const Page = async () => {
 }
 
 export default Page
-
-export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)

--- a/ui/app/(editorial-with-notion)/conditions-generales-utilisation/page.tsx
+++ b/ui/app/(editorial-with-notion)/conditions-generales-utilisation/page.tsx
@@ -12,5 +12,3 @@ export default async function CGU() {
   const notionPage = await fetchNotionPage("3086c10e9c074efdaa895c089961fcd0")
   return <CGURendererClient recordMap={notionPage} />
 }
-
-export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)

--- a/ui/app/(editorial-with-notion)/faq/page.tsx
+++ b/ui/app/(editorial-with-notion)/faq/page.tsx
@@ -32,5 +32,3 @@ export default async function FAQ({ searchParams }: { searchParams: Promise<Reco
     />
   )
 }
-
-export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)

--- a/ui/app/(editorial-with-notion)/layout.tsx
+++ b/ui/app/(editorial-with-notion)/layout.tsx
@@ -1,17 +1,12 @@
 import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
+import { Suspense } from "react"
 import { Footer } from "@/app/_components/Footer"
-import { PublicHeader } from "@/app/_components/PublicHeader"
+import { PublicHeader, PublicHeaderStatic } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
-export default async function HomeLayout({ children }: PropsWithChildren) {
-  const { user } = await getSession()
-
+export default function HomeLayout({ children }: PropsWithChildren) {
   return (
     <>
       <SkipLinks
@@ -21,9 +16,16 @@ export default async function HomeLayout({ children }: PropsWithChildren) {
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <PublicHeader user={user} hideConnectionButton={true} />
+      <Suspense fallback={<PublicHeaderStatic />}>
+        <EditorialWithNotionHeaderWithUser />
+      </Suspense>
       <Box>{children}</Box>
       <Footer />
     </>
   )
+}
+
+async function EditorialWithNotionHeaderWithUser() {
+  const { user } = await getSession()
+  return <PublicHeader user={user} hideConnectionButton={true} />
 }

--- a/ui/app/(editorial-with-notion)/layout.tsx
+++ b/ui/app/(editorial-with-notion)/layout.tsx
@@ -5,6 +5,10 @@ import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function HomeLayout({ children }: PropsWithChildren) {
   const { user } = await getSession()
 

--- a/ui/app/(editorial-with-notion)/mentions-legales/page.tsx
+++ b/ui/app/(editorial-with-notion)/mentions-legales/page.tsx
@@ -13,5 +13,3 @@ export default async function MentionsLegales() {
 
   return <MentionLegalesRendererClient mentionsLegales={mentionsLegales} />
 }
-
-export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)

--- a/ui/app/(editorial-with-notion)/politique-de-confidentialite/page.tsx
+++ b/ui/app/(editorial-with-notion)/politique-de-confidentialite/page.tsx
@@ -12,5 +12,3 @@ export default async function PolitiqueDeConfidentialite() {
   const politiqueDeConfidentialite = await fetchNotionPage("2d7d9cda6d9a4059baa84eacff592139")
   return <PolitiqueDeConfidentialiteRendererClient politiqueDeConfidentialite={politiqueDeConfidentialite} />
 }
-
-export const revalidate = 86400 // revalider toutes les 24h (API Notion rate-limitée)

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/ConnectedShellSkeleton.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/ConnectedShellSkeleton.tsx
@@ -1,0 +1,8 @@
+import { Header as DsfrHeader } from "@codegouvfr/react-dsfr/Header"
+import { DsfrHeaderProps } from "@/app/_components/Header"
+
+// Squelette affiché pendant la résolution de la session (Suspense fallback),
+// sans les éléments dépendant de l'utilisateur connecté (compte, déconnexion, navigation par rôle).
+export function ConnectedShellSkeleton() {
+  return <DsfrHeader {...DsfrHeaderProps} />
+}

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/layout.tsx
@@ -4,6 +4,10 @@ import type { PropsWithChildren } from "react"
 
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <Container maxWidth="xl" sx={{ marginTop: fr.spacing("4v") }}>

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/page.tsx
@@ -4,6 +4,10 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.dynamic.compte({ userType: ADMIN }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import GestionDesAdministrateurs from "./gestionDesAdministrateurs"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.backAdminGestionDesAdministrateurs.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/user/[userId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/user/[userId]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import EditAdministrateur from "./editAdministrateur"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ userId: string }> }): Promise<Metadata> {
   const { userId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-entreprises/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-entreprises/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import GestionEntreprises from "./gestionEntreprises"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.backAdminGestionDesEntreprises.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/layout.tsx
@@ -2,6 +2,10 @@ import type { PropsWithChildren } from "react"
 
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function Layout({ children }: PropsWithChildren) {
   return <DefaultContainer>{children}</DefaultContainer>
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/[id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/[id]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurCronTaskPage from "./ProcesseurCronTaskPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ name: string; id: string }> }): Promise<Metadata> {
   const { name, id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurCronPage from "./ProcesseurCronPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ name: string }> }): Promise<Metadata> {
   const { name } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/[id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/[id]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurJobInstancePage from "./ProcesseurJobInstancePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ name: string; id: string }> }): Promise<Metadata> {
   const { name, id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurJobPage from "./ProcesseurJobPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ name: string }> }): Promise<Metadata> {
   const { name } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/layout.tsx
@@ -1,5 +1,9 @@
 import type { PropsWithChildren } from "react"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default function AccueilAdministration({ children }: PropsWithChildren) {
   return <>{children}</>
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurPage from "./ProcesseurPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.adminProcessor.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/recruteurs/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/recruteurs/page.tsx
@@ -3,6 +3,10 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import { PAGES } from "@/utils/routes.utils"
 import { RecruteursList } from "./RecruteursList"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.backAdminGestionDesRecruteurs.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/[siret]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/[siret]/page.tsx
@@ -4,6 +4,10 @@ import { getEligibleTrainingsForAppointments, getEtablissement } from "@/utils/a
 import { PAGES } from "@/utils/routes.utils"
 import RendezVousApprentissageDetailRendererClient from "./RendezVousApprentissageDetailRendererClient"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ siret: string }> }): Promise<Metadata> {
   const { siret } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import RendezVousApprentissagePage from "./RendezVousApprentissagePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.rendezVousApprentissageRecherche.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/cfa/[establishment_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/cfa/[establishment_id]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import AdminUserCfaEntreprisePage from "./AdminUserCfaEntreprisePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: { userId: string; establishment_id: string } }): Promise<Metadata> {
   const { userId, establishment_id } = params
   return { title: PAGES.dynamic.backAdminUserCfaEntreprise({ user_id: userId, establishment_id }).getMetadata().title }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/layout.tsx
@@ -2,6 +2,10 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Container } from "@mui/material"
 import type { PropsWithChildren } from "react"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default function Layout({ children }: PropsWithChildren) {
   return (
     <Container

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/page.tsx
@@ -3,6 +3,10 @@ import { ADMIN } from "shared/constants/recruteur"
 import { PAGES } from "@/utils/routes.utils"
 import AdminOffrePage from "./AdminOffrePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ job_id: string; establishment_id: string; userId: string }> }): Promise<Metadata> {
   const { job_id, establishment_id, userId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import User from "./User"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ userId: string }> }): Promise<Metadata> {
   const { userId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/page.tsx
@@ -3,6 +3,10 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import { PAGES } from "@/utils/routes.utils"
 import { UsersList } from "./UsersList"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.backAdminHome.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/carte-d-etudiant-des-metiers/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/carte-d-etudiant-des-metiers/page.tsx
@@ -8,6 +8,10 @@ import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { DsfrIcon } from "@/components/DsfrIcon"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.espaceProCfaCarteDEtudiantDesMetiers.getMetadata()
 
 const CarteDEtudiantDesMetiersPage = () => (

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/compte/page.tsx
@@ -4,6 +4,10 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.dynamic.compte({ userType: CFA }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/[siret]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/[siret]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CreationEntrepriseDetailPage from "./CreationEntrepriseDetailPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ siret: string }> }): Promise<Metadata> {
   const { siret } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CreationEntreprisePage from "./CreationEntreprisePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.backCfaCreationEntreprise.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/creation-offre/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/creation-offre/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CfaCreationOffrePage from "./CfaCreationOffrePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string }> }): Promise<Metadata> {
   const { establishment_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/informations/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/informations/page.tsx
@@ -3,10 +3,6 @@ import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 import { EntrepriseInformationsPage } from "./EntrepriseInformationsPage"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string }> }): Promise<Metadata> {
   const { establishment_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/informations/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/informations/page.tsx
@@ -3,6 +3,10 @@ import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 import { EntrepriseInformationsPage } from "./EntrepriseInformationsPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string }> }): Promise<Metadata> {
   const { establishment_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/offre/[jobId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/offre/[jobId]/page.tsx
@@ -3,6 +3,10 @@ import { CFA } from "shared/constants/recruteur"
 import { PAGES } from "@/utils/routes.utils"
 import CfaOffrePage from "./CfaOffrePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string; jobId: string }> }): Promise<Metadata> {
   const { establishment_id, jobId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CfaEntreprisePage from "./CfaEntreprisePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string }> }): Promise<Metadata> {
   const { establishment_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/layout.tsx
@@ -4,6 +4,10 @@ import type { PropsWithChildren } from "react"
 
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <Container maxWidth="xl" sx={{ marginTop: fr.spacing("4v") }}>

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import CfaHome from "@/app/(espace-pro)/espace-pro/(connected)/_components/CfaHome"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.backCfaHome.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/compte/page.tsx
@@ -4,6 +4,10 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.dynamic.compte({ userType: ENTREPRISE }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/creation-offre/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/creation-offre/page.tsx
@@ -3,10 +3,6 @@ import { BackEntrepriseUpsertOffre } from "@/app/(espace-pro)/espace-pro/(connec
 import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.backEntrepriseCreationOffre.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/creation-offre/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/creation-offre/page.tsx
@@ -3,6 +3,10 @@ import { BackEntrepriseUpsertOffre } from "@/app/(espace-pro)/espace-pro/(connec
 import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.backEntrepriseCreationOffre.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/layout.tsx
@@ -5,6 +5,10 @@ import type { PropsWithChildren } from "react"
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 import InfoBanner from "@/components/InfoBanner/InfoBanner"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default function Layout({ children }: PropsWithChildren) {
   return (
     <Container

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/mise-en-relation/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/mise-en-relation/page.tsx
@@ -3,10 +3,6 @@ import MiseEnRelation from "@/app/(espace-pro)/_components/MiseEnRelation"
 import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ job_id: string }> }): Promise<Metadata> {
   const { job_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/mise-en-relation/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/mise-en-relation/page.tsx
@@ -3,6 +3,10 @@ import MiseEnRelation from "@/app/(espace-pro)/_components/MiseEnRelation"
 import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ job_id: string }> }): Promise<Metadata> {
   const { job_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/page.tsx
@@ -3,10 +3,6 @@ import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 import { PageWithParams } from "./PageWithParams"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ job_id: string }> }): Promise<Metadata> {
   const { job_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/page.tsx
@@ -3,6 +3,10 @@ import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 import { PageWithParams } from "./PageWithParams"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ job_id: string }> }): Promise<Metadata> {
   const { job_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx
@@ -1,22 +1,19 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
+import { redirect } from "next/navigation"
 import type { PropsWithChildren } from "react"
+import { Suspense } from "react"
 import { AuthWatcher } from "@/app/_components/AuthWatcher"
 import { Footer } from "@/app/_components/Footer"
 import { UserContextProvider } from "@/app/(espace-pro)/espace-pro/contexts/userContext"
 import { getSession } from "@/utils/get-session"
 import { ConnectedHeader } from "./_components/ConnectedHeader"
+import { ConnectedShellSkeleton } from "./_components/ConnectedShellSkeleton"
 
-export default async function EspaceProConnecteLayout({ children }: PropsWithChildren) {
-  const { user, access } = await getSession()
-
-  if (user == null) {
-    throw new Error("User is not connected")
-  }
-
+export default function EspaceProConnecteLayout({ children }: PropsWithChildren) {
   return (
-    <UserContextProvider user={user} access={access}>
+    <>
       <SkipLinks
         links={[
           { label: "Menu", anchor: "#header-links" },
@@ -24,6 +21,24 @@ export default async function EspaceProConnecteLayout({ children }: PropsWithChi
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
+      <Suspense fallback={<ConnectedShellSkeleton />}>
+        <ConnectedShell>{children}</ConnectedShell>
+      </Suspense>
+    </>
+  )
+}
+
+async function ConnectedShell({ children }: PropsWithChildren) {
+  const { user, access } = await getSession()
+
+  // ui/proxy.ts est le garde-fou principal (redirige avant même d'atteindre ce rendu React).
+  // Ce redirect est un filet de sécurité si jamais cette route est atteinte sans session valide.
+  if (user == null) {
+    redirect("/espace-pro/authentification")
+  }
+
+  return (
+    <UserContextProvider user={user} access={access}>
       <ConnectedHeader user={user} />
       <Box component="main" id="main-content" tabIndex={-1} role="main" sx={{ marginBottom: fr.spacing("8v") }}>
         {children}

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/compte/page.tsx
@@ -4,6 +4,10 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.dynamic.compte({ userType: OPCO }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/layout.tsx
@@ -4,6 +4,10 @@ import type { PropsWithChildren } from "react"
 
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <Box

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import OpcoPage from "./OpcoPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.backOpcoHome.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/layout.tsx
@@ -2,6 +2,10 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Container } from "@mui/material"
 import type { PropsWithChildren } from "react"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default function Layout({ children }: PropsWithChildren) {
   return (
     <Container

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/page.tsx
@@ -3,6 +3,10 @@ import { OPCO } from "shared/constants/recruteur"
 import { PAGES } from "@/utils/routes.utils"
 import OpcoOffrePage from "./OpcoOffrePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ jobId: string; establishment_id: string; userId: string }> }): Promise<Metadata> {
   const { jobId, establishment_id, userId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import User from "./User"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export async function generateMetadata({ params }: { params: Promise<{ userId: string }> }): Promise<Metadata> {
   const { userId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/layout.tsx
@@ -2,17 +2,12 @@ import { fr } from "@codegouvfr/react-dsfr"
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box, Container } from "@mui/material"
 import type { PropsWithChildren } from "react"
+import { Suspense } from "react"
 import { Footer } from "@/app/_components/Footer"
-import { PublicHeader } from "@/app/_components/PublicHeader"
+import { PublicHeader, PublicHeaderStatic } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
-export default async function RecruteurLayout({ children }: PropsWithChildren) {
-  const { user } = await getSession()
-
+export default function RecruteurLayout({ children }: PropsWithChildren) {
   return (
     <>
       <SkipLinks
@@ -22,7 +17,9 @@ export default async function RecruteurLayout({ children }: PropsWithChildren) {
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <PublicHeader user={user} />
+      <Suspense fallback={<PublicHeaderStatic />}>
+        <FromMailHeaderWithUser />
+      </Suspense>
       <Box component="main" role="main" id="main-content" tabIndex={-1} sx={{ marginBottom: fr.spacing("8v") }}>
         <Container maxWidth="xl" sx={{ marginTop: fr.spacing("4v") }}>
           {children}
@@ -31,4 +28,9 @@ export default async function RecruteurLayout({ children }: PropsWithChildren) {
       <Footer />
     </>
   )
+}
+
+async function FromMailHeaderWithUser() {
+  const { user } = await getSession()
+  return <PublicHeader user={user} />
 }

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/layout.tsx
@@ -6,6 +6,10 @@ import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function RecruteurLayout({ children }: PropsWithChildren) {
   const { user } = await getSession()
 

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/mise-en-relation/[establishment_id]/[job_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/mise-en-relation/[establishment_id]/[job_id]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import MiseEnRelation from "@/app/(espace-pro)/_components/MiseEnRelation"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Mise en relation avec des organismes de formation - La bonne alternance",
 }

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/cancel/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/cancel/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import { OffreActionPage } from "@/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/OffreActionPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Annuler une offre - La bonne alternance",
 }

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/provided/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/provided/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import { OffreActionPage } from "@/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/OffreActionPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Confirmation de l'offre pourvue - La bonne alternance",
 }

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/proposition/formulaire/[idFormulaire]/offre/[jobId]/siret/[siretFormateur]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/proposition/formulaire/[idFormulaire]/offre/[jobId]/siret/[siretFormateur]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import { PropositionOffreId } from "./PropositionOffreId"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Proposition d'offre - La bonne alternance",
 }

--- a/ui/app/(espace-pro)/espace-pro/authentification/confirmation/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/confirmation/page.tsx
@@ -4,6 +4,10 @@ import type { Metadata } from "next"
 import { publicConfig } from "@/config.public"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.dynamic.backCreateCFAConfirmation({ email: "" }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/authentification/en-attente/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/en-attente/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CompteEnAttente from "./CompteEnAttente"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.backCreateCFAEnAttente.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/authentification/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/layout.tsx
@@ -6,6 +6,10 @@ import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function AuthentificationLayout({ children }: PropsWithChildren) {
   const { user } = await getSession()
 

--- a/ui/app/(espace-pro)/espace-pro/authentification/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/layout.tsx
@@ -2,17 +2,12 @@ import { fr } from "@codegouvfr/react-dsfr"
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
+import { Suspense } from "react"
 import { Footer } from "@/app/_components/Footer"
-import { PublicHeader } from "@/app/_components/PublicHeader"
+import { PublicHeader, PublicHeaderStatic } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
-export default async function AuthentificationLayout({ children }: PropsWithChildren) {
-  const { user } = await getSession()
-
+export default function AuthentificationLayout({ children }: PropsWithChildren) {
   return (
     <>
       <SkipLinks
@@ -22,7 +17,9 @@ export default async function AuthentificationLayout({ children }: PropsWithChil
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <PublicHeader user={user} />
+      <Suspense fallback={<PublicHeaderStatic />}>
+        <AuthentificationHeaderWithUser />
+      </Suspense>
       <Box
         id="main-content"
         tabIndex={-1}
@@ -40,4 +37,9 @@ export default async function AuthentificationLayout({ children }: PropsWithChil
       <Footer />
     </>
   )
+}
+
+async function AuthentificationHeaderWithUser() {
+  const { user } = await getSession()
+  return <PublicHeader user={user} />
 }

--- a/ui/app/(espace-pro)/espace-pro/authentification/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import AuthentificationPage from "./AuthentificationPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.authentification.getMetadata().title,
   description: PAGES.static.authentification.getMetadata().description,

--- a/ui/app/(espace-pro)/espace-pro/authentification/validation/[id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/validation/[id]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import ValidationPage from "./ValidationPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Validation de votre email - La bonne alternance",
 }

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/[origin]/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/[origin]/page.tsx
@@ -4,6 +4,10 @@ import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.espaceProCreationCfa.getMetadata().title,
   description: PAGES.static.espaceProCreationCfa.getMetadata().description,

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/page.tsx
@@ -4,6 +4,10 @@ import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.espaceProCreationCfa.getMetadata().title,
   description: PAGES.static.espaceProCreationCfa.getMetadata().description,

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/detail/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/detail/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import CreationDetail from "./CreationDetailPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - Informations de compte - La bonne alternance",
 }

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/[origin]/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/[origin]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CreationWithOriginPage from "./CreationWithOriginPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.espaceProCreationEntreprise.getMetadata().title,
   description: PAGES.static.espaceProCreationEntreprise.getMetadata().description,

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/page.tsx
@@ -4,6 +4,10 @@ import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.espaceProCreationEntreprise.getMetadata().title,
   description: PAGES.static.espaceProCreationEntreprise.getMetadata().description,

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/fin/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/fin/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import { DepotRapideFin } from "@/app/(espace-pro)/_components/DepotRapideFin"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Fin de création d'offre - La bonne alternance",
 }

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/offre/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/offre/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import { DepotSimplifieCreationOffre } from "@/app/(espace-pro-creation-compte)/_components/DepotSimplifieCreationOffre"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - Informations de l'offre - La bonne alternance",
 }

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/layout.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/layout.tsx
@@ -8,6 +8,10 @@ import { DsfrHeaderProps } from "@/app/_components/Header"
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(espace-pro-impression)/espace-pro/offre/impression/[jobId]/page.tsx
+++ b/ui/app/(espace-pro-impression)/espace-pro/offre/impression/[jobId]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import ImpressionPage from "./ImpressionPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Impression d'offre - La bonne alternance",
 }

--- a/ui/app/(home)/layout.tsx
+++ b/ui/app/(home)/layout.tsx
@@ -1,13 +1,12 @@
 import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks"
 import type { PropsWithChildren } from "react"
+import { Suspense } from "react"
 
 import { Footer } from "@/app/_components/Footer"
-import { PublicHeader } from "@/app/_components/PublicHeader"
+import { PublicHeader, PublicHeaderStatic } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
-export default async function HomeLayout({ children }: PropsWithChildren) {
-  const { user } = await getSession()
-
+export default function HomeLayout({ children }: PropsWithChildren) {
   return (
     <>
       <SkipLinks
@@ -18,9 +17,16 @@ export default async function HomeLayout({ children }: PropsWithChildren) {
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <PublicHeader user={user} />
+      <Suspense fallback={<PublicHeaderStatic />}>
+        <PublicHeaderWithUser />
+      </Suspense>
       {children}
       <Footer />
     </>
   )
+}
+
+async function PublicHeaderWithUser() {
+  const { user } = await getSession()
+  return <PublicHeader user={user} />
 }

--- a/ui/app/(home)/page.tsx
+++ b/ui/app/(home)/page.tsx
@@ -2,6 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Container, Grid } from "@mui/material"
 
 import type { Metadata } from "next"
+import { Suspense } from "react"
 import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { AppreciationUsagers } from "@/app/(home)/_components/AppreciationUsagers"
 import { GrandsGroupesCandidat } from "@/app/(home)/_components/GrandsGroupesCandidat"
@@ -14,18 +15,12 @@ import { HomeRechercheOptIn } from "./_components/HomeRechercheOptIn"
 import { HowTo } from "./_components/HowTo"
 import { InformationsAlternance } from "./_components/InformationsAlternance"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.home.getMetadata().title,
   description: PAGES.static.home.getMetadata().description,
 }
 
-export default async function HomePage({ searchParams }: { searchParams: Promise<Record<string, string>> }) {
-  const rechercheParams = parseRecherchePageParams(new URLSearchParams(await searchParams), IRechercheMode.DEFAULT)
-
+export default function HomePage({ searchParams }: { searchParams: Promise<Record<string, string>> }) {
   return (
     <>
       <SchemaOrg
@@ -70,7 +65,9 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
             <HomeCircleImageDecoration size="high" />
           </Box>
           <Box sx={{ position: "relative", display: "grid", padding: { xs: 0, md: fr.spacing("12v") }, gap: fr.spacing("8v"), gridTemplateColumns: "1fr" }}>
-            <HomeRechercheOptIn rechercheParams={rechercheParams} />
+            <Suspense fallback={null}>
+              <HomeRechercheOptInWithParams searchParams={searchParams} />
+            </Suspense>
             <HowTo />
           </Box>
         </Box>
@@ -93,4 +90,9 @@ export default async function HomePage({ searchParams }: { searchParams: Promise
       </Container>
     </>
   )
+}
+
+async function HomeRechercheOptInWithParams({ searchParams }: { searchParams: Promise<Record<string, string>> }) {
+  const rechercheParams = parseRecherchePageParams(new URLSearchParams(await searchParams), IRechercheMode.DEFAULT)
+  return <HomeRechercheOptIn rechercheParams={rechercheParams} />
 }

--- a/ui/app/(home)/page.tsx
+++ b/ui/app/(home)/page.tsx
@@ -14,6 +14,10 @@ import { HomeRechercheOptIn } from "./_components/HomeRechercheOptIn"
 import { HowTo } from "./_components/HowTo"
 import { InformationsAlternance } from "./_components/InformationsAlternance"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.home.getMetadata().title,
   description: PAGES.static.home.getMetadata().description,

--- a/ui/app/(landing-pages)/je-suis-cfa/page.tsx
+++ b/ui/app/(landing-pages)/je-suis-cfa/page.tsx
@@ -15,6 +15,10 @@ import { getDepotCtaHref } from "@/services/get-depot-cta-href"
 import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = PAGES.static.jeSuisCFA.getMetadata()
 
 const JeSuisCFAPage = async () => {

--- a/ui/app/(landing-pages)/je-suis-cfa/page.tsx
+++ b/ui/app/(landing-pages)/je-suis-cfa/page.tsx
@@ -3,6 +3,7 @@ import Button from "@codegouvfr/react-dsfr/Button"
 import { Box, Grid, Typography } from "@mui/material"
 import type { Metadata } from "next"
 import Image from "next/image"
+import { Suspense } from "react"
 import { AUTHTYPE } from "shared/constants/recruteur"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
@@ -15,18 +16,58 @@ import { getDepotCtaHref } from "@/services/get-depot-cta-href"
 import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.jeSuisCFA.getMetadata()
 
-const JeSuisCFAPage = async () => {
+async function DepotCtaButtons() {
+  const { user } = await getSession()
+  const ctaDepotHref: string = getDepotCtaHref(user, "CFA")
+
+  return (
+    <Box display={"flex"} flexDirection={{ sm: "row", xs: "column" }} gap={fr.spacing("4v")}>
+      <Button linkProps={{ href: ctaDepotHref }} priority="primary">
+        Créer mon espace dédié
+      </Button>
+      <Button linkProps={{ href: PAGES.static.authentification.getPath() }} priority="secondary">
+        Me connecter
+      </Button>
+    </Box>
+  )
+}
+
+async function CarteMetiersCtaButtons() {
   const { user } = await getSession()
   const isCfaConnected = user && user.type === AUTHTYPE.CFA
 
-  const ctaDepotHref: string = getDepotCtaHref(user, "CFA")
+  return (
+    <Box display={"flex"} flexDirection={{ md: "row", xs: "column" }} gap={fr.spacing("2v")} justifyContent={{ md: "start", xs: "center" }} textAlign={"center"}>
+      {isCfaConnected ? (
+        <Button
+          linkProps={{ href: PAGES.static.espaceProCfaCarteDEtudiantDesMetiers.getPath() }}
+          aria-label="Accéder à la carte des métiers"
+          priority="primary"
+          style={{ margin: "auto" }}
+        >
+          Télécharger la carte des métiers
+        </Button>
+      ) : (
+        <>
+          <Box>
+            <Button linkProps={{ href: PAGES.static.authentification.getPath() }} aria-label="Accéder à la page de connexion" priority="secondary">
+              Me connecter
+            </Button>
+          </Box>
+          <Box>
+            <Button linkProps={{ href: PAGES.static.espaceProCreationCfa.getPath() }} aria-label="Accéder à la page de création de compte" priority="secondary">
+              Me créer un compte
+            </Button>
+          </Box>
+        </>
+      )}
+    </Box>
+  )
+}
 
+const JeSuisCFAPage = () => {
   return (
     <Box
       sx={{
@@ -64,14 +105,9 @@ const JeSuisCFAPage = async () => {
             <Typography variant="body1" gutterBottom>
               Créez le compte de votre CFA pour diffuser les offres de vos entreprises partenaires, et recevoir les candidatures.{" "}
             </Typography>
-            <Box display={"flex"} flexDirection={{ sm: "row", xs: "column" }} gap={fr.spacing("4v")}>
-              <Button linkProps={{ href: ctaDepotHref }} priority="primary">
-                Créer mon espace dédié
-              </Button>
-              <Button linkProps={{ href: PAGES.static.authentification.getPath() }} priority="secondary">
-                Me connecter
-              </Button>
-            </Box>
+            <Suspense fallback={<Box sx={{ height: 40 }} />}>
+              <DepotCtaButtons />
+            </Suspense>
           </Grid>
           <Grid size={{ md: 6, xs: 0 }} display={"flex"} flexDirection={"column"} justifyContent={"center"}>
             <Image
@@ -345,31 +381,9 @@ const JeSuisCFAPage = async () => {
               La carte d’étudiant des métiers ouvre droit à de nombreuses réductions pour vos alternants. Vous devez leur délivrer la carte dans les 30 jours qui suivent leur
               inscription.
             </Typography>
-            <Box display={"flex"} flexDirection={{ md: "row", xs: "column" }} gap={fr.spacing("2v")} justifyContent={{ md: "start", xs: "center" }} textAlign={"center"}>
-              {isCfaConnected ? (
-                <Button
-                  linkProps={{ href: PAGES.static.espaceProCfaCarteDEtudiantDesMetiers.getPath() }}
-                  aria-label="Accéder à la carte des métiers"
-                  priority="primary"
-                  style={{ margin: "auto" }}
-                >
-                  Télécharger la carte des métiers
-                </Button>
-              ) : (
-                <>
-                  <Box>
-                    <Button linkProps={{ href: PAGES.static.authentification.getPath() }} aria-label="Accéder à la page de connexion" priority="secondary">
-                      Me connecter
-                    </Button>
-                  </Box>
-                  <Box>
-                    <Button linkProps={{ href: PAGES.static.espaceProCreationCfa.getPath() }} aria-label="Accéder à la page de création de compte" priority="secondary">
-                      Me créer un compte
-                    </Button>
-                  </Box>
-                </>
-              )}
-            </Box>
+            <Suspense fallback={<Box sx={{ height: 40 }} />}>
+              <CarteMetiersCtaButtons />
+            </Suspense>
           </Grid>
         </Grid>
       </DefaultContainer>

--- a/ui/app/(landing-pages)/je-suis-recruteur/page.tsx
+++ b/ui/app/(landing-pages)/je-suis-recruteur/page.tsx
@@ -4,6 +4,7 @@ import Card from "@codegouvfr/react-dsfr/Card"
 import { Box, Divider, Grid, List, ListItem, Typography } from "@mui/material"
 import type { Metadata } from "next"
 import Image from "next/image"
+import { Suspense } from "react"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { FollowLinkedIn } from "@/app/(espace-pro)/_components/FollowLinkedIn"
@@ -15,10 +16,6 @@ import { getDepotCtaHref } from "@/services/get-depot-cta-href"
 import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const cardSx = {
   backgroundColor: "white",
   padding: fr.spacing("7v"),
@@ -28,11 +25,24 @@ export const cardSx = {
 }
 
 export const metadata: Metadata = PAGES.static.jeSuisRecruteur.getMetadata()
-const JeSuisRecruteurPage = async () => {
-  const { user } = await getSession()
 
+async function DepotCtaButtons() {
+  const { user } = await getSession()
   const ctaDepotHref: string = getDepotCtaHref(user, "ENTREPRISE")
 
+  return (
+    <Box display={"flex"} flexDirection={{ sm: "row", xs: "column" }} gap={fr.spacing("4v")}>
+      <Button linkProps={{ href: ctaDepotHref }} priority="primary">
+        Déposer une offre
+      </Button>
+      <Button linkProps={{ href: PAGES.static.authentification.getPath() }} priority="secondary">
+        Me connecter
+      </Button>
+    </Box>
+  )
+}
+
+const JeSuisRecruteurPage = () => {
   return (
     <>
       <Box
@@ -70,14 +80,9 @@ const JeSuisRecruteurPage = async () => {
               <Typography variant="body1" gutterBottom>
                 Exprimez vos besoins en alternance afin d’être visible auprès des jeunes en recherche de contrat, et des centres de formation pouvant vous accompagner.
               </Typography>
-              <Box display={"flex"} flexDirection={{ sm: "row", xs: "column" }} gap={fr.spacing("4v")}>
-                <Button linkProps={{ href: ctaDepotHref }} priority="primary">
-                  Déposer une offre
-                </Button>
-                <Button linkProps={{ href: PAGES.static.authentification.getPath() }} priority="secondary">
-                  Me connecter
-                </Button>
-              </Box>
+              <Suspense fallback={<Box sx={{ height: 40 }} />}>
+                <DepotCtaButtons />
+              </Suspense>
             </Grid>
             <Grid size={6} display={{ md: "flex", xs: "none" }} flexDirection={"column"} justifyContent={"center"}>
               <Image

--- a/ui/app/(landing-pages)/je-suis-recruteur/page.tsx
+++ b/ui/app/(landing-pages)/je-suis-recruteur/page.tsx
@@ -15,6 +15,10 @@ import { getDepotCtaHref } from "@/services/get-depot-cta-href"
 import { getSession } from "@/utils/get-session"
 import { PAGES } from "@/utils/routes.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const cardSx = {
   backgroundColor: "white",
   padding: fr.spacing("7v"),

--- a/ui/app/(landing-pages)/layout.tsx
+++ b/ui/app/(landing-pages)/layout.tsx
@@ -2,18 +2,13 @@ import { fr } from "@codegouvfr/react-dsfr"
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
+import { Suspense } from "react"
 
 import { Footer } from "@/app/_components/Footer"
-import { PublicHeader } from "@/app/_components/PublicHeader"
+import { PublicHeader, PublicHeaderStatic } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
-export default async function PublicLayout({ children }: PropsWithChildren) {
-  const { user } = await getSession()
-
+export default function PublicLayout({ children }: PropsWithChildren) {
   return (
     <>
       <SkipLinks
@@ -23,11 +18,18 @@ export default async function PublicLayout({ children }: PropsWithChildren) {
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <PublicHeader user={user} />
+      <Suspense fallback={<PublicHeaderStatic />}>
+        <LandingHeaderWithUser />
+      </Suspense>
       <Box component="main" role="main" sx={{ marginBottom: fr.spacing("8v") }}>
         {children}
       </Box>
       <Footer />
     </>
   )
+}
+
+async function LandingHeaderWithUser() {
+  const { user } = await getSession()
+  return <PublicHeader user={user} />
 }

--- a/ui/app/(landing-pages)/layout.tsx
+++ b/ui/app/(landing-pages)/layout.tsx
@@ -7,6 +7,10 @@ import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { getSession } from "@/utils/get-session"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function PublicLayout({ children }: PropsWithChildren) {
   const { user } = await getSession()
 

--- a/ui/app/(landing-pages)/salaire-alternant/page.tsx
+++ b/ui/app/(landing-pages)/salaire-alternant/page.tsx
@@ -4,6 +4,10 @@ import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { PAGES } from "@/utils/routes.utils"
 import { SimulateurRemuneration } from "./_components/SimulateurRemuneration"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: PAGES.static.salaireAlternant.getMetadata().title,
   description: PAGES.static.salaireAlternant.getMetadata().description,

--- a/ui/app/(rdva)/layout.tsx
+++ b/ui/app/(rdva)/layout.tsx
@@ -5,6 +5,10 @@ import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export default async function HomeLayout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(rdva)/optout/unsubscribe/[id]/page.tsx
+++ b/ui/app/(rdva)/optout/unsubscribe/[id]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import OptoutUnsubscribePage from "./OptoutUnsubscribePage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Désinscription du service Rendez-vous Apprentissage - La bonne alternance",
 }

--- a/ui/app/(rdva)/premium/[id]/page.tsx
+++ b/ui/app/(rdva)/premium/[id]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import PremiumParcoursupPage from "./PremiumParcoursupPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Activation du service Rendez-vous Apprentissage sur Parcoursup - La bonne alternance",
 }

--- a/ui/app/(rdva)/premium/affelnet/[id]/page.tsx
+++ b/ui/app/(rdva)/premium/affelnet/[id]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import PremiumAffelnetPage from "./PremiumAffelnetPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Activation du service Rendez-vous Apprentissage sur Choisir son affectation après la 3ème - La bonne alternance",
 }

--- a/ui/app/(rdva)/rdva/page.tsx
+++ b/ui/app/(rdva)/rdva/page.tsx
@@ -4,6 +4,10 @@ import { getPrdvContext } from "@/utils/api"
 
 import RdvaPage from "./RdvaPage"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Contacter un centre de formation - La bonne alternance",
 }

--- a/ui/app/beta/_components/SearchHitCard.tsx
+++ b/ui/app/beta/_components/SearchHitCard.tsx
@@ -132,7 +132,7 @@ export function SearchHitCard({ hit, currentParams, position }: SearchHitCardPro
           shadow
           enlargeLink
           horizontal
-          linkProps={{ href: detailUrl, prefetch: false, onClick: trackClick }}
+          linkProps={{ href: detailUrl, onClick: trackClick }}
           start={<HitTags hit={hit} />}
           title={
             <Typography component="span" className={fr.cx("fr-text--bold", "fr-text--md")} sx={{ color: fr.colors.decisions.text.actionHigh.grey.default }}>

--- a/ui/app/beta/recherche/page.tsx
+++ b/ui/app/beta/recherche/page.tsx
@@ -3,6 +3,10 @@ import { Suspense } from "react"
 import { SearchPageClient } from "../_components/SearchPageClient"
 import { buildSearchPageTitle, parseSearchPageParams } from "../_utils/search.params.utils"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 type Props = {
   searchParams: Promise<Record<string, string>>
 }

--- a/ui/app/healthcheck/route.ts
+++ b/ui/app/healthcheck/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server"
 
-export const dynamic = "force-static"
-
 export async function GET() {
   return NextResponse.json({ status: "ok" }, { status: 200 })
 }

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -17,6 +17,10 @@ import "@/public/styles/fonts.css"
 import "@/public/styles/notion.css"
 import "@/styles/search.css"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   metadataBase: new URL(publicConfig.baseUrl),
   manifest: "/favicon/site.webmanifest",

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -17,10 +17,6 @@ import "@/public/styles/fonts.css"
 import "@/public/styles/notion.css"
 import "@/styles/search.css"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   metadataBase: new URL(publicConfig.baseUrl),
   manifest: "/favicon/site.webmanifest",

--- a/ui/app/sitemap-offers.xml/route.ts
+++ b/ui/app/sitemap-offers.xml/route.ts
@@ -1,8 +1,5 @@
 import { publicConfig } from "@/config.public"
 
-// disable next cache. Cache is handled in the API
-export const dynamic = "force-dynamic"
-
 export async function GET(_request: Request) {
   const response = await fetch(`${publicConfig.apiEndpoint}/sitemap-offers.xml`, {
     cache: "no-cache",

--- a/ui/app/test-widget/page.tsx
+++ b/ui/app/test-widget/page.tsx
@@ -7,6 +7,10 @@ import { PublicHeader } from "@/app/_components/PublicHeader"
 import { WidgetTester } from "@/app/_components/WidgetTester"
 import { getSession } from "@/utils/get-session"
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+
 export const metadata: Metadata = {
   title: "Formulaire de test des widgets - La bonne alternance",
 }

--- a/ui/app/test-widget/page.tsx
+++ b/ui/app/test-widget/page.tsx
@@ -2,26 +2,23 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box } from "@mui/material"
 
 import type { Metadata } from "next"
+import { Suspense } from "react"
 import { Footer } from "@/app/_components/Footer"
-import { PublicHeader } from "@/app/_components/PublicHeader"
+import { PublicHeader, PublicHeaderStatic } from "@/app/_components/PublicHeader"
 import { WidgetTester } from "@/app/_components/WidgetTester"
 import { getSession } from "@/utils/get-session"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
 
 export const metadata: Metadata = {
   title: "Formulaire de test des widgets - La bonne alternance",
 }
 
-export default async function Page() {
-  const { user } = await getSession()
-
+export default function Page() {
   return (
     <html lang="en">
       <body>
-        <PublicHeader user={user} />
+        <Suspense fallback={<PublicHeaderStatic />}>
+          <TestWidgetHeaderWithUser />
+        </Suspense>
         <Box
           sx={{
             maxWidth: "xl",
@@ -35,4 +32,9 @@ export default async function Page() {
       </body>
     </html>
   )
+}
+
+async function TestWidgetHeaderWithUser() {
+  const { user } = await getSession()
+  return <PublicHeader user={user} />
 }

--- a/ui/e2e/instant-navigation.spec.ts
+++ b/ui/e2e/instant-navigation.spec.ts
@@ -30,8 +30,10 @@ test.describe("navigation instantanée — fiches offre et formation", () => {
     await page.goto("/recherche-emploi?romes=M1602")
     const offerLink = page.locator("a[href^='/emploi/']").first()
     await expect(offerLink).toBeVisible()
-    // Laisse le temps au prefetch client de compléter avant d'entrer en mode instant().
-    await page.waitForTimeout(1000)
+    // Attente déterministe (plutôt qu'un délai fixe) : le survol déclenche/confirme le prefetch
+    // du lien, puis on attend la fin des requêtes réseau associées avant d'entrer en mode instant().
+    await offerLink.hover()
+    await page.waitForLoadState("networkidle")
 
     await instant(page, async () => {
       await offerLink.click()
@@ -43,7 +45,8 @@ test.describe("navigation instantanée — fiches offre et formation", () => {
     await page.goto("/recherche-formation?romes=M1602")
     const formationLink = page.locator("a[href^='/formation/']").first()
     await expect(formationLink).toBeVisible()
-    await page.waitForTimeout(1000)
+    await formationLink.hover()
+    await page.waitForLoadState("networkidle")
 
     await instant(page, async () => {
       await formationLink.click()

--- a/ui/e2e/instant-navigation.spec.ts
+++ b/ui/e2e/instant-navigation.spec.ts
@@ -1,0 +1,69 @@
+import { instant } from "@next/playwright"
+import { expect, test } from "@playwright/test"
+
+// Pilote Cache Components : ces tests verrouillent le gain obtenu sur 4 routes
+// (accueil, fiche offre, fiche formation, dashboard entreprise) contre toute régression future.
+// Voir le plan de migration pour le détail de chaque conversion.
+
+test.describe("navigation instantanée — accueil", () => {
+  test("naviguer vers l'accueil depuis une autre page affiche le header sans attendre la session", async ({ page }) => {
+    // Page d'origine sans dépendance backend (pas d'appel API, juste du contenu statique + un simulateur client).
+    await page.goto("/salaire-alternant")
+
+    await instant(page, async () => {
+      await page.getByRole("link", { name: "Accueil - La bonne alternance" }).click()
+
+      // Contenu statique du layout (home), présent que la session soit résolue ou non.
+      await expect(page.getByRole("link", { name: "Accueil - La bonne alternance" })).toBeVisible()
+    })
+  })
+})
+
+test.describe("navigation instantanée — fiches offre et formation", () => {
+  // `use cache: private` (voir plan de migration, Étape 3bis) ne survit qu'en mémoire navigateur :
+  // il rend les navigations CLIENT (clic + prefetch) instantanées, mais pas un rechargement complet
+  // (MPA/reload), qui repart toujours d'un cache vide. Le test doit donc simuler un vrai clic depuis
+  // une page de résultats, pas un `page.reload()`.
+  // romes=M1602 (développement informatique) renvoie des résultats stables dans la base de dev locale.
+
+  test("cliquer sur un résultat de recherche vers une fiche offre est instantané", async ({ page }) => {
+    await page.goto("/recherche-emploi?romes=M1602")
+    const offerLink = page.locator("a[href^='/emploi/']").first()
+    await expect(offerLink).toBeVisible()
+    // Laisse le temps au prefetch client de compléter avant d'entrer en mode instant().
+    await page.waitForTimeout(1000)
+
+    await instant(page, async () => {
+      await offerLink.click()
+      await expect(page.locator("main")).toBeVisible()
+    })
+  })
+
+  test("cliquer sur un résultat de recherche vers une fiche formation est instantané", async ({ page }) => {
+    await page.goto("/recherche-formation?romes=M1602")
+    const formationLink = page.locator("a[href^='/formation/']").first()
+    await expect(formationLink).toBeVisible()
+    await page.waitForTimeout(1000)
+
+    await instant(page, async () => {
+      await formationLink.click()
+      await expect(page.locator("main")).toBeVisible()
+    })
+  })
+})
+
+test.describe("navigation instantanée — dashboard entreprise", () => {
+  test.skip(
+    true,
+    "Nécessite une session authentifiée réelle (cookie lba_session validé par le backend via ui/proxy.ts) — " +
+      "pas de fixture de login e2e disponible dans ce dépôt à ce jour. À activer une fois un helper de connexion e2e écrit."
+  )
+
+  test("naviguer vers le dashboard entreprise affiche le header connecté sans attendre la session", async ({ page }) => {
+    await page.goto("/espace-pro/entreprise")
+    await instant(page, async () => {
+      await page.reload()
+      await expect(page.getByRole("main")).toBeVisible()
+    })
+  })
+})

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -78,11 +78,14 @@ const nextConfig = {
   bundlePagesRouterDependencies: true,
   serverExternalPackages: ["react-pdf"],
   poweredByHeader: false,
+  cacheComponents: true,
   experimental: {
     fallbackNodePolyfills: false,
     staleTimes: {
       static: 180,
     },
+    // Uniquement pour les tests Playwright instant() en local/CI, jamais en production réelle.
+    exposeTestingApiInProductionBuild: process.env.PLAYWRIGHT_TEST_MODE === "1",
   },
   output: "standalone",
   compress: false, // disable default gzip compression by nextJS, done by Nginx

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc -b",
     "analyse": "ANALYZE=true yarn build",
     "predev": "react-dsfr update-icons",
-    "prebuild": "react-dsfr update-icons"
+    "prebuild": "react-dsfr update-icons",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@codegouvfr/react-dsfr": "1.31.0",
@@ -62,6 +63,8 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "16.0.1",
+    "@next/playwright": "16.3.0",
+    "@playwright/test": "1.62.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@tsconfig/next": "^2.0.3",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3000",
+  },
+  webServer: {
+    command: "yarn build && yarn start",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    env: { PLAYWRIGHT_TEST_MODE: "1" },
+    timeout: 180_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+})

--- a/ui/services/fetch-notion-page.ts
+++ b/ui/services/fetch-notion-page.ts
@@ -1,6 +1,12 @@
+import { cacheLife } from "next/cache"
 import { NotionAPI } from "notion-client"
 
 // https://github.com/NotionX/react-notion-x/issues/710
 const notion = new NotionAPI({ apiBaseUrl: "https://app.notion.com/api/v3" })
 
-export const fetchNotionPage = async (pageId: string) => await notion.getPage(pageId)
+export const fetchNotionPage = async (pageId: string) => {
+  "use cache"
+  cacheLife("days") // revalider toutes les 24h (API Notion rate-limitée)
+
+  return notion.getPage(pageId)
+}

--- a/ui/utils/get-session.ts
+++ b/ui/utils/get-session.ts
@@ -1,23 +1,19 @@
-import { isDynamicServerError } from "next/dist/client/components/hooks-server-context"
 import { headers } from "next/headers"
 import type { ComputedUserAccess, IUserRecruteurPublic } from "shared"
 
 export async function getSession(): Promise<{ user?: IUserRecruteurPublic | null; access?: ComputedUserAccess | null }> {
+  "use cache: private"
+
+  const headerStore = await headers()
+  const sessionRaw = headerStore.get("x-session")
+
+  if (!sessionRaw) {
+    return {}
+  }
+
   try {
-    const headerStore = await headers()
-    const sessionRaw = headerStore.get("x-session")
-
-    if (!sessionRaw) {
-      return {}
-    }
-
     return JSON.parse(sessionRaw)
-  } catch (error) {
-    // Useful for NextJS to detect dynamic routes
-    if (isDynamicServerError(error)) {
-      throw error
-    }
-
+  } catch {
     return {}
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3398,6 +3398,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/playwright@npm:16.3.0":
+  version: 16.3.0
+  resolution: "@next/playwright@npm:16.3.0"
+  peerDependencies:
+    "@playwright/test": ">=1.0.0"
+  peerDependenciesMeta:
+    "@playwright/test":
+      optional: true
+  checksum: 59f83835d96f62228d9594f6f37e37b798d9d2b165a27a63f360c48b4f19e00e6be330455c1c896994edef37d95ab74c9fa455365d4a52fbaa83c6e1e9563541
+  languageName: node
+  linkType: hard
+
 "@next/swc-darwin-arm64@npm:16.3.0":
   version: 16.3.0
   resolution: "@next/swc-darwin-arm64@npm:16.3.0"
@@ -4942,6 +4954,17 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 6ad6a00fc4f2f2cfc6bff76fb1d88b8ee20bc0601e18ebb01b6d4be583733a860239a521a7fbca73b612e66705078809483549d2b18f370eb346c5155c8e4a0f
+  languageName: node
+  linkType: hard
+
+"@playwright/test@npm:1.62.1":
+  version: 1.62.1
+  resolution: "@playwright/test@npm:1.62.1"
+  dependencies:
+    playwright: 1.62.1
+  bin:
+    playwright: cli.js
+  checksum: 168f3c0436aa6ddfdfca955ce7b329c42fddef27b1f8898d09c7af34e51f54739bc421f24058e9a851d9d9b26f68d2dec87cc9564826d15539f3b572c1ed9aea
   languageName: node
   linkType: hard
 
@@ -10759,12 +10782,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: latest
+  checksum: 97ade64e75091afee5265e6956cb72ba34db7819b4c3e94c431d4be2b19b8bb7a2d4116da417950c3425f17c8fe693d25e20212cac583ac1521ad066b77ae31f
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: latest
   checksum: 11e6ea6fea15e42461fc55b4b0e4a0a3c654faa567f1877dbd353f39156f69def97a69936d1746619d656c4b93de2238bf731f6085a03a50cabf287c9d024317
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@2.3.2#~builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: latest
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -15902,6 +15944,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.62.1":
+  version: 1.62.1
+  resolution: "playwright-core@npm:1.62.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 270674de6b921dd09e00d01e9a725117d03097f0e540ed681fb70d183d2f7855188640b0d7de1b9c0f8a2fb334eb33dedf1f34eeed86792fe88dc14633b06121
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.62.1":
+  version: 1.62.1
+  resolution: "playwright@npm:1.62.1"
+  dependencies:
+    fsevents: 2.3.2
+    playwright-core: 1.62.1
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 1e18e684d97b3d42ac6c80defe676c4c6c85d96394b690407f75b7a9007d8d44d774c9e9c40957a7319ff70a4d4dad103d6362415b81055256b823abe89abdca
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -19128,6 +19194,8 @@ __metadata:
     "@mui/material-nextjs": ^7.3.7
     "@mui/x-data-grid": ^8.17.0
     "@next/bundle-analyzer": 16.0.1
+    "@next/playwright": 16.3.0
+    "@playwright/test": 1.62.1
     "@sentry/browser": ^10.23.0
     "@sentry/cli": ^2.57.0
     "@sentry/nextjs": ^10.23.0


### PR DESCRIPTION
Closes #5114

## Changements

- Active `cacheComponents: true` (Next 16.3) + codemod officiel `instant = false` sur tout l'app pour ne rien casser.
- Migre les configs de segment existantes incompatibles (`force-dynamic`, `revalidate`) vers `use cache`/`cacheLife`.
- Convertit en profondeur 4 routes pilotes : accueil, dashboard entreprise, fiche offre, fiche formation.
  - `get-session.ts` passe en `use cache: private`, la lecture de session est poussée sous `Suspense` au lieu de bloquer les layouts.
  - Les fiches offre/formation cachent leurs données en `use cache: private` (`apiGet` lit toujours `headers()` en interne, incompatible avec un `use cache` classique).
  - Retrait du `force-dynamic` sur la fiche offre (contournement d'un bug de streaming SSR qui ne se reproduit plus).
- Réactive le prefetch sur les cartes de résultats de recherche (`LbaItemCard`, `SearchHitCard`).
- Ajoute Playwright + tests `instant()` sur les 3 routes vérifiables sans infra d'auth.

## Plan de test

- [x] `yarn typecheck` et `yarn build` propres
- [x] 3 tests Playwright `instant()` (accueil, fiche offre, fiche formation) passent en conditions réelles (backend + données réelles)
- [x] Vérification manuelle navigateur : fiche offre/formation avec vraies données, retrait du `force-dynamic` sans régression du bug de streaming SSR d'origine
- [ ] Dashboard entreprise : non vérifiable en l'état, aucun compte recruteur/entreprise seedé en base de dev locale