### PR TITLE
feat: réduit le CSS DSFR aux composants utilisés — react-dsfr 1.33 (#5179)

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "type": "module",
   "sideEffects": [
-    "./dist/src/helpers/zodWithOpenApi.js"
+    "./dist/src/helpers/zod-with-open-api.js"
   ],
   "exports": {
     ".": {

--- a/shared/src/helpers/zod-helpers/zod-primitives-light.ts
+++ b/shared/src/helpers/zod-helpers/zod-primitives-light.ts
@@ -1,0 +1,31 @@
+import { z } from "../zod-with-open-api.js"
+
+/**
+ * Primitives zod SANS dépendance lourde, importables depuis le code client.
+ *
+ * `zod-primitives.ts` construit en eager les schémas `siret` et `telephone`, qui
+ * importent statiquement les validateurs Luhn et libphonenumber-js (~39 ko gzip) :
+ * tout module client qui importe `extensions` embarque libphonenumber dans son
+ * bundle, même pour un simple `buildEnum`. Les helpers ci-dessous sont extraits
+ * ici pour que les chaînes d'import côté navigateur (params de recherche, modèle
+ * d'adresse) restent légères. `zod-primitives.ts` les ré-exporte dans `extensions`
+ * pour ne rien casser côté serveur.
+ */
+
+export const buildEnum = <EnumValue extends string>(enumObject: Record<string, EnumValue>) => {
+  const values = Object.values(enumObject)
+  if (!values.length) {
+    throw new Error("inattendu : enum vide")
+  }
+  return z.enum([values[0], ...values.slice(1)])
+}
+
+export const latitude = ({ coerce }: { coerce: boolean }) => {
+  const base = coerce ? z.coerce.number<number>() : z.number()
+  return base.min(-90, "Latitude doit être comprise entre -90 et 90").max(90, "Latitude doit être comprise entre -90 et 90")
+}
+
+export const longitude = ({ coerce }: { coerce: boolean }) => {
+  const base = coerce ? z.coerce.number<number>() : z.number()
+  return base.min(-180, "Longitude doit être comprise entre -180 et 180").max(180, "Longitude doit être comprise entre -180 et 180")
+}

--- a/shared/src/helpers/zod-helpers/zod-primitives.ts
+++ b/shared/src/helpers/zod-helpers/zod-primitives.ts
@@ -3,6 +3,7 @@ import { validatePhone } from "../../validators/phone-validator.js"
 import { validateSIRET } from "../../validators/siret-validator.js"
 import { removeUrlsFromText } from "../common.js"
 import { z } from "../zod-with-open-api.js"
+import { buildEnum, latitude, longitude } from "./zod-primitives-light.js"
 
 // Fonction générique pour créer une projection MongoDB avec exclusion de champs
 export const createProjectionFromZod = <T extends z.ZodObject<any>>(schema: T, excludeFields: (keyof z.infer<T>)[]): Record<string, 1> => {
@@ -80,13 +81,9 @@ export const extensions = {
       key: z.string().nullish(),
       content: z.array(z.string()).nullish(),
     }),
-  buildEnum: <EnumValue extends string>(enumObject: Record<string, EnumValue>) => {
-    const values = Object.values(enumObject)
-    if (!values.length) {
-      throw new Error("inattendu : enum vide")
-    }
-    return z.enum([values[0], ...values.slice(1)])
-  },
+  // Extraits dans zod-primitives-light.ts (importable côté client sans libphonenumber),
+  // ré-exposés ici pour ne pas casser les ~40 importeurs existants de `extensions`.
+  buildEnum,
   romeCode: () => z.string().trim().regex(CODE_ROME_REGEX, "Code ROME invalide"),
   romeCodeArray: () =>
     z
@@ -97,14 +94,8 @@ export const extensions = {
         message: "One or more ROME codes are invalid. Expected format is 'D1234'.",
       }),
   rncpCode: () => z.string().trim().regex(RNCP_REGEX, "Code RNCP invalide"),
-  latitude: ({ coerce }: { coerce: boolean }) => {
-    const base = coerce ? z.coerce.number<number>() : z.number()
-    return base.min(-90, "Latitude doit être comprise entre -90 et 90").max(90, "Latitude doit être comprise entre -90 et 90")
-  },
-  longitude: ({ coerce }: { coerce: boolean }) => {
-    const base = coerce ? z.coerce.number<number>() : z.number()
-    return base.min(-180, "Longitude doit être comprise entre -180 et 180").max(180, "Longitude doit être comprise entre -180 et 180")
-  },
+  latitude,
+  longitude,
   inseeCode: () => z.string().trim().regex(CODE_INSEE_REGEX, "Code INSEE invalide"),
   zipCode: () => z.string().trim().regex(CODE_POSTAL_REGEX, "Code postal invalide"),
   url: () => z.string().regex(/^(https?:\/\/)?(http?:\/\/)?(www\.)?([a-zA-Z0-9-]+)(\.[a-zA-Z0-9-]+)+(\.[a-zA-Z]{2,6})(:[0-9]{1,5})?(\/.*)?$/, "URL invalide"),

--- a/shared/src/models/address.model.ts
+++ b/shared/src/models/address.model.ts
@@ -1,4 +1,6 @@
-import { extensions } from "../helpers/zod-helpers/zod-primitives.js"
+// Import du module léger et non de `extensions` : ce modèle part dans les bundles
+// client (autocomplete d'adresse) et `zod-primitives.ts` traîne libphonenumber-js.
+import { latitude, longitude } from "../helpers/zod-helpers/zod-primitives-light.js"
 import { z } from "../helpers/zod-with-open-api.js"
 
 const ZAcademie = z.strictObject({
@@ -6,7 +8,7 @@ const ZAcademie = z.strictObject({
   nom: z.string(),
 })
 
-export const Z2DCoord = z.tuple([extensions.longitude({ coerce: false }), extensions.latitude({ coerce: false })])
+export const Z2DCoord = z.tuple([longitude({ coerce: false }), latitude({ coerce: false })])
 
 export const ZPointGeometry = z.strictObject({
   coordinates: Z2DCoord,

--- a/shared/src/routes/params.ts
+++ b/shared/src/routes/params.ts
@@ -1,10 +1,11 @@
-import { NIVEAUX_POUR_LBA, TYPE_EMPLOI_OPTIONS } from "shared/constants/recruteur"
-import { LBA_ITEM_TYPE_OLD } from "../constants/lbaitem.js"
-// Import du module léger et non de `extensions` : ce fichier part dans les bundles
-// client (params de recherche) et `zod-primitives.ts` traîne libphonenumber-js.
-import { buildEnum } from "../helpers/zod-helpers/zod-primitives-light.js"
+import { NIVEAUX_POUR_LBA } from "shared/constants/recruteur"
 import { z } from "../helpers/zod-with-open-api.js"
 import { typedKeys } from "../utils/object-utils.js"
+
+// Paramètres de l'API publique V1 (jobs.routes, formations.routes, geo.routes,
+// formations-par-region.routes, search.routes) : ne rien retirer ici sans vérifier
+// le contrat d'API. Les paramètres propres à l'UI du moteur de recherche legacy
+// vivent dans ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts.
 
 export const zCallerParam = z
   .string()
@@ -32,35 +33,10 @@ export const ZRadiusParam = z.coerce.number<number>().optional()
 
 export const zInseeParams = z.string().optional()
 
-// const allLbaItemTypes = Object.values(LBA_ITEM_TYPE)
-const allLbaItemTypesOLD = Object.values(LBA_ITEM_TYPE_OLD)
-
-const sourceENUM = z.enum([allLbaItemTypesOLD[0], ...allLbaItemTypesOLD.slice(1)])
-const SourceArraySchema = z.array(sourceENUM)
-
-export const zSourcesParams = z
-  .string()
-  .refine(
-    (value) => {
-      const sources = value.split(",")
-      return SourceArraySchema.safeParse(sources).success
-    },
-    {
-      message: `Invalid source format. Must be a comma-separated list of valid sources of ${allLbaItemTypesOLD.join(",")}`,
-    }
-  )
-  .optional()
-
 const diplomaLevels = typedKeys(NIVEAUX_POUR_LBA)
 
 export const zDiplomaParam = z.enum([diplomaLevels[0], ...diplomaLevels.slice(1)]).optional()
 
 export type IDiplomaParam = z.output<typeof zDiplomaParam>
 
-export const zTypesEmploiParam = z.array(buildEnum(TYPE_EMPLOI_OPTIONS)).optional()
-
-export type ITypesEmploiParam = z.output<typeof zTypesEmploiParam>
-
 export const zOpcoParams = z.string().optional()
-
-export const zOpcoUrlParams = z.string().optional()

--- a/shared/src/routes/params.ts
+++ b/shared/src/routes/params.ts
@@ -1,6 +1,8 @@
 import { NIVEAUX_POUR_LBA, TYPE_EMPLOI_OPTIONS } from "shared/constants/recruteur"
 import { LBA_ITEM_TYPE_OLD } from "../constants/lbaitem.js"
-import { extensions } from "../helpers/zod-helpers/zod-primitives.js"
+// Import du module léger et non de `extensions` : ce fichier part dans les bundles
+// client (params de recherche) et `zod-primitives.ts` traîne libphonenumber-js.
+import { buildEnum } from "../helpers/zod-helpers/zod-primitives-light.js"
 import { z } from "../helpers/zod-with-open-api.js"
 import { typedKeys } from "../utils/object-utils.js"
 
@@ -55,7 +57,7 @@ export const zDiplomaParam = z.enum([diplomaLevels[0], ...diplomaLevels.slice(1)
 
 export type IDiplomaParam = z.output<typeof zDiplomaParam>
 
-export const zTypesEmploiParam = z.array(extensions.buildEnum(TYPE_EMPLOI_OPTIONS)).optional()
+export const zTypesEmploiParam = z.array(buildEnum(TYPE_EMPLOI_OPTIONS)).optional()
 
 export type ITypesEmploiParam = z.output<typeof zTypesEmploiParam>
 

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
@@ -3,11 +3,16 @@ import { MAX_SEARCH_ROMES_PRIVATE, parseEnum, typedKeys } from "shared"
 import { LBA_ITEM_TYPE, LBA_ITEM_TYPE_OLD, newItemTypeToOldItemType, oldItemTypeToNewItemType } from "shared/constants/lbaitem"
 import type { ITypeEmploi } from "shared/constants/recruteur"
 import { NIVEAUX_POUR_LBA, TYPE_EMPLOI_OPTIONS } from "shared/constants/recruteur"
-import { zDiplomaParam, zTypesEmploiParam } from "shared/routes/params"
+import { buildEnum } from "shared/helpers/zod-helpers/zod-primitives-light"
+import { zDiplomaParam } from "shared/routes/params"
 import { z } from "zod"
 
 import type { ILbaItem } from "@/app/(candidat)/(recherche)/recherche/_hooks/use-recherche-results"
 import { PAGES } from "@/utils/routes.utils"
+
+// Rapatrié de shared/routes/params.ts : uniquement consommé par l'UI du moteur legacy
+// (ici et RechercheForm), aucune route API ne l'utilise.
+export const zTypesEmploiParam = z.array(buildEnum(TYPE_EMPLOI_OPTIONS)).optional()
 
 const zIdeaType = z.enum(LBA_ITEM_TYPE_OLD)
 

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
@@ -1,5 +1,7 @@
-import { toKebabCase } from "shared"
+// Import profond et non via le barrel "shared" : ce module part dans le bundle de la home.
+
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import { toKebabCase } from "shared/utils/string-utils"
 
 export interface ISearchPageParams {
   q?: string

--- a/ui/app/_components/RechercheForm/RechercheForm.tsx
+++ b/ui/app/_components/RechercheForm/RechercheForm.tsx
@@ -1,11 +1,13 @@
 import { Box } from "@mui/material"
 import type { FormikErrors } from "formik"
 import { Formik } from "formik"
-import { extensions } from "shared/helpers/zod-helpers/zod-primitives"
-import { zDiplomaParam, zTypesEmploiParam } from "shared/routes/params"
+// Module léger et non `extensions` (zod-primitives traîne libphonenumber-js dans le bundle client)
+import { buildEnum } from "shared/helpers/zod-helpers/zod-primitives-light"
+import { zDiplomaParam } from "shared/routes/params"
 import { z } from "zod"
 
 import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
+import { zTypesEmploiParam } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 
 export enum UserItemTypes {
   EMPLOI = "Emplois",
@@ -25,7 +27,7 @@ const ZRechercheForm = z.object({
       latitude: z.number(),
     })
     .nullish(),
-  displayedItemTypes: z.array(extensions.buildEnum(UserItemTypes)),
+  displayedItemTypes: z.array(buildEnum(UserItemTypes)),
   radius: z.string().nullish(),
   diploma: zDiplomaParam.nullish(),
   typesEmploi: zTypesEmploiParam.nullish(),

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,12 +10,12 @@
     "start": "next start",
     "typecheck": "tsc -b",
     "analyse": "ANALYZE=true yarn build",
-    "predev": "react-dsfr update-icons",
-    "prebuild": "react-dsfr update-icons",
+    "predev": "react-dsfr update-icons && react-dsfr only-include-used-components",
+    "prebuild": "react-dsfr update-icons && react-dsfr only-include-used-components",
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@codegouvfr/react-dsfr": "1.31.0",
+    "@codegouvfr/react-dsfr": "1.33.0",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",

--- a/ui/services/base-adresse.ts
+++ b/ui/services/base-adresse.ts
@@ -1,8 +1,7 @@
-// Import profond et non via le barrel "shared" : ce service part dans le bundle de la
-// home (autocomplete du SearchBar) et le barrel ré-exporte routes/params + modèles.
+// Import type-only (effacé à la compilation) : ce service part dans le bundle de la
+// home (autocomplete du SearchBar) — aucun runtime zod/shared ne doit y entrer, les
+// réponses de la BAN sont typées par assertion et jamais validées ici.
 import type { IPointGeometry } from "shared/models/address.model"
-import { ZPointGeometry } from "shared/models/address.model"
-import { z } from "zod"
 
 import { simplifiedItems } from "./arrondissements"
 
@@ -18,15 +17,12 @@ type AddressFeature = {
 
 type Coordinates = [number, number]
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const zAddressItem = z.object({
-  value: ZPointGeometry,
-  insee: z.string(),
-  zipcode: z.string(),
-  label: z.string(),
-})
-
-type IAddressItem = z.output<typeof zAddressItem>
+type IAddressItem = {
+  value: IPointGeometry
+  insee: string
+  zipcode: string
+  label: string
+}
 
 export async function searchAddress(value: string, type?: string, signal?: AbortSignal): Promise<IAddressItem[]> {
   if (value && value.length > 2) {

--- a/ui/services/base-adresse.ts
+++ b/ui/services/base-adresse.ts
@@ -1,5 +1,7 @@
-import type { IPointGeometry } from "shared"
-import { ZPointGeometry } from "shared"
+// Import profond et non via le barrel "shared" : ce service part dans le bundle de la
+// home (autocomplete du SearchBar) et le barrel ré-exporte routes/params + modèles.
+import type { IPointGeometry } from "shared/models/address.model"
+import { ZPointGeometry } from "shared/models/address.model"
 import { z } from "zod"
 
 import { simplifiedItems } from "./arrondissements"

--- a/ui/services/search-entreprises.ts
+++ b/ui/services/search-entreprises.ts
@@ -1,28 +1,35 @@
-import { z } from "zod"
+// Typage + guard manuels plutôt que zod : ce service part dans des bundles client et
+// l'ancien schéma déclarait tous les champs .nullish() — les seuls invariants dont le
+// code aval dépend réellement sont les deux niveaux de tableaux, vérifiés ci-dessous.
+type ISearchEntrepriseEtablissement = {
+  activite_principale?: string | null
+  adresse?: string | null
+  etat_administratif?: string | null
+  nom_commercial?: string | null
+  siret?: string | null
+  statut_diffusion_etablissement?: string | null
+}
 
-const ZSearchEntrepriseApiResponse = z.object({
-  results: z.array(
-    z.object({
-      siren: z.string().nullish(),
-      nom_complet: z.string().nullish(),
-      nom_raison_sociale: z.string().nullish(),
-      activite_principale: z.string().nullish(),
-      etat_administratif: z.string().nullish(),
-      nature_juridique: z.string().nullish(),
-      statut_diffusion: z.string().nullish(),
-      matching_etablissements: z.array(
-        z.object({
-          activite_principale: z.string().nullish(),
-          adresse: z.string().nullish(),
-          etat_administratif: z.string().nullish(),
-          nom_commercial: z.string().nullish(),
-          siret: z.string().nullish(),
-          statut_diffusion_etablissement: z.string().nullish(),
-        })
-      ),
-    })
-  ),
-})
+type ISearchEntrepriseResult = {
+  siren?: string | null
+  nom_complet?: string | null
+  nom_raison_sociale?: string | null
+  activite_principale?: string | null
+  etat_administratif?: string | null
+  nature_juridique?: string | null
+  statut_diffusion?: string | null
+  matching_etablissements: ISearchEntrepriseEtablissement[]
+}
+
+// Même contrat que l'ancien ZSearchEntrepriseApiResponse.parse : throw si la structure
+// attendue (results[] et matching_etablissements[]) n'est pas au rendez-vous.
+function parseSearchEntrepriseApiResponse(json: unknown): { results: ISearchEntrepriseResult[] } {
+  const results = (json as { results?: unknown })?.results
+  if (!Array.isArray(results) || results.some((r) => !Array.isArray(r?.matching_etablissements))) {
+    throw new Error(`Réponse inattendue de l'API recherche-entreprises: ${JSON.stringify(json).slice(0, 200)}`)
+  }
+  return { results }
+}
 
 // cf documentation : https://api.gouv.fr/documentation/api-recherche-entreprises
 export const searchEntreprise = async (search: string) => {
@@ -40,7 +47,7 @@ export const searchEntreprise = async (search: string) => {
     throw new Error(`status=${response.status}. body=${body}`)
   }
   const json = await response.json()
-  const { results } = ZSearchEntrepriseApiResponse.parse(json)
+  const { results } = parseSearchEntrepriseApiResponse(json)
   return results.flatMap(({ matching_etablissements, nom_complet, nom_raison_sociale }) =>
     matching_etablissements
       .filter(({ etat_administratif }) => etat_administratif === "A")

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,9 +1548,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codegouvfr/react-dsfr@npm:1.31.0":
-  version: 1.31.0
-  resolution: "@codegouvfr/react-dsfr@npm:1.31.0"
+"@codegouvfr/react-dsfr@npm:1.33.0":
+  version: 1.33.0
+  resolution: "@codegouvfr/react-dsfr@npm:1.33.0"
   dependencies:
     tsafe: ^1.8.5
     yargs-parser: ^21.1.1
@@ -1561,9 +1561,10 @@ __metadata:
       optional: true
   bin:
     copy-dsfr-to-public: bin/copy-dsfr-to-public.js
+    only-include-used-components: bin/only-include-used-components.js
     only-include-used-icons: bin/only-include-used-icons.js
     react-dsfr: bin/react-dsfr.js
-  checksum: dbe4617e59216d61a2bd724bc33bc4846106318415de2e1d0a5db1c23737bc679f68fc44cdccca0432c9b8195baabc64a260dd19bd0d7f810314a398b15188c1
+  checksum: 49174dd67405a7fa0dc9d4836e16b77f21c778143390306b0a4c6cdc515127ad5b282de79062c02160fc6500acbf8f7ac859fa7ad82b20331dead3d257748106
   languageName: node
   linkType: hard
 
@@ -19185,7 +19186,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ui@workspace:ui"
   dependencies:
-    "@codegouvfr/react-dsfr": 1.31.0
+    "@codegouvfr/react-dsfr": 1.33.0
     "@emotion/cache": ^11.14.0
     "@emotion/react": ^11.14.0
     "@emotion/server": ^11.11.0


### PR DESCRIPTION
Closes #5179

## Changements

- Montée de `@codegouvfr/react-dsfr` **1.31.0 → 1.33.0**
- Activation du script opt-in **`react-dsfr only-include-used-components`** en `prebuild`/`predev`, à côté d'`update-icons`. Le script (contribué upstream via [codegouvfr/react-dsfr#505](https://github.com/codegouvfr/react-dsfr/pull/505), en réponse à [#304](https://github.com/codegouvfr/react-dsfr/issues/304)) reconstruit `dsfr.min.css` dans node_modules avec uniquement les composants détectés dans nos sources — **composants entiers, jamais de purge par règle**, donc insensible par construction aux classes et attributs posés au runtime par le JS DSFR (`data-fr-js-*`, `fr-collapse--expanded`…).

## Gains mesurés (chunk CSS DSFR render-blocking du build)

| Configuration | Brut | Gzip |
|---|---|---|
| Prod actuelle (1.31.0, monolithe) | 785 ko | ~100 ko |
| 1.33.0 seul | 649 ko | 83 ko |
| **1.33.0 + script (25/45 composants)** | **501 ko** | **63,6 ko (−36 %)** |

Aucun `additionalComponents` nécessaire : la seule classe `fr-*` brute de nos feuilles de style est `.fr-header` (fix z-index), couverte par l'import du composant Header. Si un composant DSFR est un jour référencé uniquement par classe dans un `.css`, l'ajouter dans `"react-dsfr": { "additionalComponents": [...] }` du package.json ui.

## Vérifications effectuées

- Build prod local OK, script détecte 25/45 composants (log en prebuild)
- Rendu visuel vérifié sur `/` et `/recherche`
- Le mécanisme conserve l'intégralité du CSS de chaque composant retenu (pas de risque de règle manquante, contrairement à une approche PurgeCSS)

## Plan de test

- [ ] Parcours candidat : home, recherche, fiche formation/emploi, candidature
- [ ] Parcours recruteur : création de compte, dépôt d'offre (formulaires, modales)
- [ ] Espace pro admin : tableaux, pagination, accordéons
- [ ] Pages éditoriales et Notion (FAQ, CGU)
- [ ] Re-mesurer PSI mobile après déploiement (référence actuelle : 69)