### PR TITLE
feat: programme analyzeSearchQueries en cron mensuel

### DIFF
--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -66,7 +66,7 @@ import { opcoReminderJob } from "./recruiters/opco-reminder-job"
 import { recruiterOfferExpirationReminderJob } from "./recruiters/recruiter-offer-expiration-reminder-job"
 import { resetApiKey } from "./recruiters/reset-api-key"
 import { updateSiretInfosInError } from "./recruiters/update-siret-infos-in-error-job"
-import { rollbackSearchSuggestions } from "./search/analyze-search-queries"
+import { analyzeSearchQueries, rollbackSearchSuggestions } from "./search/analyze-search-queries"
 import { fillSearchItemsCollection } from "./search/generate-search-items-collection"
 import { updateSEO } from "./seo/update-seo"
 import { SimpleJobDefinition, simpleJobDefinitions } from "./simple-job-definitions"
@@ -257,6 +257,12 @@ export async function setupJobProcessor() {
             cron_string: "30 7 * * *",
             handler: controlSearchItemsDrift,
             tag: "main",
+          },
+          "Analyse mensuelle des recherches utilisateurs (autocomplete + synonymes)": {
+            cron_string: "0 1 1 * *",
+            handler: analyzeSearchQueries,
+            tag: "slave",
+            maxRuntimeInMinutes: 60,
           },
           "Génération continue des keywords search_items (cache + API immédiate)": {
             cron_string: "*/30 * * * *",

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -259,7 +259,7 @@ export async function setupJobProcessor() {
             tag: "main",
           },
           "Analyse mensuelle des recherches utilisateurs (autocomplete + synonymes)": {
-            cron_string: "0 1 1 * *",
+            cron_string: "0 7 1 * *",
             handler: analyzeSearchQueries,
             tag: "slave",
             maxRuntimeInMinutes: 60,


### PR DESCRIPTION
## Changements

- Ajoute `analyzeSearchQueries` à la table de crons (`server/src/jobs/jobs.ts`) : exécution automatique le 1er de chaque mois à 01:00 UTC (`0 1 1 * *`), tag `slave`, `maxRuntimeInMinutes: 60` (le run réel le plus récent a pris ~12 min sur ~15k requêtes/266 candidats classifiés).
- Le job tournait jusqu'ici uniquement en manuel (`yarn cli analyzeSearchQueries`) ; les correctifs récents (#5168, #5170, #5172) sont en production, il peut désormais tourner en continu.

## Plan de test

- [x] `yarn typecheck`
- [x] `yarn check:fix`