### PR TITLE
fix: corrige le nom de job invalide pour les relances d'expiration d'offre recruteur (#5133)

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -287,7 +287,7 @@ program
   .description("Envoie une relance par mail pour les offres expirant dans 7 jours")
   .requiredOption("--threshold <string>", "threshold")
   .option("-q, --queued", "Run job asynchronously", false)
-  .action(createJobAction("recruiter-offer-expiration-reminder-job"))
+  .action(createJobAction("recruiterOfferExpirationReminderJob"))
 
 program
   .command("export-offre-pole-emploi")

--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -284,7 +284,7 @@ program
 
 program
   .command("recruiter-offer-expiration-reminder-job")
-  .description("Envoie une relance par mail pour les offres expirant dans 7 jours")
+  .description("Envoie une relance par mail pour les offres expirant dans <threshold> jours")
   .requiredOption("--threshold <string>", "threshold")
   .option("-q, --queued", "Run job asynchronously", false)
   .action(createJobAction("recruiterOfferExpirationReminderJob"))

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -135,11 +135,11 @@ export async function setupJobProcessor() {
           },
           "Envoi des mails de relance pour l'expiration des offres à J+7": {
             cron_string: "20 9 * * *",
-            handler: async () => addJob({ name: "recruiter-offer-expiration-reminder-job", payload: { threshold: "7" } }),
+            handler: async () => recruiterOfferExpirationReminderJob(7),
           },
           "Envoi des mails de relance pour l'expiration des offres à J+1": {
             cron_string: "25 9 * * *",
-            handler: async () => addJob({ name: "recruiter-offer-expiration-reminder-job", payload: { threshold: "1" } }),
+            handler: async () => recruiterOfferExpirationReminderJob(1),
           },
           "Envoi du rappel de validation des utilisateurs en attente aux OPCOs": {
             cron_string: "30 0 * * 1,3,5",


### PR DESCRIPTION
Closes #5133

## Changements

- Les crons de relance d'expiration d'offre recruteur (J-7, J-1 dans `server/src/jobs/jobs.ts`) appelaient `addJob` avec le nom kebab-case `recruiter-offer-expiration-reminder-job`, qui ne correspond à aucune clé enregistrée dans le job map (clé camelCase `recruiterOfferExpirationReminderJob`). Résultat : erreur "Job not found" et emails de relance jamais envoyés (confirmé via Sentry, issue LBA-SERVER-5J7KF4ZZZT9QT, environnement recette).
- Remplacé les deux appels `addJob(...)` par un appel direct à la fonction `recruiterOfferExpirationReminderJob()`, déjà importée dans le fichier.
- La commande CLI équivalente (`server/src/commands.ts`) passait le même nom kebab-case cassé à `createJobAction` → corrigé en camelCase pour matcher la clé du job map.

## Plan de test

- [ ] Vérifier en recette que les crons J-7/J-1 s'exécutent sans erreur "Job not found" dans Sentry
- [ ] Lancer la commande CLI `recruiter-offer-expiration-reminder-job --threshold 7` et vérifier qu'elle s'exécute sans erreur