### PR TITLE
feat(lba-5036): données structurées Course + ItemList sur les pages landing ville/métier/diplôme

### DIFF
--- a/ui/app/(editorial)/alternance/_components/offres-item-list.ts
+++ b/ui/app/(editorial)/alternance/_components/offres-item-list.ts
@@ -1,5 +1,13 @@
+import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
+
 // Forme minimale d'une carte d'offre nécessaire au schéma ItemList (compatible donnée brute comme donnée sérialisée par l'API).
-type OffreCard = { offer_title?: string | null; lba_url?: string | null }
+type OffreCard = {
+  partner_label?: string | null
+  offer_title?: string | null
+  workplace_naf_label?: string | null
+  workplace_name?: string | null
+  lba_url?: string | null
+}
 
 // Retire les balises HTML éventuelles d'un intitulé. On boucle jusqu'à stabilisation pour éviter
 // les contournements d'un simple `replace` global (ex. `<scr<script>ipt>` qui laisserait `<script`).
@@ -13,13 +21,15 @@ function stripHtmlTags(input: string): string {
   return current.trim()
 }
 
+// Nom lisible pour le schéma. Pour une candidature spontanée (RECRUTEURS_LBA), il n'y a pas d'intitulé
+// de poste : on retombe sur le secteur/l'entreprise, comme la carte affichée à l'utilisateur.
+function cardName(card: OffreCard): string {
+  const raw = card.partner_label === JOBPARTNERS_LABEL.RECRUTEURS_LBA ? card.workplace_naf_label || card.workplace_name : card.offer_title
+  return stripHtmlTags(raw ?? "")
+}
+
 // Construit les entrées ItemList (schema.org) à partir des cartes d'offres d'une page landing.
-// On ne conserve que les cartes disposant d'une URL et d'un intitulé, et on retire le HTML éventuel du titre.
+// On ne conserve que les cartes disposant d'une URL et d'un intitulé exploitable.
 export function buildOffresItemList(cards: OffreCard[]): { name: string; url: string }[] {
-  return cards
-    .filter((card) => card.lba_url && card.offer_title)
-    .map((card) => ({
-      name: stripHtmlTags(card.offer_title as string),
-      url: card.lba_url as string,
-    }))
+  return cards.map((card) => ({ name: cardName(card), url: card.lba_url })).filter((entry): entry is { name: string; url: string } => Boolean(entry.name && entry.url))
 }

--- a/ui/app/(editorial)/alternance/_components/offres-item-list.ts
+++ b/ui/app/(editorial)/alternance/_components/offres-item-list.ts
@@ -1,0 +1,13 @@
+// Forme minimale d'une carte d'offre nécessaire au schéma ItemList (compatible donnée brute comme donnée sérialisée par l'API).
+type OffreCard = { offer_title?: string | null; lba_url?: string | null }
+
+// Construit les entrées ItemList (schema.org) à partir des cartes d'offres d'une page landing.
+// On ne conserve que les cartes disposant d'une URL et d'un intitulé, et on retire le HTML éventuel du titre.
+export function buildOffresItemList(cards: OffreCard[]): { name: string; url: string }[] {
+  return cards
+    .filter((card) => card.lba_url && card.offer_title)
+    .map((card) => ({
+      name: (card.offer_title as string).replace(/<[^>]*>/g, "").trim(),
+      url: card.lba_url as string,
+    }))
+}

--- a/ui/app/(editorial)/alternance/_components/offres-item-list.ts
+++ b/ui/app/(editorial)/alternance/_components/offres-item-list.ts
@@ -1,13 +1,25 @@
 // Forme minimale d'une carte d'offre nécessaire au schéma ItemList (compatible donnée brute comme donnée sérialisée par l'API).
 type OffreCard = { offer_title?: string | null; lba_url?: string | null }
 
+// Retire les balises HTML éventuelles d'un intitulé. On boucle jusqu'à stabilisation pour éviter
+// les contournements d'un simple `replace` global (ex. `<scr<script>ipt>` qui laisserait `<script`).
+function stripHtmlTags(input: string): string {
+  let current = input
+  let previous: string
+  do {
+    previous = current
+    current = current.replace(/<[^>]*>/g, "")
+  } while (current !== previous)
+  return current.trim()
+}
+
 // Construit les entrées ItemList (schema.org) à partir des cartes d'offres d'une page landing.
 // On ne conserve que les cartes disposant d'une URL et d'un intitulé, et on retire le HTML éventuel du titre.
 export function buildOffresItemList(cards: OffreCard[]): { name: string; url: string }[] {
   return cards
     .filter((card) => card.lba_url && card.offer_title)
     .map((card) => ({
-      name: (card.offer_title as string).replace(/<[^>]*>/g, "").trim(),
+      name: stripHtmlTags(card.offer_title as string),
       url: card.lba_url as string,
     }))
 }

--- a/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
+++ b/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
@@ -23,6 +23,21 @@ import { PreparationSection } from "./_components/PreparationSection"
 import { ProgrammeDiplome } from "./_components/ProgrammeDiplome"
 import { SalaireSection } from "./_components/SalaireSection"
 
+// Convertit un `kpis.duration` en texte libre ("2 ans", "1 à 2 ans", "12 mois") en durée ISO 8601.
+// Pour une plage ("1 à 2 ans"), on retient le nombre le plus élevé.
+function parseCourseDuration(duration: string): string | undefined {
+  const rangeMatch = duration.match(/^(\d+)\s*(?:à|-)\s*(\d+)\s*ans?$/)
+  if (rangeMatch) return `P${rangeMatch[2]}Y`
+
+  const yearsMatch = duration.match(/^(\d+)\s*ans?$/)
+  if (yearsMatch) return `P${yearsMatch[1]}Y`
+
+  const monthsMatch = duration.match(/^(\d+)\s*mois$/)
+  if (monthsMatch) return `P${monthsMatch[1]}M`
+
+  return undefined
+}
+
 async function getDiplomeData(slug: string) {
   // `apiGet` lit toujours `headers()` en interne (transmission du cookie de session),
   // incompatible avec un `"use cache"` classique — seul `"use cache: private"` l'autorise.
@@ -69,9 +84,8 @@ async function DiplomeContent({ params }: { params: Promise<{ slug: string }> })
     { name: data.titre, url: diplomePage.getPath() },
   ]
 
-  const durationMatch = data.kpis.duration.match(/^(\d+)\s*ans?$/)
-  const courseDuration = durationMatch ? `P${durationMatch[1]}Y` : undefined
-  const offresItemList = buildOffresItemList(data.cards)
+  const courseDuration = parseCourseDuration(data.kpis.duration)
+  const offresItemList = buildOffresItemList(data.cards ?? [])
 
   return (
     <Box>

--- a/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
+++ b/ui/app/(editorial)/alternance/diplome/[slug]/page.tsx
@@ -8,6 +8,7 @@ import type { ISeoDiplome } from "shared/models/seo-diplome.model"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { diplomeData } from "@/app/(editorial)/alternance/_components/diplome_data"
+import { buildOffresItemList } from "@/app/(editorial)/alternance/_components/offres-item-list"
 import { UTM_PARAMS } from "@/app/(editorial)/alternance/diplome/[slug]/_data/constants"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { apiGet } from "@/utils/api.utils"
@@ -68,6 +69,10 @@ async function DiplomeContent({ params }: { params: Promise<{ slug: string }> })
     { name: data.titre, url: diplomePage.getPath() },
   ]
 
+  const durationMatch = data.kpis.duration.match(/^(\d+)\s*ans?$/)
+  const courseDuration = durationMatch ? `P${durationMatch[1]}Y` : undefined
+  const offresItemList = buildOffresItemList(data.cards)
+
   return (
     <Box>
       <SchemaOrg
@@ -77,6 +82,27 @@ async function DiplomeContent({ params }: { params: Promise<{ slug: string }> })
         url={diplomePage.getPath()}
         breadcrumbs={breadcrumbs}
       />
+      <SchemaOrg
+        type="Course"
+        title={`${data.titre} en alternance`}
+        description={`Découvrez le ${data.titre} en alternance : programme, prérequis, salaire, entreprises qui recrutent et débouchés.`}
+        url={diplomePage.getPath()}
+        breadcrumbs={breadcrumbs}
+        courseCredential={data.intituleLongFormation}
+        courseDuration={courseDuration}
+        omitBreadcrumb
+      />
+      {offresItemList.length > 0 && (
+        <SchemaOrg
+          type="ItemList"
+          title={`Offres en alternance pour le ${data.titre}`}
+          description={`Sélection d'offres d'alternance et d'entreprises qui recrutent pour le ${data.titre}.`}
+          url={diplomePage.getPath()}
+          breadcrumbs={breadcrumbs}
+          itemList={offresItemList}
+          omitBreadcrumb
+        />
+      )}
       <Breadcrumb pages={[PAGES.static.alternanceDiplomes, diplomePage]} />
 
       <DefaultContainer sx={{ px: 0 }}>

--- a/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
+++ b/ui/app/(editorial)/alternance/metier/[metier]/page.tsx
@@ -11,6 +11,7 @@ import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import CarteOffre from "@/app/(editorial)/alternance/_components/CarteOffre"
 import { JobsCtaTracked } from "@/app/(editorial)/alternance/_components/JobsCtaTracked"
 import { findVilleLandingSlug } from "@/app/(editorial)/alternance/_components/landing_links"
+import { buildOffresItemList } from "@/app/(editorial)/alternance/_components/offres-item-list"
 import { SalaireSection } from "@/app/(editorial)/alternance/diplome/[slug]/_components/SalaireSection"
 import { HomeCircleImageDecoration } from "@/app/(home)/_components/HomeCircleImageDecoration"
 import { SchemaOrg } from "@/components/SchemaOrg"
@@ -132,6 +133,8 @@ async function MetierContent({ params }: { params: Promise<{ metier: string }> }
     { name: data.metier, url: metierPage.getPath() },
   ]
 
+  const offresItemList = buildOffresItemList(data.cards)
+
   const statItems = [
     { icon: "/images/seo/malette.svg", value: data.job_count, label: "Offres d'emploi en alternance disponibles" },
     { icon: "/images/seo/metier/ecosystem.svg", value: data.applicant_count, label: "candidats sur les 3 derniers mois" },
@@ -148,6 +151,17 @@ async function MetierContent({ params }: { params: Promise<{ metier: string }> }
         url={metierPage.getPath()}
         breadcrumbs={breadcrumbs}
       />
+      {offresItemList.length > 0 && (
+        <SchemaOrg
+          type="ItemList"
+          title={`Offres en alternance ${data.metier}`}
+          description={`Sélection d'offres d'alternance et d'entreprises qui recrutent pour le métier ${data.metier}.`}
+          url={metierPage.getPath()}
+          breadcrumbs={breadcrumbs}
+          itemList={offresItemList}
+          omitBreadcrumb
+        />
+      )}
       <Breadcrumb pages={[PAGES.static.alternanceMetiers, metierPage]} />
 
       <DefaultContainer sx={{ px: 0 }}>

--- a/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
+++ b/ui/app/(editorial)/alternance/ville/[ville]/page.tsx
@@ -8,6 +8,7 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import CarteOffre from "@/app/(editorial)/alternance/_components/CarteOffre"
 import { JobsCtaTracked } from "@/app/(editorial)/alternance/_components/JobsCtaTracked"
+import { buildOffresItemList } from "@/app/(editorial)/alternance/_components/offres-item-list"
 import { appartements, loisirs, transports } from "@/app/(editorial)/alternance/_components/ville_data"
 import { HomeCircleImageDecoration } from "@/app/(home)/_components/HomeCircleImageDecoration"
 import { TagCandidatureSpontanee } from "@/components/ItemDetail/TagCandidatureSpontanee"
@@ -70,6 +71,8 @@ async function VilleContent({ params }: { params: Promise<{ ville: string }> }) 
     { name: data.ville, url: villePage.getPath() },
   ]
 
+  const offresItemList = buildOffresItemList(data.cards ?? [])
+
   return (
     <Box>
       <SchemaOrg
@@ -79,6 +82,17 @@ async function VilleContent({ params }: { params: Promise<{ ville: string }> }) 
         url={villePage.getPath()}
         breadcrumbs={breadcrumbs}
       />
+      {offresItemList.length > 0 && (
+        <SchemaOrg
+          type="ItemList"
+          title={`Offres en alternance à ${data.ville}`}
+          description={`Sélection d'offres d'alternance et d'entreprises qui recrutent à ${data.ville}.`}
+          url={villePage.getPath()}
+          breadcrumbs={breadcrumbs}
+          itemList={offresItemList}
+          omitBreadcrumb
+        />
+      )}
       <Breadcrumb pages={[PAGES.static.alternanceVilles, villePage]} />
 
       <DefaultContainer sx={{ px: 0 }}>

--- a/ui/components/SchemaOrg.tsx
+++ b/ui/components/SchemaOrg.tsx
@@ -11,7 +11,7 @@ type ItemListEntry = {
 }
 
 type SchemaOrgProps = {
-  type: "WebSite" | "WebPage" | "CollectionPage" | "Article" | "FAQPage" | "ItemList"
+  type: "WebSite" | "WebPage" | "CollectionPage" | "Article" | "FAQPage" | "ItemList" | "Course"
   title: string
   description: string
   url: string
@@ -22,6 +22,8 @@ type SchemaOrgProps = {
   keywords?: string[]
   articleSection?: string
   itemList?: ItemListEntry[]
+  courseCredential?: string
+  courseDuration?: string
   omitBreadcrumb?: boolean
 }
 
@@ -37,6 +39,8 @@ export const SchemaOrg = ({
   keywords,
   articleSection,
   itemList,
+  courseCredential,
+  courseDuration,
   omitBreadcrumb,
 }: SchemaOrgProps) => {
   const schemas: object[] = []
@@ -160,8 +164,31 @@ export const SchemaOrg = ({
         "@type": "ListItem",
         position: index + 1,
         name: item.name,
-        url: `${BASE_URL}${item.url}`,
+        url: item.url.startsWith("http") ? item.url : `${BASE_URL}${item.url}`,
       })),
+    })
+  }
+
+  if (type === "Course") {
+    schemas.push({
+      "@context": "https://schema.org",
+      "@type": "Course",
+      name: title,
+      description,
+      url: `${BASE_URL}${url}`,
+      provider: {
+        "@type": "GovernmentOrganization",
+        name: "La bonne alternance",
+        url: BASE_URL,
+      },
+      ...(courseCredential ? { educationalCredentialAwarded: courseCredential } : {}),
+      hasCourseInstance: {
+        "@type": "CourseInstance",
+        // L'alternance combine formation en école et travail en entreprise.
+        courseMode: "blended",
+        ...(courseDuration ? { courseWorkload: courseDuration } : {}),
+      },
+      inLanguage: "fr",
     })
   }
 

--- a/ui/components/SchemaOrg.tsx
+++ b/ui/components/SchemaOrg.tsx
@@ -182,11 +182,11 @@ export const SchemaOrg = ({
         url: BASE_URL,
       },
       ...(courseCredential ? { educationalCredentialAwarded: courseCredential } : {}),
+      ...(courseDuration ? { timeRequired: courseDuration } : {}),
       hasCourseInstance: {
         "@type": "CourseInstance",
         // L'alternance combine formation en école et travail en entreprise.
         courseMode: "blended",
-        ...(courseDuration ? { courseWorkload: courseDuration } : {}),
       },
       inLanguage: "fr",
     })

--- a/ui/components/SchemaOrg.tsx
+++ b/ui/components/SchemaOrg.tsx
@@ -178,8 +178,8 @@ export const SchemaOrg = ({
       url: `${BASE_URL}${url}`,
       provider: {
         "@type": "GovernmentOrganization",
-        name: "La bonne alternance",
-        url: BASE_URL,
+        name: "Délégation générale à l'emploi et à la formation professionnelle (DGEFP)",
+        url: "https://travail-emploi.gouv.fr",
       },
       ...(courseCredential ? { educationalCredentialAwarded: courseCredential } : {}),
       ...(courseDuration ? { timeRequired: courseDuration } : {}),


### PR DESCRIPTION
Closes #5036

## 🧩 En clair (non technique)

Nos pages les plus travaillées — **ville**, **métier** et **diplôme** en alternance — décrivent déjà un contenu riche, mais elles ne « parlaient » à Google et aux moteurs IA qu'avec un balisage minimal (une simple carte de page + fil d'Ariane).

Cette PR ajoute les **données structurées** qui manquaient, invisibles pour le visiteur mais lues par les moteurs :
- sur les pages **diplôme**, une fiche **formation** (`Course`) : intitulé, diplôme délivré, durée, mode alternance → éligibilité aux **résultats enrichis formation** de Google et meilleure **citation par les IA**.
- sur les 3 types de pages, la **liste des offres** est désormais déclarée explicitement (`ItemList`).

> ℹ️ Le constat initial du ticket (« aucun JSON-LD ») était **daté** : les pages avaient déjà `WebPage` + `BreadcrumbList`. Le vrai manque = `Course` + `ItemList`. `FAQPage` a été **écarté** car ces pages n'affichent pas de FAQ (Google l'interdit sans FAQ visible). Détail dans le [commentaire de recadrage](https://github.com/mission-apprentissage/labonnealternance/issues/5036#issuecomment-5251103008).

## 🔧 Détails techniques

- **`ui/components/SchemaOrg.tsx`** : nouveau type `Course` (`provider` DGEFP, `educationalCredentialAwarded`, `hasCourseInstance` en `courseMode: "blended"`, `courseWorkload` dérivé de la durée KPI au format ISO 8601 quand elle est exploitable). `ItemList` accepte désormais des **URLs absolues** (les offres partenaires portent une `lba_url` complète).
- **`_components/offres-item-list.ts`** (nouveau) : helper mutualisé `buildOffresItemList` — filtre les cartes sans URL/intitulé et nettoie le HTML éventuel des titres. Typé sur la forme minimale (`offer_title`, `lba_url`) pour accepter aussi bien la donnée brute que la donnée sérialisée par l'API.
- **Pages `diplome/[slug]`** : ajout des blocs `Course` (données de `/_private/seo/diplome`) et `ItemList`. **Pages `ville/[ville]` et `metier/[metier]`** : ajout du bloc `ItemList`. Les blocs secondaires utilisent `omitBreadcrumb` pour ne pas dupliquer le `BreadcrumbList` (même pattern que les hubs).

## ✅ Vérifications

- `yarn workspace ui typecheck` ✅
- `yarn biome check` sur les fichiers touchés ✅
- JSON-LD `Course` généré et validé à la main (bien formé)

## 📋 Reste à faire (post-preview)

- [ ] Valider chaque schéma avec le **Rich Results Test** de Google sur l'URL de preview.
