### PR TITLE
feat: ajoute un écran admin de gestion des offres partenaires (#5135)

### DIFF
--- a/server/src/http/controllers/admin/jobs-partners.controller.test.ts
+++ b/server/src/http/controllers/admin/jobs-partners.controller.test.ts
@@ -1,0 +1,131 @@
+import { createJobPartner } from "@tests/utils/jobsPartners.test.utils"
+import { createAndLogUser } from "@tests/utils/login.test.utils"
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { useServer } from "@tests/utils/server.test.utils"
+import { ObjectId } from "mongodb"
+import { JOB_STATUS_ENGLISH } from "shared/models/job.model"
+import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
+import { describe, expect, it, vi } from "vitest"
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+
+vi.mock("job-processor", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("job-processor")>()
+  return { ...mod, addJob: vi.fn().mockResolvedValue(undefined) }
+})
+
+describe("admin jobs-partners controller", () => {
+  useMongo()
+  const httpClient = useServer()
+
+  it("refuse l'accès à un utilisateur non admin", async () => {
+    const { bearerToken } = await createAndLogUser(httpClient, "userCfa", { type: "CFA" })
+
+    const response = await httpClient().inject({
+      method: "GET",
+      path: "/api/admin/jobs-partners",
+      headers: bearerToken,
+    })
+
+    expect(response.statusCode).toEqual(403)
+  })
+
+  it("liste les offres partenaires et exclut les offres LBA", async () => {
+    const { bearerToken } = await createAndLogUser(httpClient, "userAdmin", { type: "ADMIN" })
+    await createJobPartner({ partner_label: "Meteojob", offer_status: JOB_STATUS_ENGLISH.ACTIVE, offer_creation: new Date("2026-01-01") })
+    await createJobPartner({ partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, offer_status: JOB_STATUS_ENGLISH.ACTIVE, offer_creation: new Date("2026-01-02") })
+
+    const response = await httpClient().inject({
+      method: "GET",
+      path: "/api/admin/jobs-partners",
+      headers: bearerToken,
+    })
+
+    expect(response.statusCode).toEqual(200)
+    const body = response.json()
+    expect(body.pagination.total).toEqual(1)
+    expect(body.jobs).toHaveLength(1)
+    expect(body.jobs[0].partner_label).toEqual("Meteojob")
+  })
+
+  it("désactive puis réactive une offre en conservant l'historique", async () => {
+    const { bearerToken, user } = await createAndLogUser(httpClient, "userAdmin", { type: "ADMIN" })
+    const jobPartner = await createJobPartner({ partner_label: "Meteojob", offer_status: JOB_STATUS_ENGLISH.ACTIVE })
+
+    const deactivateResponse = await httpClient().inject({
+      method: "POST",
+      path: `/api/admin/jobs-partners/${jobPartner._id.toString()}/deactivate`,
+      headers: bearerToken,
+      body: { reason: "raison de test" },
+    })
+    expect(deactivateResponse.statusCode).toEqual(200)
+
+    let updatedJob = await getDbCollection("jobs_partners").findOne({ _id: jobPartner._id })
+    expect(updatedJob?.offer_status).toEqual(JOB_STATUS_ENGLISH.ANNULEE)
+    expect(updatedJob?.offer_status_history.at(-1)).toMatchObject({ status: JOB_STATUS_ENGLISH.ANNULEE, reason: "raison de test", granted_by: user.email })
+
+    const deactivateAgainResponse = await httpClient().inject({
+      method: "POST",
+      path: `/api/admin/jobs-partners/${jobPartner._id.toString()}/deactivate`,
+      headers: bearerToken,
+      body: { reason: "raison de test" },
+    })
+    expect(deactivateAgainResponse.statusCode).toEqual(400)
+
+    const activateResponse = await httpClient().inject({
+      method: "POST",
+      path: `/api/admin/jobs-partners/${jobPartner._id.toString()}/activate`,
+      headers: bearerToken,
+    })
+    expect(activateResponse.statusCode).toEqual(200)
+
+    updatedJob = await getDbCollection("jobs_partners").findOne({ _id: jobPartner._id })
+    expect(updatedJob?.offer_status).toEqual(JOB_STATUS_ENGLISH.ACTIVE)
+  })
+
+  it("renvoie updated: false quand aucune entrée cache_classification ne correspond à l'offre", async () => {
+    const { bearerToken } = await createAndLogUser(httpClient, "userAdmin", { type: "ADMIN" })
+    const jobPartner = await createJobPartner({ partner_label: "Meteojob", partner_job_id: "no-entry", offer_status: JOB_STATUS_ENGLISH.ACTIVE })
+
+    const response = await httpClient().inject({
+      method: "POST",
+      path: `/api/admin/jobs-partners/${jobPartner._id.toString()}/classification`,
+      headers: bearerToken,
+      body: { classification: "unpublish" },
+    })
+
+    expect(response.statusCode).toEqual(200)
+    expect(response.json()).toEqual({ updated: false })
+  })
+
+  it("signale une offre comme CFA et l'annule automatiquement si le modèle est en désaccord", async () => {
+    const { bearerToken, user } = await createAndLogUser(httpClient, "userAdmin", { type: "ADMIN" })
+    const jobPartner = await createJobPartner({ partner_label: "Meteojob", partner_job_id: "with-entry", offer_status: JOB_STATUS_ENGLISH.ACTIVE })
+    await getDbCollection("cache_classification").insertOne({
+      _id: new ObjectId(),
+      partner_label: "Meteojob",
+      partner_job_id: "with-entry",
+      classification: "publish",
+      human_verification: null,
+      scores: { publish: 0.9, unpublish: 0.1 },
+      model: "test-model",
+      created_at: new Date(),
+    })
+
+    const response = await httpClient().inject({
+      method: "POST",
+      path: `/api/admin/jobs-partners/${jobPartner._id.toString()}/classification`,
+      headers: bearerToken,
+      body: { classification: "unpublish" },
+    })
+
+    expect(response.statusCode).toEqual(200)
+    expect(response.json()).toEqual({ updated: true })
+
+    const entry = await getDbCollection("cache_classification").findOne({ partner_label: "Meteojob", partner_job_id: "with-entry" })
+    expect(entry?.human_verification).toEqual("unpublish")
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: jobPartner._id })
+    expect(updatedJob?.offer_status).toEqual(JOB_STATUS_ENGLISH.ANNULEE)
+    expect(updatedJob?.offer_status_history.at(-1)).toMatchObject({ status: JOB_STATUS_ENGLISH.ANNULEE, granted_by: user.email })
+  })
+})

--- a/server/src/http/controllers/admin/jobs-partners.controller.ts
+++ b/server/src/http/controllers/admin/jobs-partners.controller.ts
@@ -181,15 +181,15 @@ export default (server: Server) => {
     async (req, res) => {
       const { id } = req.params
       const { classification } = req.body
-      const job = await getDbCollection("jobs_partners").findOne({ _id: id }, { projection: { partner_job_id: 1 } })
+      const job = await getDbCollection("jobs_partners").findOne({ _id: id }, { projection: { partner_job_id: 1, partner_label: 1 } })
       if (!job) throw notFound("Offre introuvable")
 
-      const existingEntry = await getDbCollection("cache_classification").findOne({ partner_job_id: job.partner_job_id })
+      const existingEntry = await getDbCollection("cache_classification").findOne({ partner_label: job.partner_label, partner_job_id: job.partner_job_id })
       if (!existingEntry) {
         return res.status(200).send({ updated: false })
       }
 
-      await updateClassificationAndSynchronise({ classification, partner_job_ids: [job.partner_job_id] })
+      await updateClassificationAndSynchronise({ classification, jobs: [{ partner_label: job.partner_label, partner_job_id: job.partner_job_id }] })
       return res.status(200).send({ updated: true })
     }
   )

--- a/server/src/http/controllers/admin/jobs-partners.controller.ts
+++ b/server/src/http/controllers/admin/jobs-partners.controller.ts
@@ -36,59 +36,67 @@ export default (server: Server) => {
       }
 
       const [{ data, totalCount }] = await getDbCollection("jobs_partners")
-        .aggregate<{ data: IJobsPartnersOfferForAdmin[]; totalCount: [{ count: number }] | [] }>([
-          { $match: match },
-          {
-            $lookup: {
-              from: "cache_classification",
-              let: { partner_job_id: "$partner_job_id", partner_label: "$partner_label" },
-              pipeline: [{ $match: { $expr: { $and: [{ $eq: ["$partner_job_id", "$$partner_job_id"] }, { $eq: ["$partner_label", "$$partner_label"] }] } } }],
-              as: "classificationEntry",
-            },
-          },
-          {
-            $facet: {
-              data: [
-                { $sort: { offer_creation: -1 } },
-                { $skip: offset },
-                { $limit: limit },
-                {
-                  $project: {
-                    _id: 1,
-                    partner_label: 1,
-                    partner_job_id: 1,
-                    offer_title: 1,
-                    offer_status: 1,
-                    offer_creation: 1,
-                    offer_expiration: 1,
-                    workplace_name: 1,
-                    workplace_legal_name: 1,
-                    workplace_siret: 1,
-                    workplace_address_city: 1,
-                    is_delegated: 1,
-                    cfa_legal_name: 1,
-                    cfa_siret: 1,
-                    created_at: 1,
-                    updated_at: 1,
-                    classification: {
-                      $let: {
-                        vars: { entry: { $arrayElemAt: ["$classificationEntry", 0] } },
-                        in: {
-                          $cond: [
-                            { $eq: ["$$entry", null] },
-                            null,
-                            { model: { $ifNull: ["$$entry.classification", null] }, human_verification: { $ifNull: ["$$entry.human_verification", null] } },
-                          ],
+        .aggregate<{ data: IJobsPartnersOfferForAdmin[]; totalCount: [{ count: number }] | [] }>(
+          [
+            { $match: match },
+            {
+              $facet: {
+                // Le $lookup (et le $project qui en dépend) est fait ici, après $skip/$limit, pour ne tourner que sur
+                // la page affichée (50 documents) plutôt que sur tout le jeu de documents matché par $match.
+                data: [
+                  { $sort: { offer_creation: -1 } },
+                  { $skip: offset },
+                  { $limit: limit },
+                  {
+                    $lookup: {
+                      from: "cache_classification",
+                      let: { partner_job_id: "$partner_job_id", partner_label: "$partner_label" },
+                      pipeline: [{ $match: { $expr: { $and: [{ $eq: ["$partner_job_id", "$$partner_job_id"] }, { $eq: ["$partner_label", "$$partner_label"] }] } } }],
+                      as: "classificationEntry",
+                    },
+                  },
+                  {
+                    $project: {
+                      _id: 1,
+                      partner_label: 1,
+                      partner_job_id: 1,
+                      offer_title: 1,
+                      offer_status: 1,
+                      offer_creation: 1,
+                      offer_expiration: 1,
+                      workplace_name: 1,
+                      workplace_legal_name: 1,
+                      workplace_siret: 1,
+                      workplace_address_city: 1,
+                      is_delegated: 1,
+                      cfa_legal_name: 1,
+                      cfa_siret: 1,
+                      created_at: 1,
+                      updated_at: 1,
+                      classification: {
+                        $let: {
+                          vars: { entry: { $arrayElemAt: ["$classificationEntry", 0] } },
+                          in: {
+                            $cond: [
+                              { $eq: ["$$entry", null] },
+                              null,
+                              { model: { $ifNull: ["$$entry.classification", null] }, human_verification: { $ifNull: ["$$entry.human_verification", null] } },
+                            ],
+                          },
                         },
                       },
                     },
                   },
-                },
-              ],
-              totalCount: [{ $count: "count" }],
+                ],
+                totalCount: [{ $count: "count" }],
+              },
             },
-          },
-        ])
+          ],
+          // Filet de sécurité : le $sort sur offer_creation porte sur tout le jeu de documents matché avant $skip/$limit
+          // (indispensable pour un tri global correct) ; l'index { offer_creation: -1 } couvre le cas courant, mais
+          // allowDiskUse évite une erreur "Sort exceeded memory limit" si un filtre combiné empêche Mongo de l'utiliser.
+          { allowDiskUse: true }
+        )
         .toArray()
 
       // Toujours reconstruite ici (pas de valeur stockée) : jobs_partners.lba_url est calculé au moment de l'écriture
@@ -189,7 +197,13 @@ export default (server: Server) => {
         return res.status(200).send({ updated: false })
       }
 
-      await updateClassificationAndSynchronise({ classification, jobs: [{ partner_label: job.partner_label, partner_job_id: job.partner_job_id }] })
+      const requestUser = getUserFromRequest(req, zRoutes.post["/admin/jobs-partners/:id/classification"]).value
+
+      await updateClassificationAndSynchronise({
+        classification,
+        jobs: [{ partner_label: job.partner_label, partner_job_id: job.partner_job_id }],
+        grantedBy: requestUser.email,
+      })
       return res.status(200).send({ updated: true })
     }
   )

--- a/server/src/http/controllers/admin/jobs-partners.controller.ts
+++ b/server/src/http/controllers/admin/jobs-partners.controller.ts
@@ -1,0 +1,196 @@
+import { badRequest, notFound } from "@hapi/boom"
+import type { Filter } from "mongodb"
+import { ObjectId } from "mongodb"
+import { JOB_STATUS_ENGLISH, zRoutes } from "shared"
+import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import type { IJobsPartnersOfferForAdmin, IJobsPartnersOfferPrivate } from "shared/models/jobs-partners.model"
+import { jobPartnersExcludedFromFlux } from "shared/models/jobs-partners.model"
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+import type { Server } from "@/http/server"
+import { getUserFromRequest } from "@/security/authentication.service"
+import { updateClassificationAndSynchronise } from "@/services/cache-classification.service"
+import { buildLbaUrl } from "@/services/jobs/job-opportunity/job-opportunity.service"
+import { syncJobPartnersToSearchItemsInBackground } from "@/services/search/search-items.service"
+
+export default (server: Server) => {
+  server.get(
+    "/admin/jobs-partners",
+    {
+      schema: zRoutes.get["/admin/jobs-partners"],
+      onRequest: server.auth(zRoutes.get["/admin/jobs-partners"]),
+    },
+    async (req, res) => {
+      const { partner_label, offer_status, id, limit = 50, offset = 0 } = req.query
+
+      const match: Filter<IJobsPartnersOfferPrivate> = {
+        partner_label: { $nin: jobPartnersExcludedFromFlux, ...(partner_label ? { $in: partner_label } : {}) },
+      }
+      if (offer_status) {
+        match.offer_status = { $in: offer_status }
+      }
+      if (id) {
+        if (!ObjectId.isValid(id)) {
+          throw badRequest("id invalide")
+        }
+        match._id = new ObjectId(id)
+      }
+
+      const [{ data, totalCount }] = await getDbCollection("jobs_partners")
+        .aggregate<{ data: IJobsPartnersOfferForAdmin[]; totalCount: [{ count: number }] | [] }>([
+          { $match: match },
+          {
+            $lookup: {
+              from: "cache_classification",
+              let: { partner_job_id: "$partner_job_id", partner_label: "$partner_label" },
+              pipeline: [{ $match: { $expr: { $and: [{ $eq: ["$partner_job_id", "$$partner_job_id"] }, { $eq: ["$partner_label", "$$partner_label"] }] } } }],
+              as: "classificationEntry",
+            },
+          },
+          {
+            $facet: {
+              data: [
+                { $sort: { offer_creation: -1 } },
+                { $skip: offset },
+                { $limit: limit },
+                {
+                  $project: {
+                    _id: 1,
+                    partner_label: 1,
+                    partner_job_id: 1,
+                    offer_title: 1,
+                    offer_status: 1,
+                    offer_creation: 1,
+                    offer_expiration: 1,
+                    workplace_name: 1,
+                    workplace_legal_name: 1,
+                    workplace_siret: 1,
+                    workplace_address_city: 1,
+                    is_delegated: 1,
+                    cfa_legal_name: 1,
+                    cfa_siret: 1,
+                    created_at: 1,
+                    updated_at: 1,
+                    classification: {
+                      $let: {
+                        vars: { entry: { $arrayElemAt: ["$classificationEntry", 0] } },
+                        in: {
+                          $cond: [
+                            { $eq: ["$$entry", null] },
+                            null,
+                            { model: { $ifNull: ["$$entry.classification", null] }, human_verification: { $ifNull: ["$$entry.human_verification", null] } },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+              totalCount: [{ $count: "count" }],
+            },
+          },
+        ])
+        .toArray()
+
+      // Toujours reconstruite ici (pas de valeur stockée) : jobs_partners.lba_url est calculé au moment de l'écriture
+      // avec le config.publicUrl de l'environnement qui a tourné le job fill-lba-url, qui peut différer de l'environnement courant.
+      const jobs = data.map((job) => ({
+        ...job,
+        lba_url: buildLbaUrl(LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES, job._id, job.workplace_siret, job.offer_title),
+      }))
+
+      return res.status(200).send({
+        jobs,
+        pagination: { total: totalCount[0]?.count ?? 0, limit, offset },
+      })
+    }
+  )
+
+  server.post(
+    "/admin/jobs-partners/:id/activate",
+    {
+      schema: zRoutes.post["/admin/jobs-partners/:id/activate"],
+      onRequest: server.auth(zRoutes.post["/admin/jobs-partners/:id/activate"]),
+    },
+    async (req, res) => {
+      const { id } = req.params
+      const job = await getDbCollection("jobs_partners").findOne({ _id: id })
+      if (!job) throw notFound("Offre introuvable")
+      if (job.offer_status === JOB_STATUS_ENGLISH.ACTIVE) throw badRequest("L'offre est déjà active")
+
+      const requestUser = getUserFromRequest(req, zRoutes.post["/admin/jobs-partners/:id/activate"]).value
+
+      await getDbCollection("jobs_partners").updateOne(
+        { _id: id },
+        {
+          $set: { offer_status: JOB_STATUS_ENGLISH.ACTIVE, updated_at: new Date() },
+          $push: {
+            offer_status_history: {
+              date: new Date(),
+              status: JOB_STATUS_ENGLISH.ACTIVE,
+              reason: "réactivation manuelle par un administrateur",
+              granted_by: requestUser.email,
+            },
+          },
+        }
+      )
+      syncJobPartnersToSearchItemsInBackground([id])
+      return res.status(200).send({})
+    }
+  )
+
+  server.post(
+    "/admin/jobs-partners/:id/deactivate",
+    {
+      schema: zRoutes.post["/admin/jobs-partners/:id/deactivate"],
+      onRequest: server.auth(zRoutes.post["/admin/jobs-partners/:id/deactivate"]),
+    },
+    async (req, res) => {
+      const { id } = req.params
+      const { reason } = req.body
+      const job = await getDbCollection("jobs_partners").findOne({ _id: id })
+      if (!job) throw notFound("Offre introuvable")
+      if (job.offer_status === JOB_STATUS_ENGLISH.ANNULEE) throw badRequest("L'offre est déjà désactivée")
+
+      const requestUser = getUserFromRequest(req, zRoutes.post["/admin/jobs-partners/:id/deactivate"]).value
+
+      await getDbCollection("jobs_partners").updateOne(
+        { _id: id },
+        {
+          $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: new Date() },
+          $push: {
+            offer_status_history: {
+              date: new Date(),
+              status: JOB_STATUS_ENGLISH.ANNULEE,
+              reason,
+              granted_by: requestUser.email,
+            },
+          },
+        }
+      )
+      syncJobPartnersToSearchItemsInBackground([id])
+      return res.status(200).send({})
+    }
+  )
+
+  server.post(
+    "/admin/jobs-partners/:id/classification",
+    {
+      schema: zRoutes.post["/admin/jobs-partners/:id/classification"],
+      onRequest: server.auth(zRoutes.post["/admin/jobs-partners/:id/classification"]),
+    },
+    async (req, res) => {
+      const { id } = req.params
+      const { classification } = req.body
+      const job = await getDbCollection("jobs_partners").findOne({ _id: id }, { projection: { partner_job_id: 1 } })
+      if (!job) throw notFound("Offre introuvable")
+
+      const existingEntry = await getDbCollection("cache_classification").findOne({ partner_job_id: job.partner_job_id })
+      if (!existingEntry) {
+        return res.status(200).send({ updated: false })
+      }
+
+      await updateClassificationAndSynchronise({ classification, partner_job_ids: [job.partner_job_id] })
+      return res.status(200).send({ updated: true })
+    }
+  )
+}

--- a/server/src/http/controllers/classification.controller.ts
+++ b/server/src/http/controllers/classification.controller.ts
@@ -1,11 +1,9 @@
 import { unauthorized } from "@hapi/boom"
-import { addJob } from "job-processor"
 import type { ICredential } from "shared"
-import { JOB_STATUS_ENGLISH, zRoutes } from "shared"
-import { COMPUTED_ERROR_SOURCE, JOB_PARTNER_BUSINESS_ERROR } from "shared/models/jobs-partners-computed.model"
+import { zRoutes } from "shared"
+import { JOB_PARTNER_BUSINESS_ERROR } from "shared/models/jobs-partners-computed.model"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import type { Server } from "@/http/server"
-import { syncJobPartnersToSearchItemsInBackground } from "@/services/search/search-items.service"
 
 type IModelTraining = {
   partner_job_id: string
@@ -117,63 +115,4 @@ export const classificationRoutes = (server: Server) => {
 
     return res.status(200).send(Array.from(deduplicatedResults.values()).map(({ partner_job_id: _partner_job_id, ...result }) => result))
   })
-
-  server.post("/classification", { schema: zRoutes.post["/classification"], onRequest: server.auth(zRoutes.post["/classification"]) }, async (req, res) => {
-    const user = req.user?.value as ICredential
-    if (user.scope !== "classification") throw unauthorized("scope classification required")
-    const { classification, partner_job_ids } = req.body
-    await updateClassificationAndSynchronise({ classification, partner_job_ids })
-    return res.status(200).send({ response: "Les mises à jour vont être traitées par le serveur", time: new Date() })
-  })
-}
-
-const updateClassificationAndSynchronise = async ({ classification, partner_job_ids }: { classification: "publish" | "unpublish"; partner_job_ids: string[] }) => {
-  // update cache_classification
-  await getDbCollection("cache_classification").updateMany({ partner_job_id: { $in: partner_job_ids } }, { $set: { human_verification: classification } })
-  // get jobs_partners to update offer_status to annulé if classification !== human_verification
-  const scopeToUpdate = await getDbCollection("cache_classification")
-    .find({ partner_job_id: { $in: partner_job_ids } }, { projection: { partner_job_id: 1, classification: 1, human_verification: 1 } })
-    .toArray()
-  // filter scopeToUpdate to keep only the jobs where classification !== human_verification
-  const filteredScope = scopeToUpdate.filter(({ classification, human_verification }) => classification !== human_verification)
-  const filteredScopeIds = filteredScope.map(({ partner_job_id }) => partner_job_id)
-
-  for await (const job of filteredScope) {
-    const jobPartners = await getDbCollection("jobs_partners").findOne({ partner_job_id: job.partner_job_id })
-    if (jobPartners) {
-      await Promise.all([
-        getDbCollection("jobs_partners").updateOne(
-          { partner_job_id: job.partner_job_id },
-          {
-            $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: new Date() },
-            $push: {
-              offer_status_history: {
-                date: new Date(),
-                status: JOB_STATUS_ENGLISH.ANNULEE,
-                reason: "classification humaine non conforme",
-                granted_by: "classification.controller",
-              },
-            },
-          }
-        ),
-        getDbCollection("computed_jobs_partners").updateOne(
-          { partner_job_id: job.partner_job_id },
-          { $set: { business_error: null, errors: [], validated: false }, $pull: { jobs_in_success: COMPUTED_ERROR_SOURCE.CLASSIFICATION } }
-        ),
-      ])
-      // Après l'update (le sync lit l'état post-annulation) : retrait de l'index de recherche.
-      syncJobPartnersToSearchItemsInBackground([jobPartners._id])
-    } else {
-      const computedJobPartner = await getDbCollection("computed_jobs_partners").findOne({ partner_job_id: job.partner_job_id })
-      if (computedJobPartner) {
-        await getDbCollection("computed_jobs_partners").updateOne(
-          { partner_job_id: job.partner_job_id },
-          { $set: { business_error: null, errors: [], validated: false }, $pull: { jobs_in_success: COMPUTED_ERROR_SOURCE.CLASSIFICATION } }
-        )
-      }
-    }
-  }
-  // add job to fill-computed-jobs-partners with the filteredScopeIds
-  await addJob({ name: "fill-computed-jobs-partners", payload: { addedMatchFilter: { partner_job_id: { $in: filteredScopeIds } } } })
-  await addJob({ name: "import-from-computed-to-jobs-partners", payload: { partner_job_id: { $in: filteredScopeIds } } })
 }

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -21,6 +21,7 @@ import { seoRouteController } from "./controllers/_private/seo.private.controlle
 import eligibleTrainingsForAppointmentRoute from "./controllers/admin/eligible-trainings-for-appointment.controller"
 import adminEtablissementRoute from "./controllers/admin/etablissement.controller"
 import formationsRoute from "./controllers/admin/formations.controller"
+import jobsPartnersAdminRoute from "./controllers/admin/jobs-partners.controller"
 import application from "./controllers/application.controller"
 import appointmentRequestRoute from "./controllers/appointment-request.controller"
 import { classificationRoutes } from "./controllers/classification.controller"
@@ -151,6 +152,7 @@ export async function bind(app: Server) {
       formulaireRoute(typedSubApp)
       etablissementsRecruteurRoute(typedSubApp)
       jobsRouteV2(typedSubApp)
+      jobsPartnersAdminRoute(typedSubApp)
 
       trainingLinks(typedSubApp)
       jobsApiV3Routes(typedSubApp)

--- a/server/src/migrations/20260811224141-add-offer-creation-index-jobs-partners.ts
+++ b/server/src/migrations/20260811224141-add-offer-creation-index-jobs-partners.ts
@@ -1,0 +1,8 @@
+import { recreateIndexes } from "@/jobs/database/recreate-indexes"
+
+export const up = async () => {
+  await recreateIndexes()
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/server/src/services/cache-classification.service.test.ts
+++ b/server/src/services/cache-classification.service.test.ts
@@ -1,0 +1,87 @@
+import { createJobPartner } from "@tests/utils/jobsPartners.test.utils"
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { ObjectId } from "mongodb"
+import { JOB_STATUS_ENGLISH } from "shared/models/job.model"
+import { describe, expect, it, vi } from "vitest"
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { updateClassificationAndSynchronise } from "./cache-classification.service"
+
+vi.mock("job-processor", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("job-processor")>()
+  return { ...mod, addJob: vi.fn().mockResolvedValue(undefined) }
+})
+
+const insertCacheClassification = async (data: { partner_label: string; partner_job_id: string; classification: string; human_verification?: "publish" | "unpublish" | null }) => {
+  await getDbCollection("cache_classification").insertOne({
+    _id: new ObjectId(),
+    partner_label: data.partner_label,
+    partner_job_id: data.partner_job_id,
+    classification: data.classification,
+    human_verification: data.human_verification ?? null,
+    scores: { publish: 0.5, unpublish: 0.5 },
+    model: "test-model",
+    created_at: new Date(),
+  })
+}
+
+describe("updateClassificationAndSynchronise", () => {
+  useMongo()
+
+  it("annule l'offre quand la vérification humaine diffère de la classification du modèle", async () => {
+    const jobPartner = await createJobPartner({ partner_label: "Meteojob", partner_job_id: "1234", offer_status: JOB_STATUS_ENGLISH.ACTIVE })
+    await insertCacheClassification({ partner_label: "Meteojob", partner_job_id: "1234", classification: "publish" })
+
+    await updateClassificationAndSynchronise({ classification: "unpublish", jobs: [{ partner_label: "Meteojob", partner_job_id: "1234" }], grantedBy: "test@beta.gouv.fr" })
+
+    const updatedEntry = await getDbCollection("cache_classification").findOne({ partner_label: "Meteojob", partner_job_id: "1234" })
+    expect(updatedEntry?.human_verification).toEqual("unpublish")
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: jobPartner._id })
+    expect(updatedJob?.offer_status).toEqual(JOB_STATUS_ENGLISH.ANNULEE)
+    expect(updatedJob?.offer_status_history.at(-1)).toMatchObject({
+      status: JOB_STATUS_ENGLISH.ANNULEE,
+      reason: "classification humaine non conforme",
+      granted_by: "test@beta.gouv.fr",
+    })
+  })
+
+  it("ne modifie pas la classification ni l'offre d'un autre partenaire partageant le même partner_job_id", async () => {
+    const sharedPartnerJobId = "5678"
+    const jobMeteojob = await createJobPartner({ partner_label: "Meteojob", partner_job_id: sharedPartnerJobId, offer_status: JOB_STATUS_ENGLISH.ACTIVE })
+    const jobApec = await createJobPartner({ partner_label: "APEC", partner_job_id: sharedPartnerJobId, offer_status: JOB_STATUS_ENGLISH.ACTIVE })
+    await insertCacheClassification({ partner_label: "Meteojob", partner_job_id: sharedPartnerJobId, classification: "publish" })
+    await insertCacheClassification({ partner_label: "APEC", partner_job_id: sharedPartnerJobId, classification: "publish" })
+
+    await updateClassificationAndSynchronise({ classification: "unpublish", jobs: [{ partner_label: "Meteojob", partner_job_id: sharedPartnerJobId }] })
+
+    const entryMeteojob = await getDbCollection("cache_classification").findOne({ partner_label: "Meteojob", partner_job_id: sharedPartnerJobId })
+    const entryApec = await getDbCollection("cache_classification").findOne({ partner_label: "APEC", partner_job_id: sharedPartnerJobId })
+    expect(entryMeteojob?.human_verification).toEqual("unpublish")
+    expect(entryApec?.human_verification).toBeNull()
+    expect(entryApec?.classification).toEqual("publish")
+
+    const updatedJobMeteojob = await getDbCollection("jobs_partners").findOne({ _id: jobMeteojob._id })
+    const updatedJobApec = await getDbCollection("jobs_partners").findOne({ _id: jobApec._id })
+    expect(updatedJobMeteojob?.offer_status).toEqual(JOB_STATUS_ENGLISH.ANNULEE)
+    expect(updatedJobApec?.offer_status).toEqual(JOB_STATUS_ENGLISH.ACTIVE)
+  })
+
+  it("ne touche pas l'offre quand la classification du modèle correspond déjà à la vérification demandée", async () => {
+    const jobPartner = await createJobPartner({ partner_label: "Meteojob", partner_job_id: "9999", offer_status: JOB_STATUS_ENGLISH.ACTIVE })
+    await insertCacheClassification({ partner_label: "Meteojob", partner_job_id: "9999", classification: "unpublish" })
+
+    await updateClassificationAndSynchronise({ classification: "unpublish", jobs: [{ partner_label: "Meteojob", partner_job_id: "9999" }] })
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: jobPartner._id })
+    expect(updatedJob?.offer_status).toEqual(JOB_STATUS_ENGLISH.ACTIVE)
+  })
+
+  it("ne fait rien quand aucune entrée cache_classification ne correspond", async () => {
+    const jobPartner = await createJobPartner({ partner_label: "Meteojob", partner_job_id: "no-entry", offer_status: JOB_STATUS_ENGLISH.ACTIVE })
+
+    await expect(updateClassificationAndSynchronise({ classification: "unpublish", jobs: [{ partner_label: "Meteojob", partner_job_id: "no-entry" }] })).resolves.not.toThrow()
+
+    const updatedJob = await getDbCollection("jobs_partners").findOne({ _id: jobPartner._id })
+    expect(updatedJob?.offer_status).toEqual(JOB_STATUS_ENGLISH.ACTIVE)
+  })
+})

--- a/server/src/services/cache-classification.service.ts
+++ b/server/src/services/cache-classification.service.ts
@@ -90,9 +90,11 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
 export const updateClassificationAndSynchronise = async ({
   classification,
   jobs,
+  grantedBy = "cache-classification.service",
 }: {
   classification: "publish" | "unpublish"
   jobs: { partner_label: string; partner_job_id: string }[]
+  grantedBy?: string
 }): Promise<void> => {
   if (!jobs.length) return
 
@@ -123,7 +125,7 @@ export const updateClassificationAndSynchronise = async ({
                 date: new Date(),
                 status: JOB_STATUS_ENGLISH.ANNULEE,
                 reason: "classification humaine non conforme",
-                granted_by: "classification.controller",
+                granted_by: grantedBy,
               },
             },
           }

--- a/server/src/services/cache-classification.service.ts
+++ b/server/src/services/cache-classification.service.ts
@@ -1,7 +1,11 @@
 import { ObjectId } from "bson"
+import { addJob } from "job-processor"
 import type { IClassificationJobsPartners } from "shared/models/cache-classification.model"
+import { JOB_STATUS_ENGLISH } from "shared/models/job.model"
+import { COMPUTED_ERROR_SOURCE } from "shared/models/jobs-partners-computed.model"
 import { getLabClassificationBatch } from "@/common/apis/classification/classification.client"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { syncJobPartnersToSearchItemsInBackground } from "@/services/search/search-items.service"
 
 export type TJobClassification = {
   partner_label: string
@@ -81,4 +85,61 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
 
     return classificationsById.get(index.toString())?.label ?? null
   })
+}
+
+export const updateClassificationAndSynchronise = async ({
+  classification,
+  partner_job_ids,
+}: {
+  classification: "publish" | "unpublish"
+  partner_job_ids: string[]
+}): Promise<void> => {
+  // update cache_classification
+  await getDbCollection("cache_classification").updateMany({ partner_job_id: { $in: partner_job_ids } }, { $set: { human_verification: classification } })
+  // get jobs_partners to update offer_status to annulé if classification !== human_verification
+  const scopeToUpdate = await getDbCollection("cache_classification")
+    .find({ partner_job_id: { $in: partner_job_ids } }, { projection: { partner_job_id: 1, classification: 1, human_verification: 1 } })
+    .toArray()
+  // filter scopeToUpdate to keep only the jobs where classification !== human_verification
+  const filteredScope = scopeToUpdate.filter(({ classification, human_verification }) => classification !== human_verification)
+  const filteredScopeIds = filteredScope.map(({ partner_job_id }) => partner_job_id)
+
+  for await (const job of filteredScope) {
+    const jobPartners = await getDbCollection("jobs_partners").findOne({ partner_job_id: job.partner_job_id })
+    if (jobPartners) {
+      await Promise.all([
+        getDbCollection("jobs_partners").updateOne(
+          { partner_job_id: job.partner_job_id },
+          {
+            $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: new Date() },
+            $push: {
+              offer_status_history: {
+                date: new Date(),
+                status: JOB_STATUS_ENGLISH.ANNULEE,
+                reason: "classification humaine non conforme",
+                granted_by: "classification.controller",
+              },
+            },
+          }
+        ),
+        getDbCollection("computed_jobs_partners").updateOne(
+          { partner_job_id: job.partner_job_id },
+          { $set: { business_error: null, errors: [], validated: false }, $pull: { jobs_in_success: COMPUTED_ERROR_SOURCE.CLASSIFICATION } }
+        ),
+      ])
+      // Après l'update (le sync lit l'état post-annulation) : retrait de l'index de recherche.
+      syncJobPartnersToSearchItemsInBackground([jobPartners._id])
+    } else {
+      const computedJobPartner = await getDbCollection("computed_jobs_partners").findOne({ partner_job_id: job.partner_job_id })
+      if (computedJobPartner) {
+        await getDbCollection("computed_jobs_partners").updateOne(
+          { partner_job_id: job.partner_job_id },
+          { $set: { business_error: null, errors: [], validated: false }, $pull: { jobs_in_success: COMPUTED_ERROR_SOURCE.CLASSIFICATION } }
+        )
+      }
+    }
+  }
+  // add job to fill-computed-jobs-partners with the filteredScopeIds
+  await addJob({ name: "fill-computed-jobs-partners", payload: { addedMatchFilter: { partner_job_id: { $in: filteredScopeIds } } } })
+  await addJob({ name: "import-from-computed-to-jobs-partners", payload: { partner_job_id: { $in: filteredScopeIds } } })
 }

--- a/server/src/services/cache-classification.service.ts
+++ b/server/src/services/cache-classification.service.ts
@@ -89,27 +89,33 @@ export const getClassificationFromLab = async (jobs: TJobClassification[]): Prom
 
 export const updateClassificationAndSynchronise = async ({
   classification,
-  partner_job_ids,
+  jobs,
 }: {
   classification: "publish" | "unpublish"
-  partner_job_ids: string[]
+  jobs: { partner_label: string; partner_job_id: string }[]
 }): Promise<void> => {
+  if (!jobs.length) return
+
+  // cache_classification n'est pas unique sur partner_job_id seul : un même partner_job_id peut exister chez plusieurs
+  // partenaires, donc on filtre systématiquement sur le couple (partner_label, partner_job_id) pour ne jamais toucher
+  // l'entrée d'un autre partenaire.
+  const jobsFilter = { $or: jobs.map(({ partner_label, partner_job_id }) => ({ partner_label, partner_job_id })) }
+
   // update cache_classification
-  await getDbCollection("cache_classification").updateMany({ partner_job_id: { $in: partner_job_ids } }, { $set: { human_verification: classification } })
+  await getDbCollection("cache_classification").updateMany(jobsFilter, { $set: { human_verification: classification } })
   // get jobs_partners to update offer_status to annulé if classification !== human_verification
   const scopeToUpdate = await getDbCollection("cache_classification")
-    .find({ partner_job_id: { $in: partner_job_ids } }, { projection: { partner_job_id: 1, classification: 1, human_verification: 1 } })
+    .find(jobsFilter, { projection: { partner_label: 1, partner_job_id: 1, classification: 1, human_verification: 1 } })
     .toArray()
   // filter scopeToUpdate to keep only the jobs where classification !== human_verification
   const filteredScope = scopeToUpdate.filter(({ classification, human_verification }) => classification !== human_verification)
-  const filteredScopeIds = filteredScope.map(({ partner_job_id }) => partner_job_id)
 
-  for await (const job of filteredScope) {
-    const jobPartners = await getDbCollection("jobs_partners").findOne({ partner_job_id: job.partner_job_id })
+  for await (const entry of filteredScope) {
+    const jobPartners = await getDbCollection("jobs_partners").findOne({ partner_label: entry.partner_label, partner_job_id: entry.partner_job_id })
     if (jobPartners) {
       await Promise.all([
         getDbCollection("jobs_partners").updateOne(
-          { partner_job_id: job.partner_job_id },
+          { partner_label: entry.partner_label, partner_job_id: entry.partner_job_id },
           {
             $set: { offer_status: JOB_STATUS_ENGLISH.ANNULEE, updated_at: new Date() },
             $push: {
@@ -123,23 +129,27 @@ export const updateClassificationAndSynchronise = async ({
           }
         ),
         getDbCollection("computed_jobs_partners").updateOne(
-          { partner_job_id: job.partner_job_id },
+          { partner_label: entry.partner_label, partner_job_id: entry.partner_job_id },
           { $set: { business_error: null, errors: [], validated: false }, $pull: { jobs_in_success: COMPUTED_ERROR_SOURCE.CLASSIFICATION } }
         ),
       ])
       // Après l'update (le sync lit l'état post-annulation) : retrait de l'index de recherche.
       syncJobPartnersToSearchItemsInBackground([jobPartners._id])
     } else {
-      const computedJobPartner = await getDbCollection("computed_jobs_partners").findOne({ partner_job_id: job.partner_job_id })
+      const computedJobPartner = await getDbCollection("computed_jobs_partners").findOne({ partner_label: entry.partner_label, partner_job_id: entry.partner_job_id })
       if (computedJobPartner) {
         await getDbCollection("computed_jobs_partners").updateOne(
-          { partner_job_id: job.partner_job_id },
+          { partner_label: entry.partner_label, partner_job_id: entry.partner_job_id },
           { $set: { business_error: null, errors: [], validated: false }, $pull: { jobs_in_success: COMPUTED_ERROR_SOURCE.CLASSIFICATION } }
         )
       }
     }
   }
-  // add job to fill-computed-jobs-partners with the filteredScopeIds
-  await addJob({ name: "fill-computed-jobs-partners", payload: { addedMatchFilter: { partner_job_id: { $in: filteredScopeIds } } } })
-  await addJob({ name: "import-from-computed-to-jobs-partners", payload: { partner_job_id: { $in: filteredScopeIds } } })
+
+  if (filteredScope.length) {
+    const filteredScopeFilter = { $or: filteredScope.map(({ partner_label, partner_job_id }) => ({ partner_label, partner_job_id })) }
+    // add job to fill-computed-jobs-partners with the filtered scope
+    await addJob({ name: "fill-computed-jobs-partners", payload: { addedMatchFilter: filteredScopeFilter } })
+    await addJob({ name: "import-from-computed-to-jobs-partners", payload: filteredScopeFilter })
+  }
 }

--- a/shared/src/models/jobs-partners.model.ts
+++ b/shared/src/models/jobs-partners.model.ts
@@ -343,6 +343,9 @@ export default {
     [{ offer_expiration: 1 }, {}],
     // Cron delta de synchronisation search_items (syncSearchItemsDelta).
     [{ updated_at: 1 }, {}],
+    // Tri par défaut de la liste admin (/admin/jobs-partners) : évite un $sort en mémoire sur toute la collection
+    // quand le filtre partner_label n'est pas assez sélectif pour qu'un index composé serve le tri.
+    [{ offer_creation: -1 }, {}],
     [{ contract_is_disabled_elligible: 1 }, {}],
     [{ "duplicates.partner_job_id": 1 }, {}],
     [{ "duplicates.partner_job_label": 1 }, {}],

--- a/shared/src/models/jobs-partners.model.ts
+++ b/shared/src/models/jobs-partners.model.ts
@@ -1,3 +1,4 @@
+import type { Jsonify } from "type-fest"
 import { z } from "zod"
 
 import { LBA_ITEM_TYPE } from "../constants/lbaitem.js"
@@ -209,6 +210,35 @@ export const ZJobsPartnersOfferPrivate = ZJobsPartnersOfferApi.omit({
 export const ZJobsPartnersOfferPrivateWithDistance = ZJobsPartnersOfferPrivate.extend({
   distance: z.number().nullish(),
 })
+
+export const ZJobsPartnersOfferForAdmin = z.object({
+  _id: ZJobsPartnersOfferPrivate.shape._id,
+  partner_label: ZJobsPartnersOfferPrivate.shape.partner_label,
+  partner_job_id: ZJobsPartnersOfferPrivate.shape.partner_job_id,
+  offer_title: ZJobsPartnersOfferPrivate.shape.offer_title,
+  offer_status: ZJobsPartnersOfferPrivate.shape.offer_status,
+  offer_creation: ZJobsPartnersOfferPrivate.shape.offer_creation,
+  offer_expiration: ZJobsPartnersOfferPrivate.shape.offer_expiration,
+  workplace_name: ZJobsPartnersOfferPrivate.shape.workplace_name,
+  workplace_legal_name: ZJobsPartnersOfferPrivate.shape.workplace_legal_name,
+  workplace_siret: ZJobsPartnersOfferPrivate.shape.workplace_siret,
+  workplace_address_city: ZJobsPartnersOfferPrivate.shape.workplace_address_city,
+  is_delegated: ZJobsPartnersOfferPrivate.shape.is_delegated,
+  cfa_legal_name: ZJobsPartnersOfferPrivate.shape.cfa_legal_name,
+  cfa_siret: ZJobsPartnersOfferPrivate.shape.cfa_siret,
+  created_at: ZJobsPartnersOfferPrivate.shape.created_at,
+  updated_at: ZJobsPartnersOfferPrivate.shape.updated_at,
+  lba_url: ZJobsPartnersOfferPrivate.shape.lba_url,
+  classification: z
+    .object({
+      model: z.enum(["publish", "unpublish"]).nullable(),
+      human_verification: z.enum(["publish", "unpublish"]).nullable(),
+    })
+    .nullable()
+    .describe("Etat de classification CFA de l'offre, si une entrée cache_classification correspondante existe"),
+})
+export type IJobsPartnersOfferForAdmin = z.output<typeof ZJobsPartnersOfferForAdmin>
+export type IJobsPartnersOfferForAdminJSON = Jsonify<z.output<typeof ZJobsPartnersOfferForAdmin>>
 
 export const ZJobsPartnersRecruteurAlgoPrivate = ZJobsPartnersOfferPrivate.omit({ workplace_siret: true, workplace_legal_name: true }).extend({
   workplace_siret: z.string().describe("Siret toujours présent pour les entreprises issue de l'algo"),

--- a/shared/src/routes/classification.routes.ts
+++ b/shared/src/routes/classification.routes.ts
@@ -26,22 +26,4 @@ export const zClassificationRoute = {
       },
     },
   },
-  post: {
-    "/classification": {
-      method: "post",
-      path: "/classification",
-      body: z.object({
-        partner_job_ids: z.string().array().min(1, "Il faut au moins un id à mettre à jour"),
-        classification: z.enum(["publish", "unpublish"]),
-      }),
-      response: {
-        200: z.object({ response: z.literal("Les mises à jour vont être traitées par le serveur"), time: z.coerce.date<Date>() }),
-      },
-      securityScheme: {
-        auth: "api-key",
-        access: null,
-        resources: {},
-      },
-    },
-  },
 } as const satisfies IRoutesDef

--- a/shared/src/routes/index.ts
+++ b/shared/src/routes/index.ts
@@ -19,6 +19,7 @@ import { zFormulaireRoute } from "./formulaire.route.js"
 import { zInserJeunesRoutes } from "./inserjeunes.routes.js"
 import { zV1JobsRoutes } from "./jobs.routes.js"
 import { zV1JobsEtFormationsRoutes } from "./jobs-et-formations.routes.js"
+import { zJobsPartnersAdminRoutes } from "./jobs-partners-admin.routes.js"
 import { zLoginRoutes } from "./login.routes.js"
 import { zMetiersRoutes } from "./metiers.routes.js"
 import { zPartnersRoutes } from "./partners.routes.js"
@@ -74,6 +75,7 @@ const zRoutesGetP5 = {
   ...zJobsRoutesV3.get,
   ...zClassificationRoute.get,
   ...zSearchRoutes.get,
+  ...zJobsPartnersAdminRoutes.get,
 } as const
 
 const zRoutesGet: typeof zRoutesGetP1 & typeof zRoutesGetP2 & typeof zRoutesGetP3 & typeof zRoutesGetP4 & typeof zRoutesGetP5 = {
@@ -98,7 +100,6 @@ const zRoutesPost2 = {
   ...zRecruiterRoutes.post,
   ...zApplicationRoutesV2.post,
   ...zAppointmentsRouteV2.post,
-  ...zClassificationRoute.post,
 }
 
 const zRoutesPost3 = {
@@ -109,6 +110,7 @@ const zRoutesPost3 = {
   ...zReportedCompanyRoutes.post,
   ...zJobsRoutesV3.post,
   ...zProcessorAdminRoutes.post,
+  ...zJobsPartnersAdminRoutes.post,
 }
 
 const zRoutesPost = {

--- a/shared/src/routes/jobs-partners-admin.routes.ts
+++ b/shared/src/routes/jobs-partners-admin.routes.ts
@@ -1,0 +1,91 @@
+import { extensions } from "../helpers/zod-helpers/zod-primitives.js"
+import { z } from "../helpers/zod-with-open-api.js"
+import { zObjectId } from "../models/common.js"
+import { JOB_STATUS_ENGLISH } from "../models/job.model.js"
+import { ZJobsPartnersOfferForAdmin } from "../models/jobs-partners.model.js"
+
+import type { IRoutesDef } from "./common.routes.js"
+
+export const zJobsPartnersAdminRoutes = {
+  get: {
+    "/admin/jobs-partners": {
+      method: "get",
+      path: "/admin/jobs-partners",
+      querystring: z.object({
+        partner_label: z
+          .union([z.string(), z.array(z.string())])
+          .transform((v) => (Array.isArray(v) ? v : [v]))
+          .optional(),
+        offer_status: z
+          .union([extensions.buildEnum(JOB_STATUS_ENGLISH), z.array(extensions.buildEnum(JOB_STATUS_ENGLISH))])
+          .transform((v) => (Array.isArray(v) ? v : [v]))
+          .optional(),
+        id: z.string().optional(),
+        limit: z.coerce.number<number>().int().min(1).max(100).optional(),
+        offset: z.coerce.number<number>().int().min(0).optional(),
+      }),
+      response: {
+        "200": z.strictObject({
+          jobs: z.array(ZJobsPartnersOfferForAdmin),
+          pagination: z.strictObject({
+            total: z.number(),
+            limit: z.number(),
+            offset: z.number(),
+          }),
+        }),
+      },
+      securityScheme: {
+        auth: "cookie-session",
+        access: "admin",
+        resources: {},
+      },
+    },
+  },
+  post: {
+    "/admin/jobs-partners/:id/activate": {
+      method: "post",
+      path: "/admin/jobs-partners/:id/activate",
+      params: z.strictObject({ id: zObjectId }),
+      response: {
+        "200": z.strictObject({}),
+      },
+      securityScheme: {
+        auth: "cookie-session",
+        access: "admin",
+        resources: {},
+      },
+    },
+    "/admin/jobs-partners/:id/deactivate": {
+      method: "post",
+      path: "/admin/jobs-partners/:id/deactivate",
+      params: z.strictObject({ id: zObjectId }),
+      body: z.strictObject({
+        reason: z.string().min(1, "La raison est obligatoire"),
+      }),
+      response: {
+        "200": z.strictObject({}),
+      },
+      securityScheme: {
+        auth: "cookie-session",
+        access: "admin",
+        resources: {},
+      },
+    },
+    "/admin/jobs-partners/:id/classification": {
+      method: "post",
+      path: "/admin/jobs-partners/:id/classification",
+      params: z.strictObject({ id: zObjectId }),
+      body: z.strictObject({
+        classification: z.enum(["publish", "unpublish"]),
+      }),
+      response: {
+        "200": z.strictObject({ updated: z.boolean() }),
+      },
+      securityScheme: {
+        auth: "cookie-session",
+        access: "admin",
+        resources: {},
+      },
+    },
+  },
+} as const satisfies IRoutesDef

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/_utils/offresPartenairesColumns.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/_utils/offresPartenairesColumns.tsx
@@ -1,0 +1,128 @@
+import { Box, Stack, Typography } from "@mui/material"
+import type { ColumnDef } from "@tanstack/react-table"
+import dayjs from "dayjs"
+import { JOB_STATUS_ENGLISH, traductionJobStatus } from "shared/models/job.model"
+import type { IJobsPartnersOfferForAdminJSON } from "shared/models/jobs-partners.model"
+
+import type { useDisclosure } from "@/app/hooks/use-disclosure"
+import { CustomTag, type CustomTagColor } from "@/components/SearchForTrainingsAndJobs/components/CustomTag"
+import { sortReactTableDate } from "@/utils/date-utils"
+import { OffresPartenairesMenu } from "../offres-partenaires/OffresPartenairesMenu"
+
+type DisclosureReturn = ReturnType<typeof useDisclosure>
+
+const statusTagColor: Record<JOB_STATUS_ENGLISH, CustomTagColor> = {
+  [JOB_STATUS_ENGLISH.ACTIVE]: "green",
+  [JOB_STATUS_ENGLISH.POURVUE]: "darkBlue",
+  [JOB_STATUS_ENGLISH.ANNULEE]: "red",
+  [JOB_STATUS_ENGLISH.EN_ATTENTE]: "yellow",
+}
+
+export function getOffresPartenairesColumns({
+  setCurrentOffer,
+  confirmationDesactivationOffre,
+  confirmationClassificationOffre,
+}: {
+  setCurrentOffer: (o: IJobsPartnersOfferForAdminJSON | null) => void
+  confirmationDesactivationOffre: DisclosureReturn
+  confirmationClassificationOffre: DisclosureReturn
+}): ColumnDef<IJobsPartnersOfferForAdminJSON>[] {
+  return [
+    {
+      id: "action",
+      header: "",
+      meta: { srOnly: "Actions sur l'offre" },
+      size: 50,
+      enableSorting: false,
+      cell: (info) => (
+        <OffresPartenairesMenu
+          row={info.row.original}
+          setCurrentOffer={setCurrentOffer}
+          confirmationDesactivationOffre={confirmationDesactivationOffre}
+          confirmationClassificationOffre={confirmationClassificationOffre}
+        />
+      ),
+    },
+    {
+      id: "partner_label",
+      header: "Partenaire",
+      accessorKey: "partner_label",
+      size: 160,
+      enableSorting: false,
+      cell: (info) => <Typography sx={{ fontSize: ".75rem", fontWeight: 700 }}>{info.getValue<string>()}</Typography>,
+    },
+    {
+      id: "offer_title",
+      header: "Offre",
+      size: 305,
+      enableSorting: false,
+      cell: (info) => {
+        const { offer_title, partner_job_id } = info.row.original
+        return (
+          <Stack spacing={0.5}>
+            <Typography sx={{ fontSize: ".75rem", fontWeight: 700 }}>{offer_title}</Typography>
+            <Typography sx={{ color: "#666666", fontSize: ".75rem" }}>Id partenaire : {partner_job_id}</Typography>
+          </Stack>
+        )
+      },
+    },
+    {
+      id: "workplace",
+      header: "Entreprise",
+      size: 260,
+      enableSorting: false,
+      cell: (info) => {
+        const { workplace_legal_name, workplace_name, workplace_siret, is_delegated, cfa_legal_name } = info.row.original
+        return (
+          <Stack spacing={0.5}>
+            <Typography sx={{ fontSize: ".75rem", fontWeight: 700 }}>{workplace_legal_name || workplace_name || "—"}</Typography>
+            <Typography sx={{ color: "#666666", fontSize: ".75rem" }}>SIRET {workplace_siret || "—"}</Typography>
+            {is_delegated && (
+              <Box>
+                <CustomTag color="yellow">Délégué à {cfa_legal_name || "un CFA"}</CustomTag>
+              </Box>
+            )}
+          </Stack>
+        )
+      },
+    },
+    {
+      id: "offer_status",
+      header: "Statut",
+      size: 120,
+      accessorKey: "offer_status",
+      enableSorting: false,
+      cell: (info) => {
+        const status = info.getValue<JOB_STATUS_ENGLISH>()
+        return <CustomTag color={statusTagColor[status]}>{traductionJobStatus(status)}</CustomTag>
+      },
+    },
+    {
+      id: "classification",
+      header: "Classification",
+      size: 180,
+      enableSorting: false,
+      cell: (info) => {
+        const classification = info.row.original.classification
+        if (!classification) return <CustomTag color="darkBlue">Non classé</CustomTag>
+        const { model, human_verification } = classification
+        if (human_verification === "unpublish") return <CustomTag color="red">CFA signalé</CustomTag>
+        if (human_verification === "publish") return <CustomTag color="green">Publiable</CustomTag>
+        if (model === "unpublish") return <CustomTag color="yellow">Suggéré CFA (ML)</CustomTag>
+        if (model === "publish") return <CustomTag color="yellow">Suggéré publiable (ML)</CustomTag>
+        return <CustomTag color="darkBlue">Non classé</CustomTag>
+      },
+    },
+    {
+      id: "offer_creation",
+      header: "Créée le",
+      accessorKey: "offer_creation",
+      size: 110,
+      sortingFn: (a, b) => sortReactTableDate(a.original.offer_creation, b.original.offer_creation),
+      cell: (info) => {
+        const value = info.getValue<string | null>()
+        return <Typography sx={{ color: "#666666", fontSize: ".75rem" }}>{value ? dayjs(value).format("DD/MM/YYYY") : "—"}</Typography>
+      },
+    },
+  ]
+}

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/OffresPartenairesList.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/OffresPartenairesList.tsx
@@ -1,0 +1,178 @@
+"use client"
+import { fr } from "@codegouvfr/react-dsfr"
+import Button from "@codegouvfr/react-dsfr/Button"
+import Input from "@codegouvfr/react-dsfr/Input"
+import { Box, Checkbox, CircularProgress, FormControl, InputLabel, ListItemText, MenuItem, OutlinedInput, Select, Typography } from "@mui/material"
+import { useQuery } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+import type { IJobsPartnersOfferForAdminJSON } from "shared/models/jobs-partners.model"
+import { JOBPARTNERS_LABEL, jobPartnersExcludedFromFlux } from "shared/models/jobs-partners.model"
+
+import { VirtualTable } from "@/app/(espace-pro)/_components/VirtualTable"
+import { useDisclosure } from "@/app/hooks/use-disclosure"
+import { getJobsPartnersForAdmin } from "@/utils/api"
+import { getOffresPartenairesColumns } from "../_utils/offresPartenairesColumns"
+import { ConfirmationClassificationOffre, ConfirmationDesactivationOffre } from "./OffresPartenairesModals"
+
+const partnerLabelOptions = Object.values(JOBPARTNERS_LABEL).filter((label) => !jobPartnersExcludedFromFlux.includes(label))
+
+const PAGE_SIZE = 50
+
+export function OffresPartenairesList() {
+  const [selectedPartnerLabels, setSelectedPartnerLabels] = useState<string[]>([])
+  const [idInput, setIdInput] = useState("")
+  const [submittedId, setSubmittedId] = useState("")
+  const [offset, setOffset] = useState(0)
+
+  const { data, isFetching } = useQuery({
+    queryKey: ["/admin/jobs-partners", selectedPartnerLabels, submittedId, offset],
+    queryFn: () =>
+      getJobsPartnersForAdmin({
+        partner_label: selectedPartnerLabels.length ? selectedPartnerLabels : undefined,
+        id: submittedId || undefined,
+        limit: PAGE_SIZE,
+        offset,
+      }),
+    staleTime: 1000 * 30,
+  })
+
+  const jobs = useMemo(() => data?.jobs ?? [], [data])
+  const total = data?.pagination.total ?? 0
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+
+  const [currentOffer, setCurrentOffer] = useState<IJobsPartnersOfferForAdminJSON | null>(null)
+  const confirmationDesactivationOffre = useDisclosure()
+  const confirmationClassificationOffre = useDisclosure()
+
+  const columns = useMemo(
+    () => getOffresPartenairesColumns({ setCurrentOffer, confirmationDesactivationOffre, confirmationClassificationOffre }),
+    [confirmationDesactivationOffre, confirmationClassificationOffre]
+  )
+
+  const onSearch = () => {
+    setOffset(0)
+    setSubmittedId(idInput.trim())
+  }
+
+  return (
+    <>
+      <ConfirmationDesactivationOffre offer={currentOffer} isOpen={confirmationDesactivationOffre.isOpen} onClose={confirmationDesactivationOffre.onClose} />
+      <ConfirmationClassificationOffre offer={currentOffer} isOpen={confirmationClassificationOffre.isOpen} onClose={confirmationClassificationOffre.onClose} />
+
+      {/* Ligne 1 : recherche par id */}
+      <Box sx={{ display: "flex", gap: fr.spacing("2v"), alignItems: "flex-end", mb: fr.spacing("3v") }}>
+        <Input
+          label="Rechercher par identifiant (_id)"
+          nativeInputProps={{
+            value: idInput,
+            placeholder: "Identifiant de l'offre...",
+            onChange: (e) => setIdInput(e.target.value),
+            onKeyDown: (e) => {
+              if (e.key === "Enter") onSearch()
+            },
+            style: { minWidth: "360px" },
+          }}
+        />
+        <Button iconId="fr-icon-search-line" priority="primary" onClick={onSearch} style={{ marginBottom: "1.5rem" }}>
+          Rechercher
+        </Button>
+      </Box>
+
+      {/* Ligne 2 : filtres */}
+      <Box sx={{ display: "flex", gap: fr.spacing("4v"), mb: fr.spacing("4v"), alignItems: "center" }}>
+        <MultiSelect
+          id="partner-label-offres-partenaires"
+          label="Partenaire"
+          width={260}
+          items={partnerLabelOptions.map((label) => ({ value: label, label }))}
+          value={selectedPartnerLabels}
+          onChange={(v) => {
+            setOffset(0)
+            setSelectedPartnerLabels(v)
+          }}
+        />
+      </Box>
+
+      {isFetching ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : jobs.length === 0 ? (
+        <Box sx={{ py: 6, textAlign: "center", color: "text.secondary" }}>Aucun résultat.</Box>
+      ) : (
+        <>
+          <VirtualTable caption={`Offres partenaires (${total} au total)`} columns={columns} data={jobs} hideSearch={true} />
+          <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", gap: fr.spacing("3v"), mt: fr.spacing("4v") }}>
+            <Button priority="secondary" disabled={offset === 0} onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}>
+              Précédent
+            </Button>
+            <Typography sx={{ fontSize: ".875rem", color: "#666666" }}>
+              Page {currentPage} / {pageCount}
+            </Typography>
+            <Button priority="secondary" disabled={currentPage >= pageCount} onClick={() => setOffset(offset + PAGE_SIZE)}>
+              Suivant
+            </Button>
+          </Box>
+        </>
+      )}
+    </>
+  )
+}
+
+function MultiSelect<T extends string>({
+  id,
+  label,
+  width,
+  items,
+  value,
+  onChange,
+}: {
+  id: string
+  label: string
+  width: number
+  items: { value: T; label: string }[]
+  value: T[]
+  onChange: (newValue: T[]) => void
+}) {
+  const allSelected = value.length === items.length
+  const someSelected = value.length > 0 && !allSelected
+
+  function handleChange(selected: string[]) {
+    if (selected.includes("__all__")) {
+      onChange(allSelected ? [] : items.map((i) => i.value))
+    } else {
+      onChange(selected as T[])
+    }
+  }
+
+  const displayLabel = value.length === 0 ? "Tous" : value.map((v) => items.find((i) => i.value === v)?.label ?? v).join(", ")
+
+  return (
+    <FormControl sx={{ width }} size="small">
+      <InputLabel id={`${id}-label`} sx={{ fontSize: ".875rem" }}>
+        {label}
+      </InputLabel>
+      <Select
+        labelId={`${id}-label`}
+        multiple
+        value={value}
+        onChange={(e) => handleChange(e.target.value as string[])}
+        input={<OutlinedInput label={label} />}
+        renderValue={() => displayLabel}
+        MenuProps={{ PaperProps: { style: { maxHeight: 300 } } }}
+      >
+        <MenuItem value="__all__" sx={{ borderBottom: "1px solid", borderColor: "divider" }}>
+          <Checkbox checked={allSelected} indeterminate={someSelected} size="small" />
+          <ListItemText primary={allSelected ? "Tout désélectionner" : "Tout sélectionner"} slotProps={{ primary: { fontSize: ".875rem" } }} />
+        </MenuItem>
+        {items.map((item) => (
+          <MenuItem key={item.value} value={item.value}>
+            <Checkbox checked={value.includes(item.value)} size="small" />
+            <ListItemText primary={item.label} slotProps={{ primary: { fontSize: ".875rem" } }} />
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+}

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/OffresPartenairesList.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/OffresPartenairesList.tsx
@@ -3,7 +3,7 @@ import { fr } from "@codegouvfr/react-dsfr"
 import Button from "@codegouvfr/react-dsfr/Button"
 import Input from "@codegouvfr/react-dsfr/Input"
 import { Box, Checkbox, CircularProgress, FormControl, InputLabel, ListItemText, MenuItem, OutlinedInput, Select, Typography } from "@mui/material"
-import { useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import { useMemo, useState } from "react"
 import type { IJobsPartnersOfferForAdminJSON } from "shared/models/jobs-partners.model"
 import { JOBPARTNERS_LABEL, jobPartnersExcludedFromFlux } from "shared/models/jobs-partners.model"
@@ -24,7 +24,7 @@ export function OffresPartenairesList() {
   const [submittedId, setSubmittedId] = useState("")
   const [offset, setOffset] = useState(0)
 
-  const { data, isFetching } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ["/admin/jobs-partners", selectedPartnerLabels, submittedId, offset],
     queryFn: () =>
       getJobsPartnersForAdmin({
@@ -34,6 +34,7 @@ export function OffresPartenairesList() {
         offset,
       }),
     staleTime: 1000 * 30,
+    placeholderData: keepPreviousData,
   })
 
   const jobs = useMemo(() => data?.jobs ?? [], [data])
@@ -94,7 +95,7 @@ export function OffresPartenairesList() {
         />
       </Box>
 
-      {isFetching ? (
+      {isLoading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
           <CircularProgress />
         </Box>

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/OffresPartenairesMenu.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/OffresPartenairesMenu.tsx
@@ -1,0 +1,65 @@
+import { JOB_STATUS_ENGLISH } from "shared/models/job.model"
+import type { IJobsPartnersOfferForAdminJSON } from "shared/models/jobs-partners.model"
+
+import type { PopoverMenuAction } from "@/app/(espace-pro)/_components/PopoverMenu"
+import { PopoverMenu } from "@/app/(espace-pro)/_components/PopoverMenu"
+import type { useDisclosure } from "@/app/hooks/use-disclosure"
+import { useJobsPartnersAdminActions } from "@/app/hooks/use-jobs-partners-admin-actions"
+
+type DisclosureReturn = ReturnType<typeof useDisclosure>
+
+export const OffresPartenairesMenu = ({
+  row,
+  setCurrentOffer,
+  confirmationDesactivationOffre,
+  confirmationClassificationOffre,
+}: {
+  row: IJobsPartnersOfferForAdminJSON
+  setCurrentOffer: (offer: IJobsPartnersOfferForAdminJSON | null) => void
+  confirmationDesactivationOffre: DisclosureReturn
+  confirmationClassificationOffre: DisclosureReturn
+}) => {
+  const { activate } = useJobsPartnersAdminActions()
+  const isCfaFlagged = row.classification?.human_verification === "unpublish"
+
+  const actions: PopoverMenuAction[] = [
+    row.lba_url
+      ? {
+          label: "Voir l'offre",
+          type: "externalLink",
+          ariaLabel: `Voir l'offre ${row.offer_title} dans un nouvel onglet`,
+          link: row.lba_url,
+        }
+      : null,
+    row.offer_status !== JOB_STATUS_ENGLISH.ACTIVE
+      ? {
+          label: "Activer l'offre",
+          type: "button",
+          ariaLabel: `Activer l'offre ${row.offer_title}`,
+          onClick: () => activate(row._id),
+        }
+      : null,
+    row.offer_status === JOB_STATUS_ENGLISH.ACTIVE
+      ? {
+          label: "Désactiver l'offre",
+          type: "button",
+          ariaLabel: `Désactiver l'offre ${row.offer_title}`,
+          onClick: () => {
+            setCurrentOffer(row)
+            confirmationDesactivationOffre.onOpen()
+          },
+        }
+      : null,
+    {
+      label: isCfaFlagged ? "Retirer le signalement CFA" : "Signaler comme offre de CFA",
+      type: "button",
+      ariaLabel: `${isCfaFlagged ? "Retirer le signalement CFA de" : "Signaler comme offre de CFA"} l'offre ${row.offer_title}`,
+      onClick: () => {
+        setCurrentOffer(row)
+        confirmationClassificationOffre.onOpen()
+      },
+    },
+  ]
+
+  return <PopoverMenu actions={actions.filter((action) => action !== null)} title={`Actions sur l'offre ${row.offer_title}`} />
+}

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/OffresPartenairesModals.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/OffresPartenairesModals.tsx
@@ -1,0 +1,91 @@
+"use client"
+import { fr } from "@codegouvfr/react-dsfr"
+import Button from "@codegouvfr/react-dsfr/Button"
+import Input from "@codegouvfr/react-dsfr/Input"
+import { Box, Typography } from "@mui/material"
+import { useState } from "react"
+import type { IJobsPartnersOfferForAdminJSON } from "shared/models/jobs-partners.model"
+import { useJobsPartnersAdminActions } from "@/app/hooks/use-jobs-partners-admin-actions"
+import { ModalReadOnly } from "@/components/ModalReadOnly"
+
+export function ConfirmationDesactivationOffre({ offer, isOpen, onClose }: { offer: IJobsPartnersOfferForAdminJSON | null; isOpen: boolean; onClose: () => void }) {
+  const [reason, setReason] = useState("")
+  const { deactivate } = useJobsPartnersAdminActions()
+
+  if (!offer) return null
+
+  const handleClose = () => {
+    setReason("")
+    onClose()
+  }
+
+  return (
+    <ModalReadOnly isOpen={isOpen} onClose={handleClose}>
+      <Box sx={{ pb: fr.spacing("4v"), px: fr.spacing("4v") }}>
+        <Typography className={fr.cx("fr-text--xl", "fr-text--bold")} sx={{ mb: fr.spacing("2v") }} component="h2">
+          Désactivation de l'offre
+        </Typography>
+        <Typography sx={{ mb: fr.spacing("2v"), color: "#3A3A3A", lineHeight: "24px" }}>
+          Vous êtes sur le point de désactiver l'offre « {offer.offer_title} ». Pouvez-vous préciser pour quelle raison ?
+        </Typography>
+        <Input label="Raison de la désactivation" nativeTextAreaProps={{ value: reason, onChange: (e) => setReason(e.target.value), rows: 3 }} textArea />
+        <Box sx={{ display: "flex", flexDirection: "row", justifyContent: "flex-end", mt: fr.spacing("3v") }}>
+          <Box sx={{ mr: fr.spacing("3v") }}>
+            <Button priority="secondary" onClick={handleClose}>
+              Annuler
+            </Button>
+          </Box>
+          <Button
+            disabled={!reason.trim()}
+            onClick={async () => {
+              await deactivate(offer._id, reason.trim())
+              handleClose()
+            }}
+          >
+            Désactiver l'offre
+          </Button>
+        </Box>
+      </Box>
+    </ModalReadOnly>
+  )
+}
+
+export function ConfirmationClassificationOffre({ offer, isOpen, onClose }: { offer: IJobsPartnersOfferForAdminJSON | null; isOpen: boolean; onClose: () => void }) {
+  const { setClassification } = useJobsPartnersAdminActions()
+
+  if (!offer) return null
+
+  const isCfaFlagged = offer.classification?.human_verification === "unpublish"
+  const nextClassification = isCfaFlagged ? "publish" : "unpublish"
+
+  return (
+    <ModalReadOnly isOpen={isOpen} onClose={onClose}>
+      <Box sx={{ pb: fr.spacing("4v"), px: fr.spacing("4v") }}>
+        <Typography className={fr.cx("fr-text--xl", "fr-text--bold")} sx={{ mb: fr.spacing("2v") }} component="h2">
+          {isCfaFlagged ? "Retirer le signalement CFA" : "Signaler comme offre de CFA"}
+        </Typography>
+        <Typography sx={{ mb: fr.spacing("2v"), color: "#3A3A3A", lineHeight: "24px" }}>
+          {isCfaFlagged
+            ? `Vous êtes sur le point de retirer le signalement CFA de l'offre « ${offer.offer_title} ».`
+            : `Vous êtes sur le point de signaler l'offre « ${offer.offer_title} » comme provenant d'un CFA.`}{" "}
+          Si le modèle de classification automatique juge l'offre différemment, elle sera automatiquement annulée et repassée dans le pipeline de traitement.
+        </Typography>
+        <Box sx={{ display: "flex", flexDirection: "row", justifyContent: "flex-end", mt: fr.spacing("3v") }}>
+          <Box sx={{ mr: fr.spacing("3v") }}>
+            <Button priority="secondary" onClick={onClose}>
+              Annuler
+            </Button>
+          </Box>
+          <Button
+            onClick={async () => {
+              await setClassification(offer._id, nextClassification)
+              onClose()
+            }}
+          >
+            {isCfaFlagged ? "Retirer le signalement" : "Signaler comme CFA"}
+          </Button>
+        </Box>
+      </Box>
+    </ModalReadOnly>
+  )
+}

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next"
+import { Breadcrumb } from "@/app/_components/Breadcrumb"
+import { PAGES } from "@/utils/routes.utils"
+import { OffresPartenairesList } from "./OffresPartenairesList"
+export const metadata: Metadata = {
+  title: PAGES.static.backAdminGestionDesOffresPartenaires.getMetadata().title,
+}
+
+export default async function GestionDesOffresPartenaires() {
+  return (
+    <>
+      <Breadcrumb pages={[PAGES.static.backAdminGestionDesOffresPartenaires]} />
+      <OffresPartenairesList />
+    </>
+  )
+}

--- a/ui/app/_components/Layout/NavigationAdmin.tsx
+++ b/ui/app/_components/Layout/NavigationAdmin.tsx
@@ -2,18 +2,27 @@
 
 import MainNavigation from "@codegouvfr/react-dsfr/MainNavigation"
 import { usePathname } from "next/navigation"
+import type { ComponentProps } from "react"
 
 import { PAGES } from "@/utils/routes.utils"
 
-type AdminNavItem = {
+type AdminNavLink = {
   text: string
   href: string
 }
 
-const ADMIN_NAV_ITEMS: AdminNavItem[] = [
-  { text: "Recruteurs à traiter", href: PAGES.static.backAdminHome.getPath() },
-  { text: "Gestion des recruteurs", href: PAGES.static.backAdminGestionDesRecruteurs.getPath() },
-  { text: "Entreprises de l'algorithme", href: PAGES.static.backAdminGestionDesEntreprises.getPath() },
+type AdminNavEntry = AdminNavLink | { text: string; children: AdminNavLink[] }
+
+const ADMIN_NAV_ITEMS: AdminNavEntry[] = [
+  {
+    text: "Recruteurs",
+    children: [
+      { text: "Recruteurs en attente de validation", href: PAGES.static.backAdminHome.getPath() },
+      { text: "Gestion des recruteurs", href: PAGES.static.backAdminGestionDesRecruteurs.getPath() },
+      { text: "Entreprises de l'algorithme", href: PAGES.static.backAdminGestionDesEntreprises.getPath() },
+      { text: "Offres partenaires", href: PAGES.static.backAdminGestionDesOffresPartenaires.getPath() },
+    ],
+  },
   { text: "Rendez-vous apprentissage", href: PAGES.static.rendezVousApprentissageRecherche.getPath() },
   { text: "Gestion des administrateurs", href: PAGES.static.backAdminGestionDesAdministrateurs.getPath() },
   { text: "Gestion des jobs", href: PAGES.static.adminProcessor.getPath() },
@@ -26,13 +35,31 @@ function isLinkActive(pathname: string, href: string): boolean {
 const NavigationAdmin = () => {
   const pathname = usePathname()
 
-  const items = ADMIN_NAV_ITEMS.map((item) => ({
-    text: item.text,
-    isActive: isLinkActive(pathname, item.href),
-    linkProps: {
-      href: item.href,
-    },
-  }))
+  type NavItem = ComponentProps<typeof MainNavigation>["items"][number]
+
+  const items: NavItem[] = ADMIN_NAV_ITEMS.map((entry): NavItem => {
+    if ("children" in entry) {
+      return {
+        text: entry.text,
+        isActive: entry.children.some((child) => isLinkActive(pathname, child.href)),
+        menuLinks: entry.children.map((child) => ({
+          text: child.text,
+          isActive: isLinkActive(pathname, child.href),
+          linkProps: {
+            href: child.href,
+          },
+        })),
+      } as NavItem
+    }
+
+    return {
+      text: entry.text,
+      isActive: isLinkActive(pathname, entry.href),
+      linkProps: {
+        href: entry.href,
+      },
+    }
+  })
 
   return <MainNavigation items={items} />
 }

--- a/ui/app/hooks/use-jobs-partners-admin-actions.ts
+++ b/ui/app/hooks/use-jobs-partners-admin-actions.ts
@@ -1,0 +1,41 @@
+import { useQueryClient } from "@tanstack/react-query"
+import { useCallback } from "react"
+import { useToast } from "@/app/hooks/useToast"
+import { activateJobPartner, deactivateJobPartner, setJobPartnerClassification } from "@/utils/api"
+
+export const useJobsPartnersAdminActions = () => {
+  const client = useQueryClient()
+  const toast = useToast()
+
+  const withToast = useCallback(
+    async (apiCall: () => Promise<unknown>, successMessage: string) => {
+      try {
+        await apiCall()
+        await client.invalidateQueries({ queryKey: ["/admin/jobs-partners"] })
+        toast({ description: successMessage, autoHideDuration: 4000 })
+      } catch (error) {
+        toast({ variant: "error", description: error instanceof Error ? error.message : "Une erreur est survenue", autoHideDuration: 5000 })
+      }
+    },
+    [client, toast]
+  )
+
+  return {
+    activate: (id: string) => withToast(() => activateJobPartner(id), "Offre réactivée"),
+    deactivate: (id: string, reason: string) => withToast(() => deactivateJobPartner(id, reason), "Offre désactivée"),
+    setClassification: async (id: string, classification: "publish" | "unpublish") => {
+      const label = classification === "unpublish" ? "Offre signalée comme CFA" : "Signalement CFA retiré"
+      try {
+        const result = await setJobPartnerClassification(id, classification)
+        await client.invalidateQueries({ queryKey: ["/admin/jobs-partners"] })
+        if (!result.updated) {
+          toast({ variant: "warning", description: "Aucune entrée de classification trouvée pour cette offre, aucune action effectuée.", autoHideDuration: 5000 })
+        } else {
+          toast({ description: label, autoHideDuration: 4000 })
+        }
+      } catch (error) {
+        toast({ variant: "error", description: error instanceof Error ? error.message : "Une erreur est survenue", autoHideDuration: 5000 })
+      }
+    },
+  }
+}

--- a/ui/utils/api.ts
+++ b/ui/utils/api.ts
@@ -16,6 +16,7 @@ import { removeUndefinedFields } from "shared"
 import type { ApplicationIntention } from "shared/constants/application"
 import type { BusinessErrorCodes } from "shared/constants/error-codes"
 import type { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import type { JOB_STATUS_ENGLISH } from "shared/models/job.model"
 import type { ILbaCompanySearchField } from "shared/routes/update-lba-company.routes"
 import type { Jsonify } from "type-fest"
 import { ApiError, apiDelete, apiGet, apiPatch, apiPost, apiPut } from "./api.utils"
@@ -113,6 +114,19 @@ export const notifyNotMyOpcoUserRole = async (userId: string, organizationId: st
   apiPost("/user/:userId/organization/:organizationId/not-my-opco", { params: { userId, organizationId }, body: { reason } })
 
 export const createSuperUser = async (user: INewSuperUser) => apiPost("/admin/users", { body: user })
+
+/**
+ * Admin - jobs_partners
+ */
+export const getJobsPartnersForAdmin = async (params: { partner_label?: string[]; offer_status?: JOB_STATUS_ENGLISH[]; id?: string; limit?: number; offset?: number }) =>
+  apiGet("/admin/jobs-partners", { querystring: removeUndefinedFields(params) })
+
+export const activateJobPartner = async (id: string) => apiPost("/admin/jobs-partners/:id/activate", { params: { id } })
+
+export const deactivateJobPartner = async (id: string, reason: string) => apiPost("/admin/jobs-partners/:id/deactivate", { params: { id }, body: { reason } })
+
+export const setJobPartnerClassification = async (id: string, classification: "publish" | "unpublish") =>
+  apiPost("/admin/jobs-partners/:id/classification", { params: { id }, body: { classification } })
 
 // Temporaire, en attendant d'ajuster le modèle pour n'avoir qu'une seul source de données pour les entreprises
 /**

--- a/ui/utils/routes.utils.ts
+++ b/ui/utils/routes.utils.ts
@@ -520,6 +520,13 @@ export const PAGES = {
         title: "Gestion des recruteurs - La bonne alternance",
       }),
     },
+    backAdminGestionDesOffresPartenaires: {
+      getPath: () => `/espace-pro/administration/offres-partenaires` as string,
+      title: "Offres partenaires",
+      getMetadata: () => ({
+        title: "Offres partenaires - La bonne alternance",
+      }),
+    },
     backOpcoHome: {
       getPath: () => `/espace-pro/opco` as string,
       title: "Accueil OPCO",


### PR DESCRIPTION
Closes #5135

## Changements

- Nouvel écran admin `/espace-pro/administration/offres-partenaires` : liste paginée côté serveur, filtre par partenaire, recherche par `_id`, colonne classification CFA
- Actions par offre : activer / désactiver (raison obligatoire + historique), signaler / retirer un signalement CFA (bascule publish/unpublish réversible avec cascade d'annulation automatique si le modèle ML est en désaccord), voir l'offre dans un nouvel onglet (URL reconstruite avec le `publicUrl` de l'environnement courant, pas la valeur stockée en base)
- Extraction de `updateClassificationAndSynchronise` dans un service partagé (`cache-classification.service.ts`), réutilisée par le nouvel écran admin
- Suppression de la route `POST /classification` (utilisée manuellement via Postman par le métier en l'absence d'UI, remplacée par l'action admin) ; le `GET /classification` reste pour l'export du lab ML
- Fusion des 4 premiers items du menu admin ("Recruteurs à traiter", "Gestion des recruteurs", "Entreprises de l'algorithme", "Offres partenaires") sous un sous-menu déroulant "Recruteurs"

## Plan de test

- [ ] Se connecter en admin, ouvrir "Recruteurs" > "Offres partenaires"
- [ ] Filtrer par partenaire, rechercher par `_id`, paginer
- [ ] Désactiver une offre (raison obligatoire), vérifier l'historique et la resynchro de recherche
- [ ] Réactiver l'offre
- [ ] Signaler une offre comme CFA, vérifier la cascade d'annulation si le modèle ML est en désaccord, puis retirer le signalement
- [ ] Vérifier que "Voir l'offre" ouvre la bonne URL (environnement courant)
- [ ] Vérifier que l'ancienne route POST /classification n'existe plus