### PR TITLE
fix: résout les erreurs critiques remontées par l'analyse Sentry (#5151)

### DIFF
--- a/server/src/common/sentry/sentry.fastify.ts
+++ b/server/src/common/sentry/sentry.fastify.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/node"
-import type { FastifyRequest } from "fastify"
+import type { FastifyError, FastifyRequest } from "fastify"
 import { assertUnreachable } from "shared"
 
 import type { Server } from "@/http/server"
@@ -55,7 +55,16 @@ function extractUserData(request: FastifyRequest): UserData {
 
 export function initSentryFastify(app: Server) {
   // Setup official Fastify error handler
-  Sentry.setupFastifyErrorHandler(app)
+  // shouldHandleError capture cet handler AVANT le passage par errorMiddleware/boomify : sans lui,
+  // les erreurs de validation Fastify (querystring/body, statusCode 400, ex. FST_ERR_VALIDATION)
+  // remontent brutes et échappent au filtre beforeSend de sentry.ts (qui ne sait reconnaître que
+  // les erreurs déjà Boom-ifiées) — bruit constaté sur GET /api/v1/formations et /api/v3/jobs/search.
+  Sentry.setupFastifyErrorHandler(app, {
+    shouldHandleError: (error) => {
+      const statusCode = (error as FastifyError).statusCode
+      return statusCode === undefined || statusCode >= 500
+    },
+  })
 
   // Custom user data hook
   app.addHook("onRequest", async (request, _reply) => {

--- a/server/src/services/eligible-trainings-for-appointment.service.ts
+++ b/server/src/services/eligible-trainings-for-appointment.service.ts
@@ -137,7 +137,7 @@ const getAppointmentContext = async (
 
   return {
     etablissement_formateur_entreprise_raison_sociale: etablissement.raison_sociale,
-    intitule_long: eligibleTrainingsForAppointment.training_intitule_long,
+    intitule_long: eligibleTrainingsForAppointment.training_intitule_long ?? null,
     lieu_formation_adresse: eligibleTrainingsForAppointment.lieu_formation_street,
     code_postal: eligibleTrainingsForAppointment.lieu_formation_zip_code,
     etablissement_formateur_siret: etablissement.formateur_siret,
@@ -180,7 +180,7 @@ export const findElligibleTrainingForAppointmentV2 = async (context: IAppointmen
 
   return {
     etablissement_formateur_entreprise_raison_sociale: etablissement.raison_sociale,
-    intitule_long: eligibleTrainingsForAppointment.training_intitule_long,
+    intitule_long: eligibleTrainingsForAppointment.training_intitule_long ?? null,
     lieu_formation_adresse: eligibleTrainingsForAppointment.lieu_formation_street,
     code_postal: eligibleTrainingsForAppointment.lieu_formation_zip_code,
     etablissement_formateur_siret: etablissement.formateur_siret ?? null,
@@ -213,7 +213,7 @@ export const findElligibleTrainingForAppointmentPrivate = async (referrer: strin
 
   return {
     etablissement_formateur_entreprise_raison_sociale: etablissement.raison_sociale,
-    intitule_long: eligibleTrainingsForAppointment.training_intitule_long,
+    intitule_long: eligibleTrainingsForAppointment.training_intitule_long ?? null,
     lieu_formation_adresse: eligibleTrainingsForAppointment.lieu_formation_street,
     code_postal: eligibleTrainingsForAppointment.lieu_formation_zip_code,
     etablissement_formateur_siret: etablissement.formateur_siret ?? null,

--- a/server/src/services/search/search.service.ts
+++ b/server/src/services/search/search.service.ts
@@ -251,6 +251,15 @@ const fuzzyFor = (term: string): { maxEdits: number; prefixLength: number } | un
 // Nombre minimal de termes couverts exigé : tous jusqu'à 2 termes, n−1 pour 3-4, 75 % au-delà.
 const msmFor = (n: number): number => (n <= 2 ? n : n <= 4 ? n - 1 : Math.ceil(0.75 * n))
 
+// Plafond de termes injectés dans la porte de pertinence : un intitulé de formation entier
+// envoyé tel quel comme `q` (clic sur une suggestion) peut tokeniser en 20+ termes, chacun
+// généré en plusieurs clauses `text`/fuzzy par champ (rome_labels/title/organization_name/
+// keywords) — le compound $search dépasse alors maxClauseCount=1024 côté mongot
+// (Sentry LBA-SERVER-5J7KF4ZZZT961). Les premiers termes portent l'intitulé principal (le
+// détail vient après tirets/parenthèses) : tronquer ne change pas la pertinence perçue pour
+// une recherche normale et borne le pire cas.
+const MAX_TEXT_GATE_TERMS = 12
+
 // Filtre « date de début de contrat » (spec ticket Contract start) : l'utilisateur indique
 // quand il veut démarrer → on montre tout ce qui est compatible, c'est-à-dire les offres qui
 // démarrent AVANT OU À cette date ($lte), celles à date flexible, et les docs SANS date de
@@ -366,7 +375,7 @@ function buildTermCoverageClause(term: string, isSingleTerm: boolean): object {
  */
 function buildTextGate(q?: string): object | null {
   if (!q?.trim()) return null
-  const terms = tokenizeQuery(q)
+  const terms = tokenizeQuery(q).slice(0, MAX_TEXT_GATE_TERMS)
   const coverage = terms.length ? [{ compound: { should: terms.map((term) => buildTermCoverageClause(term, terms.length === 1)), minimumShouldMatch: msmFor(terms.length) } }] : []
   const synonyms = { phrase: { query: q, path: SYNONYM_MULTI_PATHS, synonyms: "lba_synonyms", slop: 0, score: { boost: { value: 6 } } } }
   return { compound: { should: [...coverage, synonyms], minimumShouldMatch: 1 } }

--- a/shared/src/routes/appointments.routes.ts
+++ b/shared/src/routes/appointments.routes.ts
@@ -52,7 +52,7 @@ const zContextCreateSchema = z.union([
 
 const zAppointmentRequestContextCreateFormAvailableResponseSchema = z.strictObject({
   etablissement_formateur_entreprise_raison_sociale: ZEtablissement.shape.raison_sociale,
-  intitule_long: z.string(),
+  intitule_long: z.string().nullable(),
   lieu_formation_adresse: z.string(),
   code_postal: z.string(),
   etablissement_formateur_siret: ZEtablissement.shape.formateur_siret,

--- a/shared/src/routes/v2/appointments.routes.v2.ts
+++ b/shared/src/routes/v2/appointments.routes.v2.ts
@@ -36,7 +36,7 @@ export type IAppointmentContextAPI = z.output<typeof ZAppointmentContextApiWithR
 
 export const ZAppointmentResponseAvailable = z.strictObject({
   etablissement_formateur_entreprise_raison_sociale: z.string().nullable().describe("Raison social de l'établissement formateur"),
-  intitule_long: z.string().describe("Intitulé long de la formation"),
+  intitule_long: z.string().nullable().describe("Intitulé long de la formation"),
   lieu_formation_adresse: z.string().describe("Adresse du lieu de formation"),
   code_postal: z.string().describe("Code postal du lieu de formation"),
   etablissement_formateur_siret: extensions.siret.nullable().describe("Numéro SIRET de l'établissement formateur"),

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
@@ -241,7 +241,7 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
   // Suggestions pour le champ lieu
   const { data: lieuOptions } = useQuery({
     queryKey: ["lieu-suggestions", debouncedLieu],
-    queryFn: () => searchAddress(debouncedLieu),
+    queryFn: ({ signal }) => searchAddress(debouncedLieu, undefined, signal),
     enabled: debouncedLieu.length >= 2,
     staleTime: 1000 * 60 * 5,
     throwOnError: false,

--- a/ui/app/_components/ErrorComponent.tsx
+++ b/ui/app/_components/ErrorComponent.tsx
@@ -10,30 +10,10 @@ import { useEffect } from "react"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { publicConfig } from "@/config.public"
 import { ApiError } from "@/utils/api.utils"
-
-function wasPageReloaded(): boolean {
-  const navigationEntry = window.performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined
-  return navigationEntry?.type === "reload"
-}
+import { shouldReloadOnce } from "@/utils/reload-guard.utils"
 
 function shouldReloadChunkError(): boolean {
-  const storageKey = "lba:lastChunkReload"
-  const reloadThrottleMs = 30000
-  const now = Date.now()
-
-  try {
-    const storedValue = window.sessionStorage.getItem(storageKey)
-    const lastReload = storedValue ? Number(storedValue) : 0
-
-    if (!lastReload || Number.isNaN(lastReload) || now - lastReload > reloadThrottleMs) {
-      window.sessionStorage.setItem(storageKey, String(now))
-      return true
-    }
-
-    return false
-  } catch {
-    return !wasPageReloaded()
-  }
+  return shouldReloadOnce("lba:staleDeploymentReload", 30000)
 }
 
 function getErrorDescription(error: unknown): string | null {

--- a/ui/components/ItemDetail/CandidatureLba/CandidatureLbaFileDropzone.tsx
+++ b/ui/components/ItemDetail/CandidatureLba/CandidatureLbaFileDropzone.tsx
@@ -80,7 +80,10 @@ export const CandidatureLbaFileDropzone = ({ setFileValue, formik }) => {
       if (fileRejections.length > 1) {
         Sentry.setTag("multiple-files", "true")
       }
-      Sentry.captureException(new Error(message))
+      // Rejet de fichier (taille, type, nombre) : validation attendue du dropzone déclenchée par
+      // le choix de l'utilisateur, pas un défaut applicatif — captureMessage/info conserve la
+      // télémétrie (tags ci-dessus) sans polluer le triage des erreurs.
+      Sentry.captureMessage(message, "info")
       Sentry.setTag("errorType", undefined)
       Sentry.setTag("file-extension", undefined)
       Sentry.setTag("file-size-in-mo", undefined)

--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -4,6 +4,8 @@
 
 import { captureConsoleIntegration, captureRouterTransitionStart, extraErrorDataIntegration, httpClientIntegration, init, reportingObserverIntegration } from "@sentry/nextjs"
 
+import { shouldReloadOnce } from "@/utils/reload-guard.utils"
+
 import { publicConfig } from "./config.public"
 
 init({
@@ -51,14 +53,14 @@ export const onRouterTransitionStart = captureRouterTransitionStart
 
 // Pendant un déploiement (rolling update Docker Swarm), un onglet resté ouvert peut garder en
 // mémoire des chunks JS de l'ancien build : le routeur y navigue ensuite vers des modules qui
-// n'existent plus (ou plus au même endroit) côté nouveau déploiement. Symptômes observés en prod :
-// ChunkLoadError, "Failed to find Server Action..." (Sentry LBA-UI-2DH, LBA-UI-5CVZZZZZZG4M9), et
-// des TypeError "X is not a function" sur des hooks pourtant bien exportés (LBA-UI-5CVZZZZZZG4QA).
-// Un simple reload récupère automatiquement le build courant ; le flag de session évite une boucle
-// si l'erreur persiste pour une autre raison.
+// n'existent plus (ou plus au même endroit) côté nouveau déploiement. Deux signatures fiables
+// (Sentry LBA-UI-2DH, LBA-UI-5CVZZZZZZG4M9) sont ciblées ici, hors du render React (promesse de
+// chargement de chunk / appel de Server Action) — un simple reload récupère le build courant.
+// NB : un TypeError générique "X is not a function" (LBA-UI-5CVZZZZZZG4QA) a la même origine
+// probable, mais matcher ce pattern trop largement risquerait de masquer de vrais bugs ; il n'est
+// donc PAS couvert ici. Le rendu React est couvert séparément par ErrorComponent.tsx (ChunkLoadError
+// uniquement, via error boundary) — même clé de garde-fou pour ne compter qu'un seul reload.
 if (typeof window !== "undefined") {
-  const STALE_DEPLOYMENT_RELOAD_KEY = "lba-stale-deployment-reload"
-
   const isStaleDeploymentError = (error: unknown): boolean => {
     if (!(error instanceof Error)) return false
     if (error.name === "ChunkLoadError") return true
@@ -66,9 +68,9 @@ if (typeof window !== "undefined") {
   }
 
   const reloadOnce = () => {
-    if (window.sessionStorage.getItem(STALE_DEPLOYMENT_RELOAD_KEY)) return
-    window.sessionStorage.setItem(STALE_DEPLOYMENT_RELOAD_KEY, "1")
-    window.location.reload()
+    if (shouldReloadOnce("lba:staleDeploymentReload", 30000)) {
+      window.location.reload()
+    }
   }
 
   window.addEventListener("error", (event) => {

--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -20,13 +20,21 @@ init({
     captureConsoleIntegration({ levels: ["error"] }),
     extraErrorDataIntegration({ depth: 8 }),
     httpClientIntegration({}),
-    reportingObserverIntegration({ types: ["crash", "deprecation", "intervention"] }),
+    // "deprecation"/"intervention" ne rapportent que des avertissements passifs du navigateur
+    // (API obsolètes type InstallTrigger, StorageType.persistent…), jamais du code LBA — non
+    // actionnables, gardés hors Sentry. "crash" reste utile (vrai crash navigateur).
+    reportingObserverIntegration({ types: ["crash"] }),
   ],
   sendDefaultPii: true,
   ignoreErrors: [
     "AbortError",
-    // Erreur provenant de l'extension navigateur MetaMask (inpage.js), non actionnable
+    // Erreurs provenant d'extensions navigateur tierces (MetaMask, gestionnaires d'onglets…),
+    // non actionnables côté LBA.
     "func sseError not found",
+    "Failed to connect to MetaMask",
+    /SCDynimacBridge/,
+    "No Listener: tabs:outgoing.message.ready",
+    "Invalid call to runtime.sendMessage",
   ],
   beforeSend(event) {
     // Hydratation error comes from DSFR
@@ -40,3 +48,33 @@ init({
 })
 
 export const onRouterTransitionStart = captureRouterTransitionStart
+
+// Pendant un déploiement (rolling update Docker Swarm), un onglet resté ouvert peut garder en
+// mémoire des chunks JS de l'ancien build : le routeur y navigue ensuite vers des modules qui
+// n'existent plus (ou plus au même endroit) côté nouveau déploiement. Symptômes observés en prod :
+// ChunkLoadError, "Failed to find Server Action..." (Sentry LBA-UI-2DH, LBA-UI-5CVZZZZZZG4M9), et
+// des TypeError "X is not a function" sur des hooks pourtant bien exportés (LBA-UI-5CVZZZZZZG4QA).
+// Un simple reload récupère automatiquement le build courant ; le flag de session évite une boucle
+// si l'erreur persiste pour une autre raison.
+if (typeof window !== "undefined") {
+  const STALE_DEPLOYMENT_RELOAD_KEY = "lba-stale-deployment-reload"
+
+  const isStaleDeploymentError = (error: unknown): boolean => {
+    if (!(error instanceof Error)) return false
+    if (error.name === "ChunkLoadError") return true
+    return error.message.includes("Failed to find Server Action")
+  }
+
+  const reloadOnce = () => {
+    if (window.sessionStorage.getItem(STALE_DEPLOYMENT_RELOAD_KEY)) return
+    window.sessionStorage.setItem(STALE_DEPLOYMENT_RELOAD_KEY, "1")
+    window.location.reload()
+  }
+
+  window.addEventListener("error", (event) => {
+    if (isStaleDeploymentError(event.error)) reloadOnce()
+  })
+  window.addEventListener("unhandledrejection", (event) => {
+    if (isStaleDeploymentError(event.reason)) reloadOnce()
+  })
+}

--- a/ui/services/base-adresse.ts
+++ b/ui/services/base-adresse.ts
@@ -72,7 +72,10 @@ export async function searchAddress(value: string, type?: string, signal?: Abort
 
       return simplifiedItems(returnedItems)
     } catch (err) {
-      console.error("Fetch addresses cancelled : ", err)
+      // Requête supplantée par une saisie plus récente (React Query annule via signal à chaque
+      // frappe) : flux normal de l'autocomplétion, pas une erreur à faire remonter.
+      if (signal?.aborted) return []
+      console.error("Fetch addresses failed : ", err)
       return []
     }
   } else return []

--- a/ui/utils/reload-guard.utils.ts
+++ b/ui/utils/reload-guard.utils.ts
@@ -1,0 +1,27 @@
+function wasPageReloaded(): boolean {
+  const navigationEntry = window.performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined
+  return navigationEntry?.type === "reload"
+}
+
+/**
+ * Autorise un unique reload automatique par fenêtre de `throttleMs`, identifié par `storageKey`.
+ * Repose sur sessionStorage (peut lever en navigation privée / storage désactivé) : dans ce cas,
+ * on se rabat sur wasPageReloaded() pour éviter une boucle de reload infinie.
+ */
+export function shouldReloadOnce(storageKey: string, throttleMs: number): boolean {
+  const now = Date.now()
+
+  try {
+    const storedValue = window.sessionStorage.getItem(storageKey)
+    const lastReload = storedValue ? Number(storedValue) : 0
+
+    if (!lastReload || Number.isNaN(lastReload) || now - lastReload > throttleMs) {
+      window.sessionStorage.setItem(storageKey, String(now))
+      return true
+    }
+
+    return false
+  } catch {
+    return !wasPageReloaded()
+  }
+}


### PR DESCRIPTION
Closes #5151

## Changements

- **Recherche `/api/v1/search`** : plafonne à 12 le nombre de termes injectés dans la porte de pertinence (`buildTextGate`). Un `q` très long (ex. intitulé de formation complet envoyé tel quel via une suggestion) tokenisait en 20+ termes, chacun développé en plusieurs clauses `text`/fuzzy par champ, faisant dépasser `maxClauseCount=1024` côté mongot et renvoyant du 500 sur `/recherche`.
- **`/api/v2/appointment` (et le v1 `/appointment-request/context/create`)** : `intitule_long` devient `nullable()` dans les deux schémas de réponse, aligné sur la donnée source (`training_intitule_long` est `nullish` côté formation). Le endpoint plantait en 500 (`FST_ERR_RESPONSE_SERIALIZATION`) dès que la formation trouvée n'avait pas de libellé long, cassant la prise de RDV pour ces cas.
- **Erreurs post-déploiement** (`ChunkLoadError`, "Failed to find Server Action") : un onglet resté ouvert pendant un rolling update référence encore les chunks JS de l'ancien build. Ajout d'un reload automatique (une fois par session, garde-fou `sessionStorage` partagé et protégé — factorisé avec le mécanisme existant d'`ErrorComponent.tsx`) sur ces deux signatures précises. Investigué séparément : le `TypeError: useBuildNavigation is not a function` (LBA-UI-5CVZZZZZZG4QA) a probablement la même origine (déploiement) mais n'est **pas** couvert ici — matcher un `TypeError` générique risquerait de masquer de vrais bugs ; à surveiller si ça persiste.
- **Bruit Sentry** :
  - `Sentry.setupFastifyErrorHandler` capturait les erreurs de validation Fastify (400, ex. `FST_ERR_VALIDATION`) *avant* leur passage dans `errorMiddleware`, donc en dehors du filtre `beforeSend` qui ne reconnaît que les erreurs déjà "Boom-ifiées" → ajout d'un `shouldHandleError` explicite (>=500 uniquement).
  - `SearchBar.tsx` ne transmettait pas le `signal` React Query à `searchAddress`, donc les requêtes d'adresse obsolètes n'étaient jamais annulées proprement et remontaient en erreur à chaque frappe.
  - Le rejet de fichier trop lourd dans le dropzone de candidature utilisait `captureException` (implique un crash) au lieu de `captureMessage` pour une validation utilisateur attendue.
  - Ajout d'`ignoreErrors` pour les extensions navigateur tierces (MetaMask, gestionnaires d'onglets) et retrait des types `deprecation`/`intervention` du `reportingObserverIntegration` (avertissements passifs du navigateur, jamais du code LBA).

## Plan de test

- [x] `yarn typecheck`
- [x] `yarn test:ci` (1173 tests passés)
- [x] `yarn check:fix` (aucune erreur)
- [ ] Vérifier en recette qu'une recherche avec un `q` très long (ex. intitulé de formation complet) ne renvoie plus d'erreur 500
- [ ] Vérifier une prise de RDV sur une formation dont `intitule_long` est `null` en base