### PR TITLE
fix(lba-5038): fiabilise le JSON-LD JobPosting selon les règles Google

### DIFF
--- a/ui/components/ItemDetail/JobPostingSchema.tsx
+++ b/ui/components/ItemDetail/JobPostingSchema.tsx
@@ -20,6 +20,8 @@ export const JobPostingSchema = (props: JobPostingSchemaProps) => {
 }
 
 const buildJobPostingSchema = ({ title, description, id, job }: JobPostingSchemaProps): JobPostingSchema => {
+  const region = job?.place?.region
+
   return {
     "@context": "https://schema.org/",
     "@type": "JobPosting",
@@ -34,7 +36,10 @@ const buildJobPostingSchema = ({ title, description, id, job }: JobPostingSchema
     },
     datePosted: job?.job?.creationDate,
     validThrough: job?.job?.jobExpirationDate,
-    employmentType: "FULL_TIME",
+    // Google n'accepte que : FULL_TIME, PART_TIME, CONTRACTOR, TEMPORARY, INTERN, VOLUNTEER, PER_DIEM, OTHER.
+    // L'alternance (apprentissage / professionnalisation) ne correspond à aucune de ces valeurs → "OTHER".
+    // https://developers.google.com/search/docs/appearance/structured-data/job-posting#job-posting-definition
+    employmentType: "OTHER",
     hiringOrganization: {
       "@type": "Organization",
       name: job?.company?.name || "confidential",
@@ -45,20 +50,15 @@ const buildJobPostingSchema = ({ title, description, id, job }: JobPostingSchema
         "@type": "PostalAddress",
         streetAddress: job?.place?.numberAndStreet || null,
         addressLocality: job?.place?.city || null,
-        addressRegion: null,
+        // `addressRegion` omis quand inconnu : Google interdit les données de localisation fausses et n'exige que `addressCountry`.
+        ...(region ? { addressRegion: region } : {}),
         postalCode: job?.place?.zipCode || null,
         addressCountry: "France",
       },
     },
-    baseSalary: {
-      "@type": "MonetaryAmount",
-      currency: "EUR",
-      value: {
-        "@type": "QuantitativeValue",
-        minValue: 486.49,
-        unitText: "MONTH",
-      },
-    },
+    // `baseSalary` retiré : aucune donnée de salaire fiable par offre (l'ancienne valeur 486,49 était figée pour toutes les offres).
+    // Google : champ recommandé mais non requis → on l'omet plutôt que d'envoyer une valeur fausse.
+    // https://developers.google.com/search/docs/appearance/structured-data/job-posting#job-posting-definition
   }
 }
 
@@ -76,7 +76,7 @@ type JobPostingSchema = {
   }
   datePosted: string
   validThrough: string
-  employmentType: "FULL_TIME"
+  employmentType: "FULL_TIME" | "PART_TIME" | "CONTRACTOR" | "TEMPORARY" | "INTERN" | "VOLUNTEER" | "PER_DIEM" | "OTHER"
   hiringOrganization: {
     "@type": "Organization"
     name: string
@@ -89,20 +89,9 @@ type JobPostingSchema = {
       "@type": "PostalAddress"
       streetAddress: string
       addressLocality: string
-      addressRegion: string
+      addressRegion?: string
       postalCode: string
       addressCountry: string
-    }
-  }
-  baseSalary: {
-    "@type": "MonetaryAmount"
-    currency: string
-    value: {
-      "@type": "QuantitativeValue"
-      value?: number
-      minValue?: number
-      maxValue?: number
-      unitText: string
     }
   }
 }


### PR DESCRIPTION
## Pourquoi (non technique)

Les **données structurées des offres** (le JSON-LD `JobPosting` qu'on envoie à Google pour l'affichage enrichi dans les résultats de recherche) contenaient **trois informations fausses, identiques sur 100 % des offres** :

- le **type de contrat** était marqué « temps plein » (`FULL_TIME`) alors qu'il s'agit d'**alternance** ;
- la **région** était toujours vide (`null`) ;
- le **salaire** était **codé en dur à 486,49 €/mois** pour toutes les offres.

Envoyer de fausses données à Google est contraire à ses règles et peut **pénaliser notre référencement**. Cette PR fiabilise le schéma en suivant **à la lettre la documentation Google**. Elle traite le **volet « JobPosting »** de l'issue #5038 ; le volet **indexation (sitemap / noindex des offres partenaires et pages recruteurs)** est **hors périmètre** et sera traité séparément (décision métier en cours).

Validation prévue via le **[Rich Results Test](https://search.google.com/test/rich-results)** de Google.

## Ce qui change (technique)

Fichier : `ui/components/ItemDetail/JobPostingSchema.tsx`

| Champ | Avant | Après | Règle Google |
|---|---|---|---|
| `employmentType` | `"FULL_TIME"` (figé) | `"OTHER"` | Valeurs autorisées : `FULL_TIME, PART_TIME, CONTRACTOR, TEMPORARY, INTERN, VOLUNTEER, PER_DIEM, OTHER`. L'alternance ne correspond à aucune → `OTHER` (⚠️ `APPRENTICESHIP` **n'existe pas** côté Google). |
| `addressRegion` | `null` (figé) | **omis** si inconnu | Seul `addressCountry` est obligatoire ; Google interdit *« providing false location data »*. |
| `baseSalary` | `minValue: 486.49` (figé) | **retiré** | Champ *recommandé mais non requis* ; omission acceptable → préférable à une valeur fausse. |

Réf. Google : https://developers.google.com/search/docs/appearance/structured-data/job-posting

Chaque décision est commentée dans le code avec le lien Google correspondant.

### Vérifications
- `yarn typecheck` ✅
- `yarn biome check` ✅

Closes #5038 (partiellement — volet JobPosting uniquement)
