### PR TITLE
feat(lba-5116): termine l'adoption de Cache Components sur les routes restantes

### DIFF
--- a/ui/app/(1jeune1solution)/1jeune1solution/page.tsx
+++ b/ui/app/(1jeune1solution)/1jeune1solution/page.tsx
@@ -7,10 +7,6 @@ import { HomeRechercheForm } from "@/app/(home)/_components/HomeRechercheForm"
 import { TagCandidatureSpontanee } from "@/components/ItemDetail/TagCandidatureSpontanee"
 import { TagOffreEmploi } from "@/components/ItemDetail/TagOffreEmploi"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 const utmParams = "utm_source=lba&utm_medium=website&utm_campaign=landinglba1j1s"
 export default async function unJeune1Solution({ searchParams }: { searchParams: Promise<Record<string, string>> }) {
   const rechercheParams = parseRecherchePageParams(new URLSearchParams(await searchParams), IRechercheMode.DEFAULT)

--- a/ui/app/(1jeune1solution)/layout.tsx
+++ b/ui/app/(1jeune1solution)/layout.tsx
@@ -6,11 +6,6 @@ import type { PropsWithChildren } from "react"
 import { Footer } from "@/app/_components/Footer"
 import { DsfrHeaderProps1J1S } from "@/app/(1jeune1solution)/components/Header1J1S"
 import InfoBanner from "@/components/InfoBanner/InfoBanner"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function UnJeuneUneSolutionLayout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/(recherche)/layout.tsx
+++ b/ui/app/(candidat)/(recherche)/layout.tsx
@@ -4,11 +4,6 @@ import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { RechercheLayoutClient } from "./RechercheLayoutClient"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function RechercheLayout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/(recherche)/recherche-emploi/page.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche-emploi/page.tsx
@@ -4,10 +4,6 @@ import { RecherchePageComponentServer } from "@/app/(candidat)/(recherche)/reche
 import { IRechercheMode, parseRecherchePageParams, RechercheViewType } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { PAGES } from "@/utils/routes.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 type Props = {
   searchParams: Promise<Record<string, string>>
 }

--- a/ui/app/(candidat)/(recherche)/recherche-formation/page.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche-formation/page.tsx
@@ -4,10 +4,6 @@ import { RecherchePageComponentServer } from "@/app/(candidat)/(recherche)/reche
 import { IRechercheMode, parseRecherchePageParams, RechercheViewType } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { PAGES } from "@/utils/routes.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 type Props = {
   searchParams: Promise<Record<string, string>>
 }

--- a/ui/app/(candidat)/(recherche)/recherche/page.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/page.tsx
@@ -5,10 +5,6 @@ import { PAGES } from "@/utils/routes.utils"
 import { RecherchePageComponentServer } from "./_components/RecherchePageComponentServer"
 import { IRechercheMode, parseRecherchePageParams } from "./_utils/recherche.route.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 type Props = {
   searchParams: Promise<Record<string, string>>
 }

--- a/ui/app/(candidat)/detail-rendez-vous/[id]/layout.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/layout.tsx
@@ -4,11 +4,6 @@ import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
@@ -3,11 +3,6 @@ import { redirect } from "next/navigation"
 import { apiGet } from "@/utils/api.utils"
 import { PAGES } from "@/utils/routes.utils"
 import DetailRendezVousRendererClient from "./DetailRendezVousRendererClient"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.detailRendezVousApprentissage.getMetadata().title,
 }

--- a/ui/app/(candidat)/formulaire-intention/layout.tsx
+++ b/ui/app/(candidat)/formulaire-intention/layout.tsx
@@ -4,11 +4,6 @@ import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 import { Footer } from "@/app/_components/Footer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/formulaire-intention/page.tsx
+++ b/ui/app/(candidat)/formulaire-intention/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import FormulaireIntentionPage from "./FormulaireIntentionPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Formulaire d'intention de recrutement - La bonne alternance",
 }

--- a/ui/app/(candidat)/postuler/layout.tsx
+++ b/ui/app/(candidat)/postuler/layout.tsx
@@ -1,11 +1,6 @@
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 import { Footer } from "@/app/_components/Footer"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(candidat)/postuler/page.tsx
+++ b/ui/app/(candidat)/postuler/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import PostulerPage from "./PostulerPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.postuler.getMetadata().title,
 }

--- a/ui/app/(creation-compte-widget)/espace-pro/widget/[origin]/page.tsx
+++ b/ui/app/(creation-compte-widget)/espace-pro/widget/[origin]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - La bonne alternance",
 }

--- a/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/detail/page.tsx
+++ b/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/detail/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import DetailPage from "./DetailPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - Informations de compte - La bonne alternance",
 }

--- a/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/fin/page.tsx
+++ b/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/fin/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import FinPage from "./FinPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Fin de création d'offre - La bonne alternance",
 }

--- a/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/offre/page.tsx
+++ b/ui/app/(creation-compte-widget)/espace-pro/widget/entreprise/offre/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import { DepotSimplifieCreationOffre } from "@/app/(espace-pro-creation-compte)/_components/DepotSimplifieCreationOffre"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - Informations de l'offre - La bonne alternance",
 }

--- a/ui/app/(creation-compte-widget)/layout.tsx
+++ b/ui/app/(creation-compte-widget)/layout.tsx
@@ -1,11 +1,6 @@
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 import { DepotSimplifieLayout } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <DepotSimplifieLayout>

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/mise-en-relation/[establishment_id]/[job_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/mise-en-relation/[establishment_id]/[job_id]/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import MiseEnRelation from "@/app/(espace-pro)/_components/MiseEnRelation"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Mise en relation avec des organismes de formation - La bonne alternance",
 }

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/cancel/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/cancel/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import { OffreActionPage } from "@/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/OffreActionPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Annuler une offre - La bonne alternance",
 }

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/provided/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/provided/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import { OffreActionPage } from "@/app/(espace-pro)/espace-pro/(from-mail)/offre/[jobType]/[jobId]/OffreActionPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Confirmation de l'offre pourvue - La bonne alternance",
 }

--- a/ui/app/(espace-pro)/espace-pro/(from-mail)/proposition/formulaire/[idFormulaire]/offre/[jobId]/siret/[siretFormateur]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(from-mail)/proposition/formulaire/[idFormulaire]/offre/[jobId]/siret/[siretFormateur]/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import { PropositionOffreId } from "./PropositionOffreId"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Proposition d'offre - La bonne alternance",
 }

--- a/ui/app/(espace-pro)/espace-pro/authentification/confirmation/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/confirmation/page.tsx
@@ -3,11 +3,6 @@ import { Box, Link, Typography } from "@mui/material"
 import type { Metadata } from "next"
 import { publicConfig } from "@/config.public"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.dynamic.backCreateCFAConfirmation({ email: "" }).getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/authentification/en-attente/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/en-attente/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CompteEnAttente from "./CompteEnAttente"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.backCreateCFAEnAttente.getMetadata().title,
 }

--- a/ui/app/(espace-pro)/espace-pro/authentification/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import AuthentificationPage from "./AuthentificationPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.authentification.getMetadata().title,
   description: PAGES.static.authentification.getMetadata().description,

--- a/ui/app/(espace-pro)/espace-pro/authentification/validation/[id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/validation/[id]/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import ValidationPage from "./ValidationPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Validation de votre email - La bonne alternance",
 }

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/[origin]/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/[origin]/page.tsx
@@ -3,11 +3,6 @@ import { Suspense } from "react"
 import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.espaceProCreationCfa.getMetadata().title,
   description: PAGES.static.espaceProCreationCfa.getMetadata().description,

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/page.tsx
@@ -3,11 +3,6 @@ import { Suspense } from "react"
 import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.espaceProCreationCfa.getMetadata().title,
   description: PAGES.static.espaceProCreationCfa.getMetadata().description,

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/detail/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/detail/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import CreationDetail from "./CreationDetailPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - Informations de compte - La bonne alternance",
 }

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/[origin]/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/[origin]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next"
 import { PAGES } from "@/utils/routes.utils"
 import CreationWithOriginPage from "./CreationWithOriginPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.espaceProCreationEntreprise.getMetadata().title,
   description: PAGES.static.espaceProCreationEntreprise.getMetadata().description,

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/page.tsx
@@ -3,11 +3,6 @@ import { Suspense } from "react"
 import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.espaceProCreationEntreprise.getMetadata().title,
   description: PAGES.static.espaceProCreationEntreprise.getMetadata().description,

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/fin/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/fin/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import { DepotRapideFin } from "@/app/(espace-pro)/_components/DepotRapideFin"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Fin de création d'offre - La bonne alternance",
 }

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/offre/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/offre/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import { DepotSimplifieCreationOffre } from "@/app/(espace-pro-creation-compte)/_components/DepotSimplifieCreationOffre"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Formulaire de dépôt d'offre - Informations de l'offre - La bonne alternance",
 }

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/layout.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/layout.tsx
@@ -7,11 +7,6 @@ import { Footer } from "@/app/_components/Footer"
 import { DsfrHeaderProps } from "@/app/_components/Header"
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
 import { PAGES } from "@/utils/routes.utils"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function Layout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(espace-pro-impression)/espace-pro/offre/impression/[jobId]/page.tsx
+++ b/ui/app/(espace-pro-impression)/espace-pro/offre/impression/[jobId]/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import ImpressionPage from "./ImpressionPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Impression d'offre - La bonne alternance",
 }

--- a/ui/app/(landing-pages)/salaire-alternant/page.tsx
+++ b/ui/app/(landing-pages)/salaire-alternant/page.tsx
@@ -3,11 +3,6 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { PAGES } from "@/utils/routes.utils"
 import { SimulateurRemuneration } from "./_components/SimulateurRemuneration"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: PAGES.static.salaireAlternant.getMetadata().title,
   description: PAGES.static.salaireAlternant.getMetadata().description,

--- a/ui/app/(rdva)/layout.tsx
+++ b/ui/app/(rdva)/layout.tsx
@@ -4,11 +4,6 @@ import { Footer } from "@/app/_components/Footer"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { PublicHeader } from "@/app/_components/PublicHeader"
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export default async function HomeLayout({ children }: PropsWithChildren) {
   return (
     <>

--- a/ui/app/(rdva)/optout/unsubscribe/[id]/page.tsx
+++ b/ui/app/(rdva)/optout/unsubscribe/[id]/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import OptoutUnsubscribePage from "./OptoutUnsubscribePage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Désinscription du service Rendez-vous Apprentissage - La bonne alternance",
 }

--- a/ui/app/(rdva)/premium/[id]/page.tsx
+++ b/ui/app/(rdva)/premium/[id]/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import PremiumParcoursupPage from "./PremiumParcoursupPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Activation du service Rendez-vous Apprentissage sur Parcoursup - La bonne alternance",
 }

--- a/ui/app/(rdva)/premium/affelnet/[id]/page.tsx
+++ b/ui/app/(rdva)/premium/affelnet/[id]/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from "next"
 import PremiumAffelnetPage from "./PremiumAffelnetPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Activation du service Rendez-vous Apprentissage sur Choisir son affectation après la 3ème - La bonne alternance",
 }

--- a/ui/app/(rdva)/rdva/page.tsx
+++ b/ui/app/(rdva)/rdva/page.tsx
@@ -3,11 +3,6 @@ import type { Metadata } from "next"
 import { getPrdvContext } from "@/utils/api"
 
 import RdvaPage from "./RdvaPage"
-
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 export const metadata: Metadata = {
   title: "Contacter un centre de formation - La bonne alternance",
 }

--- a/ui/app/beta/recherche/page.tsx
+++ b/ui/app/beta/recherche/page.tsx
@@ -3,10 +3,6 @@ import { Suspense } from "react"
 import { SearchPageClient } from "../_components/SearchPageClient"
 import { buildSearchPageTitle, parseSearchPageParams } from "../_utils/search.params.utils"
 
-// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false
-
 type Props = {
   searchParams: Promise<Record<string, string>>
 }


### PR DESCRIPTION
Closes #5116

## Changes

Termine la Phase 2 de #5116 (Phase 1 déjà fusionnée via #5117) : formulaires candidat, wizards de création de compte, rdva, espace-pro from-mail/authentification.

- Retrait de `instant = false` sur les 41 derniers fichiers du dépôt encore en opt-out.
- Aucun changement de code au-delà du retrait de l'opt-out : les 41 fichiers compilent sans erreur, aucune donnée bloquante hors Suspense détectée.
- Audit préalable des `Dialog`/`Modal` (risque de préservation d'état `<Activity>` identifié dans #5116) : un seul fichier sur tout le périmètre en utilise un (`RechercheElligibleHandicapCheckbox`, une infobulle autonome sans lien avec la navigation) — risque bien plus faible qu'anticipé initialement.

Plus aucune route de l'app n'est en `instant = false`.

## Testing

- [x] `yarn typecheck` et `yarn build` propres (0 erreur sur les 41 fichiers)
- [x] Vérification manuelle : wizard de création de compte entreprise (`espace-pro/creation/entreprise`) fonctionne
- [x] Vérification manuelle : page `postuler` gère proprement une URL de test incomplète (message de validation, pas de crash)
- [ ] Pas de test de bout en bout sur les wizards multi-étapes complets (SIRET réel, session recruteur) — même limite d'infra que les PRs précédentes