### PR TITLE
fix: ne pas rejeter définitivement les candidats capés par le quota (#5172)

### DIFF
--- a/server/src/jobs/search/analyze-search-queries.ts
+++ b/server/src/jobs/search/analyze-search-queries.ts
@@ -259,7 +259,7 @@ export const analyzeSearchQueries = async () => {
     `Suggestions insérées (${insertedSuggestions.length}) : ${insertedSuggestions.join(", ") || "—"}`,
     `Synonymes insérés (${insertedSynonyms.length}) : ${insertedSynonyms.join(" ; ") || "—"}`,
     `Rejets : ${reasonsSummary || "—"}`,
-    `Rollback : \`yarn cli rollbackSearchSuggestions --runId ${runId}\``,
+    `Rollback : \`yarn cli search:suggestions:rollback --runId ${runId}\``,
   ].join("\n")
   logger.info(`analyzeSearchQueries[${runId}]:\n${message}`)
   await notifyToSlack({ subject: "ANALYSE RECHERCHES UTILISATEURS", message })

--- a/server/src/jobs/search/analyze-search-queries.ts
+++ b/server/src/jobs/search/analyze-search-queries.ts
@@ -114,6 +114,11 @@ export const analyzeSearchQueries = async () => {
   const allStats = await aggregateQueryStats()
   const rejectedReasons = new Map<string, number>()
   const countReason = (reason: string) => rejectedReasons.set(reason, (rejectedReasons.get(reason) ?? 0) + 1)
+  // Compté à part des vrais rejets (cf. plus bas) : un candidat capé n'est PAS persisté en
+  // "rejected" et sera réévalué au prochain run — le confondre avec "Rejets" dans le rapport
+  // Slack laisserait croire à tort qu'il est écarté définitivement.
+  const cappedReasons = new Map<string, number>()
+  const countCapped = (reason: string) => cappedReasons.set(reason, (cappedReasons.get(reason) ?? 0) + 1)
 
   const gatePassed: IQueryStats[] = []
   for (const stats of allStats) {
@@ -240,7 +245,7 @@ export const analyzeSearchQueries = async () => {
     // de rejet trompeur — "not_synonym_candidate" — qui masquait le vrai motif : capé). Réévalué
     // au prochain run.
     if (suggestionCapped || synonymCapped) {
-      countReason(suggestionCapped ? "suggestion_capped" : "synonym_capped")
+      countCapped(suggestionCapped ? "suggestion_capped" : "synonym_capped")
       continue
     }
 
@@ -250,15 +255,17 @@ export const analyzeSearchQueries = async () => {
   }
 
   // 6. Rapport.
-  const reasonsSummary = [...rejectedReasons.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([reason, count]) => `${reason}: ${count}`)
-    .join(", ")
+  const summarize = (reasons: Map<string, number>) =>
+    [...reasons.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => `${reason}: ${count}`)
+      .join(", ")
   const message = [
     `Run \`${runId}\` — ${allStats.length} requêtes distinctes analysées (fenêtre ${CRITERIA.WINDOW_DAYS} j), ${candidates.length} candidats après pré-filtre.`,
     `Suggestions insérées (${insertedSuggestions.length}) : ${insertedSuggestions.join(", ") || "—"}`,
     `Synonymes insérés (${insertedSynonyms.length}) : ${insertedSynonyms.join(" ; ") || "—"}`,
-    `Rejets : ${reasonsSummary || "—"}`,
+    `Rejets : ${summarize(rejectedReasons) || "—"}`,
+    `Capés par le quota du run (réévalués au prochain run, pas un rejet) : ${summarize(cappedReasons) || "—"}`,
     `Rollback : \`yarn cli search:suggestions:rollback --runId ${runId}\``,
   ].join("\n")
   logger.info(`analyzeSearchQueries[${runId}]:\n${message}`)

--- a/server/src/jobs/search/analyze-search-queries.ts
+++ b/server/src/jobs/search/analyze-search-queries.ts
@@ -185,7 +185,8 @@ export const analyzeSearchQueries = async () => {
 
     // Route suggestion (prioritaire) puis route synonyme.
     const suggestionVerdict = decideSuggestion(stats, parsed)
-    if (suggestionVerdict.verdict === "pass" && insertedSuggestions.length < CRITERIA.MAX_SUGGESTIONS_PER_RUN) {
+    const suggestionCapped = suggestionVerdict.verdict === "pass" && insertedSuggestions.length >= CRITERIA.MAX_SUGGESTIONS_PER_RUN
+    if (suggestionVerdict.verdict === "pass" && !suggestionCapped) {
       // S13 : on insère la forme canonique — re-testée contre l'anti-doublon après correction.
       const canonical = parsed.canonical!.trim()
       const canonicalStats = { ...stats, top_raw_q: canonical, q_normalized: normalizeQuery(canonical) || stats.q_normalized }
@@ -200,7 +201,8 @@ export const analyzeSearchQueries = async () => {
     }
 
     const synonymVerdict = decideSynonym(stats, parsed)
-    if (synonymVerdict.verdict === "pass" && insertedSynonyms.length < CRITERIA.MAX_SYNONYM_GROUPS_PER_RUN) {
+    const synonymCapped = synonymVerdict.verdict === "pass" && insertedSynonyms.length >= CRITERIA.MAX_SYNONYM_GROUPS_PER_RUN
+    if (synonymVerdict.verdict === "pass" && !synonymCapped) {
       const target = parsed.synonym_of!.trim()
       // Y4 — vérification empirique : la forme cible doit réellement produire des résultats.
       const control = await searchItems({ q: target, radius: 30, page: 0, hitsPerPage: 1 })
@@ -230,7 +232,19 @@ export const analyzeSearchQueries = async () => {
       continue
     }
 
-    const reason = suggestionVerdict.reason ?? synonymVerdict.reason ?? "capped"
+    // Capé par le quota du run (pas un vrai rejet IA) : ne PAS persister en "rejected", sinon
+    // `already_processed` l'exclurait à vie de tous les prochains runs — y compris de bons
+    // candidats qui n'ont simplement pas eu de place cette fois (constaté sur le run de
+    // rattrapage initial : des candidats à forte confiance comme "devops"/"design" dépassaient
+    // le quota suggestion, retombaient sur le test synonyme, et étaient reportés sous un motif
+    // de rejet trompeur — "not_synonym_candidate" — qui masquait le vrai motif : capé). Réévalué
+    // au prochain run.
+    if (suggestionCapped || synonymCapped) {
+      countReason(suggestionCapped ? "suggestion_capped" : "synonym_capped")
+      continue
+    }
+
+    const reason = suggestionVerdict.reason ?? synonymVerdict.reason ?? "rejected_both_routes"
     countReason(reason)
     await persistDecision(stats, parsed, "rejected", reason, runId, now)
   }

--- a/server/src/jobs/search/search-suggestion-criteria.ts
+++ b/server/src/jobs/search/search-suggestion-criteria.ts
@@ -30,8 +30,12 @@ export const CRITERIA = {
   SUGGESTION_MIN_LETTER_RATE: 0.8,
   /** S12 — confiance IA minimale. */
   SUGGESTION_MIN_CONFIDENCE: 0.8,
-  /** Garde-fou : insertions max par run (tri par fréquence décroissante au-delà). */
-  MAX_SUGGESTIONS_PER_RUN: 30,
+  /** Garde-fou : insertions max par run (tri par fréquence décroissante au-delà). 30 s'est
+   * révélé trop bas dès le premier run de rattrapage (backlog initial jamais traité) : ~170-180
+   * candidats suggestion légitimes passaient le filtre, la moitié capée. Le repli sur le quota
+   * n'est plus perdant (les candidats capés sont réévalués au run suivant, cf. la boucle
+   * principale), mais un quota plus large réduit la latence de mise en autocomplete. */
+  MAX_SUGGESTIONS_PER_RUN: 100,
 
   // ── Candidat → synonyme (impacte le matching global → plus strict) ──────
   /** Y1 — fréquence minimale. */


### PR DESCRIPTION
Closes #5172

## Changements

- `persistDecision` n'est plus appelé pour un candidat uniquement capé par `MAX_SUGGESTIONS_PER_RUN`/`MAX_SYNONYM_GROUPS_PER_RUN` (verdict IA "pass" mais quota du run atteint) : il n'est donc plus marqué `rejected`, ne tombe plus dans l'exclusion `already_processed`, et sera réévalué au run suivant.
- Le motif de rejet reporté dans le Slack (`suggestion_capped` / `synonym_capped`) est désormais distinct des vrais rejets IA/critères — auparavant un candidat suggestion capé qui échouait ensuite le test synonyme était reporté sous un motif trompeur (`not_synonym_candidate`), masquant le fait qu'il s'agissait en réalité d'un bon candidat sans place.
- `MAX_SUGGESTIONS_PER_RUN` : 30 → 100 (trop bas dès le premier run de rattrapage : ~170-180 candidats suggestion légitimes sur ce run, la moitié perdue par effet de quota).
- Corrige au passage la commande de rollback affichée dans la notif Slack (`yarn cli rollbackSearchSuggestions` n'existe pas côté CLI — la vraie commande est `search:suggestions:rollback`).

## Plan de test

- [x] `yarn typecheck`, `yarn test:ci server/src/jobs/search` (22 tests)
- [x] `yarn check:fix`
- [x] **Vérification en conditions réelles** : rollback du run précédent (pré-fix) sur dump local de prod, relance complète d'`analyzeSearchQueries` (15463 requêtes analysées, 266 candidats classifiés par Mistral) avec le correctif :
  - 97 suggestions actives insérées (vs 30 avant, capé) — `DevOps`, `Design`, `Assistante` (précédemment perdus par effet de quota) sont bien repassés actifs
  - 69 candidats `suggestion_capped` distincts dans le rapport, correctement absents de `search_suggestions` (pas persistés en rejected) → seront repris au prochain run