### PR TITLE
fix: inclut le job recruteurs lba dans le bilan nocturne offres partenaires (#5158)

### DIFF
--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
@@ -9,9 +9,13 @@ const MAX_MESSAGE_LENGTH = 35_000 // marge sous la limite Slack (~40k caractère
 
 export const JOB_PARTNERS_DIGEST_JOB_NAME = "Bilan nocturne offres partenaires"
 
+// Jobs de la pipeline jobs_partners enregistrés directement dans jobs.ts (tag "main"/"slave"),
+// donc absents du map `importers` ci-dessous mais dont le digest doit quand même surveiller les anomalies.
+const ADDITIONAL_MONITORED_JOB_NAMES = ["Traitement des recruteur LBA par la pipeline jobs partners"]
+
 // Calculé à l'appel (pas au chargement du module) : jobs-partners.importer.ts importe ce fichier pour enregistrer
 // son propre CronDef, donc `importers` n'est pas encore initialisé tant que ce module est en cours de chargement.
-const getJobPartnersNightlyJobNames = () => Object.keys(importers).filter((name) => name !== JOB_PARTNERS_DIGEST_JOB_NAME)
+const getJobPartnersNightlyJobNames = () => [...Object.keys(importers).filter((name) => name !== JOB_PARTNERS_DIGEST_JOB_NAME), ...ADDITIONAL_MONITORED_JOB_NAMES]
 
 type ErrorSignal = { path: string; detail: string }
 

--- a/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
+++ b/server/src/jobs/offre-partenaire/send-job-partners-nightly-digest.ts
@@ -9,13 +9,13 @@ const MAX_MESSAGE_LENGTH = 35_000 // marge sous la limite Slack (~40k caractère
 
 export const JOB_PARTNERS_DIGEST_JOB_NAME = "Bilan nocturne offres partenaires"
 
-// Jobs de la pipeline jobs_partners enregistrés directement dans jobs.ts (tag "main"/"slave"),
-// donc absents du map `importers` ci-dessous mais dont le digest doit quand même surveiller les anomalies.
+// Jobs de la pipeline jobs_partners enregistrés directement dans jobs.ts, donc absents du map
+// `importers` ci-dessous mais dont le digest doit quand même surveiller les anomalies.
 const ADDITIONAL_MONITORED_JOB_NAMES = ["Traitement des recruteur LBA par la pipeline jobs partners"]
 
 // Calculé à l'appel (pas au chargement du module) : jobs-partners.importer.ts importe ce fichier pour enregistrer
 // son propre CronDef, donc `importers` n'est pas encore initialisé tant que ce module est en cours de chargement.
-const getJobPartnersNightlyJobNames = () => [...Object.keys(importers).filter((name) => name !== JOB_PARTNERS_DIGEST_JOB_NAME), ...ADDITIONAL_MONITORED_JOB_NAMES]
+const getJobPartnersNightlyJobNames = () => [...new Set([...Object.keys(importers), ...ADDITIONAL_MONITORED_JOB_NAMES])].filter((name) => name !== JOB_PARTNERS_DIGEST_JOB_NAME)
 
 type ErrorSignal = { path: string; detail: string }
 


### PR DESCRIPTION
Closes #5158

## Changements

- `getJobPartnersNightlyJobNames()` inclut désormais `"Traitement des recruteur LBA par la pipeline jobs partners"` en plus des jobs du map `importers`, via une nouvelle liste explicite `ADDITIONAL_MONITORED_JOB_NAMES`

## Contexte

Ce job (cron hebdomadaire dominical, enregistré directement dans `jobs.ts` plutôt que dans le map `importers`) n'était jamais couvert par le bilan Slack nocturne. C'est précisément ce job qui est resté bloqué ~11h en recette lors de l'incident de ce matin (cf. #5155 / PR #5156) sans jamais être signalé par le digest.

## Plan de test

- [ ] Vérifier que le digest inclut bien ce job dans son prochain envoi (ou en local en simulant un job "running"/"errored" avec ce nom)