### PR TITLE
fix: restaure le titre métier SSR des URL /recherche?job_name= (régression bascule moteur)

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.test.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import { buildRecherchePageMetadata } from "./recherche.metadata.utils"
+
+const titleOf = (qs: string) => buildRecherchePageMetadata(new URLSearchParams(qs)).title
+
+describe("buildRecherchePageMetadata — repli SSR sur les URL du moteur legacy (?job_name=)", () => {
+  it("restaure le titre métier legacy exact pour une URL ?job_name= sans géo", () => {
+    // 2ᵉ source de trafic organique : sans ce repli, le nouveau moteur (schéma `q`) sert un titre générique.
+    expect(titleOf("display=list&job_name=Auxiliaire de puériculture&romes=J1304")).toBe("Alternance Auxiliaire de puériculture : offres et formations | La bonne alternance")
+  })
+
+  it("ajoute la ville quand l'URL legacy porte une géo libellée (lat/lon/address)", () => {
+    expect(titleOf("job_name=Plomberie&romes=F1603&lat=45.75&lon=4.85&address=Lyon")).toBe("Alternance Plomberie à Lyon : offres et formations | La bonne alternance")
+  })
+
+  it("restaure aussi description et canonical métier (parité avec la page legacy, zéro churn)", () => {
+    const meta = buildRecherchePageMetadata(new URLSearchParams("job_name=Data analyst&romes=M1403"))
+    expect(meta.description).toContain("Data analyst")
+    expect(meta.alternates?.canonical).toBe("/recherche?romes=M1403&job_name=Data+analyst")
+  })
+
+  it("laisse le titre générique quand job_name est VIDE (page de marque, ex. romes=K2101) — pas de faux titre métier", () => {
+    // Garde-fou : ces pages sont candidates au noindex ciblé (#5034), elles ne doivent pas se voir attribuer un métier.
+    expect(titleOf("display=list&job_name=&romes=K2101")).toBe("Offres en alternance | La bonne alternance")
+  })
+
+  it("laisse le titre générique pour une recherche par romes seul (comportement legacy inchangé)", () => {
+    expect(titleOf("display=list&romes=J1410")).toBe("Offres en alternance | La bonne alternance")
+  })
+
+  it("laisse le titre générique pour /recherche nue", () => {
+    expect(titleOf("")).toBe("Offres en alternance | La bonne alternance")
+  })
+
+  it("le nouveau moteur (`q`) reste prioritaire et n'utilise pas le repli legacy", () => {
+    expect(titleOf("q=boulanger")).toBe("Offres en alternance - boulanger sur la France entière | La bonne alternance")
+    // q présent gagne même si un job_name legacy traîne dans l'URL
+    expect(titleOf("q=boulanger&job_name=Plombier")).toBe("Offres en alternance - boulanger sur la France entière | La bonne alternance")
+  })
+})

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils.ts
@@ -1,0 +1,32 @@
+import type { Metadata } from "next"
+
+import { buildRechercheMetadata } from "./recherche.metadata.utils_LEGACY"
+import { IRechercheMode, parseRecherchePageParams } from "./recherche.route.utils"
+import { buildSearchPageTitle, parseSearchPageParams } from "./search.params.utils"
+
+/**
+ * Métadonnées SEO de /recherche (nouveau moteur, schéma `q`), avec repli sur le moteur legacy.
+ *
+ * Depuis la bascule du nouveau moteur (qui ne lit que `q`, plus `job_name`/`romes`), les URL
+ * indexées par Google au format legacy (`?job_name=…&romes=…`) — 2ᵉ source de trafic organique
+ * (~213k clics/an, requêtes « alternance {métier} ») — ne sont plus reconnues et servent toutes
+ * le même `<title>` générique dupliqué en SSR, cassant le match titre↔requête qui portait le trafic.
+ *
+ * Tant que le mapping complet legacy→`q` (résultats + H1 en SSR) n'est pas fait (#5033), on restaure
+ * ici le titre/description/canonical métier EXACTS que la page legacy produisait pour ces URL — donc
+ * zéro churn côté Google. Le repli ne s'active que si `job_name` est renseigné : les pages sans métier
+ * (`/recherche` nue, `job_name` vide type `romes=K2101` servi à la marque) gardent le titre générique,
+ * cohérent avec leur dé-indexation ciblée à venir (#5034).
+ */
+export function buildRecherchePageMetadata(search: URLSearchParams): Metadata {
+  const params = parseSearchPageParams(search)
+
+  if (!params.q) {
+    const legacyParams = parseRecherchePageParams(search, IRechercheMode.DEFAULT)
+    if (legacyParams?.job_name) {
+      return buildRechercheMetadata(legacyParams, "default")
+    }
+  }
+
+  return { title: buildSearchPageTitle(params) }
+}

--- a/ui/app/(candidat)/(recherche)/recherche/page.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next"
 import { Suspense } from "react"
 import { SearchPageClient } from "./_components/SearchPageClient"
-import { buildSearchPageTitle, parseSearchPageParams } from "./_utils/search.params.utils"
+import { buildRecherchePageMetadata } from "./_utils/recherche.metadata.utils"
+import { parseSearchPageParams } from "./_utils/search.params.utils"
 
 type Props = {
   searchParams: Promise<Record<string, string>>
@@ -9,10 +10,10 @@ type Props = {
 
 // Titre ajusté à la recherche (métier / lieu / mode), comme le moteur legacy.
 // Les navigations client (router.replace) re-fetchent le payload RSC → Next met à jour
-// document.title à chaque recherche.
+// document.title à chaque recherche. Repli sur les URL legacy `?job_name=` (cf. util) pour ne
+// pas servir un titre générique aux pages métier indexées par Google.
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
-  const params = parseSearchPageParams(new URLSearchParams(await searchParams))
-  return { title: buildSearchPageTitle(params) }
+  return buildRecherchePageMetadata(new URLSearchParams(await searchParams))
 }
 
 export default async function RecherchePage({ searchParams }: Props) {


### PR DESCRIPTION
## 🎯 En bref (non-tech)

**Régression détectée en prod depuis le 12/08.** La bascule du nouveau moteur de recherche a un effet de bord SEO : les pages `/recherche?job_name=…` — **2ᵉ source de trafic naturel du site (~213 000 clics/an**, requêtes type « alternance auxiliaire de puériculture ») — servent depuis 2 jours **le même titre générique** (« Offres en alternance | La bonne alternance ») au lieu du titre métier. Or ici **c'est le titre qui porte le référencement**. Sans correctif, ces pages perdront progressivement position et clics au fil du re-crawl Google.

**Ce que corrige la PR.** On restaure **à l'identique** le titre (+ description) métier que ces pages avaient avant la bascule — ex. « Alternance auxiliaire de puériculture : offres et formations | La bonne alternance ». Rien ne change pour les utilisateurs, uniquement ce que voit Google.

**Ce que la PR ne fait volontairement PAS** (rester petit et sûr) :
- les pages **de marque** (`/recherche` nue, ou `romes=K2101` qui ne sort que sur « la bonne alternance ») gardent le titre générique — elles sont de toute façon candidates à la dé-indexation ciblée **#5034** ;
- le fond (rendre offres + H1 côté serveur) reste pour **#5033**.

_Confirmé via Search Console : ces pages sortent bien sur des requêtes métier (CTR 9-14 %, position 3-6), pas sur de la marque._

## 🔧 Détail technique

**Cause.** Depuis #5139/#5140, `recherche/page.tsx` (nouveau moteur) parse l'URL via `parseSearchPageParams` (schéma `q`), qui **ignore `job_name`/`romes`** ; aucune redirection legacy→`q`. `generateMetadata` renvoyait donc `buildSearchPageTitle({ q: undefined })` = titre générique pour **toutes** les URL `?job_name=`. Vérifié en prod (view-source) : titre générique identique sur `?job_name=Auxiliaire…&romes=J1304` et sur `/recherche` nue.

**Correctif.** Nouveau `recherche.metadata.utils.ts` → `buildRecherchePageMetadata(searchParams)` : si le schéma `q` est absent **et** que `job_name` legacy est présent, on renvoie `buildRechercheMetadata(parseRecherchePageParams(…), "default")` — soit les **title/description/canonical exacts** de la page legacy (code déjà existant et testé) → zéro churn côté Google. Sinon, comportement inchangé (`buildSearchPageTitle`).

**Garde-fou** : le repli ne s'active **que si `job_name` est non vide** → `/recherche` nue et `?job_name=&romes=K2101` (marque) restent en titre générique, cohérent avec le noindex ciblé à venir.

**Tests / qualité.** `recherche.metadata.utils.test.ts` (7 cas : titre legacy exact, ajout ville via géo, description+canonical, garde-fou `job_name` vide type K2101, `romes` seul, `/recherche` nue, priorité `q`). `yarn typecheck` ✅, Biome ✅, 47 tests voisins ✅.

Refs #5033 (fond SSR), #5034 (noindex chirurgical).