### PR TITLE
feat(lba-5119): active Partial Prefetching (Next 16.3)

### DIFF
--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -79,6 +79,7 @@ const nextConfig = {
   serverExternalPackages: ["react-pdf"],
   poweredByHeader: false,
   cacheComponents: true,
+  partialPrefetching: true,
   experimental: {
     fallbackNodePolyfills: false,
     staleTimes: {


### PR DESCRIPTION
Closes #5119

## Changes

Suite du chantier Cache Components (#5116) : active Partial Prefetching, qui fait précharger l'App Shell (partie statique/cachée) de chaque `<Link>` plutôt que l'ancien rendu complet caché.

- `partialPrefetching: true` ajouté dans `ui/next.config.mjs`, aux côtés de `cacheComponents: true`.
- Bénéficie directement des 6 routes déjà converties en `use cache`/`use cache: private` (accueil, dashboard entreprise, fiches offre/formation, ville/métier/diplôme).
- Périmètre volontairement limité : pas d'audit des `<Link prefetch={true}>` du reste du repo — l'App Shell des routes non converties reste quasi vide tant qu'aucun `use cache` n'y est ajouté, ce n'est pas une régression, juste un gain différé.

## Testing

- [x] `yarn typecheck` et `yarn build` propres
- [x] Les 3 tests Playwright `instant()` existants passent toujours
- [x] Vérification manuelle : `diplome/[slug]` (seule route avec `generateStaticParams`) — pas de nouvel insight `URL data outside of Suspense`, comportement 404 correct pour un slug sans donnée backend