### PR TITLE
fix(lba-3801): renvoie un vrai 404 sur les pages introuvables (soft 404 → notFound)

### DIFF
--- a/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
-import { apiGet } from "@/utils/api.utils"
+import { ApiError, apiGet } from "@/utils/api.utils"
 import { PAGES } from "@/utils/routes.utils"
 import DetailRendezVousRendererClient from "./DetailRendezVousRendererClient"
 export const metadata: Metadata = {
@@ -20,7 +20,10 @@ export default async function DetailRendezVousPage({ params, searchParams }: { p
     })
 
     return <DetailRendezVousRendererClient appointmentId={id} appointment={appointmentRecap} token={token} />
-  } catch {
-    notFound()
+  } catch (err) {
+    if (err instanceof ApiError && err.isNotFoundError()) {
+      notFound()
+    }
+    throw err
   }
 }

--- a/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import { redirect } from "next/navigation"
+import { notFound } from "next/navigation"
 import { apiGet } from "@/utils/api.utils"
 import { PAGES } from "@/utils/routes.utils"
 import DetailRendezVousRendererClient from "./DetailRendezVousRendererClient"
@@ -21,6 +21,6 @@ export default async function DetailRendezVousPage({ params, searchParams }: { p
 
     return <DetailRendezVousRendererClient appointmentId={id} appointment={appointmentRecap} token={token} />
   } catch {
-    redirect("/404")
+    notFound()
   }
 }

--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
@@ -1,7 +1,7 @@
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import type { Metadata } from "next"
 import { cacheLife, cacheTag } from "next/cache"
-import { redirect } from "next/navigation"
+import { notFound } from "next/navigation"
 import type { ILbaItemLbaCompanyJson, /*ILbaItemLbaJobJson, */ ILbaItemPartnerJobJson } from "shared"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import { WidgetAwareHeader } from "@/app/_components/WidgetAwareHeader"
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
 export default async function JobOfferPage({ params, searchParams }: { params: Promise<{ type: LBA_ITEM_TYPE; id: string }>; searchParams: Promise<Record<string, string>> }) {
   const { type, id } = await params
   const job = await getOffreOption(type, id)
-  if (!job) redirect("/404")
+  if (!job) notFound()
 
   return (
     <>

--- a/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
+++ b/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
@@ -1,7 +1,7 @@
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import type { Metadata } from "next"
 import { cacheLife, cacheTag } from "next/cache"
-import { redirect } from "next/navigation"
+import { notFound } from "next/navigation"
 import { WidgetAwareHeader } from "@/app/_components/WidgetAwareHeader"
 import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { ApiError, apiGet } from "@/utils/api.utils"
@@ -42,7 +42,7 @@ export default async function FormationPage({ params, searchParams }: { params: 
   const { id } = await params
   const idParam = decodeURIComponent(id)
   const formation = await getFormationOption(idParam)
-  if (!formation) redirect("/404")
+  if (!formation) notFound()
 
   return (
     <>

--- a/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
+++ b/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
@@ -4,7 +4,7 @@ import { Box, Typography } from "@mui/material"
 import { cacheLife } from "next/cache"
 import Image from "next/image"
 import Link from "next/link"
-import { redirect } from "next/navigation"
+import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
@@ -118,7 +118,7 @@ async function MetierContent({ params }: { params: Promise<{ metier: string }> }
   const data = await fetchMetierData(metier)
 
   if (!data) {
-    redirect("/404")
+    notFound()
   }
 
   const romesParam = data.romes.join()

--- a/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
+++ b/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
@@ -2,7 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Typography } from "@mui/material"
 import { cacheLife } from "next/cache"
 import Image from "next/image"
-import { redirect } from "next/navigation"
+import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
@@ -60,7 +60,7 @@ async function VilleContent({ params }: { params: Promise<{ ville: string }> }) 
   const utmParams = "utm_source=lba&utm_medium=website&utm_campaign=lba_seo-prog-villes"
 
   if (!data) {
-    redirect("/404")
+    notFound()
   }
 
   const villePage = PAGES.dynamic.seoVille(ville, data.ville)

--- a/ui/app/(editorial)/metiers/[slug]/page.tsx
+++ b/ui/app/(editorial)/metiers/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Stack, Typography } from "@mui/material"
 import type { Metadata } from "next"
 import Link from "next/link"
-import { redirect } from "next/navigation"
+import { notFound } from "next/navigation"
 import path from "path"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
@@ -43,7 +43,7 @@ export default async function MetiersByJobId({ params }: { params: Promise<{ slu
   const relatedMetier = getMetierBySlug(metiers, slug)
 
   if (!relatedMetier) {
-    redirect("/404")
+    notFound()
   }
   return (
     <Box>


### PR DESCRIPTION
Closes #4571

## 🧭 En clair (non technique)

Quand une offre d'emploi expire (ou qu'une page métier/ville/formation/rendez-vous n'existe pas), le site renvoyait jusqu'ici une page « introuvable » **avec un code de succès (HTTP 200)**. Google appelle ça un **« soft 404 »** : pour lui, la page existe encore mais est vide — le pire scénario pour une page supprimée.

Conséquences côté SEO :
- Google continue de crawler ces URLs inutilement (gaspillage de budget de crawl) ;
- l'URL reste indexée bien plus longtemps ;
- le signal « cette page n'existe plus » n'est jamais envoyé clairement.

Cette PR fait renvoyer un **vrai 404** à ces pages, ce qui permet à Google de **désindexer rapidement** les offres expirées et de réallouer son crawl aux pages qui comptent. Le rapport GSC signalait **88 soft 404** de ce type.

## 🔧 Détail technique

Remplacement de `redirect("/404")` par `notFound()` (Next.js natif) sur les pages dynamiques concernées. `redirect("/404")` provoquait une redirection vers une route inexistante rendue en HTTP 200 ; `notFound()` renvoie un vrai **HTTP 404** et rend le `ui/app/not-found.tsx` déjà existant.

Fichiers modifiés (6) :
- `ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx` — offres expirées (cas cité dans l'issue)
- `ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx`
- `ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx`
- `ui/app/(editorial)/metiers/[slug]/page.tsx`
- `ui/app/(editorial)/alternance/metier/[metier]/page.tsx`
- `ui/app/(editorial)/alternance/ville/[ville]/page.tsx`

Pattern aligné sur l'existant (`alternance/diplome/[slug]/page.tsx` utilisait déjà `notFound()`).

## ✅ Vérifs
- `yarn typecheck` ✓
- `yarn biome check` ✓ (6 fichiers)
