### PR TITLE
fix: retire les mots génériques isolés des groupes de synonymes

### DIFF
--- a/docs/mongodb/search-synonyms.json
+++ b/docs/mongodb/search-synonyms.json
@@ -121,7 +121,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "FUMISTE",
       "OPTION RAMONEUR",
       "OPTION POELIER-ATRIER",
       "foropa"
@@ -338,7 +337,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "FINITIONS",
       "AMENAGEMENT DES BATIMENTS : CONCEPTION ET REALISATION",
       "fabcr",
       "fadbcer"
@@ -477,7 +475,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "QUALITE",
       "LOGISTIQUE INDUSTRIELLE ET ORGANISATION : MANAGEMENT DE LA PRODUCTION",
       "qliomp",
       "qlieomdlp"
@@ -715,7 +712,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "GENIE INDUSTRIEL ET MAINTENANCE : MANAGEMENT",
-      "METHODES",
       "MAINTENANCE INNOVANTE",
       "gimmmmi",
       "giemmmmi"
@@ -892,7 +888,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "INGENIEUR DIPLOME DE L'ECOLE SUPERIEURE DE CHIMIE",
-      "PHYSIQUE",
       "ELECTRONIQUE DE LYON",
       "SPECIALITE GENIE DES PROCEDES",
       "idescpelsgp",
@@ -1024,7 +1019,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "DIPLOME GRADE MASTER DE PARIS DAUPHINE : CONTROLE",
-      "AUDIT",
       "REPORTING FINANCIER",
       "dgmpdcarf",
       "dgmdpdcarf"
@@ -1133,8 +1127,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "AGENT DE MEDIATION",
-      "INFORMATION",
-      "SERVICES",
       "amis",
       "admis"
     ]
@@ -1143,9 +1135,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "CHIMIE ANALYTIQUE",
-      "CONTROLE",
-      "QUALITE",
-      "ENVIRONNEMENT",
       "cacqe"
     ]
   },
@@ -1439,7 +1428,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ANALYSE",
       "QUALITE ET CONTROLE DES MATERIAUX PRODUITS",
       "aqcmp",
       "aqecdmp"
@@ -1849,7 +1837,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "LANGUES",
       "LITTERATURES ET CIVILISATIONS ETRANGERES ET REGIONALES",
       "llcer",
       "lleceer"
@@ -1890,9 +1877,7 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ELECTRONIQUE",
       "ENERGIE ELECTRIQUE",
-      "AUTOMATIQUE",
       "eeea"
     ]
   },
@@ -2190,7 +2175,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "INNOVATION",
       "ENTREPRISE ET SOCIETE",
       "ies",
       "iees"
@@ -2304,7 +2288,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "DEVELOPPEMENT",
       "ANIMATION DES TERRITOIRES RURAUX",
       "datr",
       "dadtr"
@@ -2451,7 +2434,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "GESTION ADMINISTRATIVE ET COMMERCIALE DES ORGANISATIONS : MANAGEMENT DES ACTIVITES CULTURELLES",
-      "ARTISTIQUES",
       "SPORTIVES ET DE TOURISME",
       "gacomacast",
       "gaecdomdacasedt"
@@ -2761,7 +2743,6 @@
     "synonyms": [
       "INGENIEUR DIPLOME DE L'ECOLE NATIONALE VETERINAIRE",
       "AGROALIMENTAIRE ET DE L'ALIMENTATION",
-      "NANTES-ATLANTIQUE",
       "idenvaana",
       "iddlenvaedlana"
     ]
@@ -3174,7 +3155,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ANALYSE",
       "CONDUITE ET STRATEGIE DE L'ENTREPRISE AGRICOLE",
       "acsea",
       "acesdlea"
@@ -3449,7 +3429,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ARTS",
       "LETTRES ET CIVILISATIONS",
       "alc",
       "alec"
@@ -3516,8 +3495,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "GESTION DE PRODUCTION",
-      "LOGISTIQUE",
-      "ACHATS",
       "gpla",
       "gdpla"
     ]
@@ -3525,7 +3502,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ANIMATION",
       "GESTION ET ORGANISATION DES ACTIVITES PHYSIQUES ET SPORTIVES",
       "agoaps",
       "ageodapes"
@@ -4431,7 +4407,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "INSTALLATEUR",
       "DEPANNEUR EN FROID ET CONDITIONNEMENT D'AIR",
       "idfca",
       "idefecda"
@@ -4456,7 +4431,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "INGENIEUR DIPLOME DE L'ECOLE SUPERIEURE DE CHIMIE",
-      "PHYSIQUE",
       "ELECTRONIQUE DE LYON",
       "SPECIALITE INFORMATIQUE ET CYBERSECURITE",
       "idescpelsic",
@@ -5016,7 +4990,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "CARTOGRAPHIE",
       "TOPOGRAPHIE ET SYSTEMES D'INFORMATION GEOGRAPHIQUE",
       "ctsig",
       "ctesdig"
@@ -5276,7 +5249,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "AGRICULTURE BIOLOGIQUE : PRODUCTION",
-      "CONSEIL",
       "CERTIFICATION ET COMMERCIALISATION",
       "abpccc",
       "abpccec"
@@ -5554,7 +5526,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "QUALITE",
       "LOGISTIQUE INDUSTRIELLE ET ORGANISATION : MANAGEMENT DE LA TRANSFORMATION DIGITALE",
       "qliomtd",
       "qlieomdltd"
@@ -5580,8 +5551,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "AMENAGEMENT PAYSAGER : CONCEPTION",
-      "GESTION",
-      "ENTRETIEN",
       "apcge"
     ]
   },
@@ -6023,7 +5992,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "QUALITE",
       "LOGISTIQUE INDUSTRIELLE ET ORGANISATION : ORGANISATION ET SUPPLY CHAIN",
       "qlioosc",
       "qlieooesc"
@@ -6393,7 +6361,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "AGRICULTURE",
       "NUMERIQUE ET TECHNOLOGIES EMBARQUEES",
       "ante",
       "anete"
@@ -6887,7 +6854,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "ENCADREMENT SECTEUR SPORTIF OPTION ACTIVITES DE LA FORME - HALTEROPHILIE",
-      "MUSCULATION",
       "essoafhm",
       "essoadlfhm"
     ]
@@ -7193,9 +7159,7 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "CYBERSECURITE",
       "INFORMATIQUE ET RESEAUX",
-      "ELECTRONIQUE",
       "cire",
       "ciere"
     ]
@@ -7363,7 +7327,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "INGENIEUR DIPLOME DE L'ECOLE SUPERIEURE DE CHIMIE",
-      "PHYSIQUE",
       "ELECTRONIQUE DE LYON",
       "SPECIALITE INFORMATIQUE ET RESEAUX",
       "idescpelsir",
@@ -7422,16 +7385,13 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "AUDIOVISUEL",
       "MEDIAS INTERACTIFS NUMERIQUES",
-      "JEUX",
       "aminj"
     ]
   },
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "CONTROLE",
       "RAYONNEMENT IONISANTS",
       "APPLICATION TECHNIQUE DE PROTECTION",
       "criatp",
@@ -7985,7 +7945,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "RESPONSABLE DE PRODUCTIONS LEGUMIERES",
-      "FRUITIERES",
       "FLORALES ET DE PEPINIERES",
       "rplffp",
       "rdplffedp"
@@ -8019,7 +7978,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "RESPONSABLE QUALITE",
-      "SANTE",
       "SECURITE ENVIRONNEMENT",
       "rqsse"
     ]
@@ -8140,8 +8098,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "GEOGRAPHIE",
-      "AMENAGEMENT",
       "ENVIRONNEMENT ET DEVELOPPEMENT",
       "gaed",
       "gaeed"
@@ -8440,7 +8396,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "METIERS DE L'INDUSTRIE : MECATRONIQUE",
-      "ROBOTIQUE",
       "mimr",
       "mdlimr"
     ]
@@ -8449,7 +8404,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "MATHEMATIQUES APPLIQUEES",
-      "STATISTIQUE",
       "mas"
     ]
   },
@@ -8592,7 +8546,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "METIERS DE LA SANTE : NUTRITION",
-      "ALIMENTATION",
       "msna",
       "mdlsna"
     ]
@@ -8641,7 +8594,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ACTION",
       "COMMERCIALISATION DES SERVICES SPORTIFS",
       "acss",
       "acdss"
@@ -8772,9 +8724,7 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "CYBERSECURITE",
       "INFORMATIQUE ET RESEAUX",
-      "ELECTRONIQUE",
       "OPTION B ELECTRONIQUE ET RESEAUX",
       "cireober",
       "ciereobeer"
@@ -9286,8 +9236,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ASSURANCE",
-      "BANQUE",
       "FINANCE : CHARGE DE CLIENTELE",
       "abfcc",
       "abfcdc"
@@ -9386,7 +9334,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ACCOMPAGNEMENT",
       "SOINS ET SERVICES A LA PERSONNE",
       "assp",
       "asesalp"
@@ -9453,8 +9400,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "INFORMATIQUE : REALISATION D'APPLICATIONS / CONCEPTION",
-      "DEVELOPPEMENT",
-      "VALIDATION",
       "ira/cdv",
       "irda/cdv"
     ]
@@ -9778,7 +9723,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ORGANISATION",
       "MANAGEMENT DES SERVICES DE L'AUTOMOBILE",
       "omsa",
       "omdsdla"
@@ -10107,7 +10051,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "MAITRISE DE L'ENERGIE",
-      "ELECTRICITE",
       "DEVELOPPEMENT DURABLE",
       "meedd",
       "mdleedd"
@@ -10141,7 +10084,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "MAINTENANCE ET TECHNOLOGIE : ELECTRONIQUE",
-      "INSTRUMENTATION",
       "mtei",
       "metei"
     ]
@@ -10249,8 +10191,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "MECANICIEN CONDUCTEUR DES SCIERIES ET DES INDUSTRIES MECANIQUES DU BOIS OP. B : MECANICIEN AFFUTEUR DE SCIAGE",
-      "TRANCHAGE",
-      "DEROULAGE",
       "mcsimbobmastd",
       "mcdsedimdbobmadstd"
     ]
@@ -10313,9 +10253,7 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "CYBERSECURITE",
       "INFORMATIQUE ET RESEAUX",
-      "ELECTRONIQUE",
       "OPTION A INFORMATIQUE ET RESEAUX",
       "cireoir",
       "ciereoaier"
@@ -10382,7 +10320,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "SCIENCES DE LA TERRE ET DES PLANETES",
-      "ENVIRONNEMENT",
       "stpe",
       "sdltedpe"
     ]
@@ -10759,14 +10696,12 @@
     "mappingType": "equivalent",
     "synonyms": [
       "CALCUL HAUTE PERFORMANCE",
-      "SIMULATION",
       "chps"
     ]
   },
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "PACKAGING",
       "EMBALLAGE ET CONDITIONNEMENT : ECO-CONCEPTION HOMOLOGATION SUPPLY CHAIN",
       "pecechsc",
       "peecechsc"
@@ -10935,7 +10870,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "METIERS DE L'ELECTRONIQUE : MICROELECTRONIQUE",
-      "OPTRONIQUE",
       "memo",
       "mdlemo"
     ]
@@ -10960,7 +10894,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "BIOCHIMIE",
       "BIOLOGIE MOLECULAIRE",
       "bbm"
     ]
@@ -11222,7 +11155,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "PRODUCTION",
       "TRANSFORMATION ET COMMERCIALISATION DES PRODUITS FERMIERS",
       "ptcpf",
       "ptecdpf"
@@ -11248,7 +11180,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "COMPOSITES",
       "PLASTIQUES CHAUDRONNES",
       "cpc"
     ]
@@ -11591,8 +11522,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "CHIMIE : ANALYSE",
-      "CONTROLE-QUALITE",
-      "ENVIRONNEMENT",
       "cacqe"
     ]
   },
@@ -12124,8 +12053,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "TECHNIQUES",
-      "PATRIMOINE",
       "TERRITOIRES DE L'INDUSTRIE : HISTOIRE",
       "VALORISATION DIDACTIQUE",
       "tptihvd",
@@ -12143,8 +12070,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ASISTANCE",
-      "CONSEIL",
       "VENTE A DISTANCE",
       "acvd",
       "acvad"
@@ -12177,8 +12102,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ASSURANCE",
-      "BANQUE",
       "FINANCE : SUPPORTS OPERATIONNELS",
       "abfso"
     ]
@@ -12234,7 +12157,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "CIVILISATIONS",
       "CULTURES ET SOCIETES",
       "ccs",
       "cces"
@@ -12283,7 +12205,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "PACKAGING",
       "EMBALLAGE ET CONDITIONNEMENT : ECO-CONCEPTION ET INDUSTRIALISATION",
       "pececi",
       "peececei"
@@ -12590,7 +12511,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "JUSTICE",
       "PROCES ET PROCEDURES",
       "jpp",
       "jpep"
@@ -12607,7 +12527,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "ARCHEOLOGIE",
       "SCIENCES POUR L'ARCHEOLOGIE",
       "aspa",
       "aspla"
@@ -12897,7 +12816,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "BIODIVERSITE",
       "ECOLOGIE ET EVOLUTION",
       "bee",
       "beee"
@@ -13027,7 +12945,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "FACONNAGE DE PRODUITS IMPRIMES",
-      "ROUTAGE",
       "fpir",
       "fdpir"
     ]
@@ -13240,7 +13157,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "ANALYSES BIOLOGIQUES",
-      "BIOTECHNOLOGIQUES",
       "AGRICOLES ET ENVIRONNEMENTALES",
       "abbae",
       "abbaee"
@@ -13307,7 +13223,6 @@
   {
     "mappingType": "equivalent",
     "synonyms": [
-      "QUALITE",
       "LOGISTIQUE INDUSTRIELLE ET ORGANISATION : QUALITE ET MANAGEMENT INTEGRES",
       "qlioqmi",
       "qlieoqemi"
@@ -13349,7 +13264,6 @@
     "mappingType": "equivalent",
     "synonyms": [
       "INGENIEUR DIPLOME DE L'INSTITUT SUPERIEUR DES SCIENCES AGRONOMIQUES",
-      "AGROALIMENTAIRES",
       "HORTICOLES ET DU PAYSAGE",
       "idissaahp",
       "iddlisdsaahedp"

--- a/server/src/jobs/database/seed-search-synonyms.test.ts
+++ b/server/src/jobs/database/seed-search-synonyms.test.ts
@@ -1,0 +1,32 @@
+import fs from "fs"
+import path from "path"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Garde-fou de qualité de données sur `docs/mongodb/search-synonyms.json` : un groupe
+ * `equivalent` qui mélange une entrée multi-mots (phrase) avec une entrée mono-mot en
+ * MAJUSCULES (≠ abréviation, toujours en minuscules dans ce jeu de données) fait exploser
+ * mongot en maxClauseCount sur les requêtes longues contenant ce mot, ET pollue les
+ * résultats de recherche du mot seul avec tous les autres membres du groupe (confirmé sur
+ * les données de prod : "achats" seul remontait 10771 résultats via l'équivalence avec
+ * "logistique", contre 640 résultats réellement pertinents — cf. #5153).
+ */
+describe("search-synonyms.json — pas de mot générique isolé mélangé à une phrase", () => {
+  const filePath = path.resolve(__dirname, "../../../../docs/mongodb/search-synonyms.json")
+  const groups = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Array<{ mappingType: string; synonyms: string[] }>
+
+  it("charge bien 1660+ groupes depuis le fichier", () => {
+    expect(groups.length).toBeGreaterThan(1000)
+  })
+
+  it("aucun groupe ne mélange un mot isolé générique et une phrase", () => {
+    const singleUpperWord = /^[A-ZÀ-Ý'-]+$/
+    const offenders = groups.filter((g) => {
+      const singleWords = g.synonyms.filter((s) => singleUpperWord.test(s) && s.length >= 4 && !s.includes(" "))
+      const hasPhrase = g.synonyms.some((s) => s.includes(" ") && /[A-ZÀ-Ý]/.test(s))
+      return singleWords.length > 0 && hasPhrase
+    })
+
+    expect(offenders.map((o) => o.synonyms)).toEqual([])
+  })
+})

--- a/server/src/jobs/database/seed-search-synonyms.test.ts
+++ b/server/src/jobs/database/seed-search-synonyms.test.ts
@@ -1,6 +1,7 @@
 import fs from "fs"
 import path from "path"
 import { describe, expect, it } from "vitest"
+import { __dirname } from "@/common/utils/dirname"
 
 /**
  * Garde-fou de qualité de données sur `docs/mongodb/search-synonyms.json` : un groupe
@@ -12,7 +13,7 @@ import { describe, expect, it } from "vitest"
  * "logistique", contre 640 résultats réellement pertinents — cf. #5153).
  */
 describe("search-synonyms.json — pas de mot générique isolé mélangé à une phrase", () => {
-  const filePath = path.resolve(__dirname, "../../../../docs/mongodb/search-synonyms.json")
+  const filePath = path.resolve(__dirname(import.meta.url), "../../../../docs/mongodb/search-synonyms.json")
   const groups = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Array<{ mappingType: string; synonyms: string[] }>
 
   it("charge bien 1660+ groupes depuis le fichier", () => {
@@ -23,7 +24,7 @@ describe("search-synonyms.json — pas de mot générique isolé mélangé à un
     const singleUpperWord = /^[A-ZÀ-Ý'-]+$/
     const offenders = groups.filter((g) => {
       const singleWords = g.synonyms.filter((s) => singleUpperWord.test(s) && s.length >= 4 && !s.includes(" "))
-      const hasPhrase = g.synonyms.some((s) => s.includes(" ") && /[A-ZÀ-Ý]/.test(s))
+      const hasPhrase = g.synonyms.some((s) => s.includes(" "))
       return singleWords.length > 0 && hasPhrase
     })
 

--- a/server/src/migrations/20260818182821-reseed-search-synonyms-generic-word-pollution.ts
+++ b/server/src/migrations/20260818182821-reseed-search-synonyms-generic-word-pollution.ts
@@ -1,0 +1,12 @@
+import { recreateIndexes } from "@/jobs/database/recreate-indexes"
+
+// Reseed search_synonyms depuis docs/mongodb/search-synonyms.json (68 groupes patchés,
+// cf. PR mots génériques isolés / #5153) : recreateIndexes() appelle seedSearchSynonyms(),
+// qui ne touche que les groupes origin "seed" — les groupes "user_queries" générés par
+// analyzeSearchQueries ne sont pas affectés.
+export const up = async () => {
+  await recreateIndexes()
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false


### PR DESCRIPTION
Lié à #5153 — suite de #5166 (le repli sans fuzzy/synonymes protège déjà la prod, ce PR corrige la donnée à la source).

## Contexte

#5166 a montré que la clause `phrase`+`synonyms` de `buildTextGate` peut à elle seule dépasser `maxClauseCount=1024`. Investigation plus poussée par bissection contre mongot local (1660 groupes réels) pour trouver précisément quels groupes en sont responsables.

## Diagnostic

**Bissection automatisée** (dichotomie + réduction gloutonne, validée contre de faux négatifs dus à la latence de sync mongot) a isolé le coupable exact d'une requête de prod :
```json
["GESTION DE PRODUCTION", "LOGISTIQUE", "ACHATS", "gpla", "gdpla"]
```
Retirer *uniquement* ce groupe des 1660 suffit à faire passer la requête complète — validé contre mongot réel.

**Généralisation** : ce groupe suit un pattern précis — un groupe `equivalent` qui mélange une entrée multi-mots (phrase officielle) avec une entrée mono-mot générique en MAJUSCULES (≠ abréviation, toujours en minuscules dans ce jeu de données). Scan de l'ensemble de `search-synonyms.json` : **68 groupes sur 1660 (~4%)** suivent ce pattern (ex. `QUALITE` ×4 groupes, `PHYSIQUE` ×3, `CYBERSECURITE`/`ELECTRONIQUE` ×4...).

## Validation contre les données de production

Rechargement local de `search_items` avec les vraies données de prod (365 604 docs) pour valider sans se fier à un petit corpus fixture :

- **Les 3 requêtes connues en échec en prod passent désormais** (testé sur le vrai corpus, avant/après patch, puis reconfirmé contre le vrai `search_items_index` après application de la migration).
- **Le pattern n'est pas qu'un bug de performance — c'est aussi un bug de précision.** `LOGISTIQUE` et `ACHATS` étant dans le même groupe `equivalent`, chercher l'un renvoyait exactement les mêmes résultats que l'autre : `achats` seul remontait 10 771 résultats (comptage exact `$searchMeta`), dont seulement 640 réellement pertinents (comptage via couverture directe) — le reste étant des offres "logistique" polluant la recherche "achats" à cause de l'équivalence. Après retrait : 264 résultats pour `achats`, cohérent avec sa couverture directe. Idem `CYBERSECURITE` (144→1) et `CONTROLE` (2291→112) : quasi-totalité de pollution supprimée.
- Les mots retirés restent trouvables via la clause de couverture par terme (`buildTermCoverageClause`), indépendante de la clause synonymes — aucune perte de fonctionnalité, seulement le retrait d'un chemin d'entrée redondant et imprécis.

## Changements

- `docs/mongodb/search-synonyms.json` : 68 groupes patchés (entrées mono-mot génériques retirées, phrases + abréviations conservées).
- `server/src/jobs/database/seed-search-synonyms.test.ts` (nouveau) : garde-fou statique qui échoue si ce pattern est réintroduit — vérifié rouge sans le patch, vert avec.
- `server/src/migrations/20260818182821-reseed-search-synonyms-generic-word-pollution.ts` (nouveau) : reseed `search_synonyms` depuis le fichier patché en prod au déploiement (`recreateIndexes()`, même pattern que la migration du 11 août). Ne touche que les groupes `origin:"seed"` — les groupes `origin:"user_queries"` générés par `analyzeSearchQueries` ne sont pas affectés.

## Plan de test

- [x] `yarn typecheck`
- [x] `yarn check:fix`
- [x] `yarn test:ci` (1175 tests, suite complète)
- [x] `SEARCH_RELEVANCE_TESTS=true yarn vitest run src/services/search/search-result.test.ts` (59/59 contre mongot réel — comportement par défaut inchangé)
- [x] `seed-search-synonyms.test.ts` (2/2, vérifié comme vrai garde-fou par test négatif)
- [x] Les 3 requêtes de prod connues en échec validées OK contre les 365k docs réels de prod (rechargés localement)
- [x] Migration exécutée en local (`yarn migrations:up`) : 1660 synonymes réimportés, index mongot resynchronisé, les 3 requêtes passent contre le vrai `search_items_index`