### PR TITLE
fix: logue aussi les recherches en échec dans search_queries

### DIFF
--- a/server/src/http/controllers/search.controller.test.ts
+++ b/server/src/http/controllers/search.controller.test.ts
@@ -193,13 +193,15 @@ describe("search.controller", () => {
 
       it("logue status=degraded quand searchItems replie après un dépassement de maxClauseCount", async () => {
         const spy = mockFirstAggregateCallToFail("Query exceeded maxClauseCount")
+        try {
+          const response = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=degraded&page=0" })
+          expect(response.statusCode).toBe(200)
 
-        const response = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=degraded&page=0" })
-        expect(response.statusCode).toBe(200)
-        spy.mockRestore()
-
-        const doc = await waitForLoggedQuery("degraded")
-        expect(doc).toMatchObject({ status: "degraded", nb_hits: 0 })
+          const doc = await waitForLoggedQuery("degraded")
+          expect(doc).toMatchObject({ status: "degraded", nb_hits: 0 })
+        } finally {
+          spy.mockRestore()
+        }
       })
 
       it("logue status=error, nb_hits=null et renvoie 500 quand searchItems échoue", async () => {
@@ -209,12 +211,15 @@ describe("search.controller", () => {
           throw new Error("boom")
         })
 
-        const response = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=erreur&page=0" })
-        expect(response.statusCode).toBe(500)
-        spy.mockRestore()
+        try {
+          const response = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=erreur&page=0" })
+          expect(response.statusCode).toBe(500)
 
-        const doc = await waitForLoggedQuery("erreur")
-        expect(doc).toMatchObject({ status: "error", nb_hits: null })
+          const doc = await waitForLoggedQuery("erreur")
+          expect(doc).toMatchObject({ status: "error", nb_hits: null })
+        } finally {
+          spy.mockRestore()
+        }
       })
     })
   })

--- a/server/src/http/controllers/search.controller.test.ts
+++ b/server/src/http/controllers/search.controller.test.ts
@@ -1,9 +1,36 @@
 import { useMongo } from "@tests/utils/mongo.test.utils"
 import { useServer } from "@tests/utils/server.test.utils"
 import { generateSearchItemFixture } from "shared/fixtures/search-items.fixture"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
+import * as mongodbUtils from "@/common/utils/mongodb-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
+
+// Intercepte les appels `aggregate` sur search_items pour simuler un échec mongot précis
+// (même pattern que search.service.test.ts), sans toucher au reste de la stack.
+function mockFirstAggregateCallToFail(errorMessage: string) {
+  const getDbCollectionOriginal = mongodbUtils.getDbCollection
+  let aggregateCalls = 0
+  return vi.spyOn(mongodbUtils, "getDbCollection").mockImplementation((name) => {
+    const collection = getDbCollectionOriginal(name)
+    if (name !== "search_items") return collection
+    return new Proxy(collection, {
+      get(target, prop, receiver) {
+        if (prop === "aggregate") {
+          return (...args: Parameters<typeof collection.aggregate>) => {
+            aggregateCalls++
+            if (aggregateCalls === 1) {
+              return { toArray: () => Promise.reject(new Error(errorMessage)) }
+            }
+            return target.aggregate(...args)
+          }
+        }
+        const value = Reflect.get(target, prop, receiver)
+        return typeof value === "function" ? value.bind(target) : value
+      },
+    }) as typeof collection
+  })
+}
 
 describe("search.controller", () => {
   useMongo()
@@ -128,6 +155,66 @@ describe("search.controller", () => {
         })
 
         expect(response.statusCode).toBe(200)
+      })
+    })
+
+    describe("log search_queries (#5153/#5166)", () => {
+      // logSearchQuery est fire-and-forget (jamais awaited par le contrôleur, cf. commentaire
+      // search.controller.ts) : l'insert peut atterrir après que inject() a résolu la réponse.
+      const waitForLoggedQuery = (q: string) =>
+        vi.waitFor(
+          async () => {
+            const doc = await getDbCollection("search_queries").findOne({ q })
+            expect(doc).not.toBeNull()
+            return doc!
+          },
+          { timeout: 1000, interval: 20 }
+        )
+
+      it("logue status=ok sur une recherche réussie", async () => {
+        const response = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=développeur&page=0" })
+        expect(response.statusCode).toBe(200)
+
+        const doc = await waitForLoggedQuery("développeur")
+        expect(doc).toMatchObject({ status: "ok", nb_hits: 0 })
+      })
+
+      it("ne logue pas une requête interne ni une page > 0", async () => {
+        const response1 = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=interne&page=0&internal=true" })
+        const response2 = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=page1&page=1" })
+        expect(response1.statusCode).toBe(200)
+        expect(response2.statusCode).toBe(200)
+
+        // Laisse une marge à un éventuel (faux) log fire-and-forget avant de conclure à son absence.
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        expect(await getDbCollection("search_queries").findOne({ q: "interne" })).toBeNull()
+        expect(await getDbCollection("search_queries").findOne({ q: "page1" })).toBeNull()
+      })
+
+      it("logue status=degraded quand searchItems replie après un dépassement de maxClauseCount", async () => {
+        const spy = mockFirstAggregateCallToFail("Query exceeded maxClauseCount")
+
+        const response = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=degraded&page=0" })
+        expect(response.statusCode).toBe(200)
+        spy.mockRestore()
+
+        const doc = await waitForLoggedQuery("degraded")
+        expect(doc).toMatchObject({ status: "degraded", nb_hits: 0 })
+      })
+
+      it("logue status=error, nb_hits=null et renvoie 500 quand searchItems échoue", async () => {
+        const getDbCollectionOriginal = mongodbUtils.getDbCollection
+        const spy = vi.spyOn(mongodbUtils, "getDbCollection").mockImplementation((name) => {
+          if (name !== "search_items") return getDbCollectionOriginal(name)
+          throw new Error("boom")
+        })
+
+        const response = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=erreur&page=0" })
+        expect(response.statusCode).toBe(500)
+        spy.mockRestore()
+
+        const doc = await waitForLoggedQuery("erreur")
+        expect(doc).toMatchObject({ status: "error", nb_hits: null })
       })
     })
   })

--- a/server/src/http/controllers/search.controller.ts
+++ b/server/src/http/controllers/search.controller.ts
@@ -21,9 +21,9 @@ export default (server: Server) => {
       // inchangé pour le client et pour la capture Sentry standard.
       const shouldLog = !req.query.internal && req.query.q?.trim() && req.query.page === 0
       try {
-        const result = await searchItems(req.query)
+        const { degraded, ...result } = await searchItems(req.query)
         if (shouldLog) {
-          void logSearchQuery(req.query, { status: result.degraded ? "degraded" : "ok", nbHits: result.nbHits })
+          void logSearchQuery(req.query, { status: degraded ? "degraded" : "ok", nbHits: result.nbHits })
         }
         return res.status(200).send(result)
       } catch (err) {

--- a/server/src/http/controllers/search.controller.ts
+++ b/server/src/http/controllers/search.controller.ts
@@ -12,15 +12,26 @@ export default (server: Server) => {
       config: { rateLimit: { max: 30, timeWindow: "1s" } },
     },
     async (req, res) => {
-      const result = await searchItems(req.query)
       // Log des recherches au fil de l'eau : fire-and-forget (jamais d'await — zéro impact
       // sur la latence), page 0 uniquement (l'infinite scroll rejoue le même q à chaque page).
       // `internal` exclut les requêtes non issues d'un utilisateur (ex. prefetch SSR pour le SEO
       // de /recherche), qui rejouent sinon le même q que le fetch client et faussent les stats.
-      if (!req.query.internal && req.query.q?.trim() && req.query.page === 0) {
-        void logSearchQuery(req.query, result.nbHits)
+      // Loggé aussi côté échec (cf. #5153 : avant, une requête qui plantait n'était jamais
+      // loguée, seul Sentry en gardait la trace) — re-throw ensuite, comportement d'erreur
+      // inchangé pour le client et pour la capture Sentry standard.
+      const shouldLog = !req.query.internal && req.query.q?.trim() && req.query.page === 0
+      try {
+        const result = await searchItems(req.query)
+        if (shouldLog) {
+          void logSearchQuery(req.query, { status: result.degraded ? "degraded" : "ok", nbHits: result.nbHits })
+        }
+        return res.status(200).send(result)
+      } catch (err) {
+        if (shouldLog) {
+          void logSearchQuery(req.query, { status: "error", nbHits: null })
+        }
+        throw err
       }
-      return res.status(200).send(result)
     }
   )
 

--- a/server/src/jobs/search/analyze-search-queries.ts
+++ b/server/src/jobs/search/analyze-search-queries.ts
@@ -64,7 +64,10 @@ async function aggregateQueryStats(): Promise<IQueryStats[]> {
   const since = new Date(Date.now() - CRITERIA.WINDOW_DAYS * 24 * 3600 * 1000)
   return getDbCollection("search_queries")
     .aggregate<IQueryStats>([
-      { $match: { created_at: { $gte: since } } },
+      // status=error exclu : nb_hits est alors null (recherche non aboutie, aucun signal de
+      // pertinence) — l'inclure gonflerait `total` sans jamais compter dans `zero_hits_count`,
+      // ce qui ferait paraître le terme plus pertinent qu'il ne l'est (cf. #5166).
+      { $match: { created_at: { $gte: since }, status: { $ne: "error" } } },
       {
         $group: {
           _id: "$q_normalized",

--- a/server/src/services/search/search-query-log.service.ts
+++ b/server/src/services/search/search-query-log.service.ts
@@ -10,6 +10,12 @@ import { normalizeTerm, tokenizeQuery } from "./search.service"
  * Contraintes : appelé en fire-and-forget depuis le contrôleur /v1/search (jamais d'await),
  * ne doit JAMAIS throw ni ralentir la réponse. RGPD : pas d'IP / user / referer, requêtes
  * contenant des PII jamais loggées, géo arrondie à ~11 km. Cf. searchQueries.model.ts.
+ *
+ * Appelé aussi bien sur succès que sur échec de searchItems (cf. search.controller.ts) : avant
+ * #5153, les requêtes qui plantaient n'étaient jamais loguées (le log n'existait que sur le
+ * chemin de succès), rendant impossible toute analyse a posteriori des échecs réels via
+ * `search_queries` — seul Sentry gardait la trace. `status` distingue désormais succès normal,
+ * succès après repli maxClauseCount ("degraded"), et échec ("error", nb_hits alors null).
  */
 
 // Détection PII dans le texte libre : email, téléphone FR, longues séquences de chiffres
@@ -48,7 +54,9 @@ type SearchQuerystring = {
 // pour ré-identifier une personne.
 const roundCoord = (value: number) => Math.round(value * 10) / 10
 
-export async function logSearchQuery(query: SearchQuerystring, nbHits: number): Promise<void> {
+type SearchOutcome = { status: "ok" | "degraded"; nbHits: number } | { status: "error"; nbHits: null }
+
+export async function logSearchQuery(query: SearchQuerystring, outcome: SearchOutcome): Promise<void> {
   try {
     const q = query.q?.trim().slice(0, 200)
     if (!q || containsPii(q)) return
@@ -63,7 +71,8 @@ export async function logSearchQuery(query: SearchQuerystring, nbHits: number): 
       _id: new ObjectId(),
       q,
       q_normalized,
-      nb_hits: nbHits,
+      status: outcome.status,
+      nb_hits: outcome.nbHits,
       source: query.source ?? "free_text",
       filters: {
         type: query.type ?? null,

--- a/server/src/services/search/search.service.ts
+++ b/server/src/services/search/search.service.ts
@@ -753,10 +753,14 @@ export async function searchItems(params: ISearchFilters): Promise<{
   nbPages: number
   facets?: ISearchFacets
   counts?: { is_disabled_elligible: number; urgent: number; smart_apply: number }
+  // Repli maxClauseCount déclenché (cf. #5153) — pas dans le schéma de réponse publique
+  // (strippé par le type provider zod), lu uniquement par le contrôleur pour search_queries.
+  degraded?: boolean
 }> {
   const { page, hitsPerPage, latitude, longitude } = params
 
   let aggregations: Awaited<ReturnType<typeof runSearchAggregations>>
+  let degraded = false
   try {
     aggregations = await runSearchAggregations(params, false)
   } catch (err) {
@@ -767,6 +771,7 @@ export async function searchItems(params: ISearchFilters): Promise<{
     // suivre la fréquence réelle de ce repli, sans polluer le triage des vraies erreurs.
     sentryCaptureException(err, { level: "warning", extra: { q: params.q, fallback: "search-simplify-query" } })
     aggregations = await runSearchAggregations(params, true)
+    degraded = true
   }
   const { rows, chipCountArrays, metaArrays, facetGroups, chipCountKeys } = aggregations
 
@@ -813,7 +818,7 @@ export async function searchItems(params: ISearchFilters): Promise<{
     number
   >
 
-  return { hits, nbHits, page, nbPages, facets, counts }
+  return { hits, nbHits, page, nbPages, facets, counts, degraded }
 }
 
 // Autocomplétion sur le contenu indexé (title + rome_labels, edgeGram).

--- a/shared/src/models/search-queries.model.ts
+++ b/shared/src/models/search-queries.model.ts
@@ -15,7 +15,13 @@ export const ZSearchQuery = z.object({
   _id: zObjectId,
   q: z.string().max(200).describe("Requête brute saisie (tronquée à 200 caractères, PII pré-filtrées)"),
   q_normalized: z.string().describe("Clé d'agrégation : termes tokenizeQuery normalisés, joints par espace"),
-  nb_hits: z.number().describe("Nombre de résultats retournés"),
+  // "degraded" : searchItems a dû retenter sans fuzzy/synonymes suite à maxClauseCount dépassé
+  // (cf. #5153) — succès quand même, mais signal à part du "ok" pour repérer les requêtes qui
+  // stressent le moteur. "error" : searchItems a levé une exception non récupérée ; nb_hits est
+  // alors null (avant #5153/#5166, la quasi-totalité des échecs n'étaient jamais logués du tout
+  // puisque ce log n'était appelé qu'après un succès — ce champ comble ce trou).
+  status: z.enum(["ok", "degraded", "error"]).describe("Issue de la recherche : succès normal, succès après repli, ou échec"),
+  nb_hits: z.number().nullable().describe("Nombre de résultats retournés (null si status=error)"),
   source: z.enum(["suggestion", "free_text"]).describe("Suggestion d'autocomplete sélectionnée vs texte libre"),
   filters: z
     .object({


### PR DESCRIPTION
Closes #5169

## Résumé

- Avant ce correctif, `logSearchQuery` n'était appelé qu'après un succès de `searchItems` : une requête qui plantait, ou qui repliait suite à un dépassement de `maxClauseCount` (#5153/#5166), n'était jamais loguée dans `search_queries` — seul Sentry en gardait la trace, sans possibilité d'analyse a posteriori.
- Ajoute un champ `status: "ok" | "degraded" | "error"` sur `ZSearchQuery` : succès normal, succès après repli maxClauseCount, ou échec. `nb_hits` devient nullable (`null` si `status=error`).
- Le contrôleur `/v1/search` englobe désormais `searchItems()` dans un try/catch : logue sur le chemin de succès (`ok`/`degraded` selon le flag `degraded` renvoyé par `searchItems`) comme sur le chemin d'échec (`error`, `nb_hits: null`), puis re-throw — comportement d'erreur inchangé côté client et pour la capture Sentry standard.
- `analyzeSearchQueries` (`aggregateQueryStats`) exclut désormais `status=error` de sa fenêtre d'agrégation : ces lignes n'ont pas de `nb_hits` exploitable, les inclure gonflerait `total` sans jamais compter dans `zero_hits_count` et ferait paraître un terme plus pertinent qu'il ne l'est.

## Test plan

- [x] `yarn typecheck`
- [x] Tests ciblés (`search.controller.test.ts`, `search-query-log.service.test.ts`, `search.service.test.ts`, `analyze-search-queries` et suites `jobs/database`) : tous verts
- [x] Nouveaux tests contrôleur couvrant les 3 statuts (`ok`, `degraded` via simulation d'un dépassement maxClauseCount, `error` via échec forcé de l'agrégation) + non-log sur requête `internal`/page > 0
- [x] `yarn check:fix`
