### PR TITLE
fix: corrige le menu du header masqué par le bandeau de recherche sticky

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
@@ -220,10 +220,11 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
         <Box sx={{ display: { xs: "none", lg: "block" }, flex: 1, overflowX: "clip" }}>
           <DefaultContainer sx={{ py: fr.spacing("4v") }}>
             {/* Bandeau : champs + chips, panneau blanc arrondi comme le design — sticky au scroll.
-                z-index > 500 : les cartes DSFR shadow portent z-index calc(--ground + 500) ;
-                on reste sous les poppers des chips et les modales (1250-1300). */}
+                z-index > 500 (cartes DSFR shadow), < 1100 (.fr-header, cf application.css) et
+                < 1250 (modales DSFR). Le header a son propre z-index garanti globalement — pas
+                besoin de deviner la valeur DSFR interne du menu déroulant ici. */}
             <Box ref={stickySentinelRef} aria-hidden="true" sx={{ height: 0 }} />
-            <Box sx={{ position: "sticky", top: 0, zIndex: 1000 }}>
+            <Box sx={{ position: "sticky", top: 0, zIndex: 999 }}>
               {/* Bandeau collé : fond blanc pleine largeur (comme le legacy) — couvre les
                   gouttières latérales du container et masque les résultats qui défilent
                   derrière (encoches des coins arrondis comprises). */}
@@ -285,8 +286,9 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
             sx={{
               position: "sticky",
               top: 0,
-              // > 500 (cartes DSFR shadow), < 1250 (modales mobiles).
-              zIndex: 1000,
+              // > 500 (cartes DSFR shadow), < 1100 (.fr-header, cf application.css), < 1250
+              // (modales DSFR) — voir commentaire desktop ci-dessus.
+              zIndex: 999,
               flexShrink: 0,
               px: fr.spacing("4v"),
               py: fr.spacing("2v"),

--- a/ui/public/styles/application.css
+++ b/ui/public/styles/application.css
@@ -49,7 +49,7 @@ EXTERNAL LINK
 /**
 HEADER — garantit que le header (et ses menus déroulants "Je suis alternant/recruteur/CFA")
 passe toujours au-dessus du contenu de page. Le DSFR ne fixe le z-index de .fr-header qu'à
-partir de 992px (calc(--ground + 750)) ; sous ce seuil, ou tant qu'aucune règle DSFR ne
+partir de 992px (calc(var(--ground) + 750)) ; sous ce seuil, ou tant qu'aucune règle DSFR ne
 s'applique, il vaut "auto" — n'importe quel élément de page avec un z-index positif (bandeau
 sticky, carte, etc.) passe alors devant, quelle que soit sa valeur. On fixe donc ici un
 z-index explicite, stable sur tous les breakpoints, sous les modales DSFR (1250+).

--- a/ui/public/styles/application.css
+++ b/ui/public/styles/application.css
@@ -47,6 +47,19 @@ EXTERNAL LINK
 }
 
 /**
+HEADER — garantit que le header (et ses menus déroulants "Je suis alternant/recruteur/CFA")
+passe toujours au-dessus du contenu de page. Le DSFR ne fixe le z-index de .fr-header qu'à
+partir de 992px (calc(--ground + 750)) ; sous ce seuil, ou tant qu'aucune règle DSFR ne
+s'applique, il vaut "auto" — n'importe quel élément de page avec un z-index positif (bandeau
+sticky, carte, etc.) passe alors devant, quelle que soit sa valeur. On fixe donc ici un
+z-index explicite, stable sur tous les breakpoints, sous les modales DSFR (1250+).
+*/
+.fr-header {
+  position: relative;
+  z-index: 1100;
+}
+
+/**
 PAGE NOTION
 */
 .disable-chakra {


### PR DESCRIPTION
## Changements

- Sur la page de résultats de recherche, le bandeau sticky (champs + chips) partageait le même z-index (1000) que le menu déroulant du header DSFR (`Je suis alternant` / `Je suis recruteur` / `Je suis CFA`). En cas d'égalité, l'ordre DOM tranchait en faveur du bandeau (rendu après le header), qui passait donc devant et masquait le menu ouvert.
- Le vrai problème sous-jacent : `.fr-header` ne fixe son propre z-index (`calc(--ground + 750)`) qu'à partir de 992px ; en dessous de ce seuil, ou selon l'état du composant, il vaut `auto`, et n'importe quel z-index positif posé côté page passait alors devant, quelle que soit sa valeur.
- Ajout d'un z-index explicite et stable sur `.fr-header` (1100) dans `application.css`, garanti sur tous les breakpoints, sous les modales DSFR (1250+) mais au-dessus de tout contenu de page.
- Ajustement du z-index du bandeau sticky de la page de recherche (desktop + mobile) à 999 pour rester cohérent avec cette nouvelle référence.

## Plan de test

- [ ] Sur `/recherche`, ouvrir chaque menu du header (`Je suis alternant`, `Je suis recruteur`, `Je suis CFA`) et vérifier qu'il s'affiche bien au-dessus du bandeau de recherche, scrollé ou non
- [ ] Vérifier l'absence de régression sur les autres pages (header toujours au bon niveau, pas de recouvrement de modales)