### PR TITLE
fix(lba-5121): corrige les états figés après navigation retour (Activity)

### DIFF
--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabs.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabs.tsx
@@ -5,7 +5,7 @@ import { Box, Typography } from "@mui/material"
 import { useQueryClient } from "@tanstack/react-query"
 import dayjs from "dayjs"
 import Image from "next/image"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import type { IJobJson, IRecruiterJson, JOB_START_TYPE } from "shared"
 import { JOB_STATUS } from "shared"
 import { RECRUITER_STATUS } from "shared/constants/index"
@@ -86,6 +86,14 @@ export const OffresTabs = ({
   const searchParams = new URLSearchParams(window.location.search)
   const jobId = searchParams.get("jobId")
   const [currentOfferId, setCurrentOfferId] = useState<string>(jobId ?? null)
+
+  // <Activity> garde ce tableau de bord monté au retour arrière (ex : créer une offre →
+  // redirection ici avec ?jobId=A → retour → créer une autre offre → redirection ici avec
+  // ?jobId=B, même URL de dashboard) — sans resync, l'onglet reste sur A alors que l'URL
+  // pointe déjà vers B.
+  useEffect(() => {
+    setCurrentOfferId(jobId ?? null)
+  }, [jobId])
 
   const currentOffre = jobs.find((job) => job._id === currentOfferId)
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabs.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/_components/OffresTabs.tsx
@@ -85,7 +85,7 @@ export const OffresTabs = ({
   const jobs: LocalJob[] = recruiter?.jobs ?? []
   const searchParams = new URLSearchParams(window.location.search)
   const jobId = searchParams.get("jobId")
-  const [currentOfferId, setCurrentOfferId] = useState<string>(jobId ?? null)
+  const [currentOfferId, setCurrentOfferId] = useState<string | null>(jobId ?? null)
 
   // <Activity> garde ce tableau de bord monté au retour arrière (ex : créer une offre →
   // redirection ici avec ?jobId=A → retour → créer une autre offre → redirection ici avec

--- a/ui/app/_components/FormComponents/AutocompleteAsync.tsx
+++ b/ui/app/_components/FormComponents/AutocompleteAsync.tsx
@@ -97,8 +97,17 @@ export function AutocompleteAsync<T>(props: AutocompleteAsyncProps<T>) {
   const [{ onBlur, value }, meta] = useField(props.id)
   const { setFieldValue } = useFormikContext()
 
-  const [query, setQuery] = useState(meta.initialValue ? getOptionLabel(meta.initialValue) : "")
+  const initialQueryLabel = meta.initialValue ? getOptionLabel(meta.initialValue) : ""
+  const [query, setQuery] = useState(initialQueryLabel)
   const debouncedQuery = useThrottle(query, 300)
+
+  // Formik enableReinitialize met à jour meta.initialValue quand initialValues change SANS
+  // démonter ce composant (formulaire de recherche : <Activity> garde l'instance montée au
+  // retour home ⇄ résultats) — sans resync, le champ reste affiché sur l'ancienne saisie
+  // alors que la valeur réellement appliquée (meta.value) est déjà à jour.
+  useEffect(() => {
+    setQuery(initialQueryLabel)
+  }, [initialQueryLabel])
 
   const enabled = isOpen && debouncedQuery.length > 0
 

--- a/ui/app/_components/RechercheForm/RechercheForm.tsx
+++ b/ui/app/_components/RechercheForm/RechercheForm.tsx
@@ -117,7 +117,22 @@ export function RechercheForm(props: {
   const initialValues: IRechercheForm = rechercheParamsToRechercheForm(rechercheParams)
 
   return (
-    <Formik<IRechercheForm> initialValues={initialValues} enableReinitialize validate={validate(zodSchema)} validateOnBlur={false} onSubmit={props.onSubmit}>
+    <Formik<IRechercheForm>
+      initialValues={initialValues}
+      enableReinitialize
+      validate={validate(zodSchema)}
+      validateOnBlur={false}
+      onSubmit={(values, { setSubmitting }) => {
+        // La « soumission » ne fait que déclencher une navigation client (router.push/replace),
+        // jamais réinitialisée par Formik ensuite : sur la home, rechercheParams est un littéral
+        // statique, donc enableReinitialize ne se redéclenche jamais après le 1er envoi. Sans ce
+        // reset, isSubmitting reste bloqué à true — invisible tant que le formulaire était démonté
+        // en quittant la page, mais <Activity> le garde monté au retour arrière : le bouton Rechercher
+        // reste alors désactivé indéfiniment.
+        props.onSubmit(values)
+        setSubmitting(false)
+      }}
+    >
       {(formik) => {
         return (
           <Box component={"form"} onSubmit={formik.handleSubmit}>

--- a/ui/app/_components/RechercheForm/RechercheForm.tsx
+++ b/ui/app/_components/RechercheForm/RechercheForm.tsx
@@ -129,8 +129,11 @@ export function RechercheForm(props: {
         // reset, isSubmitting reste bloqué à true — invisible tant que le formulaire était démonté
         // en quittant la page, mais <Activity> le garde monté au retour arrière : le bouton Rechercher
         // reste alors désactivé indéfiniment.
-        props.onSubmit(values)
-        setSubmitting(false)
+        try {
+          props.onSubmit(values)
+        } finally {
+          setSubmitting(false)
+        }
       }}
     >
       {(formik) => {

--- a/ui/app/beta/_components/SearchBar.tsx
+++ b/ui/app/beta/_components/SearchBar.tsx
@@ -191,6 +191,20 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
   // restauration au blur (le champ ne doit jamais afficher un texte ≠ critère actif).
   const [appliedLieuLabel, setAppliedLieuLabel] = useState(initialLieuLabel ?? "")
 
+  // Cache Components (<Activity>) garde l'instance de ce composant montée (masquée, pas
+  // démontée) d'une navigation à l'autre — sans ceci, revenir en arrière puis relancer une
+  // recherche depuis la home laisse le champ affiché sur l'ancienne saisie alors que l'URL
+  // et les résultats reflètent déjà la nouvelle (initialQ/initialLieuLabel ne sont relus
+  // qu'au montage via useState). Ne s'exécute que quand la prop change réellement — un
+  // onSubmit/onLieuChange local la fait déjà pointer vers la valeur déjà affichée.
+  useEffect(() => {
+    setInputValue(initialQ)
+  }, [initialQ])
+  useEffect(() => {
+    setLieuInput(initialLieuLabel ?? "")
+    setAppliedLieuLabel(initialLieuLabel ?? "")
+  }, [initialLieuLabel])
+
   const debouncedInput = useThrottle(inputValue, 300)
   const debouncedLieu = useThrottle(lieuInput, 300)
 


### PR DESCRIPTION
Closes #5121

## Changes

Avec `cacheComponents` actif, `<Activity>` garde les composants montés (masqués) au lieu de les démonter au retour arrière — plusieurs composants seedaient leur état local depuis une prop via `useState(prop)` sans jamais le resynchroniser, un défaut invisible tant que la navigation retour provoquait un remount complet.

- `SearchBar` (moteur beta) : `inputValue`/`lieuInput`/`appliedLieuLabel` resync sur changement de `initialQ`/`initialLieuLabel`.
- `AutocompleteAsync` (champs métier/lieu du moteur legacy `/recherche`, autocomplete SIRET) : `query` resync sur `meta.initialValue`.
- `OffresTabs` (dashboard espace-pro) : onglet d'offre resync sur `?jobId=`.
- `RechercheForm` : bug plus sévère découvert en vérifiant le correctif ci-dessus — sur la home, `isSubmitting` de Formik n'était jamais réinitialisé après soumission (`rechercheParams` y est un littéral statique, `enableReinitialize` ne se redéclenche donc jamais). Le bouton "Rechercher" de la home restait **définitivement désactivé** après une recherche suivie d'un retour arrière.

## Testing

- Repro manuelle en navigateur (moteurs beta et legacy) : recherche "Marketing" → résultats → retour arrière → recherche "developpeur" → champ et bouton corrects avant/après correctif sur les deux moteurs.
- `yarn typecheck` et `yarn check:fix` propres.