### PR TITLE
feat: purge le CSS DSFR inutilisé en postbuild — POC PurgeCSS (#5147)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,8 @@
   "repository": "https://github.com/mission-apprentissage/labonnealternance.git",
   "scripts": {
     "dev": "yarn predev && SENTRY_SUPPRESS_GLOBAL_ERROR_HANDLER_FILE_WARNING=1 next dev",
-    "build": "yarn prebuild && SENTRY_SUPPRESS_GLOBAL_ERROR_HANDLER_FILE_WARNING=1 NODE_OPTIONS=--max_old_space_size=2048 next build",
+    "build": "yarn prebuild && SENTRY_SUPPRESS_GLOBAL_ERROR_HANDLER_FILE_WARNING=1 NODE_OPTIONS=--max_old_space_size=2048 next build && yarn postbuild",
+    "postbuild": "node scripts/purge-dsfr-css.mjs",
     "start": "next start",
     "typecheck": "tsc -b",
     "analyse": "ANALYZE=true yarn build",
@@ -74,6 +75,7 @@
     "@types/react": "19.2.6",
     "@types/react-csv": "^1.1.10",
     "dotenv": "^17.2.3",
+    "purgecss": "^8.0.0",
     "sass": "^1.93.3",
     "type-fest": "^5.2.0",
     "typescript": "^7.0.2"

--- a/ui/scripts/purge-dsfr-css.mjs
+++ b/ui/scripts/purge-dsfr-css.mjs
@@ -62,7 +62,16 @@ const DYNAMIC_COMPONENT_PREFIXES = [
 ]
 
 async function main() {
-  const allCssFiles = (await fs.readdir(cssDir)).filter((f) => f.endsWith(".css")).map((f) => path.join(cssDir, f))
+  // Listing récursif : Next peut émettre des chunks CSS dans des sous-dossiers,
+  // et un dossier absent doit produire une erreur explicite plutôt qu'une ENOENT brute.
+  let entries
+  try {
+    entries = await fs.readdir(cssDir, { recursive: true })
+  } catch {
+    console.error(`purge-dsfr-css: dossier ${cssDir} introuvable — lancer après \`next build\``)
+    process.exit(1)
+  }
+  const allCssFiles = entries.filter((f) => f.endsWith(".css")).map((f) => path.join(cssDir, f))
 
   // On ne purge QUE le chunk DSFR : les CSS tiers (react-dates, notion…) utilisent
   // des classes composées au runtime qui échappent au scan statique.

--- a/ui/scripts/purge-dsfr-css.mjs
+++ b/ui/scripts/purge-dsfr-css.mjs
@@ -1,0 +1,122 @@
+/**
+ * POC PurgeCSS — supprime les règles DSFR inutilisées des chunks CSS après le build Next.
+ *
+ * Contexte : react-dsfr injecte l'intégralité de dsfr.min.css (~737 ko bruts / ~100 ko gzip),
+ * dont ~87 % est inutilisé (cf. https://github.com/codegouvfr/react-dsfr/issues/304).
+ * Ce script réécrit en place les CSS de .next/static/chunks en ne gardant que les
+ * sélecteurs référencés dans les bundles JS (client + serveur) et les sources.
+ *
+ * Précautions issues du thread #304 :
+ * - le JS du DSFR ajoute des attributs data-fr-js-* au runtime → safelist "greedy"
+ * - certaines classes (fr-collapse, fr-menu, états des modales/tableaux…) sont
+ *   ajoutées dynamiquement → safelist par préfixe de composant
+ * - les variables CSS ne sont jamais purgées (comportement par défaut de PurgeCSS)
+ */
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { gzipSync } from "node:zlib"
+import { PurgeCSS } from "purgecss"
+
+const uiDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const nextDir = path.join(uiDir, ".next")
+const cssDir = path.join(nextDir, "static", "chunks")
+
+const content = [
+  // Bundles client : contiennent toutes les classes utilisées par les composants React
+  path.join(nextDir, "static", "chunks", "**", "*.js"),
+  // Rendu serveur (RSC/HTML prérendu) : classes émises côté serveur uniquement
+  path.join(nextDir, "server", "**", "*.{js,html,rsc}"),
+  // Sources : filet de sécurité pour les classes construites via fr.cx(...)
+  path.join(uiDir, "app", "**", "*.{ts,tsx}"),
+  path.join(uiDir, "components", "**", "*.{ts,tsx}"),
+]
+
+// Composants dont le DSFR ajoute/retire des classes au runtime (menu mobile,
+// modales, accordéons, tableaux, onglets…) : on garde tout leur CSS.
+const DYNAMIC_COMPONENT_PREFIXES = [
+  /^fr-collapse/,
+  /^fr-menu/,
+  /^fr-modal/,
+  /^fr-nav/,
+  /^fr-tabs/,
+  /^fr-table/,
+  /^fr-accordion/,
+  /^fr-pagination/,
+  /^fr-tooltip/,
+  /^fr-toggle/,
+  /^fr-checkbox/,
+  /^fr-radio/,
+  /^fr-range/,
+  /^fr-select/,
+  /^fr-header/,
+  /^fr-footer/,
+  /^fr-sidemenu/,
+  /^fr-consent/,
+  /^fr-transcription/,
+  /^fr-translate/,
+  /^fr-artwork/,
+  // Icônes : déjà réduites par `react-dsfr update-icons`, on n'y retouche pas
+  /^fr-icon-/,
+  /^fr-fi-/,
+]
+
+async function main() {
+  const allCssFiles = (await fs.readdir(cssDir)).filter((f) => f.endsWith(".css")).map((f) => path.join(cssDir, f))
+
+  // On ne purge QUE le chunk DSFR : les CSS tiers (react-dates, notion…) utilisent
+  // des classes composées au runtime qui échappent au scan statique.
+  const cssFiles = []
+  for (const file of allCssFiles) {
+    const css = await fs.readFile(file, "utf8")
+    const dsfrRuleCount = (css.match(/\.fr-[a-z]/g) || []).length
+    if (dsfrRuleCount > 500) {
+      cssFiles.push(file)
+    }
+  }
+
+  if (cssFiles.length === 0) {
+    console.error(`purge-dsfr-css: aucun chunk DSFR trouvé dans ${cssDir} — lancer après \`next build\``)
+    process.exit(1)
+  }
+
+  const before = new Map()
+  for (const file of cssFiles) {
+    before.set(file, await fs.readFile(file, "utf8"))
+  }
+
+  const results = await new PurgeCSS().purge({
+    content,
+    css: cssFiles,
+    defaultExtractor: (c) => c.match(/[\w-/:%.]+(?<!:)/g) || [],
+    safelist: {
+      standard: ["dark", "light", ...DYNAMIC_COMPONENT_PREFIXES],
+      // "greedy" : conserve tout sélecteur dont une partie matche — indispensable
+      // pour les attributs data-fr-js-* posés au runtime (bordures de <Table>, etc.)
+      greedy: [/data-fr/],
+    },
+    dynamicAttributes: ["aria-expanded", "aria-selected", "aria-current", "aria-disabled", "aria-hidden", "open", "disabled", "target"],
+  })
+
+  const fmt = (n) => `${(n / 1024).toFixed(1)} ko`
+  const gz = (s) => gzipSync(Buffer.from(s)).length
+  let totalBefore = 0
+  let totalAfter = 0
+  let totalGzBefore = 0
+  let totalGzAfter = 0
+
+  for (const { file, css } of results) {
+    const original = before.get(file)
+    await fs.writeFile(file, css)
+    const [b, a, gb, ga] = [Buffer.byteLength(original), Buffer.byteLength(css), gz(original), gz(css)]
+    totalBefore += b
+    totalAfter += a
+    totalGzBefore += gb
+    totalGzAfter += ga
+    console.log(`purge-dsfr-css: ${path.basename(file)} ${fmt(b)} → ${fmt(a)} (gzip ${fmt(gb)} → ${fmt(ga)})`)
+  }
+
+  console.log(`purge-dsfr-css: TOTAL ${fmt(totalBefore)} → ${fmt(totalAfter)} (gzip ${fmt(totalGzBefore)} → ${fmt(totalGzAfter)})`)
+}
+
+await main()

--- a/yarn.lock
+++ b/yarn.lock
@@ -8649,6 +8649,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^12.1.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 68e9818b00fc1ed9cdab9eb16905551c2b768a317ae69a5e3c43924c2b20ac9bb65b27e1cab36aeda7b6496376d4da908996ba2c0b5d79463e0fb1e77935d514
+  languageName: node
+  linkType: hard
+
 "commander@npm:^14.0.1, commander@npm:^14.0.2":
   version: 14.0.2
   resolution: "commander@npm:14.0.2"
@@ -10311,7 +10318,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.3.3":
+"fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -14494,6 +14501,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: db804317d337b41602666f23014e399d1263033d13a903955c246378256fd4e002519e87199ca40b19aff52274965ac7cc6e70c13a63e194e15c4664724602d3
+  languageName: node
+  linkType: hard
+
 "napi-build-utils@npm:^2.0.0":
   version: 2.0.0
   resolution: "napi-build-utils@npm:2.0.0"
@@ -16019,6 +16035,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.4.47":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
+  dependencies:
+    nanoid: ^3.3.17
+    picocolors: ^1.1.1
+    source-map-js: ^1.2.1
+  checksum: 719b1acd7db117cffa1514a6ed47e71ba4159ebddd1be2616b65dc1580a6bb9289abb8a78d26e08b45ab5a03277662483a6413e4b08325df0260831f4c2bc11b
+  languageName: node
+  linkType: hard
+
 "postgres-array@npm:~2.0.0":
   version: 2.0.0
   resolution: "postgres-array@npm:2.0.0"
@@ -16271,6 +16298,20 @@ __metadata:
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: bb0a0ceedca4c3c57a9b981b90601579058903c62be23c5e8e843d2c2d4148a3ecf029d5133486fb0e1822b098ba8bba09e89d6b21742d02fa26bda6441a6fb2
+  languageName: node
+  linkType: hard
+
+"purgecss@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "purgecss@npm:8.0.0"
+  dependencies:
+    commander: ^12.1.0
+    fast-glob: ^3.3.2
+    postcss: ^8.4.47
+    postcss-selector-parser: ^7.0.0
+  bin:
+    purgecss: bin/purgecss.js
+  checksum: 9b808d49c5a09e7ecdc4566d5ceabd848781666d9ae541e419b89637ed9ed1d0030275a986aa65c6c0c4d2a2e2f2914660c5a5d20f83f75967141b7842fdfaa9
   languageName: node
   linkType: hard
 
@@ -19229,6 +19270,7 @@ __metadata:
     next-recompose-plugins: ^3.0.1
     notion-client: 7.10.0
     notistack: ^3.0.2
+    purgecss: ^8.0.0
     react: 19.2.6
     react-csv: ^2.2.2
     react-dates: ^21.8.0


### PR DESCRIPTION
Fait partie de https://github.com/mission-apprentissage/labonnealternance/issues/5147 (sans la fermer — les quick wins sont dans une PR séparée).

## Contexte

react-dsfr injecte l'intégralité de `dsfr.min.css` en render-blocking (limitation connue : [codegouvfr/react-dsfr#304](https://github.com/codegouvfr/react-dsfr/issues/304), où une proposition amont `only-include-used-components` a été faite). En attendant un fix upstream, ce POC purge les règles inutilisées après le build.

## Changements

- Script `ui/scripts/purge-dsfr-css.mjs` branché en postbuild : réécrit en place les chunks CSS de `.next/static/chunks`.
- **Résultat : le chunk DSFR render-blocking passe de 767 → 435 ko bruts, soit 97 → 55 ko gzip (−43 %).**

Deux garde-fous :

- **Purge restreinte au seul chunk DSFR** (heuristique : >500 règles `.fr-*`) : les CSS tiers (react-dates, Notion) utilisent des classes composées au runtime qui échappent au scan statique — la première itération vidait le CSS de react-dates.
- **Safelist** : préfixes des composants à classes dynamiques (`fr-collapse*`, `fr-menu*`, `fr-modal*`, `fr-table*`…) + mode greedy sur `data-fr*` pour les attributs `data-fr-js-*` posés par le JS du DSFR (piège documenté dans l'issue amont : bordures de tableaux, accordéons).

## Vérifications effectuées

- Croisement automatique des classes `fr-*` présentes dans le DOM vs CSS purgé sur `/`, `/recherche` et `/je-suis-recruteur` : zéro règle manquante.
- Règles du mécanisme collapse/menu identiques octet pour octet à l'original.
- Rendu visuel home/recherche/FAQ conforme sur build prod local.

## Avant de sortir du draft

- [ ] Passer la suite e2e Playwright complète
- [ ] Revue visuelle des pages espace-pro (composants dynamiques : tableaux, modales, accordéons)
- [ ] Vérifier le comportement au re-build Docker (le script tourne dans l'image, après `next build`)
- [ ] Re-mesurer PageSpeed Insights mobile en recette