### PR TITLE
feat: digest nocturne unique pour les notifs slack offre-partenaire (#5126)

### DIFF
--- a/server/src/jobs/offre-partenaire/apec/import-apec.ts
+++ b/server/src/jobs/offre-partenaire/apec/import-apec.ts
@@ -8,7 +8,7 @@ const rawCollectionName = rawApecModel.collectionName
 const offerXmlTag = "Offre_emploi"
 
 export const importApecRaw = async (sourceStream: NodeJS.ReadableStream) => {
-  await importFromStreamInXml({
+  return importFromStreamInXml({
     destinationCollection: rawCollectionName,
     offerXmlTag,
     stream: sourceStream,
@@ -18,7 +18,7 @@ export const importApecRaw = async (sourceStream: NodeJS.ReadableStream) => {
 }
 
 export const importApecToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.APEC,
     zodInput: ZApecJob,

--- a/server/src/jobs/offre-partenaire/apec/process-apec.ts
+++ b/server/src/jobs/offre-partenaire/apec/process-apec.ts
@@ -3,6 +3,7 @@ import { importApecRaw, importApecToComputed } from "./import-apec"
 
 export const processApec = async () => {
   const sourceStream = await getApecJobs()
-  await importApecRaw(sourceStream)
-  await importApecToComputed()
+  const raw = await importApecRaw(sourceStream)
+  const computed = await importApecToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/block-bad-rome-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/block-bad-rome-jobs-partners.ts
@@ -24,4 +24,5 @@ export const blockBadRomeJobsPartners = async ({ addedMatchFilter }: FillCompute
   })
 
   jobLogger.info(`job ${job} : enrichissement terminé. modifiedCount=${result.modifiedCount}`)
+  return { modifiedCount: result.modifiedCount }
 }

--- a/server/src/jobs/offre-partenaire/block-jobs-partners-from-cfa-list.test.ts
+++ b/server/src/jobs/offre-partenaire/block-jobs-partners-from-cfa-list.test.ts
@@ -26,7 +26,7 @@ describe("blockJobsPartnersFromCfaListTask", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromCfaList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -44,7 +44,7 @@ describe("blockJobsPartnersFromCfaListTask", () => {
       },
     ])
 
-    await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromCfaList({})
 
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -61,7 +61,7 @@ describe("blockJobsPartnersFromCfaListTask", () => {
       },
     ])
 
-    await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromCfaList({})
 
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -79,7 +79,7 @@ describe("blockJobsPartnersFromCfaListTask", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromCfaList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -97,7 +97,7 @@ describe("blockJobsPartnersFromCfaListTask", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromCfaList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -115,7 +115,7 @@ describe("blockJobsPartnersFromCfaListTask", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromCfaList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)

--- a/server/src/jobs/offre-partenaire/block-jobs-partners-from-expiration-date.test.ts
+++ b/server/src/jobs/offre-partenaire/block-jobs-partners-from-expiration-date.test.ts
@@ -20,7 +20,7 @@ describe("block-jobs-partners-from-expiration-date", () => {
       },
     ])
 
-    await blockJobsPartnersFromExpirationDate({ shouldNotifySlack: false })
+    await blockJobsPartnersFromExpirationDate({})
 
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -37,7 +37,7 @@ describe("block-jobs-partners-from-expiration-date", () => {
       },
     ])
 
-    await blockJobsPartnersFromExpirationDate({ shouldNotifySlack: false })
+    await blockJobsPartnersFromExpirationDate({})
 
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -54,7 +54,7 @@ describe("block-jobs-partners-from-expiration-date", () => {
       },
     ])
 
-    await blockJobsPartnersFromExpirationDate({ shouldNotifySlack: false })
+    await blockJobsPartnersFromExpirationDate({})
 
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -72,7 +72,7 @@ describe("block-jobs-partners-from-expiration-date", () => {
       },
     ])
 
-    await blockJobsPartnersFromExpirationDate({ shouldNotifySlack: false })
+    await blockJobsPartnersFromExpirationDate({})
 
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)

--- a/server/src/jobs/offre-partenaire/block-jobs-partners-from-flux-company-list.test.ts
+++ b/server/src/jobs/offre-partenaire/block-jobs-partners-from-flux-company-list.test.ts
@@ -17,7 +17,7 @@ describe("block-jobs-partners-from-flux-company-list", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromFluxCompanyList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromFluxCompanyList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -33,7 +33,7 @@ describe("block-jobs-partners-from-flux-company-list", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromFluxCompanyList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromFluxCompanyList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -49,7 +49,7 @@ describe("block-jobs-partners-from-flux-company-list", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromFluxCompanyList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromFluxCompanyList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -66,7 +66,7 @@ describe("block-jobs-partners-from-flux-company-list", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromFluxCompanyList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromFluxCompanyList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -82,7 +82,7 @@ describe("block-jobs-partners-from-flux-company-list", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromFluxCompanyList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromFluxCompanyList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -99,7 +99,7 @@ describe("block-jobs-partners-from-flux-company-list", () => {
       },
     ])
     // when
-    await blockJobsPartnersFromFluxCompanyList({ shouldNotifySlack: false })
+    await blockJobsPartnersFromFluxCompanyList({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)

--- a/server/src/jobs/offre-partenaire/block-jobs-partners-with-naf85.ts
+++ b/server/src/jobs/offre-partenaire/block-jobs-partners-with-naf85.ts
@@ -22,4 +22,5 @@ export const blockJobsPartnersWithNaf85 = async ({ addedMatchFilter }: FillCompu
   })
 
   jobLogger.info(`job ${job} : enrichissement terminé. modifiedCount=${result.modifiedCount}`)
+  return { modifiedCount: result.modifiedCount }
 }

--- a/server/src/jobs/offre-partenaire/clever-connect/import-clever-connect.ts
+++ b/server/src/jobs/offre-partenaire/clever-connect/import-clever-connect.ts
@@ -11,15 +11,15 @@ export const importCleverConnectRaw = async (destinationCollection: CollectionNa
   if (!url && !sourceStream) throw new Error("url or sourceStream is required")
 
   if (sourceStream) {
-    await importFromStreamInXml({ destinationCollection, offerXmlTag, stream: sourceStream, importName: partnerLabel })
+    return importFromStreamInXml({ destinationCollection, offerXmlTag, stream: sourceStream, importName: partnerLabel })
   }
   if (url) {
-    await importFromUrlInXml({ destinationCollection, url, offerXmlTag, partnerLabel })
+    return importFromUrlInXml({ destinationCollection, url, offerXmlTag, partnerLabel })
   }
 }
 
 export const importCleverConnectToComputed = async (collectionSource: CollectionName, partnerLabel: JOBPARTNERS_LABEL) => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource,
     partnerLabel,
     zodInput: ZCleverConnectJob,

--- a/server/src/jobs/offre-partenaire/clever-connect/process-clever-connect.ts
+++ b/server/src/jobs/offre-partenaire/clever-connect/process-clever-connect.ts
@@ -9,8 +9,9 @@ import config from "@/config"
 import { importCleverConnectRaw, importCleverConnectToComputed } from "./import-clever-connect"
 
 const cleverConnectProcessor = async (model: { collectionName: CollectionName }, label: JOBPARTNERS_LABEL, url: string) => {
-  await importCleverConnectRaw(model.collectionName, label, url)
-  await importCleverConnectToComputed(model.collectionName, label)
+  const raw = await importCleverConnectRaw(model.collectionName, label, url)
+  const computed = await importCleverConnectToComputed(model.collectionName, label)
+  return { raw, computed }
 }
 
 export const processAtlas = async () => cleverConnectProcessor(rawAtlasModel, JOBPARTNERS_LABEL.ATLAS, config.cleverConnect.atlasUrl)

--- a/server/src/jobs/offre-partenaire/decathlon/import-decathlon.ts
+++ b/server/src/jobs/offre-partenaire/decathlon/import-decathlon.ts
@@ -20,7 +20,7 @@ export const importDecathlonRaw = async (sourceStream?: NodeJS.ReadableStream) =
     })
     sourceStream = response.data
   }
-  await importFromStreamInJson({
+  return importFromStreamInJson({
     destinationCollection: rawCollectionName,
     stream: sourceStream!,
     partnerLabel: JOBPARTNERS_LABEL.DECATHLON,
@@ -32,7 +32,7 @@ export const importDecathlonRaw = async (sourceStream?: NodeJS.ReadableStream) =
 }
 
 export const importDecathlonToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.DECATHLON,
     zodInput: ZDecathlonJob,
@@ -41,6 +41,7 @@ export const importDecathlonToComputed = async () => {
 }
 
 export const processDecathlon = async () => {
-  await importDecathlonRaw()
-  await importDecathlonToComputed()
+  const raw = await importDecathlonRaw()
+  const computed = await importDecathlonToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/detect-classification-jobs-partners.test.ts
+++ b/server/src/jobs/offre-partenaire/detect-classification-jobs-partners.test.ts
@@ -9,7 +9,7 @@ import { getDbCollection } from "@/common/utils/mongodb-utils"
 import config from "@/config"
 import { detectClassificationJobsPartners as detectClassificationJobsPartnersRaw } from "./detect-classification-jobs-partners"
 
-const detectClassificationJobsPartners = async () => detectClassificationJobsPartnersRaw({ shouldNotifySlack: false })
+const detectClassificationJobsPartners = async () => detectClassificationJobsPartnersRaw({})
 
 const offer_title = "vendeur / vendeuse"
 const workplace_name = "decathlon"

--- a/server/src/jobs/offre-partenaire/detect-classification-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/detect-classification-jobs-partners.ts
@@ -6,7 +6,7 @@ import { getClassificationFromLab } from "@/services/cache-classification.servic
 import type { FillComputedJobsPartnersContext } from "./fill-computed-jobs-partners"
 import { fillFieldsForComputedPartnersFactory } from "./fill-fields-for-partners-factory"
 
-export const detectClassificationJobsPartners = async ({ addedMatchFilter, shouldNotifySlack }: FillComputedJobsPartnersContext) => {
+export const detectClassificationJobsPartners = async ({ addedMatchFilter }: FillComputedJobsPartnersContext) => {
   const filledFields = ["business_error"] as const satisfies (keyof IComputedJobsPartners)[]
 
   const filters: Filter<IComputedJobsPartners>[] = [{ partner_label: { $nin: PARTNER_WHITELIST } }, { workplace_siret: { $nin: GEIQ_WHITELIST } }]
@@ -46,6 +46,5 @@ export const detectClassificationJobsPartners = async ({ addedMatchFilter, shoul
         return result
       })
     },
-    shouldNotifySlack,
   })
 }

--- a/server/src/jobs/offre-partenaire/detect-duplicate-job-partners.ts
+++ b/server/src/jobs/offre-partenaire/detect-duplicate-job-partners.ts
@@ -13,7 +13,6 @@ import { logger } from "@/common/logger"
 import { deduplicate, getPairs } from "@/common/utils/array"
 import { asyncForEach } from "@/common/utils/async-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 import type { FillComputedJobsPartnersContext } from "./fill-computed-jobs-partners"
 import { defaultFillComputedJobsPartnersContext } from "./fill-computed-jobs-partners"
 
@@ -76,12 +75,10 @@ export const detectDuplicateJobPartners = async ({ addedMatchFilter }: FillCompu
   })
   const executionDurationInSeconds = Math.round((new Date().getTime() - startDate.getTime()) / 1000)
   if (executionDurationInSeconds > 60 * 5) {
-    await notifyToSlack({
-      subject: `Détection des offres en doublon`,
-      message: `Temps d'exécution : ${executionDurationInSeconds} secondes`,
-      error: true,
-    })
+    logger.warn(`detectDuplicateJobPartners: temps d'exécution anormalement long : ${executionDurationInSeconds} secondes`)
   }
+
+  return { executionDurationInSeconds }
 }
 
 const logOversizedGroups = async (groupField: keyof IComputedJobsPartners, computedJobPartnersFilter: Filter<IComputedJobsPartners>) => {

--- a/server/src/jobs/offre-partenaire/detect-duplicate-job-partners.ts
+++ b/server/src/jobs/offre-partenaire/detect-duplicate-job-partners.ts
@@ -74,11 +74,12 @@ export const detectDuplicateJobPartners = async ({ addedMatchFilter }: FillCompu
     logger.info(message)
   })
   const executionDurationInSeconds = Math.round((new Date().getTime() - startDate.getTime()) / 1000)
-  if (executionDurationInSeconds > 60 * 5) {
+  const executionDurationError = executionDurationInSeconds > 60 * 5
+  if (executionDurationError) {
     logger.warn(`detectDuplicateJobPartners: temps d'exécution anormalement long : ${executionDurationInSeconds} secondes`)
   }
 
-  return { executionDurationInSeconds }
+  return { executionDurationInSeconds, executionDurationError }
 }
 
 const logOversizedGroups = async (groupField: keyof IComputedJobsPartners, computedJobPartnersFilter: Filter<IComputedJobsPartners>) => {

--- a/server/src/jobs/offre-partenaire/edf/import-edf.ts
+++ b/server/src/jobs/offre-partenaire/edf/import-edf.ts
@@ -12,7 +12,7 @@ const offerXmlTag = "offer"
 
 export const importEdfRaw = async (sourceStream?: NodeJS.ReadableStream) => {
   if (sourceStream) {
-    await importFromStreamInXml({
+    return importFromStreamInXml({
       destinationCollection: rawCollectionName,
       offerXmlTag,
       stream: sourceStream,
@@ -20,7 +20,7 @@ export const importEdfRaw = async (sourceStream?: NodeJS.ReadableStream) => {
       conflictingOpeningTagWithoutAttributes: true,
     })
   } else {
-    await importFromUrlInXml({
+    return importFromUrlInXml({
       destinationCollection: rawCollectionName,
       url: config.edfUrl,
       offerXmlTag,
@@ -31,7 +31,7 @@ export const importEdfRaw = async (sourceStream?: NodeJS.ReadableStream) => {
 }
 
 export const importEdfToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.EDF,
     zodInput: ZEnedisJob, // same structure as Enedis, so we can reuse the same Zod schema

--- a/server/src/jobs/offre-partenaire/edf/process-edf.ts
+++ b/server/src/jobs/offre-partenaire/edf/process-edf.ts
@@ -1,6 +1,7 @@
 import { importEdfRaw, importEdfToComputed } from "./import-edf"
 
 export const processEdf = async () => {
-  await importEdfRaw()
-  await importEdfToComputed()
+  const raw = await importEdfRaw()
+  const computed = await importEdfToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/emploi-inclusion/import-emploi-inclusion.ts
+++ b/server/src/jobs/offre-partenaire/emploi-inclusion/import-emploi-inclusion.ts
@@ -7,7 +7,6 @@ import { getAllEmploiInclusionJobsByDepartement, ZEmploiInclusionJob } from "@/c
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 import config from "@/config"
 import { emploiInclusionJobToJobsPartners, isEligiblePoste } from "./emploi-inclusion.mapper"
 
@@ -40,13 +39,8 @@ export const importEmploiInclusionRaw = async () => {
     await getDbCollection(rawCollectionName).insertMany([...jobsById.values()].map((job) => ({ ...job, _id: new ObjectId(), createdAt: now })))
   }
 
-  const message = `import ${partnerLabel} terminé : ${jobsById.size} offres importées`
-  logger.info(message)
-  // biome-ignore lint/nursery/noFloatingPromises: migration
-  notifyToSlack({
-    subject: `import des offres ${partnerLabel} dans raw`,
-    message,
-  })
+  logger.info(`import ${partnerLabel} terminé : ${jobsById.size} offres importées`)
+  return { jobCount: jobsById.size }
 }
 
 export const importEmploiInclusionToComputed = async () => {
@@ -100,12 +94,14 @@ export const importEmploiInclusionToComputed = async () => {
     logger.info({ counters }, `emploi-inclusion: fin du parcours cursor`)
   }
 
-  const message = `import dans computed_jobs_partners pour partner_label=${partnerLabel} terminé. rawOk=${counters.rawOk}, rawParseError=${counters.rawParseError}, postesTotal=${counters.postesTotal}, postesEligibles=${counters.postesEligibles}, success=${counters.success}, insertError=${counters.insertError}`
-  logger.info(message)
-  await notifyToSlack({ subject: `mapping Raw => computed_jobs_partners`, message, error: counters.rawParseError > 0 || counters.insertError > 0 })
+  logger.info(
+    `import dans computed_jobs_partners pour partner_label=${partnerLabel} terminé. rawOk=${counters.rawOk}, rawParseError=${counters.rawParseError}, postesTotal=${counters.postesTotal}, postesEligibles=${counters.postesEligibles}, success=${counters.success}, insertError=${counters.insertError}`
+  )
+  return counters
 }
 
 export const processEmploiInclusion = async () => {
-  await importEmploiInclusionRaw()
-  await importEmploiInclusionToComputed()
+  const raw = await importEmploiInclusionRaw()
+  const computed = await importEmploiInclusionToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/enedis/import-enedis.ts
+++ b/server/src/jobs/offre-partenaire/enedis/import-enedis.ts
@@ -11,7 +11,7 @@ const offerXmlTag = "offer"
 
 export const importEnedisRaw = async (sourceStream?: NodeJS.ReadableStream) => {
   if (sourceStream) {
-    await importFromStreamInXml({
+    return importFromStreamInXml({
       destinationCollection: rawCollectionName,
       offerXmlTag,
       stream: sourceStream,
@@ -19,7 +19,7 @@ export const importEnedisRaw = async (sourceStream?: NodeJS.ReadableStream) => {
       conflictingOpeningTagWithoutAttributes: true,
     })
   } else {
-    await importFromUrlInXml({
+    return importFromUrlInXml({
       destinationCollection: rawCollectionName,
       url: config.enedisUrl,
       offerXmlTag,
@@ -30,7 +30,7 @@ export const importEnedisRaw = async (sourceStream?: NodeJS.ReadableStream) => {
 }
 
 export const importEnedisToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.ENEDIS,
     zodInput: ZEnedisJob,

--- a/server/src/jobs/offre-partenaire/enedis/process-enedis.ts
+++ b/server/src/jobs/offre-partenaire/enedis/process-enedis.ts
@@ -1,6 +1,7 @@
 import { importEnedisRaw, importEnedisToComputed } from "./import-enedis"
 
 export const processEnedis = async () => {
-  await importEnedisRaw()
-  await importEnedisToComputed()
+  const raw = await importEnedisRaw()
+  const computed = await importEnedisToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/etudiant/process-etudiant.ts
+++ b/server/src/jobs/offre-partenaire/etudiant/process-etudiant.ts
@@ -4,7 +4,6 @@ import rawEtudiantModel from "shared/models/raw-etudiant.model"
 import { getJobEtudiantJobs, ZJobEtudiantJob } from "@/common/apis/etudiant/etudiant.client"
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 import { rawToComputedJobsPartners } from "@/jobs/offre-partenaire/raw-to-computed-jobs-partners"
 import { ETUDIANT_ELIGIBLE_CONTRACT_FR, etudiantJobToJobsPartners } from "./etudiant.mapper"
 
@@ -23,16 +22,12 @@ export const importEtudiantRaw = async () => {
     await getDbCollection(rawCollectionName).insertMany(jobs.map((job) => ({ ...job, _id: new ObjectId(), createdAt: now })))
   }
 
-  const message = `import ${partnerLabel} terminé : ${jobs.length} offres importées`
-  logger.info(message)
-  await notifyToSlack({
-    subject: `import des offres ${partnerLabel} dans raw`,
-    message,
-  })
+  logger.info(`import ${partnerLabel} terminé : ${jobs.length} offres importées`)
+  return { jobCount: jobs.length }
 }
 
 export const importEtudiantToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel,
     zodInput: ZJobEtudiantJob,
@@ -42,6 +37,7 @@ export const importEtudiantToComputed = async () => {
 }
 
 export const processEtudiant = async () => {
-  await importEtudiantRaw()
-  await importEtudiantToComputed()
+  const raw = await importEtudiantRaw()
+  const computed = await importEtudiantToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/fill-computed-jobs-partners.test.ts
+++ b/server/src/jobs/offre-partenaire/fill-computed-jobs-partners.test.ts
@@ -72,7 +72,7 @@ describe("fill-computed-jobs-partners", () => {
         },
       ])
       // when
-      await blockJobsPartnersFromCfaList({ shouldNotifySlack: false })
+      await blockJobsPartnersFromCfaList({})
       // then
       const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
       expect.soft(job.business_error).toBeNull()
@@ -90,7 +90,7 @@ describe("fill-computed-jobs-partners", () => {
         },
       ])
       // when — no lab API nock needed: OPCO EP is filtered out by the query so getData is never called
-      await detectClassificationJobsPartners({ shouldNotifySlack: false })
+      await detectClassificationJobsPartners({})
       // then
       const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
       expect.soft(job.business_error).toBeNull()

--- a/server/src/jobs/offre-partenaire/fill-computed-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/fill-computed-jobs-partners.ts
@@ -20,35 +20,36 @@ import { validateComputedJobPartners } from "./validate-computed-job-partners"
 
 export type FillComputedJobsPartnersContext = {
   addedMatchFilter?: Filter<IComputedJobsPartners>
-  shouldNotifySlack: boolean
 }
 
-export const defaultFillComputedJobsPartnersContext: FillComputedJobsPartnersContext = {
-  shouldNotifySlack: true,
-}
+export const defaultFillComputedJobsPartnersContext: FillComputedJobsPartnersContext = {}
 
 export const fillComputedJobsPartners = async (partialContext: Partial<FillComputedJobsPartnersContext> = {}) => {
   logger.info("début de fillComputedJobsPartners")
   const context: FillComputedJobsPartnersContext = { ...defaultFillComputedJobsPartnersContext, ...partialContext }
-  await blockJobsPartnersFromFluxCompanyList(context)
-  await blockJobsPartnersFromExpirationDate(context)
-  await fillEntrepriseEngagementComputedJobsPartners(context)
-  await formatTextFieldsJobsPartners(context)
-  await blockJobsPartnersFromCfaList(context)
-  await detectClassificationJobsPartners(context)
 
-  await fillOpcoInfosForPartners(context)
-  await fillSiretInfosForPartners(context)
-  await blockJobsPartnersWithNaf85(context)
-  await fillLocationInfosForPartners(context)
-  await fillRomeForPartners(context)
-  await blockBadRomeJobsPartners(context)
+  const steps = {
+    blockJobsPartnersFromFluxCompanyList: await blockJobsPartnersFromFluxCompanyList(context),
+    blockJobsPartnersFromExpirationDate: await blockJobsPartnersFromExpirationDate(context),
+    fillEntrepriseEngagementComputedJobsPartners: await fillEntrepriseEngagementComputedJobsPartners(context),
+    formatTextFieldsJobsPartners: await formatTextFieldsJobsPartners(context),
+    blockJobsPartnersFromCfaList: await blockJobsPartnersFromCfaList(context),
+    detectClassificationJobsPartners: await detectClassificationJobsPartners(context),
 
-  await rankJobPartners(context)
-  await detectDuplicateJobPartners(context)
+    fillOpcoInfosForPartners: await fillOpcoInfosForPartners(context),
+    fillSiretInfosForPartners: await fillSiretInfosForPartners(context),
+    blockJobsPartnersWithNaf85: await blockJobsPartnersWithNaf85(context),
+    fillLocationInfosForPartners: await fillLocationInfosForPartners(context),
+    fillRomeForPartners: await fillRomeForPartners(context),
+    blockBadRomeJobsPartners: await blockBadRomeJobsPartners(context),
 
-  await validateComputedJobPartners(context)
+    rankJobPartners: await rankJobPartners(context),
+    detectDuplicateJobPartners: await detectDuplicateJobPartners(context),
+
+    validateComputedJobPartners: await validateComputedJobPartners(context),
+  }
   logger.info("fin de fillComputedJobsPartners")
+  return steps
 }
 
 export const blankComputedJobPartner = (now: Date): Omit<IComputedJobsPartners, "_id" | "partner_label" | "partner_job_id"> => ({

--- a/server/src/jobs/offre-partenaire/fill-computed-recruteurs-lba.ts
+++ b/server/src/jobs/offre-partenaire/fill-computed-recruteurs-lba.ts
@@ -19,7 +19,7 @@ const computedJobFilter: Filter<IComputedJobsPartners> = {
 }
 
 export const fillComputedRecruteursLba = async () => {
-  const context: FillComputedJobsPartnersContext = { addedMatchFilter: computedJobFilter, shouldNotifySlack: false }
+  const context: FillComputedJobsPartnersContext = { addedMatchFilter: computedJobFilter }
 
   await removeMissingRecruteursLbaFromComputedJobPartners()
   await removeUnsubscribedRecruteursLbaFromComputedJobPartners()

--- a/server/src/jobs/offre-partenaire/fill-fields-for-partners-factory.ts
+++ b/server/src/jobs/offre-partenaire/fill-fields-for-partners-factory.ts
@@ -8,7 +8,6 @@ import type { COMPUTED_ERROR_SOURCE, IComputedJobsPartners } from "shared/models
 import { logger as globalLogger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 
 /**
  * Fonction permettant de facilement enrichir un computedJobPartner avec de nouvelles données provenant d'une source async
@@ -31,7 +30,6 @@ export const fillFieldsForComputedPartnersFactory = async <SourceFields extends 
   groupSize,
   replaceMatchFilter,
   addedMatchFilter,
-  shouldNotifySlack = true,
 }: {
   job: COMPUTED_ERROR_SOURCE
   sourceFields: readonly SourceFields[]
@@ -40,7 +38,6 @@ export const fillFieldsForComputedPartnersFactory = async <SourceFields extends 
   groupSize: number
   replaceMatchFilter?: Filter<IComputedJobsPartners>
   addedMatchFilter?: Filter<IComputedJobsPartners>
-  shouldNotifySlack?: boolean
 }) => {
   const logger = globalLogger.child({ job })
   logger.info(`job ${job} : début d'enrichissement des données`)
@@ -154,16 +151,9 @@ export const fillFieldsForComputedPartnersFactory = async <SourceFields extends 
 
   await pipeline(sourceStream, groupTransform, processGroup)
 
-  const message = `job ${job} : enrichissement terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}`
-  logger.info(message)
+  logger.info(`job ${job} : enrichissement terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}`)
 
-  if (counters.error > 0 && shouldNotifySlack) {
-    await notifyToSlack({
-      subject: `computedJobPartners: enrichissement de données`,
-      message,
-      error: true,
-    })
-  }
+  return counters
 }
 
 /**
@@ -187,7 +177,6 @@ export const fillFieldsForPartnersFactory = async <SourceFields extends keyof IJ
   groupSize,
   replaceMatchFilter,
   addedMatchFilter,
-  shouldNotifySlack = true,
 }: {
   job: COMPUTED_ERROR_SOURCE
   sourceFields: readonly SourceFields[]
@@ -196,7 +185,6 @@ export const fillFieldsForPartnersFactory = async <SourceFields extends keyof IJ
   groupSize: number
   replaceMatchFilter?: Filter<IJobsPartnersOfferPrivate>
   addedMatchFilter?: Filter<IJobsPartnersOfferPrivate>
-  shouldNotifySlack?: boolean
 }) => {
   const logger = globalLogger.child({ job })
   logger.info(`job ${job} : début d'enrichissement des données`)
@@ -259,16 +247,9 @@ export const fillFieldsForPartnersFactory = async <SourceFields extends keyof IJ
 
   await pipeline(sourceStream, groupTransform, processGroup)
 
-  const message = `job ${job} : enrichissement terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}`
-  logger.info(message)
+  logger.info(`job ${job} : enrichissement terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}`)
 
-  if (counters.error > 0 && shouldNotifySlack) {
-    await notifyToSlack({
-      subject: `jobs_partners: enrichissement de données`,
-      message,
-      error: true,
-    })
-  }
+  return counters
 }
 
 function groupTransformFactory(groupSize: number) {

--- a/server/src/jobs/offre-partenaire/fill-location-infos-for-partners.ts
+++ b/server/src/jobs/offre-partenaire/fill-location-infos-for-partners.ts
@@ -9,7 +9,7 @@ import { fillFieldsForComputedPartnersFactory } from "./fill-fields-for-partners
 const API_ADRESSE_MIN_SCORE = 0.6 // entre 0 et 1, 1 signifiant que l'api est certaine de sa réponse
 // j'ai pu constater des adresses à strasbourg alors que la vraie adresse est à Caen avec un score à 0.52 : https://api-adresse.data.gouv.fr/search?q=General%20Eisenhower%2014000%20CAEN
 
-export const fillLocationInfosForPartners = async ({ addedMatchFilter, shouldNotifySlack }: FillComputedJobsPartnersContext = defaultFillComputedJobsPartnersContext) => {
+export const fillLocationInfosForPartners = async ({ addedMatchFilter }: FillComputedJobsPartnersContext = defaultFillComputedJobsPartnersContext) => {
   const sourceFields = ["workplace_address_label"] as const satisfies (keyof IComputedJobsPartners)[]
 
   const filledFields = [
@@ -92,7 +92,6 @@ export const fillLocationInfosForPartners = async ({ addedMatchFilter, shouldNot
 
       return [result]
     },
-    shouldNotifySlack,
   })
 }
 

--- a/server/src/jobs/offre-partenaire/fill-rome-for-partners.ts
+++ b/server/src/jobs/offre-partenaire/fill-rome-for-partners.ts
@@ -7,7 +7,7 @@ import type { FillComputedJobsPartnersContext } from "./fill-computed-jobs-partn
 import { defaultFillComputedJobsPartnersContext } from "./fill-computed-jobs-partners"
 import { fillFieldsForComputedPartnersFactory } from "./fill-fields-for-partners-factory"
 
-export const fillRomeForPartners = async ({ addedMatchFilter, shouldNotifySlack }: FillComputedJobsPartnersContext = defaultFillComputedJobsPartnersContext) => {
+export const fillRomeForPartners = async ({ addedMatchFilter }: FillComputedJobsPartnersContext = defaultFillComputedJobsPartnersContext) => {
   const filledFields = ["offer_rome_codes"] as const satisfies (keyof IComputedJobsPartners)[]
 
   const finalFilter: Filter<IComputedJobsPartners> = {
@@ -26,7 +26,6 @@ export const fillRomeForPartners = async ({ addedMatchFilter, shouldNotifySlack 
     filledFields,
     groupSize: MAX_DIAGORIENTE_PAYLOAD_SIZE,
     replaceMatchFilter: finalFilter,
-    shouldNotifySlack,
     getData: async (documents) => {
       const validDocuments = documents.flatMap((document) => (document.offer_title ? [document] : []))
       const queries = validDocuments.map(({ offer_title, workplace_naf_label, offer_description, _id }) => ({

--- a/server/src/jobs/offre-partenaire/france-travail-CEGID/import-france-travail-cegid.ts
+++ b/server/src/jobs/offre-partenaire/france-travail-CEGID/import-france-travail-cegid.ts
@@ -76,7 +76,7 @@ export const importFranceTravailCEGIDRaw = async (sourceStream?: NodeJS.Readable
 
     sourceStream = stringToStream(JSON.stringify(offers))
   }
-  await importFromStreamInJson({
+  return importFromStreamInJson({
     destinationCollection: rawCollectionName,
     stream: sourceStream!,
     partnerLabel: JOBPARTNERS_LABEL.FRANCE_TRAVAIL_CEGID,
@@ -89,7 +89,7 @@ export const importFranceTravailCEGIDRaw = async (sourceStream?: NodeJS.Readable
 
 export const importFranceTravailCEGIDToComputed = async () => {
   const agences = await parseAgences()
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.FRANCE_TRAVAIL_CEGID,
     zodInput: ZFranceTravailCEGIDJob,
@@ -98,8 +98,9 @@ export const importFranceTravailCEGIDToComputed = async () => {
 }
 
 export const processFranceTravailCEGID = async () => {
-  await importFranceTravailCEGIDRaw()
-  await importFranceTravailCEGIDToComputed()
+  const raw = await importFranceTravailCEGIDRaw()
+  const computed = await importFranceTravailCEGIDToComputed()
+  return { raw, computed }
 }
 
 async function searchCEGIDOffers(url: string, token: string) {

--- a/server/src/jobs/offre-partenaire/france-travail/import-jobs-france-travail.ts
+++ b/server/src/jobs/offre-partenaire/france-travail/import-jobs-france-travail.ts
@@ -8,7 +8,6 @@ import rawFranceTravailModel from "shared/models/raw-france-travail.model"
 import { getAllFTJobsByDepartments } from "@/common/apis/france-travail/france-travail.client"
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 
 import config from "@/config"
 import { rawToComputedJobsPartners } from "@/jobs/offre-partenaire/raw-to-computed-jobs-partners"
@@ -51,16 +50,12 @@ export const importFranceTravailRaw = async () => {
   })
   await getDbCollection("raw_francetravail").updateMany({ updatedAt: { $lt: now } }, { $set: { unpublishedAt: now, updatedAt: now } })
 
-  const message = `import France Travail terminé : ${count} offres importées`
-  logger.info(message)
-  await notifyToSlack({
-    subject: `import des offres France Travail dans raw`,
-    message,
-  })
+  logger.info(`import France Travail terminé : ${count} offres importées`)
+  return { count }
 }
 
 export const importFranceTravailToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawFranceTravailModel.collectionName,
     partnerLabel: JOBPARTNERS_LABEL.FRANCE_TRAVAIL,
     zodInput: ZFTJobRaw,

--- a/server/src/jobs/offre-partenaire/france-travail/process-france-travail.ts
+++ b/server/src/jobs/offre-partenaire/france-travail/process-france-travail.ts
@@ -1,6 +1,7 @@
 import { importFranceTravailRaw, importFranceTravailToComputed } from "./import-jobs-france-travail"
 
 export const processFranceTravail = async () => {
-  await importFranceTravailRaw()
-  await importFranceTravailToComputed()
+  const raw = await importFranceTravailRaw()
+  const computed = await importFranceTravailToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/hellowork-buddi/import-hello-work-buddi.ts
+++ b/server/src/jobs/offre-partenaire/hellowork-buddi/import-hello-work-buddi.ts
@@ -12,7 +12,7 @@ const offerXmlTag = "job"
 
 export const importHelloWorkBuddiRaw = async (sourceStream?: NodeJS.ReadableStream) => {
   if (sourceStream) {
-    await importFromStreamInXml({
+    return importFromStreamInXml({
       destinationCollection: rawCollectionName,
       offerXmlTag,
       stream: sourceStream,
@@ -20,7 +20,7 @@ export const importHelloWorkBuddiRaw = async (sourceStream?: NodeJS.ReadableStre
       conflictingOpeningTagWithoutAttributes: true,
     })
   } else {
-    await importFromUrlInXml({
+    return importFromUrlInXml({
       destinationCollection: rawCollectionName,
       url: config.helloworkBuddiUrl,
       offerXmlTag,
@@ -31,7 +31,7 @@ export const importHelloWorkBuddiRaw = async (sourceStream?: NodeJS.ReadableStre
 }
 
 export const importHelloWorkBuddiToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.HELLOWORK_BUDDI,
     zodInput: ZHelloWorkBuddiJob,

--- a/server/src/jobs/offre-partenaire/hellowork-merge/process-hellowork.ts
+++ b/server/src/jobs/offre-partenaire/hellowork-merge/process-hellowork.ts
@@ -3,11 +3,13 @@ import { importHelloWorkBuddiRaw, importHelloWorkBuddiToComputed } from "@/jobs/
 import { deduplicateHellowork } from "./deduplicate-hellowork"
 
 export const processHellowork = async () => {
-  await importHelloWorkRaw()
-  await importHelloWorkBuddiRaw()
+  const helloWorkRaw = await importHelloWorkRaw()
+  const helloWorkBuddiRaw = await importHelloWorkBuddiRaw()
 
   await deduplicateHellowork()
 
-  await importHelloWorkToComputed()
-  await importHelloWorkBuddiToComputed()
+  const helloWorkComputed = await importHelloWorkToComputed()
+  const helloWorkBuddiComputed = await importHelloWorkBuddiToComputed()
+
+  return { helloWorkRaw, helloWorkBuddiRaw, helloWorkComputed, helloWorkBuddiComputed }
 }

--- a/server/src/jobs/offre-partenaire/hellowork/import-hello-work.ts
+++ b/server/src/jobs/offre-partenaire/hellowork/import-hello-work.ts
@@ -11,7 +11,7 @@ const offerXmlTag = "job"
 
 export const importHelloWorkRaw = async (sourceStream?: NodeJS.ReadableStream) => {
   if (sourceStream) {
-    await importFromStreamInXml({
+    return importFromStreamInXml({
       destinationCollection: rawCollectionName,
       offerXmlTag,
       stream: sourceStream,
@@ -19,7 +19,7 @@ export const importHelloWorkRaw = async (sourceStream?: NodeJS.ReadableStream) =
       conflictingOpeningTagWithoutAttributes: true,
     })
   } else {
-    await importFromUrlInXml({
+    return importFromUrlInXml({
       destinationCollection: rawCollectionName,
       url: config.helloworkUrl,
       offerXmlTag,
@@ -30,7 +30,7 @@ export const importHelloWorkRaw = async (sourceStream?: NodeJS.ReadableStream) =
 }
 
 export const importHelloWorkToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.HELLOWORK,
     zodInput: ZHelloWorkJob,

--- a/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.test.ts
+++ b/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.test.ts
@@ -91,7 +91,7 @@ describe("when computed_jobs_partners updateOne in the catch block fails", () =>
       return collection
     })
 
-    await expect(importFromComputedToJobsPartners()).resolves.toBeUndefined()
+    await expect(importFromComputedToJobsPartners()).resolves.toEqual({ total: 1, success: 0, error: 1 })
     expect(sentrySpy).toHaveBeenCalledTimes(2)
 
     sentrySpy.mockRestore()
@@ -111,7 +111,7 @@ describe("offer_status_history lors de l'import", () => {
     await createJobPartner({ partner_job_id: "reactivated_1", offer_status: JOB_STATUS_ENGLISH.ANNULEE })
     await createComputedJobPartner({ partner_job_id: "reactivated_1", offer_status: JOB_STATUS_ENGLISH.ACTIVE, validated: true })
 
-    await importFromComputedToJobsPartners({}, false)
+    await importFromComputedToJobsPartners({})
 
     const job = await getDbCollection("jobs_partners").findOne({ partner_job_id: "reactivated_1" })
     expect.soft(job?.offer_status).toEqual(JOB_STATUS_ENGLISH.ACTIVE)
@@ -126,7 +126,7 @@ describe("offer_status_history lors de l'import", () => {
     await createJobPartner({ partner_job_id: "already_active_1", offer_status: JOB_STATUS_ENGLISH.ACTIVE })
     await createComputedJobPartner({ partner_job_id: "already_active_1", offer_status: JOB_STATUS_ENGLISH.ACTIVE, validated: true })
 
-    await importFromComputedToJobsPartners({}, false)
+    await importFromComputedToJobsPartners({})
 
     const job = await getDbCollection("jobs_partners").findOne({ partner_job_id: "already_active_1" })
     expect.soft(job?.offer_status_history.filter(({ reason }) => reason === "réactivée par le flux source")).toHaveLength(0)
@@ -136,7 +136,7 @@ describe("offer_status_history lors de l'import", () => {
     await createJobPartner({ partner_job_id: "stay_cancelled_1", offer_status: JOB_STATUS_ENGLISH.ANNULEE })
     await createComputedJobPartner({ partner_job_id: "stay_cancelled_1", offer_status: JOB_STATUS_ENGLISH.ANNULEE, validated: true })
 
-    await importFromComputedToJobsPartners({}, false)
+    await importFromComputedToJobsPartners({})
 
     const job = await getDbCollection("jobs_partners").findOne({ partner_job_id: "stay_cancelled_1" })
     expect.soft(job?.offer_status_history.filter(({ reason }) => reason === "réactivée par le flux source")).toHaveLength(0)
@@ -146,7 +146,7 @@ describe("offer_status_history lors de l'import", () => {
     const historyEntry = { date: new Date(), status: JOB_STATUS_ENGLISH.ANNULEE, reason: "supprimée du flux source", granted_by: "cancel-removed-jobs-partners" }
     await createComputedJobPartner({ partner_job_id: "with_history_1", validated: true, offer_status_history: [historyEntry] })
 
-    await importFromComputedToJobsPartners({}, false)
+    await importFromComputedToJobsPartners({})
 
     const job = await getDbCollection("jobs_partners").findOne({ partner_job_id: "with_history_1" })
     expect.soft(job?.offer_status_history.map(({ status, reason, granted_by }) => ({ status, reason, granted_by }))).toContainEqual({

--- a/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.ts
@@ -10,10 +10,9 @@ import { pipeline } from "stream/promises"
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 import { limitStream } from "@/common/utils/stream-utils"
 
-export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter<IComputedJobsPartners>, shouldNotifySlack = true) => {
+export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter<IComputedJobsPartners>) => {
   logger.info(`import dans jobs_partners commencé`)
   const filters: Filter<IComputedJobsPartners>[] = [{ validated: true, business_error: null }]
   if (addedMatchFilter) {
@@ -152,13 +151,7 @@ export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter
 
   await pipeline(stream, transform)
 
-  const message = `import dans jobs_partners terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}`
-  if (shouldNotifySlack) {
-    await notifyToSlack({
-      subject: `jobsPartners: import de données`,
-      message,
-    })
-  }
-
   logger.info({ counters }, "import dans jobs_partners terminé")
+
+  return counters
 }

--- a/server/src/jobs/offre-partenaire/import-from-stream-in-csv.ts
+++ b/server/src/jobs/offre-partenaire/import-from-stream-in-csv.ts
@@ -5,7 +5,6 @@ import type { CollectionName } from "shared/models/models"
 import { logger } from "@/common/logger"
 import { parseCsv } from "@/common/utils/file-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 
 export const importFromStreamInCsv = async ({
   stream,
@@ -50,13 +49,7 @@ export const importFromStreamInCsv = async ({
           reject(err)
         } else {
           logger.info("Pipeline succeeded.")
-          const message = `import ${partnerLabel} terminé : ${offerInsertCount} offres importées`
-          logger.info(message)
-          // biome-ignore lint/nursery/noFloatingPromises: migration
-          notifyToSlack({
-            subject: `import des offres ${partnerLabel} dans raw`,
-            message,
-          })
+          logger.info(`import ${partnerLabel} terminé : ${offerInsertCount} offres importées`)
           resolve({
             offerInsertCount,
           })

--- a/server/src/jobs/offre-partenaire/import-from-stream-in-json.ts
+++ b/server/src/jobs/offre-partenaire/import-from-stream-in-json.ts
@@ -8,7 +8,6 @@ import { logger } from "@/common/logger"
 import { asyncForEach } from "@/common/utils/async-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 
 export const importFromStreamInJson = async ({
   stream,
@@ -57,22 +56,12 @@ export const importFromStreamInJson = async ({
     error.cause = err
     logger.error(err, error.message)
     sentryCaptureException(error)
-    await notifyToSlack({
-      subject: `import des offres ${partnerLabel} dans raw`,
-      message: `import ${partnerLabel} en erreur : ${err instanceof Error ? err.message : String(err)}`,
-      error: true,
-    })
     throw error
   }
 
   logger.info(`${offerInsertCount} offers inserted`)
   logger.info("Pipeline succeeded.")
-  const message = `import ${partnerLabel} terminé : ${offerInsertCount} offres importées`
-  logger.info(message)
-  await notifyToSlack({
-    subject: `import des offres ${partnerLabel} dans raw`,
-    message,
-  })
+  logger.info(`import ${partnerLabel} terminé : ${offerInsertCount} offres importées`)
   return {
     offerInsertCount,
   }

--- a/server/src/jobs/offre-partenaire/import-from-stream-in-xml.ts
+++ b/server/src/jobs/offre-partenaire/import-from-stream-in-xml.ts
@@ -7,7 +7,6 @@ import * as xml2j from "xml2js"
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 
 const XML_PREVIEW_LENGTH = 500
 
@@ -116,14 +115,7 @@ export const importFromStreamInXml = async ({
         reject(err)
       } else {
         logger.info("Pipeline succeeded.")
-        const message = `import ${importName} terminé : ${offerInsertCount} offres importées. ${offerErrorCount} offres en erreur.`
-        logger.info(message)
-        // biome-ignore lint/nursery/noFloatingPromises: migration
-        notifyToSlack({
-          subject: `import des offres ${importName} dans raw`,
-          message,
-          error: offerErrorCount > 0,
-        })
+        logger.info(`import ${importName} terminé : ${offerInsertCount} offres importées. ${offerErrorCount} offres en erreur.`)
         resolve({
           offerInsertCount,
           offerErrorCount,

--- a/server/src/jobs/offre-partenaire/jobs-partners.importer.ts
+++ b/server/src/jobs/offre-partenaire/jobs-partners.importer.ts
@@ -19,6 +19,7 @@ import { processPass } from "./pass/process-pass"
 import { processComputedAndImportToJobPartners } from "./process-job-partners"
 import { processMissingRomeAndImportToJobPartners } from "./process-missing-rome-and-import-to-job-partners"
 import { processRhAlternance } from "./rh-alternance/process-rh-alternance"
+import { JOB_PARTNERS_DIGEST_JOB_NAME, sendJobPartnersNightlyDigest } from "./send-job-partners-nightly-digest"
 
 const timings = {
   import_source: "0 0 * * *",
@@ -186,5 +187,13 @@ export const importers: Record<string, CronDef> = {
     maxRuntimeInMinutes: 300,
     tag: "slave",
     resumable: true,
+  },
+
+  // Bilan unique des jobs ci-dessus, envoyé une fois le pire cas (5h de "Process computed...") passé
+  [JOB_PARTNERS_DIGEST_JOB_NAME]: {
+    cron_string: "30 5 * * *",
+    handler: sendJobPartnersNightlyDigest,
+    checkinMargin: 30,
+    maxRuntimeInMinutes: 10,
   },
 }

--- a/server/src/jobs/offre-partenaire/jobteaser/import-jobteaser.ts
+++ b/server/src/jobs/offre-partenaire/jobteaser/import-jobteaser.ts
@@ -13,7 +13,7 @@ const offerXmlTag = "job"
 type ListType = { last_modified: string; mode: number; name: string; size: number }
 export const importJobteaserRaw = async (sourceStream?: NodeJS.ReadableStream) => {
   if (sourceStream) {
-    await importFromStreamInXml({
+    return importFromStreamInXml({
       destinationCollection: rawCollectionName,
       offerXmlTag,
       stream: sourceStream,
@@ -54,7 +54,7 @@ export const importJobteaserRaw = async (sourceStream?: NodeJS.ReadableStream) =
     const nodeStream = Readable.fromWeb(fileResponse.body!)
     const gunzip = createGunzip()
     const fileSourceStream = nodeStream.pipe(gunzip)
-    await importFromStreamInXml({
+    return importFromStreamInXml({
       destinationCollection: rawCollectionName,
       offerXmlTag,
       stream: fileSourceStream,
@@ -65,7 +65,7 @@ export const importJobteaserRaw = async (sourceStream?: NodeJS.ReadableStream) =
 }
 
 export const importJobteaserToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.JOBTEASER,
     zodInput: ZJobteaserJob,

--- a/server/src/jobs/offre-partenaire/jobteaser/process-jobteaser.ts
+++ b/server/src/jobs/offre-partenaire/jobteaser/process-jobteaser.ts
@@ -1,6 +1,7 @@
 import { importJobteaserRaw, importJobteaserToComputed } from "./import-jobteaser"
 
 export const processJobteaser = async () => {
-  await importJobteaserRaw()
-  await importJobteaserToComputed()
+  const raw = await importJobteaserRaw()
+  const computed = await importJobteaserToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/kelio/import-kelio.ts
+++ b/server/src/jobs/offre-partenaire/kelio/import-kelio.ts
@@ -11,7 +11,7 @@ const offerXmlTag = "job"
 
 export const importKelioRaw = async (sourceStream?: NodeJS.ReadableStream) => {
   if (sourceStream) {
-    await importFromStreamInXml({
+    return importFromStreamInXml({
       destinationCollection: rawCollectionName,
       offerXmlTag,
       stream: sourceStream,
@@ -19,7 +19,7 @@ export const importKelioRaw = async (sourceStream?: NodeJS.ReadableStream) => {
       conflictingOpeningTagWithoutAttributes: true,
     })
   } else {
-    await importFromUrlInXml({
+    return importFromUrlInXml({
       destinationCollection: rawCollectionName,
       url: config.kelioUrl,
       offerXmlTag,
@@ -30,7 +30,7 @@ export const importKelioRaw = async (sourceStream?: NodeJS.ReadableStream) => {
 }
 
 export const importKelioToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.KELIO,
     zodInput: ZKelioJob,

--- a/server/src/jobs/offre-partenaire/kelio/process-kelio.ts
+++ b/server/src/jobs/offre-partenaire/kelio/process-kelio.ts
@@ -1,6 +1,7 @@
 import { importKelioRaw, importKelioToComputed } from "./import-kelio"
 
 export const processKelio = async () => {
-  await importKelioRaw()
-  await importKelioToComputed()
+  const raw = await importKelioRaw()
+  const computed = await importKelioToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/laposte/import-laposte.ts
+++ b/server/src/jobs/offre-partenaire/laposte/import-laposte.ts
@@ -11,7 +11,7 @@ const offerXmlTag = "offre"
 
 export const importLaposteRaw = async (sourceStream?: NodeJS.ReadableStream) => {
   if (sourceStream) {
-    await importFromStreamInXml({
+    return importFromStreamInXml({
       destinationCollection: rawCollectionName,
       offerXmlTag,
       stream: sourceStream,
@@ -19,7 +19,7 @@ export const importLaposteRaw = async (sourceStream?: NodeJS.ReadableStream) => 
       conflictingOpeningTagWithoutAttributes: true,
     })
   } else {
-    await importFromUrlInXml({
+    return importFromUrlInXml({
       destinationCollection: rawCollectionName,
       url: config.laposteUrl,
       offerXmlTag,
@@ -30,7 +30,7 @@ export const importLaposteRaw = async (sourceStream?: NodeJS.ReadableStream) => 
 }
 
 export const importLaposteToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.LAPOSTE,
     zodInput: ZLaposteJob,

--- a/server/src/jobs/offre-partenaire/laposte/process-laposte.ts
+++ b/server/src/jobs/offre-partenaire/laposte/process-laposte.ts
@@ -1,6 +1,7 @@
 import { importLaposteRaw, importLaposteToComputed } from "./import-laposte"
 
 export const processLaposte = async () => {
-  await importLaposteRaw()
-  await importLaposteToComputed()
+  const raw = await importLaposteRaw()
+  const computed = await importLaposteToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/leboncoin/import-leboncoin.ts
+++ b/server/src/jobs/offre-partenaire/leboncoin/import-leboncoin.ts
@@ -11,14 +11,14 @@ const documentJobRoot = "job"
 
 export const importLeboncoin = async (sourceStream?: NodeJS.ReadableStream) => {
   if (sourceStream) {
-    await importFromStreamInCsv({
+    return importFromStreamInCsv({
       destinationCollection: rawCollectionName,
       stream: sourceStream,
       partnerLabel: JOBPARTNERS_LABEL.LEBONCOIN,
       parseOptions: { delimiter: "," },
     })
   } else {
-    await importFromUrlInCsv({
+    return importFromUrlInCsv({
       destinationCollection: rawCollectionName,
       url: config.leboncoinUrl,
       partnerLabel: JOBPARTNERS_LABEL.LEBONCOIN,
@@ -28,7 +28,7 @@ export const importLeboncoin = async (sourceStream?: NodeJS.ReadableStream) => {
 }
 
 export const importLeboncoinToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.LEBONCOIN,
     zodInput: ZLeboncoinJob,

--- a/server/src/jobs/offre-partenaire/leboncoin/process-leboncoin.ts
+++ b/server/src/jobs/offre-partenaire/leboncoin/process-leboncoin.ts
@@ -1,6 +1,7 @@
 import { importLeboncoin, importLeboncoinToComputed } from "./import-leboncoin"
 
 export const processLeboncoin = async () => {
-  await importLeboncoin()
-  await importLeboncoinToComputed()
+  const raw = await importLeboncoin()
+  const computed = await importLeboncoinToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/pass/import-pass.ts
+++ b/server/src/jobs/offre-partenaire/pass/import-pass.ts
@@ -11,14 +11,14 @@ const offerXmlTag = "item"
 
 export const importPassRaw = async (sourceStream?: NodeJS.ReadableStream) => {
   if (sourceStream) {
-    await importFromStreamInXml({ destinationCollection: rawCollectionName, offerXmlTag, stream: sourceStream, importName: JOBPARTNERS_LABEL.PASS })
+    return importFromStreamInXml({ destinationCollection: rawCollectionName, offerXmlTag, stream: sourceStream, importName: JOBPARTNERS_LABEL.PASS })
   } else {
-    await importFromUrlInXml({ destinationCollection: rawCollectionName, url: config.passUrl, offerXmlTag, partnerLabel: JOBPARTNERS_LABEL.PASS })
+    return importFromUrlInXml({ destinationCollection: rawCollectionName, url: config.passUrl, offerXmlTag, partnerLabel: JOBPARTNERS_LABEL.PASS })
   }
 }
 
 export const importPassToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.PASS,
     zodInput: ZPassJob,

--- a/server/src/jobs/offre-partenaire/pass/process-pass.ts
+++ b/server/src/jobs/offre-partenaire/pass/process-pass.ts
@@ -1,6 +1,7 @@
 import { importPassRaw, importPassToComputed } from "./import-pass"
 
 export const processPass = async () => {
-  await importPassRaw()
-  await importPassToComputed()
+  const raw = await importPassRaw()
+  const computed = await importPassToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/process-fill-rome-standalone.ts
+++ b/server/src/jobs/offre-partenaire/process-fill-rome-standalone.ts
@@ -7,6 +7,6 @@ export const jobPartnersByFlux = Object.values(JOBPARTNERS_LABEL).filter((jobPar
 export const processFillRomeStandalone = async () => {
   logger.info("début de processFillRomeStandalone")
   const filter = { partner_label: { $in: jobPartnersByFlux } }
-  await fillRomeForPartners({ addedMatchFilter: filter, shouldNotifySlack: true })
+  await fillRomeForPartners({ addedMatchFilter: filter })
   logger.info("fin de processFillRomeStandalone")
 }

--- a/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
+++ b/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
@@ -20,8 +20,8 @@ export const processJobPartnersForApi = async () => {
   )
 
   const filter = { currently_processed_id: processId }
-  await fillComputedJobsPartners({ addedMatchFilter: filter, shouldNotifySlack: false })
-  await importFromComputedToJobsPartners(filter, false)
+  await fillComputedJobsPartners({ addedMatchFilter: filter })
+  await importFromComputedToJobsPartners(filter)
   await fillLbaUrl()
   await getDbCollection("computed_jobs_partners").deleteMany({ $and: [filter, { validated: true }] })
   await getDbCollection("computed_jobs_partners").updateMany(filter, { $set: { currently_processed_id: null } })
@@ -30,8 +30,8 @@ export const processJobPartnersForApi = async () => {
 
 export const processJobPartnersWithFilter = async (filter: Filter<IComputedJobsPartners>) => {
   logger.info({ filter }, "début de processJobPartnersWithFilter")
-  await fillComputedJobsPartners({ addedMatchFilter: filter, shouldNotifySlack: false })
-  await importFromComputedToJobsPartners(filter, false)
+  await fillComputedJobsPartners({ addedMatchFilter: filter })
+  await importFromComputedToJobsPartners(filter)
   await fillLbaUrl()
   await getDbCollection("computed_jobs_partners").deleteMany({ $and: [filter, { validated: true }] })
   logger.info({ filter }, "fin de processJobPartnersWithFilter")

--- a/server/src/jobs/offre-partenaire/process-job-partners.ts
+++ b/server/src/jobs/offre-partenaire/process-job-partners.ts
@@ -18,23 +18,24 @@ export const cancelRemovedJobsPartnersFlux = async () => {
 }
 
 export const fillComputedJobsPartnersFlux = async () => {
-  await fillComputedJobsPartners({ addedMatchFilter: { partner_label: { $in: jobPartnersByFlux } }, shouldNotifySlack: true })
+  return fillComputedJobsPartners({ addedMatchFilter: { partner_label: { $in: jobPartnersByFlux } } })
 }
 
 export const detectDuplicateJobPartnersFlux = async () => {
-  await detectDuplicateJobPartners({ addedMatchFilter: { partner_label: { $in: jobPartnersByFlux } }, shouldNotifySlack: true })
+  return detectDuplicateJobPartners({ addedMatchFilter: { partner_label: { $in: jobPartnersByFlux } } })
 }
 
 export const validateComputedJobPartnersFlux = async () => {
-  await validateComputedJobPartners({ addedMatchFilter: { partner_label: { $in: jobPartnersByFlux } }, shouldNotifySlack: true })
+  return validateComputedJobPartners({ addedMatchFilter: { partner_label: { $in: jobPartnersByFlux } } })
 }
 
 export const processComputedAndImportToJobPartners = async () => {
   logger.info("début de processComputedAndImportToJobPartners")
   const filter = { partner_label: { $in: jobPartnersByFlux } }
-  await fillComputedJobsPartners({ addedMatchFilter: filter })
-  await importFromComputedToJobsPartners(filter)
+  const filled = await fillComputedJobsPartners({ addedMatchFilter: filter })
+  const imported = await importFromComputedToJobsPartners(filter)
   await cancelRemovedJobsPartnersFlux()
   await fillLbaUrl()
   logger.info("fin de processComputedAndImportToJobPartners")
+  return { filled, imported }
 }

--- a/server/src/jobs/offre-partenaire/process-missing-rome-and-import-to-job-partners.ts
+++ b/server/src/jobs/offre-partenaire/process-missing-rome-and-import-to-job-partners.ts
@@ -24,14 +24,14 @@ export const processMissingRomeAndImportToJobPartners = async () => {
   const processFilter = { currently_processed_id: processId }
 
   try {
-    await fillRomeForPartners({ addedMatchFilter: processFilter })
-    await validateComputedJobPartners({ addedMatchFilter: processFilter })
+    const filled = await fillRomeForPartners({ addedMatchFilter: processFilter })
+    const validated = await validateComputedJobPartners({ addedMatchFilter: processFilter })
 
     const validatedOffers = await getDbCollection("computed_jobs_partners")
       .find({ $and: [processFilter, { validated: true, business_error: null }] }, { projection: { partner_label: 1, partner_job_id: 1 } })
       .toArray()
 
-    await importFromComputedToJobsPartners(processFilter)
+    const imported = await importFromComputedToJobsPartners(processFilter)
 
     const BATCH_SIZE = 500
     for (let i = 0; i < validatedOffers.length; i += BATCH_SIZE) {
@@ -42,6 +42,8 @@ export const processMissingRomeAndImportToJobPartners = async () => {
         },
       })
     }
+
+    return { filled, validated, imported }
   } finally {
     await getDbCollection("computed_jobs_partners").updateMany(processFilter, { $set: { currently_processed_id: null } })
     logger.info("fin de processMissingRomeAndImportToJobPartners")

--- a/server/src/jobs/offre-partenaire/process-missing-rome-and-import-to-job-partners.ts
+++ b/server/src/jobs/offre-partenaire/process-missing-rome-and-import-to-job-partners.ts
@@ -24,14 +24,14 @@ export const processMissingRomeAndImportToJobPartners = async () => {
   const processFilter = { currently_processed_id: processId }
 
   try {
-    await fillRomeForPartners({ addedMatchFilter: processFilter, shouldNotifySlack: false })
-    await validateComputedJobPartners({ addedMatchFilter: processFilter, shouldNotifySlack: false })
+    await fillRomeForPartners({ addedMatchFilter: processFilter })
+    await validateComputedJobPartners({ addedMatchFilter: processFilter })
 
     const validatedOffers = await getDbCollection("computed_jobs_partners")
       .find({ $and: [processFilter, { validated: true, business_error: null }] }, { projection: { partner_label: 1, partner_job_id: 1 } })
       .toArray()
 
-    await importFromComputedToJobsPartners(processFilter, false)
+    await importFromComputedToJobsPartners(processFilter)
 
     const BATCH_SIZE = 500
     for (let i = 0; i < validatedOffers.length; i += BATCH_SIZE) {

--- a/server/src/jobs/offre-partenaire/raw-to-computed-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/raw-to-computed-jobs-partners.ts
@@ -12,7 +12,6 @@ import type { ZodObject } from "zod"
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 
 export const rawToComputedJobsPartners = async <ZodInput extends ZodObject<any>>({
   collectionSource,
@@ -74,11 +73,8 @@ export const rawToComputedJobsPartners = async <ZodInput extends ZodObject<any>>
     })
   )
 
-  const message = `import dans computed_jobs_partners pour partner_label=${partnerLabel} terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}, filtered=${counters.filtered}`
-  logger.info(message)
-  await notifyToSlack({
-    subject: `mapping Raw => computed_jobs_partners`,
-    message,
-    error: counters.error > 0,
-  })
+  logger.info(
+    `import dans computed_jobs_partners pour partner_label=${partnerLabel} terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}, filtered=${counters.filtered}`
+  )
+  return counters
 }

--- a/server/src/jobs/offre-partenaire/recruteur-lba/import-recruteurs-lba-raw.ts
+++ b/server/src/jobs/offre-partenaire/recruteur-lba/import-recruteurs-lba-raw.ts
@@ -14,7 +14,6 @@ import { logger } from "@/common/logger"
 import { getS3FileLastUpdate, s3ReadAsStream } from "@/common/utils/aws-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 import { groupStreamData } from "@/common/utils/stream-utils"
 import config from "@/config"
 import { recruteursLbaToJobPartners } from "./recruteurs-lba-mapper"
@@ -37,10 +36,7 @@ export const checkIfAlgoFileAlreadyProcessed = async (): Promise<boolean> => {
   const recruteurLbaRaw = await getDbCollection("raw_recruteurslba").findOne({}, { projection: { createdAt: 1 } })
   if (!recruteurLbaRaw) return false
   if (algoFileLastModificationDate.getTime() < recruteurLbaRaw.createdAt.getTime()) {
-    await notifyToSlack({
-      subject: `import des offres recruteurs lba dans raw`,
-      message: `dernier fichier en date déjà traité.`,
-    })
+    logger.info(`import des offres recruteurs lba dans raw : dernier fichier en date déjà traité.`)
     return true
   }
   return false
@@ -86,25 +82,16 @@ const importRecruteursLbaToRawCollection = async (sourceStream: Stream.Readable)
 
   await pipeline(sourceStream, parser(), streamArray(), validationStream, groupStreamData({ size: 10_000 }), insertionStream)
 
-  const message = `import recruteurs lba terminé : ${count} recruteurs importées`
-  logger.info(message)
-  await notifyToSlack({
-    subject: `import des offres recruteurs lba dans raw`,
-    message,
-  })
+  logger.info(`import recruteurs lba terminé : ${count} recruteurs importées`)
+  return { count }
 }
 
 export const importRecruteursLbaRaw = async (sourceFileReadStream?: Stream.Readable) => {
-  try {
-    logger.info(`début de importRecruteursLbaRaw`)
-    const readStream = sourceFileReadStream ?? (await s3ReadAsStream("storage", S3_FILE))
-    await importRecruteursLbaToRawCollection(readStream)
-    logger.info(`fin de importRecruteursLbaRaw`)
-  } catch (err) {
-    await notifyToSlack({ subject: `import des offres recruteurs lba dans raw`, message: `import recruteurs lba terminé : echec de l'import`, error: true })
-    logger.error(err)
-    sentryCaptureException(err)
-  }
+  logger.info(`début de importRecruteursLbaRaw`)
+  const readStream = sourceFileReadStream ?? (await s3ReadAsStream("storage", S3_FILE))
+  const result = await importRecruteursLbaToRawCollection(readStream)
+  logger.info(`fin de importRecruteursLbaRaw`)
+  return result
 }
 
 export const importRecruteurLbaToComputed = async () => {
@@ -213,14 +200,9 @@ export const importRecruteurLbaToComputed = async () => {
 
   await pipeline(getDbCollection(rawRecruteursLbaModel.collectionName).find({}).stream(), groupStreamData({ size: 10_000 }), transformStream)
 
-  const message = `import dans computed_jobs_partners pour partner_label=${partnerLabel} terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}`
-  logger.info(message)
+  logger.info(`import dans computed_jobs_partners pour partner_label=${partnerLabel} terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}`)
 
-  await notifyToSlack({
-    subject: `mapping Raw recruteurs LBA => computed_jobs_partners`,
-    message,
-    error: counters.error > 0,
-  })
+  return counters
 }
 
 export const removeMissingRecruteursLbaFromComputedJobPartners = async () => {
@@ -259,12 +241,8 @@ export const removeMissingRecruteursLbaFromComputedJobPartners = async () => {
     total += batch.length
   }
 
-  const message = `clean-up dans computed_jobs_partners pour partner_label=${JOBPARTNERS_LABEL.RECRUTEURS_LBA} terminé. total=${total}`
-  logger.info(message)
-  await notifyToSlack({
-    subject: `mapping Raw => computed_jobs_partners`,
-    message,
-  })
+  logger.info(`clean-up dans computed_jobs_partners pour partner_label=${JOBPARTNERS_LABEL.RECRUTEURS_LBA} terminé. total=${total}`)
+  return { total }
 }
 
 export const removeUnsubscribedRecruteursLbaFromComputedJobPartners = async () => {
@@ -296,12 +274,8 @@ export const removeUnsubscribedRecruteursLbaFromComputedJobPartners = async () =
     total += batch.length
   }
 
-  const message = `suppression dans computed_jobs_partners des recruteurs désinscrits terminée. total=${total}`
-  logger.info(message)
-  await notifyToSlack({
-    subject: `mapping Raw => computed_jobs_partners`,
-    message,
-  })
+  logger.info(`suppression dans computed_jobs_partners des recruteurs désinscrits terminée. total=${total}`)
+  return { total }
 }
 
 export const clearBlacklistedEmailsRecruteursLba = async () => {

--- a/server/src/jobs/offre-partenaire/recruteur-lba/import-recruteurs-lba-raw.ts
+++ b/server/src/jobs/offre-partenaire/recruteur-lba/import-recruteurs-lba-raw.ts
@@ -88,10 +88,16 @@ const importRecruteursLbaToRawCollection = async (sourceStream: Stream.Readable)
 
 export const importRecruteursLbaRaw = async (sourceFileReadStream?: Stream.Readable) => {
   logger.info(`début de importRecruteursLbaRaw`)
-  const readStream = sourceFileReadStream ?? (await s3ReadAsStream("storage", S3_FILE))
-  const result = await importRecruteursLbaToRawCollection(readStream)
-  logger.info(`fin de importRecruteursLbaRaw`)
-  return result
+  try {
+    const readStream = sourceFileReadStream ?? (await s3ReadAsStream("storage", S3_FILE))
+    const result = await importRecruteursLbaToRawCollection(readStream)
+    logger.info(`fin de importRecruteursLbaRaw`)
+    return result
+  } catch (err) {
+    logger.error(err, "importRecruteursLbaRaw: échec de l'import")
+    sentryCaptureException(err)
+    throw err
+  }
 }
 
 export const importRecruteurLbaToComputed = async () => {

--- a/server/src/jobs/offre-partenaire/recruteur-lba/process-recruteurs-lba.test.ts
+++ b/server/src/jobs/offre-partenaire/recruteur-lba/process-recruteurs-lba.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs"
+import { Readable } from "node:stream"
 import { createJobPartner } from "@tests/utils/jobsPartners.test.utils"
 import { useMongo } from "@tests/utils/mongo.test.utils"
 import omit from "lodash-es/omit"
@@ -11,7 +12,9 @@ import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
 import type { IRecruteursLbaRaw } from "shared/models/raw-recruteurs-lba.model"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
+import * as sentryUtils from "@/common/utils/sentry-utils"
 import { stringToStream } from "@/common/utils/stream-utils"
+import { importRecruteursLbaRaw } from "./import-recruteurs-lba-raw"
 import { processRecruteursLba } from "./process-recruteurs-lba"
 
 useMongo()
@@ -196,5 +199,20 @@ describe("import-recruteurs-lba-raw", () => {
     // then
     const publishedJobPartners = await getDbCollection("jobs_partners").find({ partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA }).toArray()
     expect.soft(publishedJobPartners.length).toBe(0)
+  })
+
+  it("propage l'erreur (et la capture dans Sentry) au lieu de l'avaler silencieusement quand le flux source échoue", async () => {
+    // biome-ignore lint/suspicious/noEmptyBlockStatements: test
+    const sentrySpy = vi.spyOn(sentryUtils, "sentryCaptureException").mockImplementation(() => {})
+    const brokenStream = new Readable({
+      read() {
+        this.emit("error", new Error("s3 stream failed"))
+      },
+    })
+
+    await expect(importRecruteursLbaRaw(brokenStream)).rejects.toThrow("s3 stream failed")
+    expect(sentrySpy).toHaveBeenCalledTimes(1)
+
+    sentrySpy.mockRestore()
   })
 })

--- a/server/src/jobs/offre-partenaire/recruteur-lba/process-recruteurs-lba.ts
+++ b/server/src/jobs/offre-partenaire/recruteur-lba/process-recruteurs-lba.ts
@@ -26,9 +26,10 @@ export const processRecruteursLba = async ({ sourceFileReadStream, skipCheckFile
     }
   }
 
-  await importRecruteursLbaRaw(sourceFileReadStream)
-  await processRecruteursLbaRawToEnd()
+  const raw = await importRecruteursLbaRaw(sourceFileReadStream)
+  const rest = await processRecruteursLbaRawToEnd()
   logger.info("fin de processRecruteursLba")
+  return { raw, ...rest }
 }
 
 const recruteursLbaFilter: Filter<IComputedJobsPartners> = {
@@ -44,10 +45,12 @@ export const cancelRemovedJobsPartnersRecruteursLba = async () => {
 }
 
 export async function processRecruteursLbaRawToEnd() {
-  await importRecruteurLbaToComputed()
+  const computed = await importRecruteurLbaToComputed()
   await fillComputedRecruteursLba()
 
-  await importFromComputedToJobsPartners(recruteursLbaFilter)
+  const imported = await importFromComputedToJobsPartners(recruteursLbaFilter)
   await fillLbaUrl()
   await cancelRemovedJobsPartnersRecruteursLba()
+
+  return { computed, imported }
 }

--- a/server/src/jobs/offre-partenaire/rh-alternance/import-rh-alternance.ts
+++ b/server/src/jobs/offre-partenaire/rh-alternance/import-rh-alternance.ts
@@ -13,7 +13,6 @@ import { z } from "zod"
 
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 import config from "@/config"
 import { blankComputedJobPartner } from "@/jobs/offre-partenaire/fill-computed-jobs-partners"
 
@@ -65,16 +64,12 @@ export const importRHAlternanceRaw = async () => {
     }
     jobCount += savedJobs.length
   }
-  const message = `import RH Alternance terminé : ${jobCount} offres importées`
-  logger.info(message)
-  await notifyToSlack({
-    subject: `import des offres RH Alternance dans raw`,
-    message,
-  })
+  logger.info(`import RH Alternance terminé : ${jobCount} offres importées`)
+  return { jobCount }
 }
 
 export const importRHAlternanceToComputed = async () => {
-  await rawToComputedJobsPartners({
+  return rawToComputedJobsPartners({
     collectionSource: rawCollectionName,
     partnerLabel: JOBPARTNERS_LABEL.RH_ALTERNANCE,
     zodInput: ZRawRHAlternanceJob,

--- a/server/src/jobs/offre-partenaire/rh-alternance/process-rh-alternance.ts
+++ b/server/src/jobs/offre-partenaire/rh-alternance/process-rh-alternance.ts
@@ -1,6 +1,7 @@
 import { importRHAlternanceRaw, importRHAlternanceToComputed } from "./import-rh-alternance"
 
 export const processRhAlternance = async () => {
-  await importRHAlternanceRaw()
-  await importRHAlternanceToComputed()
+  const raw = await importRHAlternanceRaw()
+  const computed = await importRHAlternanceToComputed()
+  return { raw, computed }
 }

--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
@@ -10,9 +10,9 @@ vi.mock("job-processor", async (importOriginal) => {
 
 const { sendJobPartnersNightlyDigest } = await import("./send-job-partners-nightly-digest")
 
-const cronTask = (params: { name: string; status: string; result?: unknown; error?: string | null; started_at?: Date }) => {
-  const { name, status, result = null, error = null, started_at } = params
-  return { name, type: "cron_task", status, started_at, output: { duration: "1s", result, error } }
+const cronTask = (params: { name: string; status: string; result?: unknown; error?: string | null; started_at?: Date; ended_at?: Date }) => {
+  const { name, status, result = null, error = null, started_at, ended_at } = params
+  return { name, type: "cron_task", status, started_at, ended_at, output: { duration: "1s", result, error } }
 }
 
 describe("sendJobPartnersNightlyDigest", () => {
@@ -91,5 +91,42 @@ describe("sendJobPartnersNightlyDigest", () => {
     expect(payload.error).toBe(true)
     expect(payload.message).toContain("Import Emploi Inclusion")
     expect(payload.message).toContain("toujours en cours")
+  })
+
+  it("regroupe plusieurs exécutions en anomalie du même job en une seule ligne", async () => {
+    findJobsMock.mockResolvedValueOnce([
+      cronTask({ name: "Process missing Rome and import to Jobs Partners", status: "errored", error: "timeout", ended_at: new Date("2026-08-10T06:00:00Z") }),
+      cronTask({ name: "Process missing Rome and import to Jobs Partners", status: "errored", error: "timeout", ended_at: new Date("2026-08-10T06:15:00Z") }),
+      cronTask({ name: "Process missing Rome and import to Jobs Partners", status: "errored", error: "dernier timeout", ended_at: new Date("2026-08-10T06:30:00Z") }),
+    ])
+    const notifySpy = vi.spyOn(slackUtils, "notifyToSlack").mockResolvedValue(undefined)
+
+    const result = await sendJobPartnersNightlyDigest()
+
+    expect(result).toEqual({ total: 3, anomalies: 3 })
+    const [payload] = notifySpy.mock.calls[0]
+    const occurrences = payload.message.split("Process missing Rome and import to Jobs Partners").length - 1
+    expect(occurrences).toBe(1)
+    expect(payload.message).toContain("3 exécutions en anomalie")
+    expect(payload.message).toContain("dernier timeout")
+  })
+
+  it("détecte une anomalie signalée par un booléen *Error* (ex. dépassement de durée)", async () => {
+    findJobsMock.mockResolvedValueOnce([
+      cronTask({ name: "Import RHAlternance", status: "finished", result: { offerInsertCount: 42 } }),
+      cronTask({
+        name: "Process computed and import to Jobs Partners",
+        status: "finished",
+        result: { steps: { detectDuplicateJobPartners: { executionDurationInSeconds: 400, executionDurationError: true } } },
+      }),
+    ])
+    const notifySpy = vi.spyOn(slackUtils, "notifyToSlack").mockResolvedValue(undefined)
+
+    const result = await sendJobPartnersNightlyDigest()
+
+    expect(result).toEqual({ total: 2, anomalies: 1 })
+    const [payload] = notifySpy.mock.calls[0]
+    expect(payload.error).toBe(true)
+    expect(payload.message).toContain("Process computed and import to Jobs Partners")
   })
 })

--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest"
+import * as slackUtils from "@/common/utils/slack-utils"
+
+const findJobsMock = vi.fn()
+
+vi.mock("job-processor", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("job-processor")>()
+  return { ...mod, findJobs: findJobsMock }
+})
+
+const { sendJobPartnersNightlyDigest } = await import("./send-job-partners-nightly-digest")
+
+const cronTask = (params: { name: string; status: string; result?: unknown; error?: string | null }) => {
+  const { name, status, result = null, error = null } = params
+  return { name, type: "cron_task", status, output: { duration: "1s", result, error } }
+}
+
+describe("sendJobPartnersNightlyDigest", () => {
+  it("n'envoie rien si aucun job n'a tourné dans la fenêtre", async () => {
+    findJobsMock.mockResolvedValueOnce([])
+    const notifySpy = vi.spyOn(slackUtils, "notifyToSlack").mockResolvedValue(undefined)
+
+    const result = await sendJobPartnersNightlyDigest()
+
+    expect(result).toEqual({ total: 0, anomalies: 0 })
+    expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it("envoie un message calme quand tous les jobs sont OK", async () => {
+    findJobsMock.mockResolvedValueOnce([
+      cronTask({ name: "Import RHAlternance", status: "finished", result: { offerInsertCount: 42 } }),
+      cronTask({ name: "Import Decathlon", status: "finished", result: { total: 10, success: 10, error: 0 } }),
+    ])
+    const notifySpy = vi.spyOn(slackUtils, "notifyToSlack").mockResolvedValue(undefined)
+
+    const result = await sendJobPartnersNightlyDigest()
+
+    expect(result).toEqual({ total: 2, anomalies: 0 })
+    expect(notifySpy).toHaveBeenCalledTimes(1)
+    const [payload] = notifySpy.mock.calls[0]
+    expect(payload.error).toBe(false)
+    expect(payload.message).toContain("2/2 jobs offre-partenaire OK")
+  })
+
+  it("regroupe les jobs en erreur dans un unique message", async () => {
+    findJobsMock.mockResolvedValueOnce([
+      cronTask({ name: "Import RHAlternance", status: "finished", result: { offerInsertCount: 42 } }),
+      cronTask({ name: "Import Decathlon", status: "finished", result: { total: 10, success: 8, error: 2 } }),
+      cronTask({ name: "Import EDF", status: "errored", error: "boom" }),
+    ])
+    const notifySpy = vi.spyOn(slackUtils, "notifyToSlack").mockResolvedValue(undefined)
+
+    const result = await sendJobPartnersNightlyDigest()
+
+    expect(result).toEqual({ total: 3, anomalies: 2 })
+    expect(notifySpy).toHaveBeenCalledTimes(1)
+    const [payload] = notifySpy.mock.calls[0]
+    expect(payload.error).toBe(true)
+    expect(payload.message).toContain("1/3 jobs OK, 2 en erreur")
+    expect(payload.message).toContain("Import Decathlon")
+    expect(payload.message).toContain("Import EDF")
+    expect(payload.message).toContain("boom")
+  })
+
+  it("interroge job_processor.jobs sur le périmètre offre-partenaire, sans inclure le digest lui-même", async () => {
+    findJobsMock.mockResolvedValueOnce([])
+    vi.spyOn(slackUtils, "notifyToSlack").mockResolvedValue(undefined)
+
+    await sendJobPartnersNightlyDigest()
+
+    expect(findJobsMock).toHaveBeenCalledTimes(1)
+    const [filter] = findJobsMock.mock.calls[0]
+    expect(filter.type).toBe("cron_task")
+    expect(filter.name.$in).toContain("Import RHAlternance")
+    expect(filter.name.$in).not.toContain("Bilan nocturne offres partenaires")
+  })
+})

--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
@@ -10,9 +10,9 @@ vi.mock("job-processor", async (importOriginal) => {
 
 const { sendJobPartnersNightlyDigest } = await import("./send-job-partners-nightly-digest")
 
-const cronTask = (params: { name: string; status: string; result?: unknown; error?: string | null }) => {
-  const { name, status, result = null, error = null } = params
-  return { name, type: "cron_task", status, output: { duration: "1s", result, error } }
+const cronTask = (params: { name: string; status: string; result?: unknown; error?: string | null; started_at?: Date }) => {
+  const { name, status, result = null, error = null, started_at } = params
+  return { name, type: "cron_task", status, started_at, output: { duration: "1s", result, error } }
 }
 
 describe("sendJobPartnersNightlyDigest", () => {
@@ -73,5 +73,23 @@ describe("sendJobPartnersNightlyDigest", () => {
     expect(filter.type).toBe("cron_task")
     expect(filter.name.$in).toContain("Import RHAlternance")
     expect(filter.name.$in).not.toContain("Bilan nocturne offres partenaires")
+    // un job "running" n'a pas de ended_at : il doit rester inclus malgré la fenêtre temporelle
+    expect(filter.$or).toContainEqual({ status: "running" })
+  })
+
+  it("signale un job encore en cours à l'heure du digest comme une anomalie", async () => {
+    findJobsMock.mockResolvedValueOnce([
+      cronTask({ name: "Import RHAlternance", status: "finished", result: { offerInsertCount: 42 } }),
+      cronTask({ name: "Import Emploi Inclusion", status: "running", started_at: new Date("2026-08-10T00:00:00Z") }),
+    ])
+    const notifySpy = vi.spyOn(slackUtils, "notifyToSlack").mockResolvedValue(undefined)
+
+    const result = await sendJobPartnersNightlyDigest()
+
+    expect(result).toEqual({ total: 2, anomalies: 1 })
+    const [payload] = notifySpy.mock.calls[0]
+    expect(payload.error).toBe(true)
+    expect(payload.message).toContain("Import Emploi Inclusion")
+    expect(payload.message).toContain("toujours en cours")
   })
 })

--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
@@ -1,0 +1,76 @@
+import type { IJobsCronTask } from "job-processor"
+import { findJobs } from "job-processor"
+import { logger } from "@/common/logger"
+import { notifyToSlack } from "@/common/utils/slack-utils"
+import { importers } from "./jobs-partners.importer"
+
+const DIGEST_WINDOW_HOURS = 24
+
+export const JOB_PARTNERS_DIGEST_JOB_NAME = "Bilan nocturne offres partenaires"
+
+// Calculé à l'appel (pas au chargement du module) : jobs-partners.importer.ts importe ce fichier pour enregistrer
+// son propre CronDef, donc `importers` n'est pas encore initialisé tant que ce module est en cours de chargement.
+const getJobPartnersNightlyJobNames = () => Object.keys(importers).filter((name) => name !== JOB_PARTNERS_DIGEST_JOB_NAME)
+
+const hasNonZeroErrorCount = (value: unknown): boolean => {
+  if (value == null) return false
+  if (Array.isArray(value)) return value.some(hasNonZeroErrorCount)
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(([key, val]) => {
+      if (/error/i.test(key) && typeof val === "number") return val > 0
+      return hasNonZeroErrorCount(val)
+    })
+  }
+  return false
+}
+
+const isAnomalous = (job: IJobsCronTask): boolean => {
+  if (job.status === "errored" || job.status === "killed") return true
+  return hasNonZeroErrorCount(job.output?.result)
+}
+
+const formatAnomaly = (job: IJobsCronTask): string => {
+  const duration = job.output?.duration ?? "?"
+  if (job.status === "errored" || job.status === "killed") {
+    return `• ${job.name} (${job.status}, ${duration}) : ${job.output?.error ?? "erreur inconnue"}`
+  }
+  return `• ${job.name} (${duration}) : ${JSON.stringify(job.output?.result)}`
+}
+
+/**
+ * Bilan unique des jobs offre-partenaire de la nuit, construit à partir de job_processor.jobs
+ * (déjà persisté par job-processor : status, durée, output.result de chaque cron_task).
+ * Remplace les notifications Slack de routine envoyées individuellement par chaque job.
+ */
+export const sendJobPartnersNightlyDigest = async () => {
+  const since = new Date(Date.now() - DIGEST_WINDOW_HOURS * 60 * 60 * 1000)
+
+  const jobs = await findJobs<IJobsCronTask>({
+    type: "cron_task",
+    name: { $in: getJobPartnersNightlyJobNames() },
+    ended_at: { $gte: since },
+  })
+
+  if (jobs.length === 0) {
+    logger.info("sendJobPartnersNightlyDigest: aucun job à rapporter sur la période")
+    return { total: 0, anomalies: 0 }
+  }
+
+  const anomalousJobs = jobs.filter(isAnomalous)
+  const okCount = jobs.length - anomalousJobs.length
+
+  const summaryLine =
+    anomalousJobs.length === 0 ? `${okCount}/${jobs.length} jobs offre-partenaire OK, aucune anomalie.` : `${okCount}/${jobs.length} jobs OK, ${anomalousJobs.length} en erreur :`
+
+  const message = [summaryLine, ...anomalousJobs.map(formatAnomaly)].join("\n")
+
+  await notifyToSlack({
+    subject: "Bilan nocturne offres partenaires",
+    message,
+    error: anomalousJobs.length > 0,
+  })
+
+  logger.info({ total: jobs.length, anomalies: anomalousJobs.length }, "sendJobPartnersNightlyDigest: digest envoyé")
+
+  return { total: jobs.length, anomalies: anomalousJobs.length }
+}

--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
@@ -18,7 +18,10 @@ const hasNonZeroErrorCount = (value: unknown): boolean => {
   if (Array.isArray(value)) return value.some(hasNonZeroErrorCount)
   if (typeof value === "object") {
     return Object.entries(value as Record<string, unknown>).some(([key, val]) => {
-      if (/error/i.test(key) && typeof val === "number") return val > 0
+      if (/error/i.test(key)) {
+        if (typeof val === "number") return val > 0
+        if (typeof val === "boolean") return val === true
+      }
       return hasNonZeroErrorCount(val)
     })
   }
@@ -31,15 +34,40 @@ const isAnomalous = (job: IJobsCronTask): boolean => {
   return hasNonZeroErrorCount(job.output?.result)
 }
 
-const formatAnomaly = (job: IJobsCronTask): string => {
+const jobTimestamp = (job: IJobsCronTask): number => (job.ended_at ?? job.started_at ?? new Date(0)).getTime()
+
+const describeAnomaly = (job: IJobsCronTask): string => {
   const duration = job.output?.duration ?? "?"
   if (job.status === "running") {
-    return `• ${job.name} (toujours en cours, démarré à ${job.started_at?.toISOString() ?? "?"})`
+    return `toujours en cours, démarré à ${job.started_at?.toISOString() ?? "?"}`
   }
   if (job.status === "errored" || job.status === "killed") {
-    return `• ${job.name} (${job.status}, ${duration}) : ${job.output?.error ?? "erreur inconnue"}`
+    return `${job.status}, ${duration} : ${job.output?.error ?? "erreur inconnue"}`
   }
-  return `• ${job.name} (${duration}) : ${JSON.stringify(job.output?.result)}`
+  return `${duration} : ${JSON.stringify(job.output?.result)}`
+}
+
+// Un même job (ex. "Process missing Rome...", ~65 exécutions/jour) peut échouer en boucle sur la fenêtre :
+// on regroupe par nom pour garder un digest lisible plutôt qu'une ligne par exécution en anomalie.
+const formatAnomalyGroup = (name: string, jobsForName: IJobsCronTask[]): string => {
+  const [mostRecent] = [...jobsForName].sort((a, b) => jobTimestamp(b) - jobTimestamp(a))
+  if (jobsForName.length === 1) {
+    return `• ${name} (${describeAnomaly(mostRecent)})`
+  }
+  return `• ${name} : ${jobsForName.length} exécutions en anomalie sur la période (dernière : ${describeAnomaly(mostRecent)})`
+}
+
+const groupByName = (jobs: IJobsCronTask[]): [string, IJobsCronTask[]][] => {
+  const groups = new Map<string, IJobsCronTask[]>()
+  for (const job of jobs) {
+    const group = groups.get(job.name)
+    if (group) {
+      group.push(job)
+    } else {
+      groups.set(job.name, [job])
+    }
+  }
+  return [...groups.entries()]
 }
 
 /**
@@ -69,7 +97,8 @@ export const sendJobPartnersNightlyDigest = async () => {
   const summaryLine =
     anomalousJobs.length === 0 ? `${okCount}/${jobs.length} jobs offre-partenaire OK, aucune anomalie.` : `${okCount}/${jobs.length} jobs OK, ${anomalousJobs.length} en erreur :`
 
-  let message = [summaryLine, ...anomalousJobs.map(formatAnomaly)].join("\n")
+  const anomalyLines = groupByName(anomalousJobs).map(([name, jobsForName]) => formatAnomalyGroup(name, jobsForName))
+  let message = [summaryLine, ...anomalyLines].join("\n")
   if (message.length > MAX_MESSAGE_LENGTH) {
     message = `${message.slice(0, MAX_MESSAGE_LENGTH)}\n… (message tronqué, voir les logs pour le détail complet)`
   }

--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
@@ -5,6 +5,7 @@ import { notifyToSlack } from "@/common/utils/slack-utils"
 import { importers } from "./jobs-partners.importer"
 
 const DIGEST_WINDOW_HOURS = 24
+const MAX_MESSAGE_LENGTH = 35_000 // marge sous la limite Slack (~40k caractères) pour le champ `text`
 
 export const JOB_PARTNERS_DIGEST_JOB_NAME = "Bilan nocturne offres partenaires"
 
@@ -25,12 +26,16 @@ const hasNonZeroErrorCount = (value: unknown): boolean => {
 }
 
 const isAnomalous = (job: IJobsCronTask): boolean => {
-  if (job.status === "errored" || job.status === "killed") return true
+  // "running" à l'heure du digest : le job aurait dû se terminer avant (cf. timing du cron) — signe d'un job bloqué
+  if (job.status === "errored" || job.status === "killed" || job.status === "running") return true
   return hasNonZeroErrorCount(job.output?.result)
 }
 
 const formatAnomaly = (job: IJobsCronTask): string => {
   const duration = job.output?.duration ?? "?"
+  if (job.status === "running") {
+    return `• ${job.name} (toujours en cours, démarré à ${job.started_at?.toISOString() ?? "?"})`
+  }
   if (job.status === "errored" || job.status === "killed") {
     return `• ${job.name} (${job.status}, ${duration}) : ${job.output?.error ?? "erreur inconnue"}`
   }
@@ -48,7 +53,9 @@ export const sendJobPartnersNightlyDigest = async () => {
   const jobs = await findJobs<IJobsCronTask>({
     type: "cron_task",
     name: { $in: getJobPartnersNightlyJobNames() },
-    ended_at: { $gte: since },
+    // un job encore "running" n'a pas de ended_at : on le remonte quand même, sinon un job bloqué
+    // à l'heure du digest disparaîtrait silencieusement du rapport
+    $or: [{ ended_at: { $gte: since } }, { status: "running" }],
   })
 
   if (jobs.length === 0) {
@@ -62,10 +69,13 @@ export const sendJobPartnersNightlyDigest = async () => {
   const summaryLine =
     anomalousJobs.length === 0 ? `${okCount}/${jobs.length} jobs offre-partenaire OK, aucune anomalie.` : `${okCount}/${jobs.length} jobs OK, ${anomalousJobs.length} en erreur :`
 
-  const message = [summaryLine, ...anomalousJobs.map(formatAnomaly)].join("\n")
+  let message = [summaryLine, ...anomalousJobs.map(formatAnomaly)].join("\n")
+  if (message.length > MAX_MESSAGE_LENGTH) {
+    message = `${message.slice(0, MAX_MESSAGE_LENGTH)}\n… (message tronqué, voir les logs pour le détail complet)`
+  }
 
   await notifyToSlack({
-    subject: "Bilan nocturne offres partenaires",
+    subject: JOB_PARTNERS_DIGEST_JOB_NAME,
     message,
     error: anomalousJobs.length > 0,
   })

--- a/server/src/jobs/offre-partenaire/validate-computed-job-partners.test.ts
+++ b/server/src/jobs/offre-partenaire/validate-computed-job-partners.test.ts
@@ -26,7 +26,7 @@ describe("fill-computed-jobs-partners", () => {
     // given
     await givenSomeComputedJobPartners([generateComputedJobsPartnersFull()])
     // when
-    await validateComputedJobPartners({ shouldNotifySlack: false })
+    await validateComputedJobPartners({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)
@@ -41,7 +41,7 @@ describe("fill-computed-jobs-partners", () => {
       }),
     ])
     // when
-    await validateComputedJobPartners({ shouldNotifySlack: false })
+    await validateComputedJobPartners({})
     // then
     const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
     expect.soft(jobs.length).toBe(1)

--- a/server/src/jobs/offre-partenaire/validate-computed-job-partners.ts
+++ b/server/src/jobs/offre-partenaire/validate-computed-job-partners.ts
@@ -7,7 +7,6 @@ import type { IComputedJobsPartners } from "shared/models/jobs-partners-computed
 import { COMPUTED_ERROR_SOURCE } from "shared/models/jobs-partners-computed.model"
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
 import { groupStreamData } from "@/common/utils/stream-utils"
 import type { FillComputedJobsPartnersContext } from "./fill-computed-jobs-partners"
 
@@ -16,7 +15,7 @@ const zodModel = jobsPartnersModel.zod
 
 type BulkOperation = AnyBulkWriteOperation<IComputedJobsPartners>
 
-export const validateComputedJobPartners = async ({ addedMatchFilter, shouldNotifySlack }: FillComputedJobsPartnersContext) => {
+export const validateComputedJobPartners = async ({ addedMatchFilter }: FillComputedJobsPartnersContext) => {
   logger.info("validation des computed_job_partners")
 
   const finalFilter: Filter<IComputedJobsPartners> = {
@@ -95,10 +94,5 @@ export const validateComputedJobPartners = async ({ addedMatchFilter, shouldNoti
 
   logger.info({ counters }, "validation terminé")
 
-  if (shouldNotifySlack) {
-    await notifyToSlack({
-      subject: `computedJobPartners: validation des offres`,
-      message: `validation terminé. total=${counters.total}, success=${counters.success}, errors=${counters.error}`,
-    })
-  }
+  return counters
 }


### PR DESCRIPTION
Closes #5126

## Changements

- Retrait des appels `notifyToSlack` de routine dans les jobs `offre-partenaire` (import raw/computed, validation, factories fill/block, détection de doublons) : chaque fonction retourne désormais ses compteurs au lieu de poster sur Slack.
- Propagation de ces résultats jusqu'aux handlers de cron (les ~18 imports partenaires + le pipeline `fillComputedJobsPartners`/`processComputedAndImportToJobPartners`), automatiquement persistés par `job-processor` dans `job_processor.jobs.output.result`.
- Suppression du flag `shouldNotifySlack`, devenu inutile partout où il était threadé.
- Nouveau job `sendJobPartnersNightlyDigest` : lit `job_processor.jobs` via `findJobs` (déjà exporté par `job-processor`) et envoie un seul message Slack récapitulatif (calme si tout est OK, détaillé pour les jobs en erreur), au lieu des ~40 messages individuels envoyés chaque nuit.
- Nouveau cron `Bilan nocturne offres partenaires` (`30 5 * * *`), planifié après le pire cas de durée des jobs existants.
- Aucun changement sur l'exécution/le parallélisme/l'isolation des jobs partenaires.

## Plan de test

- [x] `yarn typecheck` sur `server/`
- [x] `yarn test --run server/src/jobs/offre-partenaire` (44 fichiers, 203 tests + 1 nouveau digest)
- [x] `yarn check:fix`
- [ ] Vérifier en recette que le digest s'envoie bien une fois par nuit avec un contenu cohérent