### PR TITLE
fix: backfill du champ status manquant sur search_queries (#5170)

### DIFF
--- a/server/src/migrations/20260818194937-backfill-search-queries-status.ts
+++ b/server/src/migrations/20260818194937-backfill-search-queries-status.ts
@@ -1,0 +1,17 @@
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+
+/**
+ * #5168 rend `status: "ok" | "degraded" | "error"` obligatoire sur search_queries, mais tous
+ * les documents déjà en base ont été écrits par l'ancien logSearchQuery, qui n'existait
+ * qu'après succès de searchItems — implicitement des "ok". Sans ce backfill, le validateur
+ * MongoDB (généré depuis le modèle Zod) les considère invalides et le job db:validate
+ * (déclenché après chaque migrations:up) lève une exception Sentry fatal.
+ */
+export const up = async () => {
+  const result = await getDbCollection("search_queries").updateMany({ status: { $exists: false } }, { $set: { status: "ok" } })
+  logger.info(`backfill-search-queries-status: ${result.modifiedCount} document(s) mis à jour`)
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false


### PR DESCRIPTION
Closes #5170

## Changements

- Nouvelle migration `20260818194937-backfill-search-queries-status` : `updateMany({ status: { $exists: false } }, { $set: { status: "ok" } })` sur `search_queries`.
- #5168 rend `status` obligatoire dans le modèle, mais tous les documents déjà en base (prod comme les dumps locaux) ont été écrits par l'ancien `logSearchQuery`, qui n'existait qu'après succès — implicitement des `ok`. Sans backfill, le validateur MongoDB (`$jsonSchema` généré depuis le modèle) les considère invalides, et `db:validate` (déclenché automatiquement après chaque `migrations:up`) lève une exception Sentry `fatal`.

## Plan de test

- [x] `yarn typecheck`
- [x] Migration testée en local : `yarn workspace server build && yarn migrations:up` → 416 944 documents mis à jour (dump local de search_queries)
- [x] `db:validate` relancé après coup : plus aucun document invalide
- [x] `yarn check:fix`