### PR TITLE
fix: protège le bulkWrite du job recruteurs lba contre les échecs mongo (#5155)

### DIFF
--- a/server/src/jobs/offre-partenaire/recruteur-lba/import-recruteurs-lba-raw.ts
+++ b/server/src/jobs/offre-partenaire/recruteur-lba/import-recruteurs-lba-raw.ts
@@ -6,6 +6,7 @@ import { pipeline } from "node:stream/promises"
 import { internal } from "@hapi/boom"
 import { ObjectId } from "bson"
 import type { AnyBulkWriteOperation } from "mongodb"
+import { MongoBulkWriteError } from "mongodb"
 import { extensions } from "shared/helpers/zod-helpers/zod-primitives"
 import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
 import type { IComputedJobsPartners } from "shared/models/jobs-partners-computed.model"
@@ -200,9 +201,14 @@ export const importRecruteurLbaToComputed = async () => {
         try {
           await getDbCollection("computed_jobs_partners").bulkWrite(operations, { ordered: true })
         } catch (err) {
-          counters.success -= operations.length
-          counters.error += operations.length
-          const newError = internal(`error lors du bulkWrite d'un groupe de documents pour partner_label=${partnerLabel}`)
+          // en écriture ordonnée, tout ce qui précède le premier échec a bien été appliqué
+          const succeededOperations = err instanceof MongoBulkWriteError ? err.matchedCount + err.upsertedCount : 0
+          const failedOperations = operations.length - succeededOperations
+          counters.success -= failedOperations
+          counters.error += failedOperations
+          const newError = internal(
+            `error lors du bulkWrite d'un groupe de documents pour partner_label=${partnerLabel} (${failedOperations}/${operations.length} opérations en échec)`
+          )
           logger.error(err, newError.message)
           newError.cause = err
           sentryCaptureException(newError)

--- a/server/src/jobs/offre-partenaire/recruteur-lba/import-recruteurs-lba-raw.ts
+++ b/server/src/jobs/offre-partenaire/recruteur-lba/import-recruteurs-lba-raw.ts
@@ -197,7 +197,16 @@ export const importRecruteurLbaToComputed = async () => {
       }
 
       if (operations.length > 0) {
-        await getDbCollection("computed_jobs_partners").bulkWrite(operations, { ordered: true })
+        try {
+          await getDbCollection("computed_jobs_partners").bulkWrite(operations, { ordered: true })
+        } catch (err) {
+          counters.success -= operations.length
+          counters.error += operations.length
+          const newError = internal(`error lors du bulkWrite d'un groupe de documents pour partner_label=${partnerLabel}`)
+          logger.error(err, newError.message)
+          newError.cause = err
+          sentryCaptureException(newError)
+        }
       }
 
       callback()


### PR DESCRIPTION
Closes #5155

## Changements

- `importRecruteurLbaToComputed` : le `bulkWrite` final du Transform stream est maintenant protégé par un try/catch (aligné sur le pattern déjà utilisé dans `fill-fields-for-partners-factory.ts`)
- En cas d'échec (ex. validation de schéma Mongo), l'erreur est loguée et envoyée à Sentry, les compteurs ajustés, et `callback()` est toujours appelé — le stream ne reste plus jamais bloqué

## Contexte

Incident Sentry du 2026-08-16 : 11 cron monitors sont passés en "missed check-in" en cascade sur lba-server (recette puis production). Le scheduler de jobs traite les crons en séquence ; un `bulkWrite` non catché a laissé un job gelé indéfiniment en `status: running`, bloquant tous les crons suivants du même tag.

## Plan de test

- [ ] Vérifier en local qu'une erreur de validation Mongo dans le bulkWrite ne bloque plus le pipeline stream (job se termine, erreur loguée)
- [ ] Après déploiement, débloquer manuellement les jobs actuellement gelés en base (recette + prod)
- [ ] Vérifier sur Sentry que les monitors reprennent leurs check-ins normalement