### PR TITLE
feat: quick wins Lighthouse mobile — CSS notion, fonts, Matomo, images LCP (#5147)

### DIFF
--- a/ui/app/(editorial-with-notion)/layout.tsx
+++ b/ui/app/(editorial-with-notion)/layout.tsx
@@ -1,4 +1,9 @@
 import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks"
+
+// CSS Notion chargé ici plutôt que dans le layout racine : seules les pages de ce
+// groupe rendent du contenu Notion, inutile de bloquer le rendu des autres pages avec.
+import "react-notion-x/src/styles.css"
+import "@/public/styles/notion.css"
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
 import { Suspense } from "react"

--- a/ui/app/(home)/_components/HowTo.tsx
+++ b/ui/app/(home)/_components/HowTo.tsx
@@ -27,6 +27,8 @@ export const HowTo = () => (
         justifyContent: "center",
       }}
     >
+      {/* Seule la 1re illustration garde priority : c'est l'élément LCP mobile (1 colonne),
+          les deux autres sont sous la ligne de flottaison et se disputaient la bande passante */}
       <Image fetchPriority="high" priority src="/images/howto1.svg" alt="" unoptimized width={286} height={141} style={{ width: "100%", height: "auto" }} />
       <Box sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("2v") }}>
         <Typography className={fr.cx("fr-text--bold", "fr-text--lg")}>Le job de vos rêves</Typography>
@@ -52,7 +54,7 @@ export const HowTo = () => (
         position: "relative",
       }}
     >
-      <Image fetchPriority="high" priority src="/images/howto2.svg" alt="" unoptimized width={299} height={145} style={{ width: "100%", height: "auto" }} />
+      <Image src="/images/howto2.svg" alt="" unoptimized width={299} height={145} style={{ width: "100%", height: "auto" }} />
       <Box sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("2v") }}>
         <Typography className={fr.cx("fr-text--bold", "fr-text--lg")}>En un clin d’oeil</Typography>
         <Typography>
@@ -73,7 +75,7 @@ export const HowTo = () => (
         position: "relative",
       }}
     >
-      <Image fetchPriority="high" priority src="/images/howto3.svg" alt="" unoptimized width={285} height={140} style={{ width: "100%", height: "auto" }} />
+      <Image src="/images/howto3.svg" alt="" unoptimized width={285} height={140} style={{ width: "100%", height: "auto" }} />
       <Box sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("2v") }}>
         <Typography className={fr.cx("fr-text--bold", "fr-text--lg")}>Un contact facile</Typography>
         <Typography>

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -11,10 +11,8 @@ import RootTemplate from "./client_only_providers"
 import { DsfrProvider, StartDsfrOnHydration } from "./dsfr-setup"
 import { DsfrHead, getHtmlAttributes } from "./dsfr-setup/server-only-index"
 
-import "react-notion-x/src/styles.css"
 import "@/public/styles/application.css"
 import "@/public/styles/fonts.css"
-import "@/public/styles/notion.css"
 import "@/styles/search.css"
 
 export const metadata: Metadata = {
@@ -36,7 +34,9 @@ export default function RootLayout({ children }: PropsWithChildren) {
     <html {...getHtmlAttributes({ lang })}>
       <head>
         <HeadLaBonneAlternance />
-        <DsfrHead preloadFonts={["Marianne-Regular", "Marianne-Bold"]} doDisableFavicon={true} />
+        {/* Marianne-Medium est aussi préchargée : sans elle, la police n'est découverte
+            qu'après le parse du CSS DSFR et devient la plus longue chaîne critique (~1,3 s mobile) */}
+        <DsfrHead preloadFonts={["Marianne-Regular", "Marianne-Medium", "Marianne-Bold"]} doDisableFavicon={true} />
         <Matomo />
       </head>
       <body>

--- a/ui/public/styles/application.css
+++ b/ui/public/styles/application.css
@@ -60,6 +60,15 @@ z-index explicite, stable sur tous les breakpoints, sous les modales DSFR (1250+
 }
 
 /**
+Le logo opérateur est rendu par le Header DSFR sans attributs width/height (l'API
+react-dsfr ne les expose pas) : on fixe le ratio du SVG (213×55) pour réserver
+l'espace avant chargement et éviter le layout shift (audit Lighthouse unsized-images).
+*/
+.fr-header__operator img[src$="logo_LBA.svg"] {
+  aspect-ratio: 213 / 55;
+}
+
+/**
 PAGE NOTION
 */
 .disable-chakra {

--- a/ui/tracking/trackingMatomo.tsx
+++ b/ui/tracking/trackingMatomo.tsx
@@ -7,8 +7,10 @@ import { isWidget } from "@/utils/is-widget.utils"
 
 export const Matomo = () => {
   if (!isWidget()) {
+    // lazyOnload : le conteneur Matomo (~86 ko + plugin heatmap) sort du chemin
+    // critique et ne charge qu'après le load, sans perte de page vue
     return (
-      <Script id="matomo" strategy="afterInteractive">
+      <Script id="matomo" strategy="lazyOnload">
         {`
       var _mtm = window._mtm = window._mtm || [];
       var _paq = window._paq = window._paq || [];

--- a/ui/tracking/trackingMatomo.tsx
+++ b/ui/tracking/trackingMatomo.tsx
@@ -8,7 +8,7 @@ import { isWidget } from "@/utils/is-widget.utils"
 export const Matomo = () => {
   if (!isWidget()) {
     // lazyOnload : le conteneur Matomo (~86 ko + plugin heatmap) sort du chemin
-    // critique et ne charge qu'après le load, sans perte de page vue
+    // critique et ne charge qu'après `window.load` (un rebond avant `load` ne sera pas tracké).
     return (
       <Script id="matomo" strategy="lazyOnload">
         {`


### PR DESCRIPTION
Closes #5147

## Changements

- **CSS Notion scoped** : `react-notion-x/src/styles.css` et `notion.css` sont déplacés du layout racine vers le groupe `(editorial-with-notion)` — seules les pages FAQ/CGU/mentions légales/accessibilité/politique de confidentialité rendent du contenu Notion. Gain : ~11 ko gzip de CSS render-blocking en moins sur toutes les autres pages (96 % en était inutilisé).
- **Préchargement de Marianne-Medium** : la police n'était découverte qu'après le parse du CSS DSFR et constituait la plus longue chaîne critique (~1,3 s sur mobile). Regular et Bold étaient déjà préchargées.
- **Matomo en `lazyOnload`** : le conteneur (~86 ko + plugin heatmap) sort du chemin critique et ne charge qu'après le `load`, sans perte de page vue.
- **Priorité de chargement limitée à l'illustration LCP** : seule `howto1.svg` (élément LCP mobile, layout 1 colonne) garde `priority` ; les deux autres illustrations sont sous la ligne de flottaison et se disputaient la bande passante au démarrage.
- **Ratio explicite sur le logo du header** : le Header DSFR rend le logo opérateur sans `width`/`height` (non exposés par l'API react-dsfr) ; `aspect-ratio: 213/55` réserve l'espace et corrige l'audit Lighthouse `unsized-images`.

## Vérifications effectuées (build prod local)

- typecheck OK, build OK
- les 3 preloads de fonts présents dans le `<head>`
- zéro règle `notion-*` chargée sur `/`, 480 règles sur `/faq` (rendu visuel conforme)
- `_mtm` Matomo fonctionnel après `load`
- rendu visuel home/FAQ inchangé

## Plan de test

- [ ] Vérifier le rendu des 5 pages Notion (FAQ, CGU, mentions légales, accessibilité, politique de confidentialité)
- [ ] Vérifier qu'une page vue Matomo est bien trackée (réseau : `container_*.js` chargé après le load)
- [ ] Vérifier le header (logo, menus) sur mobile et desktop
- [ ] Re-mesurer PageSpeed Insights mobile une fois déployé en recette