### PR TITLE
fix: corrige une assertion de test qui ne détectait pas un dump JSON complet

### DIFF
--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts
@@ -153,8 +153,9 @@ describe("sendJobPartnersNightlyDigest", () => {
     await sendJobPartnersNightlyDigest()
 
     const [payload] = notifySpy.mock.calls[0]
+    // un dump JSON complet contiendrait cette clé (step sans erreur) : sa présence trahirait un retour en arrière
+    expect(payload.message).not.toContain("blockJobsPartnersFromFluxCompanyList")
     // les compteurs à 0 et le flag executionDurationError=false ne doivent pas apparaître
-    expect(payload.message).not.toContain("JSON")
     expect(payload.message).not.toContain('"error":0')
     expect(payload.message).not.toContain("executionDurationError")
     // seules les 3 vraies anomalies doivent ressortir, avec leur ratio


### PR DESCRIPTION
Suite à la review Copilot sur #5137 (commentaire https://github.com/mission-apprentissage/labonnealternance/pull/5137#discussion_r3766483564) : `expect(payload.message).not.toContain("JSON")` est toujours vrai puisque `JSON.stringify(...)` ne produit jamais littéralement la sous-chaîne "JSON" — l'assertion ne détectait donc pas un retour en arrière vers un dump JSON complet.

## Changements

- Remplace l'assertion par `not.toContain("blockJobsPartnersFromFluxCompanyList")` : cette clé (un step sans erreur) n'apparaîtrait dans le message que si le résumé était contourné et que le JSON complet était de nouveau dumpé.

## Plan de test

- [x] `yarn test:ci server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.test.ts` (8 tests)