### PR TITLE
fix: repli sans fuzzy sur maxClauseCount dépassé (#5153)

### DIFF
--- a/server/src/services/search/search.service.test.ts
+++ b/server/src/services/search/search.service.test.ts
@@ -1,0 +1,102 @@
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { generateSearchItemFixture } from "shared/fixtures/search-items.fixture"
+import { beforeAll, describe, expect, it, vi } from "vitest"
+import * as mongodbUtils from "@/common/utils/mongodb-utils"
+import { createSearchIndexes, getDbCollection } from "@/common/utils/mongodb-utils"
+import * as sentryUtils from "@/common/utils/sentry-utils"
+import { searchItems } from "@/services/search/search.service"
+
+/**
+ * Repli sans fuzzy quand mongot dépasse maxClauseCount=1024 (#5153) : le fix précédent
+ * plafonnant le nombre de termes n'avait aucun effet (la requête fautive en prod ne
+ * comptait que 6 termes) — la vraie cause est l'expansion interne des clauses `fuzzy` par
+ * champ, indépendante du nombre de termes, et mongot n'expose aucun réglage pour relever
+ * la limite. `searchItems` retente désormais la même requête avec le fuzzy désactivé au
+ * lieu de renvoyer un 500.
+ *
+ * ⚠️ Nécessite mongot (sidecar MongoDB Search), comme search-result.test.ts — gated :
+ *   SEARCH_RELEVANCE_TESTS=true yarn vitest run src/services/search/search.service.test.ts
+ */
+const RUN_RELEVANCE = process.env.SEARCH_RELEVANCE_TESTS === "true"
+
+const CORPUS = [generateSearchItemFixture()]
+
+async function seedCorpus() {
+  await getDbCollection("search_items").insertMany(CORPUS)
+}
+
+async function waitForSearchIndexSync(timeoutMs = 120_000) {
+  const start = Date.now()
+  for (;;) {
+    try {
+      const { nbHits } = await searchItems({ radius: 30, page: 0, hitsPerPage: 1 })
+      if (nbHits >= CORPUS.length) return
+    } catch {
+      // index pas encore créé côté mongot → on réessaie
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`mongot n'a pas indexé le corpus en ${timeoutMs}ms — la stack locale (mongodb + mongot) tourne-t-elle ?`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000))
+  }
+}
+
+// Intercepte les appels `aggregate` sur search_items pour simuler un échec mongot précis,
+// sans toucher au reste (les autres appels passent par le vrai driver / la vraie stack locale).
+function mockFirstAggregateCallToFail(errorMessage: string) {
+  const getDbCollectionOriginal = mongodbUtils.getDbCollection
+  let aggregateCalls = 0
+  return vi.spyOn(mongodbUtils, "getDbCollection").mockImplementation((name) => {
+    const collection = getDbCollectionOriginal(name)
+    if (name !== "search_items") return collection
+    return new Proxy(collection, {
+      get(target, prop, receiver) {
+        if (prop === "aggregate") {
+          return (...args: Parameters<typeof collection.aggregate>) => {
+            aggregateCalls++
+            if (aggregateCalls === 1) {
+              return { toArray: () => Promise.reject(new Error(errorMessage)) }
+            }
+            return target.aggregate(...args)
+          }
+        }
+        const value = Reflect.get(target, prop, receiver)
+        return typeof value === "function" ? value.bind(target) : value
+      },
+    }) as typeof collection
+  })
+}
+
+describe.runIf(RUN_RELEVANCE)("searchItems — repli sans fuzzy sur maxClauseCount dépassé", () => {
+  useMongo(seedCorpus, "beforeAll")
+
+  beforeAll(async () => {
+    await createSearchIndexes()
+    await waitForSearchIndexSync()
+  })
+
+  it("retente sans fuzzy et renvoie un résultat au lieu de propager l'erreur", async () => {
+    // biome-ignore lint/suspicious/noEmptyBlockStatements: test
+    const sentrySpy = vi.spyOn(sentryUtils, "sentryCaptureException").mockImplementation(() => {})
+    const getDbCollectionSpy = mockFirstAggregateCallToFail(
+      "MongoServerError: Executor error during aggregate command on namespace: labonnealternance.search_items :: caused by :: maxClauseCount is set to 1024"
+    )
+
+    const result = await searchItems({ q: "développeur", radius: 30, page: 0, hitsPerPage: 10 })
+
+    expect(result.hits.length).toBeGreaterThan(0)
+    expect(sentrySpy).toHaveBeenCalledTimes(1)
+    expect(sentrySpy).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ level: "warning" }))
+
+    sentrySpy.mockRestore()
+    getDbCollectionSpy.mockRestore()
+  })
+
+  it("propage sans repli une erreur qui n'est pas liée à maxClauseCount", async () => {
+    const getDbCollectionSpy = mockFirstAggregateCallToFail("connection reset")
+
+    await expect(searchItems({ q: "développeur", radius: 30, page: 0, hitsPerPage: 10 })).rejects.toThrow("connection reset")
+
+    getDbCollectionSpy.mockRestore()
+  })
+})

--- a/server/src/services/search/search.service.ts
+++ b/server/src/services/search/search.service.ts
@@ -4,6 +4,7 @@ import { JOB_START_TYPE } from "shared/models/job.model"
 
 import { getDistanceInKm } from "@/common/utils/geolib"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { sentryCaptureException } from "@/common/utils/sentry-utils"
 
 const HIGHLIGHT_MAX_PASSAGES = 5
 const HIGHLIGHT_MAX_CHARS = 300
@@ -325,8 +326,8 @@ const buildLevelFilter = (level: string[]) => ({ in: { path: "level", value: [..
 //   exige déjà les autres termes ailleurs ("monteur vidéo" : « vidéo » légitimement couvert
 //   par les keywords d'une offre dont le title porte « monteur »). Les keywords restent un
 //   signal de score pour tous les types (cf. buildTextBonusClauses).
-function buildTermCoverageClause(term: string, isSingleTerm: boolean): object {
-  const fuzzy = fuzzyFor(term)
+function buildTermCoverageClause(term: string, isSingleTerm: boolean, disableFuzzy: boolean): object {
+  const fuzzy = disableFuzzy ? undefined : fuzzyFor(term)
   const text = (path: string, boost: number) => ({ text: { query: term, path, ...(fuzzy ? { fuzzy } : {}), score: { boost: { value: boost } } } })
   return {
     compound: {
@@ -364,10 +365,12 @@ function buildTermCoverageClause(term: string, isSingleTerm: boolean): object {
  * token (« vigile » → « agent de sécurité » laissait entrer tout doc contenant « agent » —
  * agents commerciaux compris, recette #3) ; `phrase` exige la séquence complète du synonyme.
  */
-function buildTextGate(q?: string): object | null {
+function buildTextGate(q: string | undefined, disableFuzzy: boolean): object | null {
   if (!q?.trim()) return null
   const terms = tokenizeQuery(q)
-  const coverage = terms.length ? [{ compound: { should: terms.map((term) => buildTermCoverageClause(term, terms.length === 1)), minimumShouldMatch: msmFor(terms.length) } }] : []
+  const coverage = terms.length
+    ? [{ compound: { should: terms.map((term) => buildTermCoverageClause(term, terms.length === 1, disableFuzzy)), minimumShouldMatch: msmFor(terms.length) } }]
+    : []
   const synonyms = { phrase: { query: q, path: SYNONYM_MULTI_PATHS, synonyms: "lba_synonyms", slop: 0, score: { boost: { value: 6 } } } }
   return { compound: { should: [...coverage, synonyms], minimumShouldMatch: 1 } }
 }
@@ -388,7 +391,7 @@ function buildTextBonusClauses(q?: string): object[] {
   ]
 }
 
-function buildCompoundOperator(filters: ISearchFilters) {
+function buildCompoundOperator(filters: ISearchFilters, disableFuzzy: boolean) {
   const {
     q,
     type,
@@ -411,7 +414,7 @@ function buildCompoundOperator(filters: ISearchFilters) {
   const hasGeo = latitude !== undefined && longitude !== undefined
   const proximity = sort === "proximity" && hasGeo
 
-  const gate = buildTextGate(q)
+  const gate = buildTextGate(q, disableFuzzy)
 
   const filter: object[] = []
 
@@ -536,7 +539,7 @@ function isDimensionActive(filters: ISearchFilters, key: FacetDimension): boolea
 // Faceting DISJONCTIF : compound = texte + géo + type + tous les filtres de dimension
 // SAUF `exclude`. Ainsi une facette ne masque pas ses propres options en multi-sélection,
 // mais reflète bien les restrictions imposées par les AUTRES filtres (filtres synchronisés).
-function buildFacetCompound(filters: ISearchFilters, exclude: FacetDimension | null) {
+function buildFacetCompound(filters: ISearchFilters, exclude: FacetDimension | null, disableFuzzy: boolean) {
   const {
     q,
     type,
@@ -557,7 +560,7 @@ function buildFacetCompound(filters: ISearchFilters, exclude: FacetDimension | n
   } = filters
   const hasGeo = latitude !== undefined && longitude !== undefined
   // Même porte de pertinence que la recherche → les counts de facettes reflètent le même result set.
-  const gate = buildTextGate(q)
+  const gate = buildTextGate(q, disableFuzzy)
   const filter: object[] = []
 
   if (type) filter.push({ equals: { path: "type", value: type } })
@@ -597,14 +600,14 @@ type FacetMetaRow = { facet?: Record<string, { buckets: { _id: string; count: nu
 // mongot ne supportent que string/number/date) → un count dédié par chip via $searchMeta.
 // Disjonctif comme les facettes : le filtre de la chip est exclu de son propre compound
 // pour que le compteur reste stable quand l'utilisateur active le filtre.
-function buildChipCountCompounds(filters: ISearchFilters) {
-  const handi = buildFacetCompound({ ...filters, is_disabled_elligible: undefined }, null)
+function buildChipCountCompounds(filters: ISearchFilters, disableFuzzy: boolean) {
+  const handi = buildFacetCompound({ ...filters, is_disabled_elligible: undefined }, null, disableFuzzy)
   handi.filter.push({ equals: { path: "is_disabled_elligible", value: true } })
 
-  const urgent = buildFacetCompound({ ...filters, start_type: undefined }, null)
+  const urgent = buildFacetCompound({ ...filters, start_type: undefined }, null, disableFuzzy)
   urgent.filter.push({ equals: { path: "start_type", value: JOB_START_TYPE.DES_QUE_POSSIBLE } })
 
-  const smartApply = buildFacetCompound({ ...filters, smart_apply: undefined }, null)
+  const smartApply = buildFacetCompound({ ...filters, smart_apply: undefined }, null, disableFuzzy)
   smartApply.filter.push({ equals: { path: "smart_apply", value: true } })
 
   return { is_disabled_elligible: handi, urgent, smart_apply: smartApply }
@@ -615,12 +618,12 @@ function buildChipCountCompounds(filters: ISearchFilters) {
 //   compteurs informatifs — sub_type alimente le détail par type d'offre de l'événement
 //   Matomo search_results_displayed), calculé avec tous les filtres actifs ;
 // - 1 groupe par dimension sélectionnée, calculé en excluant cette dimension.
-function buildFacetGroups(filters: ISearchFilters): { keys: string[]; compound: object }[] {
+function buildFacetGroups(filters: ISearchFilters, disableFuzzy: boolean): { keys: string[]; compound: object }[] {
   const activeDims = FACET_DIMENSIONS.filter((k) => isDimensionActive(filters, k))
   const inactiveDims = FACET_DIMENSIONS.filter((k) => !activeDims.includes(k))
 
-  const groups: { keys: string[]; compound: object }[] = [{ keys: [...inactiveDims, "type", "sub_type"], compound: buildFacetCompound(filters, null) }]
-  for (const dim of activeDims) groups.push({ keys: [dim], compound: buildFacetCompound(filters, dim) })
+  const groups: { keys: string[]; compound: object }[] = [{ keys: [...inactiveDims, "type", "sub_type"], compound: buildFacetCompound(filters, null, disableFuzzy) }]
+  for (const dim of activeDims) groups.push({ keys: [dim], compound: buildFacetCompound(filters, dim, disableFuzzy) })
   return groups
 }
 
@@ -637,18 +640,20 @@ export type SearchHit = ISearchItem & {
 // membres du replica set (la répartition de charge sur les secondaires redeviendra souhaitable).
 const SEARCH_AGGREGATE_OPTIONS = { readPreference: "primary" } as const
 
-export async function searchItems(params: ISearchFilters): Promise<{
-  hits: SearchHit[]
-  nbHits: number
-  page: number
-  nbPages: number
-  facets?: ISearchFacets
-  counts?: { is_disabled_elligible: number; urgent: number; smart_apply: number }
-}> {
-  const { page, hitsPerPage, latitude, longitude } = params
-  const compound = buildCompoundOperator(params)
-  const facetGroups = buildFacetGroups(params)
-  const chipCountCompounds = buildChipCountCompounds(params)
+// mongot n'expose pas de réglage pour relever cette limite (ni en config Docker/preview, ni en
+// déploiement natif prod — vérifié dans les deux repos d'infra) : une clause `fuzzy` par terme
+// long peut à elle seule expandre en dizaines/centaines de sous-clauses selon le vocabulaire
+// indexé, indépendamment du nombre de termes de la requête (cf. #5153, le fix précédent
+// plafonnant le nombre de termes n'avait aucun effet).
+function isMaxClauseCountError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("maxClauseCount")
+}
+
+async function runSearchAggregations(params: ISearchFilters, disableFuzzy: boolean) {
+  const { page, hitsPerPage } = params
+  const compound = buildCompoundOperator(params, disableFuzzy)
+  const facetGroups = buildFacetGroups(params, disableFuzzy)
+  const chipCountCompounds = buildChipCountCompounds(params, disableFuzzy)
   const chipCountKeys = Object.keys(chipCountCompounds) as (keyof typeof chipCountCompounds)[]
 
   const [rows, chipCountArrays, ...metaArrays] = await Promise.all([
@@ -722,6 +727,32 @@ export async function searchItems(params: ISearchFilters): Promise<{
     ),
   ])
 
+  return { rows, chipCountArrays, metaArrays, facetGroups, chipCountKeys }
+}
+
+export async function searchItems(params: ISearchFilters): Promise<{
+  hits: SearchHit[]
+  nbHits: number
+  page: number
+  nbPages: number
+  facets?: ISearchFacets
+  counts?: { is_disabled_elligible: number; urgent: number; smart_apply: number }
+}> {
+  const { page, hitsPerPage, latitude, longitude } = params
+
+  let aggregations: Awaited<ReturnType<typeof runSearchAggregations>>
+  try {
+    aggregations = await runSearchAggregations(params, false)
+  } catch (err) {
+    if (!isMaxClauseCountError(err)) throw err
+    // Dégradation gracieuse plutôt qu'un 500 : on retente sans fuzzy (tolérance aux fautes de
+    // frappe perdue pour cette requête précise seulement) — capturé en warning pour suivre la
+    // fréquence réelle de ce repli, sans polluer le triage des vraies erreurs.
+    sentryCaptureException(err, { level: "warning", extra: { q: params.q, fallback: "search-disable-fuzzy" } })
+    aggregations = await runSearchAggregations(params, true)
+  }
+  const { rows, chipCountArrays, metaArrays, facetGroups, chipCountKeys } = aggregations
+
   const nbHits = rows[0]?._meta?.count?.total ?? 0
   const nbPages = Math.ceil(nbHits / hitsPerPage)
 
@@ -760,7 +791,10 @@ export async function searchItems(params: ISearchFilters): Promise<{
     }
   })
 
-  const counts = Object.fromEntries(chipCountKeys.map((key, i) => [key, chipCountArrays[i][0]?.count?.total ?? 0])) as Record<keyof typeof chipCountCompounds, number>
+  const counts = Object.fromEntries(chipCountKeys.map((key, i) => [key, chipCountArrays[i][0]?.count?.total ?? 0])) as Record<
+    keyof ReturnType<typeof buildChipCountCompounds>,
+    number
+  >
 
   return { hits, nbHits, page, nbPages, facets, counts }
 }

--- a/server/src/services/search/search.service.ts
+++ b/server/src/services/search/search.service.ts
@@ -251,15 +251,6 @@ const fuzzyFor = (term: string): { maxEdits: number; prefixLength: number } | un
 // Nombre minimal de termes couverts exigé : tous jusqu'à 2 termes, n−1 pour 3-4, 75 % au-delà.
 const msmFor = (n: number): number => (n <= 2 ? n : n <= 4 ? n - 1 : Math.ceil(0.75 * n))
 
-// Plafond de termes injectés dans la porte de pertinence : un intitulé de formation entier
-// envoyé tel quel comme `q` (clic sur une suggestion) peut tokeniser en 20+ termes, chacun
-// généré en plusieurs clauses `text`/fuzzy par champ (rome_labels/title/organization_name/
-// keywords) — le compound $search dépasse alors maxClauseCount=1024 côté mongot
-// (Sentry LBA-SERVER-5J7KF4ZZZT961). Les premiers termes portent l'intitulé principal (le
-// détail vient après tirets/parenthèses) : tronquer ne change pas la pertinence perçue pour
-// une recherche normale et borne le pire cas.
-const MAX_TEXT_GATE_TERMS = 12
-
 // Filtre « date de début de contrat » (spec ticket Contract start) : l'utilisateur indique
 // quand il veut démarrer → on montre tout ce qui est compatible, c'est-à-dire les offres qui
 // démarrent AVANT OU À cette date ($lte), celles à date flexible, et les docs SANS date de
@@ -375,7 +366,7 @@ function buildTermCoverageClause(term: string, isSingleTerm: boolean): object {
  */
 function buildTextGate(q?: string): object | null {
   if (!q?.trim()) return null
-  const terms = tokenizeQuery(q).slice(0, MAX_TEXT_GATE_TERMS)
+  const terms = tokenizeQuery(q)
   const coverage = terms.length ? [{ compound: { should: terms.map((term) => buildTermCoverageClause(term, terms.length === 1)), minimumShouldMatch: msmFor(terms.length) } }] : []
   const synonyms = { phrase: { query: q, path: SYNONYM_MULTI_PATHS, synonyms: "lba_synonyms", slop: 0, score: { boost: { value: 6 } } } }
   return { compound: { should: [...coverage, synonyms], minimumShouldMatch: 1 } }


### PR DESCRIPTION
Lié à #5153 (ne ferme pas l'issue — voir note en bas)

## Changements

1. **Retire le plafond de 12 termes** (`MAX_TEXT_GATE_TERMS`) introduit précédemment dans `buildTextGate` — retour Copilot confirmé par investigation : la requête qui plantait en prod ne comptait que ~6 termes, très en dessous du plafond. Ce correctif n'avait aucun effet réel.

2. **Retry sans fuzzy en repli sur maxClauseCount dépassé** (server/src/services/search/search.service.ts) — le vrai fix. La cause réelle : chaque terme long (fuzzy-éligible) génère une clause `fuzzy` par champ (`rome_labels`/`title`/`keywords`), et l'expansion interne de cette clause par mongot/Lucene dépend du vocabulaire indexé, indépendamment du nombre de termes de la requête. mongot n'expose aucun réglage pour relever `maxClauseCount=1024` (vérifié dans la conf de ce repo et du repo infra prod dédié, + métriques live du nœud primaire — pas de lien mémoire non plus).
   - `searchItems` catch désormais l'erreur mongot et **retente la même requête avec le fuzzy désactivé** plutôt que de renvoyer un 500.
   - Zéro impact sur les recherches normales : le fuzzy reste actif par défaut, confirmé par les 59 tests de non-régression pertinence (`search-result.test.ts`, exécutés contre mongot réel).
   - Le repli est capturé en `warning` Sentry (pas `error`) pour suivre sa fréquence réelle sans polluer le triage.

3. **Tests** (`search.service.test.ts`, nouveau) — simule un échec mongot réel (message `maxClauseCount`) via un `Proxy` autour de `getDbCollection` sur le premier appel d'agrégation, reste de la stack réel (mongo + mongot locaux) :
   - vérifie que `searchItems` retente et renvoie un résultat au lieu de propager l'erreur, et capture le warning Sentry attendu ;
   - vérifie qu'une erreur non liée à `maxClauseCount` continue de se propager normalement (pas de repli à tort).

## Plan de test

- [x] `yarn typecheck`
- [x] `yarn check:fix`
- [x] `SEARCH_RELEVANCE_TESTS=true yarn vitest run src/services/search/search-result.test.ts` (59/59, contre mongot réel)
- [x] `SEARCH_RELEVANCE_TESTS=true yarn vitest run src/services/search/search.service.test.ts` (nouveau, 2/2)
- [ ] Vérifier en recette qu'une recherche avec un `q` très long/multi-termes-fuzzy ne renvoie plus d'erreur 500

---
Ne ferme pas #5153 : ce ticket documente aussi les pistes de fix alternatives évaluées et écartées (réduire le fuzzy par défaut, notamment) — à garder ouvert pour référence même une fois ce PR mergé, ou à fermer manuellement si l'équipe estime le sujet clos.