### PR TITLE
fix: corrige les faux échecs de preview dus au bug TLS node24

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -25,7 +25,10 @@ jobs:
 
       - name: Comment PR Preview
         if: github.event.issue.state != 'closed'
+        continue-on-error: true
         uses: thollander/actions-comment-pull-request@v3
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         with:
           message: |
             ### :rocket: Prévisualisation
@@ -133,7 +136,10 @@ jobs:
 
       - name: Comment PR Preview
         if: github.event.issue.state != 'closed'
+        continue-on-error: true
         uses: thollander/actions-comment-pull-request@v3
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         with:
           message: |
             ### :rocket: Prévisualisation
@@ -149,7 +155,10 @@ jobs:
 
       - name: Comment PR Preview when failed
         if: failure() && github.event.issue.state != 'closed'
+        continue-on-error: true
         uses: thollander/actions-comment-pull-request@v3
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         with:
           message: |
             ### :ambulance: Prévisualisation failed
@@ -166,7 +175,10 @@ jobs:
 
       - name: Comment PR Preview when cancelled
         if: cancelled() && github.event.issue.state != 'closed'
+        continue-on-error: true
         uses: thollander/actions-comment-pull-request@v3
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         with:
           message: |
             ### :ambulance: Prévisualisation cancelled


### PR DESCRIPTION
## Changements

- Les steps "Comment PR Preview" (thollander/actions-comment-pull-request@v3) échouent de manière intermittente depuis le 07/08 avec `Error: self-signed certificate`, car GitHub Actions force ces actions déclarées `node20` à tourner sous node24 par défaut, ce qui déclenche un bug TLS connu et non corrigé côté action (issue amont non mergée).
- Conséquence observée sur la PR 5128 : un déploiement réellement réussi finit marqué "failure", et un commentaire trompeur "Prévisualisation failed" est posté sur la PR.
- Ajout de `env: ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` sur les 4 steps de commentaire du workflow `deploy_preview.yml` pour forcer l'exécution en node20 réel (workaround officiel GitHub, évite le bug TLS).
- Ajout de `continue-on-error: true` sur ces mêmes steps en filet de sécurité, pour qu'un commentaire flaky ne fasse plus jamais basculer un déploiement réussi en "failed".

## Plan de test

- [ ] Déclencher un déploiement de preview (commentaire 🚀 sur une PR) et vérifier que le workflow passe en succès sans erreur TLS sur les steps de commentaire
- [ ] Vérifier que le commentaire "Prévisualisation" est bien posté sur la PR