### PR TITLE
chore: documente les principes d'architecture pour les agents et active la review Copilot dédiée

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 **La Bonne Alternance (LBA)** is a French government platform for finding apprenticeship training and job opportunities. It's a full-stack web application serving job seekers, employers, and training centers.
 
 **Repository Size**: ~93,000 lines of TypeScript/JavaScript code across 3 workspaces  
-**Tech Stack**: Node.js 26, Yarn, TypeScript 7, Next.js 16.3 (UI), Fastify (Server), MongoDB, Biome, Zod 4, Vitest  
+**Tech Stack**: Node.js (>=24, CI runs on 26), Yarn, TypeScript 7, Next.js 16.3 (UI), Fastify (Server), MongoDB, Biome, Zod 4, Vitest  
 **Architecture**: Monorepo with 3 workspaces: `server` (API), `ui` (Next.js frontend), `shared` (common code)
 
 ## Architecture Principles to Enforce
@@ -14,7 +14,7 @@ These apply when generating code **and** when reviewing it — flag violations e
 
 **Deep Modules**: a module should expose a simple interface that hides significant implementation complexity (Ousterhout, *A Philosophy of Software Design*). Avoid shallow modules — wrappers whose interface is nearly as complex as their implementation. When a service or component grows and mixes several responsibilities, extract a deep module with a narrow interface rather than splitting it into small interdependent files.
 
-**File naming**: kebab-case for all `.ts` files (services, hooks, utils, jobs, models); PascalCase unchanged for `.tsx` components. Not yet enforced by Biome (no naming rule in `biome.json`) — apply and flag in review regardless.
+**File naming**: kebab-case for all `.ts` files (services, hooks, utils, jobs, models); PascalCase unchanged for `.tsx` components, except Next.js App Router reserved filenames (`page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`, `not-found.tsx`, `template.tsx`, `default.tsx`), which keep Next's own lowercase convention. Not yet enforced by Biome (no naming rule in `biome.json`) — apply and flag in review regardless.
 
 **Next.js — Cache Components & Partial Prefetching**: `cacheComponents: true` and `partialPrefetching: true` are enabled globally in `ui/next.config.mjs`. For dynamic routes/fetches, use `"use cache: private"` with `cacheTag()` and `cacheLife({ revalidate })` — never `"use cache"` (plain) once `headers()`/session cookies are read, and never reintroduce `export const instant = false` (a completed migration flag). `<Activity>` pitfall: components stay mounted across back-navigation instead of remounting, so any state derived from an initial prop (`useState(initialProp)`) needs an explicit `useEffect(() => setState(prop), [prop])` to resync — check for this on every page/component with prop-derived initial state.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,8 +5,28 @@
 **La Bonne Alternance (LBA)** is a French government platform for finding apprenticeship training and job opportunities. It's a full-stack web application serving job seekers, employers, and training centers.
 
 **Repository Size**: ~93,000 lines of TypeScript/JavaScript code across 3 workspaces  
-**Tech Stack**: Node.js, Yarn, TypeScript, Next.js (UI), Fastify (Server), MongoDB, Vitest  
+**Tech Stack**: Node.js 26, Yarn, TypeScript 7, Next.js 16.3 (UI), Fastify (Server), MongoDB, Biome, Zod 4, Vitest  
 **Architecture**: Monorepo with 3 workspaces: `server` (API), `ui` (Next.js frontend), `shared` (common code)
+
+## Architecture Principles to Enforce
+
+These apply when generating code **and** when reviewing it — flag violations even where no lint/CI rule currently checks for them.
+
+**Deep Modules**: a module should expose a simple interface that hides significant implementation complexity (Ousterhout, *A Philosophy of Software Design*). Avoid shallow modules — wrappers whose interface is nearly as complex as their implementation. When a service or component grows and mixes several responsibilities, extract a deep module with a narrow interface rather than splitting it into small interdependent files.
+
+**File naming**: kebab-case for all `.ts` files (services, hooks, utils, jobs, models); PascalCase unchanged for `.tsx` components. Not yet enforced by Biome (no naming rule in `biome.json`) — apply and flag in review regardless.
+
+**Next.js — Cache Components & Partial Prefetching**: `cacheComponents: true` and `partialPrefetching: true` are enabled globally in `ui/next.config.mjs`. For dynamic routes/fetches, use `"use cache: private"` with `cacheTag()` and `cacheLife({ revalidate })` — never `"use cache"` (plain) once `headers()`/session cookies are read, and never reintroduce `export const instant = false` (a completed migration flag). `<Activity>` pitfall: components stay mounted across back-navigation instead of remounting, so any state derived from an initial prop (`useState(initialProp)`) needs an explicit `useEffect(() => setState(prop), [prop])` to resync — check for this on every page/component with prop-derived initial state.
+
+**Zod v4**: use top-level validators (`z.email()`, not `z.string().email()`); use `z.codec(input, output, { decode, encode })` instead of `.transform()` for two-way schemas; `AnyZodObject`/`ZodTypeAny` are gone, use `z.ZodObject<any>`/`z.ZodType`.
+
+## Autonomous Agent Files — Do Not Touch
+
+`ui/AGENTS.md` is auto-generated/re-added by `next dev` (see `node_modules/next/dist/server/lib/generate-agent-files.js`). Leave it alone — do not merge its content elsewhere or edit it.
+
+## PR Process
+
+PRs go through the `pull-request-lba` skill: dedicated branch, commit, PR opened with title `type(lba-XXX): subject` and `Closes #XXX` as the first line of the description, then automatic sync of the linked issue's status in the "La bonne alternance" GitHub Project.
 
 ## Critical Build & Test Requirements
 
@@ -148,7 +168,7 @@ server/              # Backend API (Fastify)
 ui/                  # Frontend (Next.js 16)
 shared/              # Shared types & utilities
 package.json         # Root workspace config
-eslint.config.mjs    # ESLint flat config
+biome.json           # Biome lint + format config
 vitest.config.ts     # Vitest test configuration
 tsconfig.json        # Root TypeScript config
 docker-compose.yml   # Local services (MongoDB, ClamAV, SMTP)
@@ -223,7 +243,7 @@ Steps executed in order:
 
 1. **npm-packages-check**: Security check via `mna-npm-check`
 2. **tests**: Main test suite
-   - Node.js 24
+   - Node.js 26
    - `yarn install --immutable` (validate lockfile)
    - `yarn dedupe --check` (must pass)
    - `yarn typecheck`
@@ -447,7 +467,7 @@ yarn services:clean   # Remove all services & volumes
 
 - 4 separate `tsconfig.json` files (root, server, ui, shared)
 - Build references: shared must build before others
-- Path aliases configured per workspace in `eslint.config.mjs`
+- Path aliases configured per workspace in each `tsconfig.json`
 
 ### Workspace Dependencies
 
@@ -513,7 +533,7 @@ yarn seed:update          # Update seed from local DB
 
 - **Use async/await**: Wrap awaits in try/catch with structured errors
 - **Guard early**: Check edge cases at function start to avoid deep nesting
-- **No floating promises**: All promises must be awaited or handled (enforced by ESLint)
+- **No floating promises**: All promises must be awaited or handled (enforced by Biome)
 - **Structured logging**: Send errors through Sentry and logging utilities
 
 ### Security Practices

--- a/.github/instructions/review-server-shared.instructions.md
+++ b/.github/instructions/review-server-shared.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: "{server,shared}/**/*.ts"
+excludeAgent: "coding-agent"
+---
+
+# Review guidelines — server/ and shared/
+
+Flag violations of these architecture principles even where no lint/CI rule currently checks for them.
+
+- **Deep Modules**: a service/module should expose a simple interface hiding real complexity. Flag shallow wrappers that just delegate without reducing exposed complexity, and large service files mixing multiple responsibilities that should be split into a deep module with a narrow interface instead of several interdependent small files.
+- **File naming**: all `.ts` files (services, jobs, utils, models, controllers) must be kebab-case. Flag any new file that isn't.
+- **Zod v4**: flag `z.string().email()` (should be `z.email()`), `.transform()` used for two-way schemas (should be `z.codec(input, output, { decode, encode })`), and any leftover `AnyZodObject`/`ZodTypeAny` type (should be `z.ZodObject<any>`/`z.ZodType`).

--- a/.github/instructions/review-ui.instructions.md
+++ b/.github/instructions/review-ui.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "ui/**/*.{ts,tsx}"
+excludeAgent: "coding-agent"
+---
+
+# Review guidelines — ui/
+
+Flag violations of these architecture principles even where no lint/CI rule currently checks for them.
+
+- **Deep Modules**: a component/hook/service should expose a simple interface hiding real complexity. Flag shallow wrappers that just delegate without reducing exposed complexity, and large files mixing multiple responsibilities that should be split into a deep module with a narrow interface instead of several interdependent small files.
+- **File naming**: `.ts` files (hooks, utils, services) must be kebab-case. `.tsx` components stay PascalCase. Flag any new `.ts` file that isn't kebab-case.
+- **Cache Components / Partial Prefetching**: dynamic fetches must use `"use cache: private"` with `cacheTag()` and `cacheLife({ revalidate })`, never `"use cache"` once `headers()`/session cookies are read. Flag any reintroduction of `export const instant = false` (a completed migration flag, should never come back).
+- **`<Activity>` resync pitfall**: components stay mounted across back-navigation instead of remounting. Flag any `useState(initialProp)` (or similar prop-derived initial state) that lacks a `useEffect(() => setState(prop), [prop])` to resync on prop change.
+- **Zod v4**: flag `z.string().email()` (should be `z.email()`) and `.transform()` used for two-way schemas (should be `z.codec(input, output, { decode, encode })`).

--- a/.github/instructions/review-ui.instructions.md
+++ b/.github/instructions/review-ui.instructions.md
@@ -8,7 +8,7 @@ excludeAgent: "coding-agent"
 Flag violations of these architecture principles even where no lint/CI rule currently checks for them.
 
 - **Deep Modules**: a component/hook/service should expose a simple interface hiding real complexity. Flag shallow wrappers that just delegate without reducing exposed complexity, and large files mixing multiple responsibilities that should be split into a deep module with a narrow interface instead of several interdependent small files.
-- **File naming**: `.ts` files (hooks, utils, services) must be kebab-case. `.tsx` components stay PascalCase. Flag any new `.ts` file that isn't kebab-case.
+- **File naming**: `.ts` files (hooks, utils, services) must be kebab-case. `.tsx` components stay PascalCase, *except* Next.js App Router reserved filenames (`page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`, `not-found.tsx`, `template.tsx`, `default.tsx`), which follow Next's own lowercase convention and must never be renamed. Flag any new `.ts` file that isn't kebab-case.
 - **Cache Components / Partial Prefetching**: dynamic fetches must use `"use cache: private"` with `cacheTag()` and `cacheLife({ revalidate })`, never `"use cache"` once `headers()`/session cookies are read. Flag any reintroduction of `export const instant = false` (a completed migration flag, should never come back).
 - **`<Activity>` resync pitfall**: components stay mounted across back-navigation instead of remounting. Flag any `useState(initialProp)` (or similar prop-derived initial state) that lacks a `useEffect(() => setState(prop), [prop])` to resync on prop change.
 - **Zod v4**: flag `z.string().email()` (should be `z.email()`) and `.transform()` used for two-way schemas (should be `z.codec(input, output, { decode, encode })`).


### PR DESCRIPTION
Closes #5124

## Changements

- Met à jour `.github/copilot-instructions.md` : corrige des faits obsolètes (contrainte Node réelle `>=24`, CI sur 26 ; suppression des mentions d'ESLint comme outil actif, remplacé par Biome) et ajoute les principes d'architecture à faire respecter (Deep Modules, nommage kebab-case avec exception pour les fichiers réservés Next.js App Router, Cache Components/Partial Prefetching Next.js avec le piège `<Activity>`, Zod v4), le processus de PR via le skill `pull-request-lba`, et une note sur `ui/AGENTS.md` (autonome, auto-généré par `next dev`, à ne pas modifier).
- Ajoute `.github/instructions/review-ui.instructions.md` et `.github/instructions/review-server-shared.instructions.md` : instructions scopées par périmètre (`applyTo`), réservées à Copilot code review (`excludeAgent: coding-agent`) pour ne pas polluer le coding agent ni les reviews server avec des règles UI-only.

Un `CLAUDE.md` équivalent a aussi été créé en local pour Claude Code, mais il est volontairement exclu du repo (`.gitignore`) donc absent de ce diff.

## Plan de test

- [ ] Activer le Ruleset GitHub "Automatically request Copilot code review" (Settings > Rules > Rulesets) si ce n'est pas déjà fait — action manuelle
- [ ] Une fois activé, vérifier sur une PR de test que Copilot applique bien les principes des fichiers `.github/instructions/*.instructions.md`
- [ ] Vérifier que `.github/copilot-instructions.md` ne contient plus de contrainte Node incorrecte ni de mention d'ESLint comme outil actuellement utilisé (la mention historique "replaces ESLint + Prettier" reste, elle est correcte)