### PR TITLE
feat: étend Cache Components au lot mécanique restant (#5116)

### DIFF
--- a/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
+++ b/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box } from "@mui/material"
 import type { Metadata } from "next"
+import { cacheLife } from "next/cache"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import type { ISeoDiplome } from "shared/models/seo-diplome.model"
@@ -25,6 +26,7 @@ async function getDiplomeData(slug: string) {
   // `apiGet` lit toujours `headers()` en interne (transmission du cookie de session),
   // incompatible avec un `"use cache"` classique — seul `"use cache: private"` l'autorise.
   "use cache: private"
+  cacheLife("hours")
   return await apiGet("/_private/seo/diplome/:diplome", { params: { diplome: slug } })
 }
 

--- a/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
+++ b/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box } from "@mui/material"
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
+import { Suspense } from "react"
 import type { ISeoDiplome } from "shared/models/seo-diplome.model"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
@@ -20,12 +21,11 @@ import { PreparationSection } from "./_components/PreparationSection"
 import { ProgrammeDiplome } from "./_components/ProgrammeDiplome"
 import { SalaireSection } from "./_components/SalaireSection"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
-function getDiplomeData(slug: string) {
-  return apiGet("/_private/seo/diplome/:diplome", { params: { diplome: slug } })
+async function getDiplomeData(slug: string) {
+  // `apiGet` lit toujours `headers()` en interne (transmission du cookie de session),
+  // incompatible avec un `"use cache"` classique — seul `"use cache: private"` l'autorise.
+  "use cache: private"
+  return await apiGet("/_private/seo/diplome/:diplome", { params: { diplome: slug } })
 }
 
 export function generateStaticParams() {
@@ -43,7 +43,15 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   }
 }
 
-export default async function DiplomePage({ params }: { params: Promise<{ slug: string }> }) {
+export default function DiplomePage({ params }: { params: Promise<{ slug: string }> }) {
+  return (
+    <Suspense fallback={null}>
+      <DiplomeContent params={params} />
+    </Suspense>
+  )
+}
+
+async function DiplomeContent({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
   const rawData = await getDiplomeData(slug)
 

--- a/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
+++ b/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
@@ -1,6 +1,7 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import Button from "@codegouvfr/react-dsfr/Button"
 import { Box, Typography } from "@mui/material"
+import { cacheLife } from "next/cache"
 import Image from "next/image"
 import Link from "next/link"
 import { redirect } from "next/navigation"
@@ -60,6 +61,7 @@ async function fetchMetierData(metier: string) {
   // `apiGet` lit toujours `headers()` en interne (transmission du cookie de session),
   // incompatible avec un `"use cache"` classique — seul `"use cache: private"` l'autorise.
   "use cache: private"
+  cacheLife("hours")
   return apiGet("/_private/seo/metier/:metier", { params: { metier } })
 }
 
@@ -91,8 +93,11 @@ export async function generateMetadata({ params }: { params: Promise<{ metier: s
     .map((e) => e.nom)
     .join(", ")
 
-  const firstFormation = (data.formations as { title: string }[]).pop() ?? { title: "" }
-  const lastFormation = (data.formations as { title: string }[]).shift() ?? { title: "" }
+  const formationsForMetadata = data.formations as { title: string }[]
+  // .at() non-mutatif : data.formations est réutilisé plus bas dans le rendu de page
+  // (et peut provenir du même objet mis en cache par use cache: private).
+  const firstFormation = formationsForMetadata.at(-1) ?? { title: "" }
+  const lastFormation = formationsForMetadata.at(0) ?? { title: "" }
 
   return {
     title: `Alternance en ${data.metier} : ${jobCount} Offres, ${data.salaire.salaire_brut_moyen}€/mois | La bonne alternance`,

--- a/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
+++ b/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
@@ -4,6 +4,7 @@ import { Box, Typography } from "@mui/material"
 import Image from "next/image"
 import Link from "next/link"
 import { redirect } from "next/navigation"
+import { Suspense } from "react"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import CarteOffre from "@/app/(editorial)/alternance/_components/CarteOffre"
@@ -15,10 +16,6 @@ import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
 import { apiGet } from "@/utils/api.utils"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
 
 const UTM_PARAMS = "utm_source=lba&utm_medium=website&utm_campaign=lba_seo-prog-metiers"
 
@@ -60,6 +57,9 @@ const threeColGridSx = {
 }
 
 async function fetchMetierData(metier: string) {
+  // `apiGet` lit toujours `headers()` en interne (transmission du cookie de session),
+  // incompatible avec un `"use cache"` classique — seul `"use cache: private"` l'autorise.
+  "use cache: private"
   return apiGet("/_private/seo/metier/:metier", { params: { metier } })
 }
 
@@ -100,7 +100,15 @@ export async function generateMetadata({ params }: { params: Promise<{ metier: s
   }
 }
 
-export default async function Metier({ params }: { params: Promise<{ metier: string }> }) {
+export default function Metier({ params }: { params: Promise<{ metier: string }> }) {
+  return (
+    <Suspense fallback={null}>
+      <MetierContent params={params} />
+    </Suspense>
+  )
+}
+
+async function MetierContent({ params }: { params: Promise<{ metier: string }> }) {
   const { metier } = await params
   const data = await fetchMetierData(metier)
 

--- a/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
+++ b/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
@@ -1,5 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Typography } from "@mui/material"
+import { cacheLife } from "next/cache"
 import Image from "next/image"
 import { redirect } from "next/navigation"
 import { Suspense } from "react"
@@ -20,6 +21,7 @@ async function getVilleData(ville: string) {
   // `apiGet` lit toujours `headers()` en interne (transmission du cookie de session),
   // incompatible avec un `"use cache"` classique — seul `"use cache: private"` l'autorise.
   "use cache: private"
+  cacheLife("hours")
   return await apiGet("/_private/seo/ville/:ville", { params: { ville } })
 }
 

--- a/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
+++ b/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
@@ -2,6 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Typography } from "@mui/material"
 import Image from "next/image"
 import { redirect } from "next/navigation"
+import { Suspense } from "react"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import CarteOffre from "@/app/(editorial)/alternance/_components/CarteOffre"
@@ -15,13 +16,16 @@ import { ArrowRightLine } from "@/theme/components/icons"
 import { apiGet } from "@/utils/api.utils"
 import { PAGES } from "@/utils/routes.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
+async function getVilleData(ville: string) {
+  // `apiGet` lit toujours `headers()` en interne (transmission du cookie de session),
+  // incompatible avec un `"use cache"` classique — seul `"use cache: private"` l'autorise.
+  "use cache: private"
+  return await apiGet("/_private/seo/ville/:ville", { params: { ville } })
+}
 
 export async function generateMetadata({ params }: { params: Promise<{ ville: string }> }) {
   const { ville } = await params
-  const data = await apiGet("/_private/seo/ville/:ville", { params: { ville } })
+  const data = await getVilleData(ville)
 
   if (!data) {
     return {
@@ -39,9 +43,17 @@ export async function generateMetadata({ params }: { params: Promise<{ ville: st
   }
 }
 
-export default async function Ville({ params }: { params: Promise<{ ville: string }> }) {
+export default function Ville({ params }: { params: Promise<{ ville: string }> }) {
+  return (
+    <Suspense fallback={null}>
+      <VilleContent params={params} />
+    </Suspense>
+  )
+}
+
+async function VilleContent({ params }: { params: Promise<{ ville: string }> }) {
   const { ville } = await params
-  const data = await apiGet("/_private/seo/ville/:ville", { params: { ville } })
+  const data = await getVilleData(ville)
 
   const utmParams = "utm_source=lba&utm_medium=website&utm_campaign=lba_seo-prog-villes"
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/layout.tsx
@@ -3,11 +3,6 @@ import { Container } from "@mui/material"
 import type { PropsWithChildren } from "react"
 
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <Container maxWidth="xl" sx={{ marginTop: fr.spacing("4v") }}>

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/page.tsx
@@ -3,11 +3,6 @@ import { ADMIN } from "shared/constants/recruteur"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.dynamic.compte({ userType: ADMIN }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import GestionDesAdministrateurs from "./gestionDesAdministrateurs"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.backAdminGestionDesAdministrateurs.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/user/[userId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/user/[userId]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import EditAdministrateur from "./editAdministrateur"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ userId: string }> }): Promise<Metadata> {
   const { userId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-entreprises/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-entreprises/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import GestionEntreprises from "./gestionEntreprises"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.backAdminGestionDesEntreprises.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/layout.tsx
@@ -1,11 +1,6 @@
 import type { PropsWithChildren } from "react"
 
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function Layout({ children }: PropsWithChildren) {
   return <DefaultContainer>{children}</DefaultContainer>
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/[id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/[id]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurCronTaskPage from "./ProcesseurCronTaskPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ name: string; id: string }> }): Promise<Metadata> {
   const { name, id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurCronPage from "./ProcesseurCronPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ name: string }> }): Promise<Metadata> {
   const { name } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/[id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/[id]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurJobInstancePage from "./ProcesseurJobInstancePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ name: string; id: string }> }): Promise<Metadata> {
   const { name, id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurJobPage from "./ProcesseurJobPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ name: string }> }): Promise<Metadata> {
   const { name } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/layout.tsx
@@ -1,9 +1,4 @@
 import type { PropsWithChildren } from "react"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default function AccueilAdministration({ children }: PropsWithChildren) {
   return <>{children}</>
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import ProcesseurPage from "./ProcesseurPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.adminProcessor.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/recruteurs/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/recruteurs/page.tsx
@@ -2,11 +2,6 @@ import type { Metadata } from "next"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import { PAGES } from "@/utils/routes.utils"
 import { RecruteursList } from "./RecruteursList"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.backAdminGestionDesRecruteurs.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/[siret]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/[siret]/page.tsx
@@ -3,11 +3,6 @@ import LoadingEmptySpace from "@/app/(espace-pro)/_components/LoadingEmptySpace"
 import { getEligibleTrainingsForAppointments, getEtablissement } from "@/utils/api"
 import { PAGES } from "@/utils/routes.utils"
 import RendezVousApprentissageDetailRendererClient from "./RendezVousApprentissageDetailRendererClient"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ siret: string }> }): Promise<Metadata> {
   const { siret } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import RendezVousApprentissagePage from "./RendezVousApprentissagePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.rendezVousApprentissageRecherche.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/cfa/[establishment_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/cfa/[establishment_id]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import AdminUserCfaEntreprisePage from "./AdminUserCfaEntreprisePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: { userId: string; establishment_id: string } }): Promise<Metadata> {
   const { userId, establishment_id } = params
   return { title: PAGES.dynamic.backAdminUserCfaEntreprise({ user_id: userId, establishment_id }).getMetadata().title }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/layout.tsx
@@ -1,11 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Container } from "@mui/material"
 import type { PropsWithChildren } from "react"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default function Layout({ children }: PropsWithChildren) {
   return (
     <Container

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/page.tsx
@@ -2,11 +2,6 @@ import type { Metadata } from "next"
 import { ADMIN } from "shared/constants/recruteur"
 import { PAGES } from "@/utils/routes.utils"
 import AdminOffrePage from "./AdminOffrePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ job_id: string; establishment_id: string; userId: string }> }): Promise<Metadata> {
   const { job_id, establishment_id, userId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import User from "./User"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ userId: string }> }): Promise<Metadata> {
   const { userId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/page.tsx
@@ -2,11 +2,6 @@ import type { Metadata } from "next"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import { PAGES } from "@/utils/routes.utils"
 import { UsersList } from "./UsersList"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.backAdminHome.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/carte-d-etudiant-des-metiers/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/carte-d-etudiant-des-metiers/page.tsx
@@ -7,11 +7,6 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { DsfrIcon } from "@/components/DsfrIcon"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = PAGES.static.espaceProCfaCarteDEtudiantDesMetiers.getMetadata()
 
 const CarteDEtudiantDesMetiersPage = () => (

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/compte/page.tsx
@@ -3,11 +3,6 @@ import { CFA } from "shared/constants/recruteur"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.dynamic.compte({ userType: CFA }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/[siret]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/[siret]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CreationEntrepriseDetailPage from "./CreationEntrepriseDetailPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ siret: string }> }): Promise<Metadata> {
   const { siret } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CreationEntreprisePage from "./CreationEntreprisePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.backCfaCreationEntreprise.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/creation-offre/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/creation-offre/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CfaCreationOffrePage from "./CfaCreationOffrePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string }> }): Promise<Metadata> {
   const { establishment_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/offre/[jobId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/offre/[jobId]/page.tsx
@@ -2,11 +2,6 @@ import type { Metadata } from "next"
 import { CFA } from "shared/constants/recruteur"
 import { PAGES } from "@/utils/routes.utils"
 import CfaOffrePage from "./CfaOffrePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string; jobId: string }> }): Promise<Metadata> {
   const { establishment_id, jobId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CfaEntreprisePage from "./CfaEntreprisePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string }> }): Promise<Metadata> {
   const { establishment_id } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/layout.tsx
@@ -3,11 +3,6 @@ import { Container } from "@mui/material"
 import type { PropsWithChildren } from "react"
 
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <Container maxWidth="xl" sx={{ marginTop: fr.spacing("4v") }}>

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import CfaHome from "@/app/(espace-pro)/espace-pro/(connected)/_components/CfaHome"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.backCfaHome.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/compte/page.tsx
@@ -3,11 +3,6 @@ import { ENTREPRISE } from "shared/constants/recruteur"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.dynamic.compte({ userType: ENTREPRISE }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/layout.tsx
@@ -4,11 +4,6 @@ import type { PropsWithChildren } from "react"
 
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 import InfoBanner from "@/components/InfoBanner/InfoBanner"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default function Layout({ children }: PropsWithChildren) {
   return (
     <Container

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/compte/page.tsx
@@ -3,11 +3,6 @@ import { OPCO } from "shared/constants/recruteur"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.dynamic.compte({ userType: OPCO }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/layout.tsx
@@ -3,11 +3,6 @@ import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <Box

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import OpcoPage from "./OpcoPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.backOpcoHome.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/layout.tsx
@@ -1,11 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Container } from "@mui/material"
 import type { PropsWithChildren } from "react"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default function Layout({ children }: PropsWithChildren) {
   return (
     <Container

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/page.tsx
@@ -2,11 +2,6 @@ import type { Metadata } from "next"
 import { OPCO } from "shared/constants/recruteur"
 import { PAGES } from "@/utils/routes.utils"
 import OpcoOffrePage from "./OpcoOffrePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ jobId: string; establishment_id: string; userId: string }> }): Promise<Metadata> {
   const { jobId, establishment_id, userId } = await params
   return {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import User from "./User"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export async function generateMetadata({ params }: { params: Promise<{ userId: string }> }): Promise<Metadata> {
   const { userId } = await params
   return {


### PR DESCRIPTION
Closes #5116

Traite la Phase 1 (lot mécanique, faible risque) de #5116 — les formulaires multi-étapes (Phase 2) restent en `instant = false`, à traiter dans un ticket séparé après audit des Dialog/Modal.

## Changements

- 3 pages éditoriales dynamiques (`alternance/ville/[ville]`, `alternance/diplome/[slug]`, `alternance/metier/[metier]`) : même pattern que les fiches offre/formation (`apiGet` incompatible avec `use cache` classique -> `use cache: private`). Ces pages sont entièrement pilotées par la donnée, tout le contenu est poussé sous un seul `Suspense`.
- Reste de `espace-pro/(connected)` (administration, cfa, opco — 37 fichiers) : simple retrait de `instant = false`, aucune erreur de build. Ces pages consomment la session via le contexte client (`useConnectedSessionClient`), déjà couvert par le `Suspense` du layout `(connected)`.

83 → 41 routes restantes en `instant = false` (le reste = Phase 2, formulaires multi-étapes).

## Plan de test

- [x] `yarn typecheck` et `yarn build` propres
- [x] Vérification manuelle : route admin protégée redirige proprement (307 -> authentification) sans crash
- [ ] Pas de vérification en conditions réelles avec session authentifiée (même limite que #5115, pas de compte recruteur seedé en local)