### PR TITLE
fix: résume les erreurs imbriquées dans le digest offre-partenaire

### DIFF
--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
@@ -129,4 +129,37 @@ describe("sendJobPartnersNightlyDigest", () => {
     expect(payload.error).toBe(true)
     expect(payload.message).toContain("Process computed and import to Jobs Partners")
   })
+
+  it("résume les erreurs imbriquées au lieu de dumper le JSON complet (cas réel de recette)", async () => {
+    findJobsMock.mockResolvedValueOnce([
+      cronTask({
+        name: "Process computed and import to Jobs Partners",
+        status: "finished",
+        result: {
+          filled: {
+            blockJobsPartnersFromFluxCompanyList: { total: 40945, success: 40945, error: 0 },
+            fillSiretInfosForPartners: { total: 15334, success: 15299, error: 35 },
+            fillRomeForPartners: { total: 7223, success: 4294, error: 2929 },
+            blockBadRomeJobsPartners: { modifiedCount: 13 },
+            detectDuplicateJobPartners: { executionDurationInSeconds: 29, executionDurationError: false },
+            validateComputedJobPartners: { total: 22524, success: 19729, error: 2795 },
+          },
+          imported: { total: 19729, success: 19729, error: 0 },
+        },
+      }),
+    ])
+    const notifySpy = vi.spyOn(slackUtils, "notifyToSlack").mockResolvedValue(undefined)
+
+    await sendJobPartnersNightlyDigest()
+
+    const [payload] = notifySpy.mock.calls[0]
+    // les compteurs à 0 et le flag executionDurationError=false ne doivent pas apparaître
+    expect(payload.message).not.toContain("JSON")
+    expect(payload.message).not.toContain('"error":0')
+    expect(payload.message).not.toContain("executionDurationError")
+    // seules les 3 vraies anomalies doivent ressortir, avec leur ratio
+    expect(payload.message).toContain("filled.fillSiretInfosForPartners.error : 35/15334")
+    expect(payload.message).toContain("filled.fillRomeForPartners.error : 2929/7223")
+    expect(payload.message).toContain("filled.validateComputedJobPartners.error : 2795/22524")
+  })
 })

--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
@@ -13,48 +13,68 @@ export const JOB_PARTNERS_DIGEST_JOB_NAME = "Bilan nocturne offres partenaires"
 // son propre CronDef, donc `importers` n'est pas encore initialisé tant que ce module est en cours de chargement.
 const getJobPartnersNightlyJobNames = () => Object.keys(importers).filter((name) => name !== JOB_PARTNERS_DIGEST_JOB_NAME)
 
-const hasNonZeroErrorCount = (value: unknown): boolean => {
-  if (value == null) return false
-  if (Array.isArray(value)) return value.some(hasNonZeroErrorCount)
-  if (typeof value === "object") {
-    return Object.entries(value as Record<string, unknown>).some(([key, val]) => {
-      if (/error/i.test(key)) {
-        if (typeof val === "number") return val > 0
-        if (typeof val === "boolean") return val === true
+type ErrorSignal = { path: string; detail: string }
+
+// Parcourt récursivement un résultat de job (souvent imbriqué : { filled: { step1: {total,success,error}, ... } })
+// et n'en extrait que les champs *error* non nuls, avec leur chemin et leur total si disponible.
+// Évite de dumper le JSON complet (souvent illisible sur Slack) pour ne montrer que ce qui compte.
+const findErrorSignals = (value: unknown, path: string[] = []): ErrorSignal[] => {
+  if (value == null || typeof value !== "object") return []
+  if (Array.isArray(value)) return value.flatMap((item, i) => findErrorSignals(item, [...path, String(i)]))
+
+  const record = value as Record<string, unknown>
+  const signals: ErrorSignal[] = []
+
+  for (const [key, val] of Object.entries(record)) {
+    if (/error/i.test(key)) {
+      if (typeof val === "number" && val > 0) {
+        const total = typeof record.total === "number" ? `/${record.total}` : ""
+        signals.push({ path: [...path, key].join("."), detail: `${val}${total}` })
+      } else if (typeof val === "boolean" && val) {
+        signals.push({ path: [...path, key].join("."), detail: "signalé" })
       }
-      return hasNonZeroErrorCount(val)
-    })
+    } else {
+      signals.push(...findErrorSignals(val, [...path, key]))
+    }
   }
-  return false
+  return signals
 }
 
 const isAnomalous = (job: IJobsCronTask): boolean => {
   // "running" à l'heure du digest : le job aurait dû se terminer avant (cf. timing du cron) — signe d'un job bloqué
   if (job.status === "errored" || job.status === "killed" || job.status === "running") return true
-  return hasNonZeroErrorCount(job.output?.result)
+  return findErrorSignals(job.output?.result).length > 0
 }
 
 const jobTimestamp = (job: IJobsCronTask): number => (job.ended_at ?? job.started_at ?? new Date(0)).getTime()
 
-const describeAnomaly = (job: IJobsCronTask): string => {
+// headline : résumé tenant sur une ligne, toujours sûr à afficher entre parenthèses.
+// details : liste optionnelle de sous-puces (une par champ *error*), affichée après la parenthèse fermante.
+type AnomalyDescription = { headline: string; details?: string }
+
+const describeAnomaly = (job: IJobsCronTask): AnomalyDescription => {
   const duration = job.output?.duration ?? "?"
   if (job.status === "running") {
-    return `toujours en cours, démarré à ${job.started_at?.toISOString() ?? "?"}`
+    return { headline: `toujours en cours, démarré à ${job.started_at?.toISOString() ?? "?"}` }
   }
   if (job.status === "errored" || job.status === "killed") {
-    return `${job.status}, ${duration} : ${job.output?.error ?? "erreur inconnue"}`
+    return { headline: `${job.status}, ${duration} : ${job.output?.error ?? "erreur inconnue"}` }
   }
-  return `${duration} : ${JSON.stringify(job.output?.result)}`
+  const signals = findErrorSignals(job.output?.result)
+  if (signals.length === 0) return { headline: `${duration} : anomalie non détaillée` }
+  const details = signals.map(({ path, detail }) => `\n    ◦ ${path} : ${detail}`).join("")
+  return { headline: duration, details }
 }
 
 // Un même job (ex. "Process missing Rome...", ~65 exécutions/jour) peut échouer en boucle sur la fenêtre :
 // on regroupe par nom pour garder un digest lisible plutôt qu'une ligne par exécution en anomalie.
 const formatAnomalyGroup = (name: string, jobsForName: IJobsCronTask[]): string => {
   const [mostRecent] = [...jobsForName].sort((a, b) => jobTimestamp(b) - jobTimestamp(a))
+  const { headline, details = "" } = describeAnomaly(mostRecent)
   if (jobsForName.length === 1) {
-    return `• ${name} (${describeAnomaly(mostRecent)})`
+    return `• ${name} (${headline})${details}`
   }
-  return `• ${name} : ${jobsForName.length} exécutions en anomalie sur la période (dernière : ${describeAnomaly(mostRecent)})`
+  return `• ${name} : ${jobsForName.length} exécutions en anomalie sur la période (dernière : ${headline})${details}`
 }
 
 const groupByName = (jobs: IJobsCronTask[]): [string, IJobsCronTask[]][] => {


### PR DESCRIPTION
## Changements

- `describeAnomaly` ne fait plus de `JSON.stringify(job.output?.result)` brut sur les jobs "finished" en anomalie (illisible sur Slack sur des payloads imbriqués comme "Process computed and import to Jobs Partners").
- Nouvelle fonction `findErrorSignals` : parcourt récursivement le résultat du job et n'extrait que les champs `*error*` non nuls (nombre > 0 ou booléen `true`), avec leur chemin complet et leur ratio `x/total` quand un `total` est disponible au même niveau.
- Réutilisée à la fois pour la détection d'anomalie (`isAnomalous`) et pour l'affichage (`describeAnomaly`), donc aucun changement de comportement sur ce qui est considéré anomal — uniquement sur le rendu.
- `formatAnomalyGroup` : séparation du résumé une ligne (`headline`, affiché entre parenthèses) et des sous-puces de détail (`details`, affichées après), pour éviter une parenthèse fermante orpheline en fin de bloc multi-lignes.

## Plan de test

- [x] `yarn test:ci server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts` (8 tests, dont un nouveau reproduisant le payload réel observé en recette)
- [x] `yarn test:ci server/src/jobs/offre-partenaire` (208 tests, aucune régression)
- [x] `yarn typecheck` sur `server/`