### PR TITLE
chore: ajoute un budget de performance du first-load en CI (#5191)

### DIFF
--- a/.github/workflows/perf_budget.yml
+++ b/.github/workflows/perf_budget.yml
@@ -1,0 +1,75 @@
+name: Perf Budget
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "ui/**"
+      - "shared/**"
+      - "yarn.lock"
+      - ".github/workflows/perf_budget.yml"
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: "perf-budget-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  perf-budget:
+    name: Budget de performance
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      # `shared` est résolu depuis ./dist/src (shared/package.json) : sans ce build, le build UI échoue.
+      # Même ordre que le stage builder_ui du Dockerfile.
+      - name: Build shared
+        run: yarn workspace shared build
+
+      - name: Build UI
+        run: yarn workspace ui build
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+          # `production` : on mesure ce que les usagers téléchargent réellement.
+          NEXT_PUBLIC_ENV: production
+          # Requis par ui/config.public.ts (getVersion lève sinon). Valeur constante et non un SHA :
+          # la version est inlinée dans le bundle, une valeur variable rendrait la mesure non reproductible.
+          NEXT_PUBLIC_VERSION: 0.0.0-perf-budget
+          __SENTRY_DEBUG__: false
+          __RRWEB_EXCLUDE_IFRAME__: true
+          __RRWEB_EXCLUDE_SHADOW_DOM__: true
+          __SENTRY_EXCLUDE_REPLAY_WORKER__: true
+          NODE_OPTIONS: --max-old-space-size=3072
+
+      # --report-only : un dépassement de seuil n'échoue pas (mode informatif). Une erreur de
+      # mesure échoue quand même — retirer ce flag pour rendre les seuils bloquants.
+      - name: Mesure du budget de performance
+        run: node ui/scripts/perf-budget.mjs --report-only --out=perf-budget-report.md
+
+      - name: Add job summary
+        if: always()
+        run: cat perf-budget-report.md >> "$GITHUB_STEP_SUMMARY" || true
+
+      # Pas de PR à commenter sur l'événement merge_group. Étape ignorée si la mesure a échoué.
+      - name: Comment PR
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          file-path: perf-budget-report.md
+          comment-tag: perf_budget
+          mode: upsert

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ _temp/
 
 # Mot de passe mongot local généré depuis le vault par yarn setup (env:init)
 .infra/local/mongot_password
+
+# Rapport généré par ui/scripts/perf-budget.mjs --out
+perf-budget-report.md

--- a/ui/perf-budget.json
+++ b/ui/perf-budget.json
@@ -1,0 +1,27 @@
+{
+  "$comment": "Budgets du first-load, contrôlés par ui/scripts/perf-budget.mjs (issue #5191). Seuils en octets gzip (niveau ci-dessous), sauf globalMaxFirstLoadJsRaw en octets non compressés. null = budget non renseigné : la mesure est affichée mais rien n'est contrôlé. Pour relever un seuil, reporter la mesure affichée par le job et justifier la hausse en description de PR.",
+  "$measured": {
+    "$comment": "Mesures de référence ayant servi à fixer les seuils (build de production, NEXT_PUBLIC_ENV=production, NEXT_PUBLIC_VERSION constante). Le script les re-dérive à chaque exécution : un écart se lit dans la colonne Marge.",
+    "commit": "23457dcc1",
+    "/ firstLoadJsGzip": 503681,
+    "/ firstLoadCssGzip": 65059,
+    "/recherche firstLoadJsGzip": 605176,
+    "globalMaxFirstLoadJsRaw": 2457682
+  },
+  "gzipLevel": 9,
+  "routes": {
+    "/": {
+      "firstLoadJsGzip": 524288,
+      "firstLoadCssGzip": 67584
+    },
+    "/recherche": {
+      "firstLoadJsGzip": 624640
+    }
+  },
+  "globalMaxFirstLoadJsRaw": 2560000,
+  "forbiddenOnFirstLoad": {
+    "/": [
+      "libphonenumber-js"
+    ]
+  }
+}

--- a/ui/scripts/perf-budget.mjs
+++ b/ui/scripts/perf-budget.mjs
@@ -8,9 +8,10 @@
  *  - `.next/server/app/<route>.html` : les feuilles CSS du first-load d'une route prérendue.
  *  - les sourcemaps des chunks : pour asserter l'absence d'un package sur le first-load.
  *
- * Deux classes de sortie, volontairement distinctes :
+ * Trois classes de sortie, volontairement distinctes :
  *  - dépassement de budget → jugement, assouplissable par `--report-only` ;
- *  - erreur de mesure (fichier absent, sourcemap introuvable, route inconnue) → toujours exit 1.
+ *  - erreur de mesure (fichier absent, sourcemap introuvable, route inconnue) → toujours exit 1 ;
+ *  - usage invalide (flag inconnu, fichier de budgets mal formé) → toujours exit 1.
  * Sinon un run vert serait indiscernable d'un run qui n'a rien mesuré.
  *
  * Usage : node ui/scripts/perf-budget.mjs [--report-only] [--json] [--ui-dir=…] [--config=…] [--out=…]
@@ -25,6 +26,14 @@ export class MeasureError extends Error {
   constructor(message) {
     super(message)
     this.name = "MeasureError"
+  }
+}
+
+/** Usage invalide : flag inconnu ou fichier de budgets mal formé. Jamais assoupli non plus. */
+export class UsageError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = "UsageError"
   }
 }
 
@@ -226,6 +235,37 @@ export function findForbiddenPackages(uiDir, chunkPaths, packages) {
   return { hits, chunksAnalysed: jsChunks.length, chunksWithSources, sourceCount }
 }
 
+/**
+ * Le fichier de budgets est une entrée non validée : une clé mal orthographiée (`routs`) ou une
+ * route citée dans `forbiddenOnFirstLoad` sans être dans `routes` désactive un contrôle **sans rien
+ * afficher**, et le job sort vert. On refuse plutôt que de mesurer à moitié en silence.
+ */
+const KNOWN_CONFIG_KEYS = new Set(["gzipLevel", "routes", "globalMaxFirstLoadJsRaw", "forbiddenOnFirstLoad"])
+
+export function validateConfig(config) {
+  // Les clés `$…` sont la convention de commentaire du fichier ($comment, $measured).
+  const unknown = Object.keys(config).filter((key) => !key.startsWith("$") && !KNOWN_CONFIG_KEYS.has(key))
+  if (unknown.length > 0) {
+    throw new UsageError(
+      `clé(s) inconnue(s) dans le fichier de budgets : ${unknown.join(", ")}. Faute de frappe probable — ` +
+        `le contrôle correspondant ne serait pas exécuté. Clés acceptées : ${[...KNOWN_CONFIG_KEYS].join(", ")}.`
+    )
+  }
+
+  const routes = Object.keys(config.routes ?? {})
+  if (routes.length === 0 && config.globalMaxFirstLoadJsRaw === undefined) {
+    throw new UsageError("fichier de budgets sans « routes » ni « globalMaxFirstLoadJsRaw » : rien ne serait contrôlé")
+  }
+
+  const orphans = Object.keys(config.forbiddenOnFirstLoad ?? {}).filter((route) => !routes.includes(route))
+  if (orphans.length > 0) {
+    throw new UsageError(
+      `« forbiddenOnFirstLoad » cite des routes absentes de « routes » : ${orphans.join(", ")}. Le scan n'est ` +
+        `exécuté que sur les routes de « routes » — ces interdits ne seraient jamais vérifiés.`
+    )
+  }
+}
+
 function judge(measured, budget) {
   if (budget === null || budget === undefined) {
     return "unset"
@@ -234,6 +274,7 @@ function judge(measured, budget) {
 }
 
 export function evaluate({ uiDir, config }) {
+  validateConfig(config)
   const level = config.gzipLevel ?? 9
   const stats = readRouteStats(uiDir)
   const rows = []
@@ -349,7 +390,17 @@ export function formatMarkdown(report, { configPath, reportOnly }) {
   return lines.join("\n")
 }
 
-function budgetFailureMessage(report, configPath) {
+/** Les deux familles de violation cohabitent : les clés s'additionnent, aucune n'est un fallback. */
+export function concernedConfigKeys(report) {
+  return [
+    ...report.rows
+      .filter((row) => row.status === "over")
+      .map((row) => (row.kind === "global" ? "globalMaxFirstLoadJsRaw" : `routes["${row.route}"].firstLoad${row.kind === "js" ? "Js" : "Css"}Gzip`)),
+    ...new Set(report.forbidden.filter((item) => item.chunks.length > 0).map((item) => `forbiddenOnFirstLoad["${item.route}"]`)),
+  ]
+}
+
+export function budgetFailureMessage(report, configPath) {
   return [
     `Budget de performance dépassé : ${report.violations.join(", ")}.`,
     "",
@@ -358,29 +409,64 @@ function budgetFailureMessage(report, configPath) {
     `  2. si la hausse est assumée, mettre à jour le seuil dans ${configPath} avec la mesure`,
     "     affichée ci-dessus, et justifier la hausse en description de PR.",
     "",
-    `Clés concernées : ${
-      report.rows
-        .filter((row) => row.status === "over")
-        .map((row) => (row.kind === "global" ? "globalMaxFirstLoadJsRaw" : `routes["${row.route}"].firstLoad${row.kind === "js" ? "Js" : "Css"}Gzip`))
-        .join(", ") || "forbiddenOnFirstLoad"
-    }`,
+    `Clés concernées : ${concernedConfigKeys(report).join(", ")}`,
   ].join("\n")
 }
 
-export function main(argv = []) {
-  const flags = new Set(argv.filter((arg) => !arg.includes("=")))
-  const options = Object.fromEntries(argv.filter((arg) => arg.includes("=")).map((arg) => [arg.slice(0, arg.indexOf("=")), arg.slice(arg.indexOf("=") + 1)]))
-  const reportOnly = flags.has("--report-only")
-  const uiDir = path.resolve(options["--ui-dir"] ?? DEFAULT_UI_DIR)
-  const configPath = path.resolve(options["--config"] ?? path.join(uiDir, "perf-budget.json"))
+const KNOWN_FLAGS = new Set(["--report-only", "--json"])
+const KNOWN_OPTIONS = new Set(["--ui-dir", "--config", "--out"])
 
+/**
+ * Un flag mal orthographié ne doit pas être ignoré : `--reportonly` ferait passer le job en mode
+ * bloquant à l'insu de l'appelant, et `--out=` vide supprimerait le rapport sans un mot.
+ */
+export function parseArgv(argv) {
+  const expected = [...KNOWN_FLAGS, ...[...KNOWN_OPTIONS].map((option) => `${option}=…`)].join(", ")
+  const flags = new Set()
+  const options = {}
+  for (const arg of argv) {
+    const separator = arg.indexOf("=")
+    if (separator === -1) {
+      if (!KNOWN_FLAGS.has(arg)) {
+        throw new UsageError(`argument inconnu : ${arg}. Attendu : ${expected}.`)
+      }
+      flags.add(arg)
+      continue
+    }
+    const key = arg.slice(0, separator)
+    const value = arg.slice(separator + 1)
+    if (!KNOWN_OPTIONS.has(key)) {
+      throw new UsageError(`argument inconnu : ${key}. Attendu : ${expected}.`)
+    }
+    if (value === "") {
+      throw new UsageError(`option ${key} sans valeur.`)
+    }
+    options[key] = value
+  }
+  return { flags, options }
+}
+
+export function main(argv = []) {
+  let flags
+  let options
+  let reportOnly = false
+  let configPath
   let report
   try {
+    ;({ flags, options } = parseArgv(argv))
+    reportOnly = flags.has("--report-only")
+    const uiDir = path.resolve(options["--ui-dir"] ?? DEFAULT_UI_DIR)
+    configPath = path.resolve(options["--config"] ?? path.join(uiDir, "perf-budget.json"))
     report = evaluate({ uiDir, config: readJsonFile(configPath, "fichier de budgets") })
   } catch (error) {
+    // Ni la mesure ni l'usage ne sont assouplis par --report-only : un run vert doit prouver
+    // qu'il a mesuré quelque chose.
     if (error instanceof MeasureError) {
-      // Erreur de mesure : jamais assouplie par --report-only.
       console.error(`❌ mesure impossible — ${error.message}`)
+      return 1
+    }
+    if (error instanceof UsageError) {
+      console.error(`❌ usage invalide — ${error.message}`)
       return 1
     }
     throw error

--- a/ui/scripts/perf-budget.mjs
+++ b/ui/scripts/perf-budget.mjs
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+/**
+ * Budget de performance du first-load — issue #5191.
+ *
+ * Sources de mesure (toutes produites par `next build`, aucune constante dérivée à la main) :
+ *  - `.next/diagnostics/route-bundle-stats.json` : écrit sans condition par Next 16
+ *    (`writeRouteBundleStats`) → { route, firstLoadUncompressedJsBytes, firstLoadChunkPaths }.
+ *  - `.next/server/app/<route>.html` : les feuilles CSS du first-load d'une route prérendue.
+ *  - les sourcemaps des chunks : pour asserter l'absence d'un package sur le first-load.
+ *
+ * Deux classes de sortie, volontairement distinctes :
+ *  - dépassement de budget → jugement, assouplissable par `--report-only` ;
+ *  - erreur de mesure (fichier absent, sourcemap introuvable, route inconnue) → toujours exit 1.
+ * Sinon un run vert serait indiscernable d'un run qui n'a rien mesuré.
+ *
+ * Usage : node ui/scripts/perf-budget.mjs [--report-only] [--json] [--ui-dir=…] [--config=…] [--out=…]
+ */
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { gzipSync } from "node:zlib"
+
+/** Erreur de mesure : la CI doit échouer même en `--report-only`. */
+export class MeasureError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = "MeasureError"
+  }
+}
+
+const DEFAULT_UI_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+export function readJsonFile(filePath, what) {
+  if (!existsSync(filePath)) {
+    throw new MeasureError(`${what} introuvable : ${filePath}`)
+  }
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"))
+  } catch (error) {
+    throw new MeasureError(`${what} illisible (${filePath}) : ${error.message}`)
+  }
+}
+
+export function readRouteStats(uiDir) {
+  const statsPath = path.join(uiDir, ".next", "diagnostics", "route-bundle-stats.json")
+  const stats = readJsonFile(statsPath, "route-bundle-stats.json (produit par `next build` de Next >= 16 ; lancer le build avant ce script)")
+  if (!Array.isArray(stats) || stats.length === 0) {
+    throw new MeasureError(`route-bundle-stats.json vide ou de forme inattendue : ${statsPath}`)
+  }
+  return stats
+}
+
+export function findRouteEntry(stats, route) {
+  const entry = stats.find((item) => item.route === route)
+  if (!entry) {
+    throw new MeasureError(
+      `route « ${route} » absente de route-bundle-stats.json. Routes connues les plus proches : ` +
+        `${
+          stats
+            .map((item) => item.route)
+            .filter((known) => known.startsWith(route.slice(0, 4)))
+            .slice(0, 5)
+            .join(", ") || "aucune"
+        }`
+    )
+  }
+  if (!Array.isArray(entry.firstLoadChunkPaths) || entry.firstLoadChunkPaths.length === 0) {
+    throw new MeasureError(`route « ${route} » sans firstLoadChunkPaths — format de Next inattendu`)
+  }
+  return entry
+}
+
+export function gzipSize(buffer, level) {
+  return gzipSync(buffer, { level }).byteLength
+}
+
+/** Somme gzip des chunks JS du first-load. Les chemins du JSON sont relatifs au dossier `ui`. */
+export function measureFirstLoadJs(uiDir, entry, level) {
+  let total = 0
+  for (const relPath of entry.firstLoadChunkPaths) {
+    const absPath = path.join(uiDir, relPath)
+    if (!existsSync(absPath)) {
+      throw new MeasureError(`chunk du first-load de « ${entry.route} » introuvable : ${absPath}`)
+    }
+    total += gzipSize(readFileSync(absPath), level)
+  }
+  return total
+}
+
+/**
+ * Toutes les feuilles CSS référencées par le HTML prérendu, dédoublonnées.
+ * On prend aussi les `rel="preload" as="style"` : Next en émet (constaté sur la home) et le
+ * navigateur les télécharge au premier chargement, donc elles pèsent dans le first-load.
+ */
+export function extractCssHrefs(html) {
+  const hrefs = []
+  for (const match of html.matchAll(/href="(\/_next\/[^"]+?\.css)"/g)) {
+    if (!hrefs.includes(match[1])) {
+      hrefs.push(match[1])
+    }
+  }
+  return hrefs
+}
+
+export function routeHtmlFile(route) {
+  return route === "/" ? "index.html" : `${route.replace(/^\//, "")}.html`
+}
+
+export function measureFirstLoadCss(uiDir, route, level) {
+  const htmlPath = path.join(uiDir, ".next", "server", "app", routeHtmlFile(route))
+  if (!existsSync(htmlPath)) {
+    throw new MeasureError(
+      `HTML prérendu de « ${route} » introuvable : ${htmlPath}. La route n'est probablement pas ` +
+        `prérendue — retirer « firstLoadCssGzip » de cette route dans le fichier de budgets.`
+    )
+  }
+  const hrefs = extractCssHrefs(readFileSync(htmlPath, "utf8"))
+  if (hrefs.length === 0) {
+    throw new MeasureError(`aucune feuille CSS trouvée dans ${htmlPath} — format de Next inattendu`)
+  }
+  let total = 0
+  for (const href of hrefs) {
+    const absPath = path.join(uiDir, ".next", href.replace(/^\/_next\//, ""))
+    if (!existsSync(absPath)) {
+      throw new MeasureError(`feuille CSS du first-load de « ${route} » introuvable : ${absPath}`)
+    }
+    total += gzipSize(readFileSync(absPath), level)
+  }
+  return { bytes: total, count: hrefs.length }
+}
+
+/**
+ * Turbopack nomme la sourcemap avec un hash différent de celui du chunk
+ * (`0u6odem8truz3.js` → `0p4wlissmmxc7.js.map`) : `chunk + ".map"` ne résout rien et ferait
+ * conclure à tort qu'un package est absent. On lit donc le commentaire `sourceMappingURL`.
+ */
+export function resolveSourceMapPath(chunkPath) {
+  const content = readFileSync(chunkPath, "utf8")
+  const matches = [...content.matchAll(/\/\/#\s*sourceMappingURL=(\S+)/g)]
+  if (matches.length === 0) {
+    throw new MeasureError(
+      `aucun commentaire sourceMappingURL dans ${chunkPath} — impossible d'asserter le contenu du ` + `chunk. Vérifier que « productionBrowserSourceMaps » est actif.`
+    )
+  }
+  const url = matches[matches.length - 1][1]
+  if (url.startsWith("data:")) {
+    throw new MeasureError(`sourcemap inline (data:) non gérée pour ${chunkPath}`)
+  }
+  const mapPath = path.resolve(path.dirname(chunkPath), url)
+  if (!existsSync(mapPath)) {
+    throw new MeasureError(`sourcemap déclarée par ${chunkPath} introuvable : ${mapPath}`)
+  }
+  return mapPath
+}
+
+/**
+ * Les sourcemaps de Turbopack sont indexées : `sources` est vide à la racine et le contenu réel
+ * vit dans `sections[].map.sources`. Lire `map.sources` seul renvoie [] et donc un faux « absent ».
+ *
+ * Une map peut légitimement n'avoir aucune source (chunk de code généré : runtime Turbopack,
+ * polyfills, injection de debugId) — c'est une mesure valide, pas une panne. En revanche une forme
+ * non reconnue (ni « sources » ni « sections ») est une panne : on échoue.
+ */
+export function readSourceMapSources(mapPath) {
+  const map = readJsonFile(mapPath, "sourcemap")
+  if (!Array.isArray(map.sources) && !Array.isArray(map.sections)) {
+    throw new MeasureError(
+      `sourcemap de forme non reconnue : ${mapPath}. Ni « sources » ni « sections » — le format de ` +
+        `sortie du bundler a probablement changé, l'assertion d'absence de package serait un faux négatif.`
+    )
+  }
+  const sources = []
+  if (Array.isArray(map.sources)) {
+    sources.push(...map.sources)
+  }
+  if (Array.isArray(map.sections)) {
+    for (const section of map.sections) {
+      if (Array.isArray(section?.map?.sources)) {
+        sources.push(...section.map.sources)
+      }
+    }
+  }
+  return sources
+}
+
+/**
+ * Un package est présent si un chemin source contient `node_modules/<pkg>/` (préfixe exact, pour
+ * qu'un homonyme comme `libphonenumber-js-mock` ne déclenche rien).
+ *
+ * Garde-fou d'observabilité : si aucun chunk de la route ne remonte la moindre source, la méthode
+ * est en panne (format changé, sourcemaps désactivées) et répondrait « package absent » sur tout.
+ * Le décompte des chunks réellement analysés est remonté dans le rapport.
+ */
+export function findForbiddenPackages(uiDir, chunkPaths, packages) {
+  const hits = new Map()
+  const jsChunks = chunkPaths.filter((relPath) => relPath.endsWith(".js"))
+  let chunksWithSources = 0
+  let sourceCount = 0
+
+  for (const relPath of jsChunks) {
+    const absPath = path.join(uiDir, relPath)
+    if (!existsSync(absPath)) {
+      throw new MeasureError(`chunk introuvable pour l'analyse des sources : ${absPath}`)
+    }
+    const sources = readSourceMapSources(resolveSourceMapPath(absPath))
+    if (sources.length > 0) {
+      chunksWithSources += 1
+      sourceCount += sources.length
+    }
+    for (const pkg of packages) {
+      if (sources.some((source) => source.includes(`node_modules/${pkg}/`))) {
+        const chunks = hits.get(pkg) ?? []
+        chunks.push(relPath)
+        hits.set(pkg, chunks)
+      }
+    }
+  }
+
+  if (jsChunks.length > 0 && sourceCount === 0) {
+    throw new MeasureError(
+      `aucune source exploitable sur les ${jsChunks.length} chunks analysés : l'assertion d'absence ` +
+        `de package n'a rien pu vérifier. Cause probable : sourcemaps désactivées ou format de map changé.`
+    )
+  }
+
+  return { hits, chunksAnalysed: jsChunks.length, chunksWithSources, sourceCount }
+}
+
+function judge(measured, budget) {
+  if (budget === null || budget === undefined) {
+    return "unset"
+  }
+  return measured > budget ? "over" : "ok"
+}
+
+export function evaluate({ uiDir, config }) {
+  const level = config.gzipLevel ?? 9
+  const stats = readRouteStats(uiDir)
+  const rows = []
+  const forbidden = []
+  const scans = []
+
+  for (const [route, budgets] of Object.entries(config.routes ?? {})) {
+    const entry = findRouteEntry(stats, route)
+    const jsGzip = measureFirstLoadJs(uiDir, entry, level)
+    rows.push({
+      label: `JS first-load ${route}`,
+      route,
+      kind: "js",
+      measured: jsGzip,
+      budget: budgets.firstLoadJsGzip,
+      status: judge(jsGzip, budgets.firstLoadJsGzip),
+      detail: `${entry.firstLoadChunkPaths.length} chunks`,
+    })
+
+    if ("firstLoadCssGzip" in budgets) {
+      const css = measureFirstLoadCss(uiDir, route, level)
+      rows.push({
+        label: `CSS first-load ${route}`,
+        route,
+        kind: "css",
+        measured: css.bytes,
+        budget: budgets.firstLoadCssGzip,
+        status: judge(css.bytes, budgets.firstLoadCssGzip),
+        detail: `${css.count} feuilles`,
+      })
+    }
+
+    const packages = config.forbiddenOnFirstLoad?.[route] ?? []
+    if (packages.length > 0) {
+      const { hits, chunksAnalysed, chunksWithSources, sourceCount } = findForbiddenPackages(uiDir, entry.firstLoadChunkPaths, packages)
+      for (const pkg of packages) {
+        forbidden.push({ route, pkg, chunks: hits.get(pkg) ?? [] })
+      }
+      scans.push({ route, chunksAnalysed, chunksWithSources, sourceCount })
+    }
+  }
+
+  const worst = stats.reduce((max, item) => (item.firstLoadUncompressedJsBytes > max.firstLoadUncompressedJsBytes ? item : max))
+  rows.push({
+    label: "JS first-load max (toutes routes, brut)",
+    route: worst.route,
+    kind: "global",
+    measured: worst.firstLoadUncompressedJsBytes,
+    budget: config.globalMaxFirstLoadJsRaw,
+    status: judge(worst.firstLoadUncompressedJsBytes, config.globalMaxFirstLoadJsRaw),
+    detail: worst.route,
+  })
+
+  return {
+    gzipLevel: level,
+    routeCount: stats.length,
+    rows,
+    forbidden,
+    scans,
+    violations: [
+      ...rows.filter((row) => row.status === "over").map((row) => row.label),
+      ...forbidden.filter((item) => item.chunks.length > 0).map((item) => `${item.pkg} sur ${item.route}`),
+    ],
+    unset: rows.filter((row) => row.status === "unset").map((row) => row.label),
+  }
+}
+
+export function formatKo(bytes) {
+  return `${(bytes / 1024).toFixed(1).replace(".", ",")} ko`
+}
+
+const STATUS_ICON = { ok: "✅", over: "⚠️", unset: "❔" }
+
+export function formatMarkdown(report, { configPath, reportOnly }) {
+  const lines = ["### 📦 Budget de performance du first-load", "", `| | Métrique | Mesure | Budget | Marge |`, `|---|---|---|---|---|`]
+  for (const row of report.rows) {
+    const budget = row.budget === null || row.budget === undefined ? "—" : formatKo(row.budget)
+    const margin = row.budget === null || row.budget === undefined ? "—" : `${(((row.budget - row.measured) / row.budget) * 100).toFixed(1).replace(".", ",")} %`
+    lines.push(`| ${STATUS_ICON[row.status]} | ${row.label} | ${formatKo(row.measured)} | ${budget} | ${margin} |`)
+  }
+  const scanFootnote = report.scans.map((scan) => `${scan.route} : ${scan.chunksWithSources}/${scan.chunksAnalysed} chunks tracés (${scan.sourceCount} sources)`).join(" · ")
+  lines.push("", `<sub>gzip niveau ${report.gzipLevel} · ${report.routeCount} routes analysées${scanFootnote ? ` · ${scanFootnote}` : ""}</sub>`)
+
+  if (report.forbidden.length > 0) {
+    lines.push("", "**Packages interdits sur le first-load**", "")
+    for (const item of report.forbidden) {
+      lines.push(
+        item.chunks.length === 0
+          ? `- ✅ \`${item.pkg}\` absent de ${item.route}`
+          : `- ⚠️ \`${item.pkg}\` présent sur ${item.route} — chunks : ${item.chunks.map((chunk) => `\`${path.basename(chunk)}\``).join(", ")}`
+      )
+    }
+  }
+
+  if (report.unset.length > 0) {
+    lines.push(
+      "",
+      `> ❔ **${report.unset.length} budget(s) non renseigné(s)** dans \`${configPath}\` : rien n'est ` +
+        `contrôlé pour ces lignes. Reporter les mesures ci-dessus (+ marge) pour activer le garde-fou.`
+    )
+  }
+
+  if (report.violations.length > 0) {
+    lines.push(
+      "",
+      reportOnly
+        ? `> ⚠️ **${report.violations.length} dépassement(s)** — mode informatif, la CI ne bloque pas. ` +
+            `Si la hausse est assumée, relever le seuil dans \`${configPath}\` et le justifier en description de PR.`
+        : `> ⛔ **${report.violations.length} dépassement(s)** — job en échec.`
+    )
+  }
+
+  return lines.join("\n")
+}
+
+function budgetFailureMessage(report, configPath) {
+  return [
+    `Budget de performance dépassé : ${report.violations.join(", ")}.`,
+    "",
+    "Deux issues :",
+    "  1. réduire le bundle (import ciblé plutôt qu'un barrel, composant DSFR en moins, lazy-load) ;",
+    `  2. si la hausse est assumée, mettre à jour le seuil dans ${configPath} avec la mesure`,
+    "     affichée ci-dessus, et justifier la hausse en description de PR.",
+    "",
+    `Clés concernées : ${
+      report.rows
+        .filter((row) => row.status === "over")
+        .map((row) => (row.kind === "global" ? "globalMaxFirstLoadJsRaw" : `routes["${row.route}"].firstLoad${row.kind === "js" ? "Js" : "Css"}Gzip`))
+        .join(", ") || "forbiddenOnFirstLoad"
+    }`,
+  ].join("\n")
+}
+
+export function main(argv = []) {
+  const flags = new Set(argv.filter((arg) => !arg.includes("=")))
+  const options = Object.fromEntries(argv.filter((arg) => arg.includes("=")).map((arg) => [arg.slice(0, arg.indexOf("=")), arg.slice(arg.indexOf("=") + 1)]))
+  const reportOnly = flags.has("--report-only")
+  const uiDir = path.resolve(options["--ui-dir"] ?? DEFAULT_UI_DIR)
+  const configPath = path.resolve(options["--config"] ?? path.join(uiDir, "perf-budget.json"))
+
+  let report
+  try {
+    report = evaluate({ uiDir, config: readJsonFile(configPath, "fichier de budgets") })
+  } catch (error) {
+    if (error instanceof MeasureError) {
+      // Erreur de mesure : jamais assouplie par --report-only.
+      console.error(`❌ mesure impossible — ${error.message}`)
+      return 1
+    }
+    throw error
+  }
+
+  const displayConfigPath = path.relative(process.cwd(), configPath) || configPath
+  const markdown = formatMarkdown(report, { configPath: displayConfigPath, reportOnly })
+  if (flags.has("--json")) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    console.log(markdown)
+  }
+  if (options["--out"]) {
+    writeFileSync(options["--out"], `${markdown}\n`)
+  }
+
+  if (report.violations.length > 0) {
+    console.error(`\n${budgetFailureMessage(report, displayConfigPath)}`)
+    if (!reportOnly) {
+      return 1
+    }
+  }
+  if (report.unset.length > 0) {
+    console.error(`\n⚠️ budget(s) non renseigné(s) : ${report.unset.join(", ")} — aucun contrôle sur ces lignes.`)
+    if (!reportOnly) {
+      return 1
+    }
+  }
+  return 0
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(main(process.argv.slice(2)))
+}

--- a/ui/scripts/perf-budget.test.ts
+++ b/ui/scripts/perf-budget.test.ts
@@ -3,7 +3,19 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { evaluate, extractCssHrefs, findForbiddenPackages, MeasureError, main, readSourceMapSources, routeHtmlFile } from "./perf-budget.mjs"
+import {
+  concernedConfigKeys,
+  evaluate,
+  extractCssHrefs,
+  findForbiddenPackages,
+  MeasureError,
+  main,
+  parseArgv,
+  readSourceMapSources,
+  routeHtmlFile,
+  UsageError,
+  validateConfig,
+} from "./perf-budget.mjs"
 
 type ChunkSpec = {
   /** Nom du fichier chunk, ex. "aaa.js". */
@@ -311,5 +323,89 @@ describe("jugement des seuils", () => {
     expect(global.route).toBe("/lourd")
     expect(global.measured).toBe(9_000)
     expect(report.violations).toEqual(["JS first-load max (toutes routes, brut)"])
+  })
+})
+
+describe("validation du fichier de budgets — un contrôle muet est un bug", () => {
+  /** Build où `libphonenumber-js` est réellement présent : les cas ci-dessous ne sont pas vacuous. */
+  function buildWithForbiddenPackage() {
+    makeBuild({
+      chunks: [{ name: "home.js", sources: [PHONE_SOURCE] }],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+    })
+  }
+
+  it("échoue quand « forbiddenOnFirstLoad » cite une route absente de « routes »", () => {
+    // Sans garde, la route n'est jamais scannée : le package interdit passe et le job sort vert.
+    buildWithForbiddenPackage()
+    const config = { routes: {}, globalMaxFirstLoadJsRaw: 10_000, forbiddenOnFirstLoad: { "/": ["libphonenumber-js"] } }
+
+    expect(run(config, ["--report-only"])).toBe(1)
+    expect(() => validateConfig(config)).toThrow(UsageError)
+  })
+
+  it("échoue sur une clé racine mal orthographiée plutôt que de n'en contrôler aucune", () => {
+    buildWithForbiddenPackage()
+
+    expect(run({ routs: { "/": { firstLoadJsGzip: 1 } }, globalMaxFirstLoadJsRaw: 10_000 }, ["--report-only"])).toBe(1)
+    expect(run({ routes: { "/": { firstLoadJsGzip: 1 } }, forbidenOnFirstLoad: { "/": ["libphonenumber-js"] } }, ["--report-only"])).toBe(1)
+  })
+
+  it("accepte les clés de commentaire $comment et $measured", () => {
+    buildWithForbiddenPackage()
+    const config = { $comment: "…", $measured: { commit: "abc" }, routes: { "/": { firstLoadJsGzip: 10_000 } }, globalMaxFirstLoadJsRaw: 10_000 }
+
+    expect(() => validateConfig(config)).not.toThrow()
+    expect(run(config)).toBe(0)
+  })
+
+  it("échoue quand ni « routes » ni « globalMaxFirstLoadJsRaw » ne sont renseignés", () => {
+    buildWithForbiddenPackage()
+
+    expect(run({ routes: {} }, ["--report-only"])).toBe(1)
+  })
+})
+
+describe("arguments de ligne de commande", () => {
+  beforeEach(() => {
+    makeBuild({
+      chunks: [{ name: "home.js", sources: ["turbopack:///[project]/ui/app/page.tsx"] }],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+    })
+  })
+
+  it("rejette un flag mal orthographié au lieu de basculer en mode bloquant en silence", () => {
+    // Un parseur permissif ignore `--reportonly` et repasse en mode bloquant : le code de sortie
+    // est le même (1) que celui du rejet, seule la cause diffère. On assert donc l'erreur elle-même.
+    const config = { routes: { "/": { firstLoadJsGzip: 1 } }, globalMaxFirstLoadJsRaw: 10_000 }
+
+    expect(() => parseArgv(["--reportonly"])).toThrow(UsageError)
+    expect(run(config, ["--reportonly"])).toBe(1)
+    expect(run(config, ["--report-only"])).toBe(0)
+  })
+
+  it("rejette une option sans valeur au lieu de perdre le rapport en silence", () => {
+    expect(run({ routes: { "/": { firstLoadJsGzip: 10_000 } }, globalMaxFirstLoadJsRaw: 10_000 }, ["--out="])).toBe(1)
+  })
+
+  it("sort 0 en mode strict quand tous les seuils sont renseignés et tenus", () => {
+    // Chemin exact de la bascule en bloquant : il ne doit pas échouer sur un « unset » oublié.
+    expect(run({ routes: { "/": { firstLoadJsGzip: 10_000 } }, globalMaxFirstLoadJsRaw: 10_000 })).toBe(0)
+  })
+})
+
+describe("message d'échec", () => {
+  it("cumule les clés de seuil et les clés de packages interdits", () => {
+    makeBuild({
+      chunks: [{ name: "home.js", sources: [PHONE_SOURCE] }],
+      routes: [{ route: "/", chunks: ["home.js"], rawBytes: 9_000 }],
+    })
+
+    const report = evaluate({
+      uiDir,
+      config: { routes: { "/": { firstLoadJsGzip: 1 } }, globalMaxFirstLoadJsRaw: 8_999, forbiddenOnFirstLoad: { "/": ["libphonenumber-js"] } },
+    })
+
+    expect(concernedConfigKeys(report)).toEqual(['routes["/"].firstLoadJsGzip', "globalMaxFirstLoadJsRaw", 'forbiddenOnFirstLoad["/"]'])
   })
 })

--- a/ui/scripts/perf-budget.test.ts
+++ b/ui/scripts/perf-budget.test.ts
@@ -1,0 +1,315 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { evaluate, extractCssHrefs, findForbiddenPackages, MeasureError, main, readSourceMapSources, routeHtmlFile } from "./perf-budget.mjs"
+
+type ChunkSpec = {
+  /** Nom du fichier chunk, ex. "aaa.js". */
+  name: string
+  /** Nom du fichier map. Volontairement différent du chunk : c'est ce que fait Turbopack. */
+  mapName?: string | null
+  /** Chemins sources tels qu'ils apparaissent dans la sourcemap. */
+  sources?: string[]
+  /** Map "indexée" (sections[].map.sources) comme Turbopack, ou map plate. */
+  indexed?: boolean
+  /** Écrit une map de forme non reconnue (ni sources ni sections). */
+  unknownShape?: boolean
+}
+
+type BuildSpec = {
+  chunks: ChunkSpec[]
+  routes: { route: string; chunks: string[]; rawBytes?: number }[]
+  html?: Record<string, string>
+}
+
+let uiDir: string
+
+function writeChunk(spec: ChunkSpec) {
+  const chunkPath = path.join(uiDir, ".next", "static", "chunks", spec.name)
+  const mapName = spec.mapName === undefined ? spec.name.replace(/\.js$/, ".map-hash-differente.js.map") : spec.mapName
+  const body = `console.log("${spec.name}");${"/* padding compressible */".repeat(20)}\n`
+  writeFileSync(chunkPath, mapName === null ? body : `${body}//# sourceMappingURL=${mapName}\n`)
+
+  if (mapName === null) {
+    return
+  }
+  const sources = spec.sources ?? []
+  const map = spec.unknownShape
+    ? { version: 3, unexpected: true }
+    : spec.indexed === false
+      ? { version: 3, sources }
+      : { version: 3, sources: [], sections: [{ offset: { line: 0, column: 0 }, map: { version: 3, sources } }] }
+  writeFileSync(path.join(uiDir, ".next", "static", "chunks", mapName), JSON.stringify(map))
+}
+
+function makeBuild(spec: BuildSpec) {
+  mkdirSync(path.join(uiDir, ".next", "static", "chunks"), { recursive: true })
+  mkdirSync(path.join(uiDir, ".next", "diagnostics"), { recursive: true })
+  mkdirSync(path.join(uiDir, ".next", "server", "app"), { recursive: true })
+
+  for (const chunk of spec.chunks) {
+    writeChunk(chunk)
+  }
+  writeFileSync(
+    path.join(uiDir, ".next", "diagnostics", "route-bundle-stats.json"),
+    JSON.stringify(
+      spec.routes.map((route) => ({
+        route: route.route,
+        firstLoadUncompressedJsBytes: route.rawBytes ?? 1000,
+        firstLoadChunkPaths: route.chunks.map((name) => path.join(".next", "static", "chunks", name)),
+      }))
+    )
+  )
+  for (const [file, content] of Object.entries(spec.html ?? {})) {
+    writeFileSync(path.join(uiDir, ".next", "server", "app", file), content)
+  }
+}
+
+function writeConfig(config: unknown) {
+  const configPath = path.join(uiDir, "perf-budget.json")
+  writeFileSync(configPath, JSON.stringify(config))
+  return configPath
+}
+
+function run(config: unknown, flags: string[] = []) {
+  const configPath = writeConfig(config)
+  return main([`--ui-dir=${uiDir}`, `--config=${configPath}`, ...flags])
+}
+
+const PHONE_SOURCE = "turbopack:///[project]/node_modules/libphonenumber-js/min/exports/parsePhoneNumber.js"
+
+beforeEach(() => {
+  uiDir = mkdtempSync(path.join(tmpdir(), "perf-budget-"))
+  vi.spyOn(console, "log").mockImplementation(() => undefined)
+  vi.spyOn(console, "error").mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  rmSync(uiDir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+describe("détection d'un package sur le first-load — faux positifs d'abord", () => {
+  it("ne signale pas un package présent seulement dans un chunk hors first-load (near-miss)", () => {
+    makeBuild({
+      chunks: [
+        { name: "home.js", sources: ["turbopack:///[project]/ui/app/page.tsx"] },
+        { name: "ailleurs.js", sources: [PHONE_SOURCE] },
+      ],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+    })
+
+    const report = evaluate({
+      uiDir,
+      config: { routes: { "/": { firstLoadJsGzip: null } }, forbiddenOnFirstLoad: { "/": ["libphonenumber-js"] } },
+    })
+
+    expect(report.forbidden).toEqual([{ route: "/", pkg: "libphonenumber-js", chunks: [] }])
+    expect(report.violations).toEqual([])
+  })
+
+  it("ne confond pas un homonyme plus long (libphonenumber-js-mock) avec le package interdit", () => {
+    makeBuild({
+      chunks: [{ name: "home.js", sources: ["turbopack:///[project]/node_modules/libphonenumber-js-mock/index.js"] }],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+    })
+
+    const report = evaluate({
+      uiDir,
+      config: { routes: { "/": { firstLoadJsGzip: null } }, forbiddenOnFirstLoad: { "/": ["libphonenumber-js"] } },
+    })
+
+    expect(report.forbidden[0].chunks).toEqual([])
+  })
+
+  it("détecte le package même quand la sourcemap porte un hash différent du chunk", () => {
+    // Non-vacuité : avec un `chunk + ".map"` naïf, aucune map n'est résolue et ce test échoue.
+    makeBuild({
+      chunks: [{ name: "home.js", mapName: "tout-autre-hash.js.map", sources: [PHONE_SOURCE] }],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+    })
+
+    const report = evaluate({
+      uiDir,
+      config: { routes: { "/": { firstLoadJsGzip: null } }, forbiddenOnFirstLoad: { "/": ["libphonenumber-js"] } },
+    })
+
+    expect(report.forbidden[0].chunks).toEqual([path.join(".next", "static", "chunks", "home.js")])
+    expect(report.violations).toEqual(["libphonenumber-js sur /"])
+  })
+
+  it("lit les sources d'une map indexée comme d'une map plate", () => {
+    makeBuild({
+      chunks: [
+        { name: "indexed.js", sources: [PHONE_SOURCE], indexed: true },
+        { name: "plate.js", sources: [PHONE_SOURCE], indexed: false },
+      ],
+      routes: [{ route: "/", chunks: ["indexed.js", "plate.js"] }],
+    })
+
+    const { hits } = findForbiddenPackages(uiDir, [path.join(".next", "static", "chunks", "indexed.js"), path.join(".next", "static", "chunks", "plate.js")], ["libphonenumber-js"])
+
+    expect(hits.get("libphonenumber-js")).toHaveLength(2)
+  })
+
+  it("tolère un chunk généré sans aucune source dès qu'un autre chunk est tracé", () => {
+    makeBuild({
+      chunks: [
+        { name: "runtime.js", sources: [] },
+        { name: "home.js", sources: [PHONE_SOURCE] },
+      ],
+      routes: [{ route: "/", chunks: ["runtime.js", "home.js"] }],
+    })
+
+    const scan = findForbiddenPackages(uiDir, [path.join(".next", "static", "chunks", "runtime.js"), path.join(".next", "static", "chunks", "home.js")], ["libphonenumber-js"])
+
+    expect(scan.chunksAnalysed).toBe(2)
+    expect(scan.chunksWithSources).toBe(1)
+    expect(scan.hits.get("libphonenumber-js")).toHaveLength(1)
+  })
+})
+
+describe("erreurs de mesure — jamais assouplies par --report-only", () => {
+  it("échoue quand un chunk ne déclare aucune sourcemap", () => {
+    makeBuild({
+      chunks: [{ name: "home.js", mapName: null }],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+    })
+
+    expect(run({ routes: { "/": { firstLoadJsGzip: null } }, forbiddenOnFirstLoad: { "/": ["libphonenumber-js"] } }, ["--report-only"])).toBe(1)
+  })
+
+  it("échoue quand aucun chunk de la route n'a de source exploitable", () => {
+    makeBuild({
+      chunks: [
+        { name: "a.js", sources: [] },
+        { name: "b.js", sources: [] },
+      ],
+      routes: [{ route: "/", chunks: ["a.js", "b.js"] }],
+    })
+
+    expect(run({ routes: { "/": { firstLoadJsGzip: null } }, forbiddenOnFirstLoad: { "/": ["libphonenumber-js"] } }, ["--report-only"])).toBe(1)
+  })
+
+  it("échoue sur une sourcemap de forme non reconnue", () => {
+    makeBuild({
+      chunks: [{ name: "home.js", unknownShape: true }],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+    })
+
+    expect(() => readSourceMapSources(path.join(uiDir, ".next", "static", "chunks", "home.map-hash-differente.js.map"))).toThrow(MeasureError)
+  })
+
+  it("échoue quand la route demandée est absente des stats", () => {
+    makeBuild({
+      chunks: [{ name: "home.js", sources: ["turbopack:///[project]/ui/app/page.tsx"] }],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+    })
+
+    expect(run({ routes: { "/inconnue": { firstLoadJsGzip: null } } }, ["--report-only"])).toBe(1)
+  })
+
+  it("échoue quand route-bundle-stats.json est absent", () => {
+    mkdirSync(path.join(uiDir, ".next"), { recursive: true })
+
+    expect(run({ routes: { "/": { firstLoadJsGzip: null } } }, ["--report-only"])).toBe(1)
+  })
+
+  it("échoue quand un budget CSS est demandé sur une route sans HTML prérendu", () => {
+    makeBuild({
+      chunks: [{ name: "home.js", sources: ["turbopack:///[project]/ui/app/page.tsx"] }],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+    })
+
+    expect(run({ routes: { "/": { firstLoadJsGzip: null, firstLoadCssGzip: null } } }, ["--report-only"])).toBe(1)
+  })
+})
+
+describe("feuilles CSS du first-load", () => {
+  it("compte les stylesheet et les preload as=style, sans doublon", () => {
+    const html = `<link rel="stylesheet" href="/_next/static/chunks/a.css" data-precedence="next"/>
+      <link rel="preload" href="/_next/static/chunks/b.css" as="style"/>
+      <link rel="stylesheet" href="/_next/static/chunks/a.css"/>
+      <script src="/_next/static/chunks/x.js"></script>`
+
+    expect(extractCssHrefs(html)).toEqual(["/_next/static/chunks/a.css", "/_next/static/chunks/b.css"])
+  })
+
+  it("mesure les feuilles référencées par le HTML de la route", () => {
+    makeBuild({
+      chunks: [{ name: "home.js", sources: ["turbopack:///[project]/ui/app/page.tsx"] }],
+      routes: [{ route: "/", chunks: ["home.js"] }],
+      html: {
+        "index.html": `<link rel="stylesheet" href="/_next/static/chunks/dsfr.css"/><link rel="preload" href="/_next/static/chunks/page.css" as="style"/>`,
+      },
+    })
+    writeFileSync(path.join(uiDir, ".next", "static", "chunks", "dsfr.css"), ".a{color:red}".repeat(500))
+    writeFileSync(path.join(uiDir, ".next", "static", "chunks", "page.css"), ".b{color:blue}".repeat(10))
+
+    const report = evaluate({ uiDir, config: { routes: { "/": { firstLoadJsGzip: null, firstLoadCssGzip: null } } } })
+    const css = report.rows.find((row) => row.kind === "css")
+
+    expect(css.detail).toBe("2 feuilles")
+    expect(css.measured).toBeGreaterThan(0)
+  })
+
+  it("mappe la route sur son fichier HTML", () => {
+    expect(routeHtmlFile("/")).toBe("index.html")
+    expect(routeHtmlFile("/recherche")).toBe("recherche.html")
+  })
+})
+
+describe("jugement des seuils", () => {
+  function buildAtSize() {
+    makeBuild({
+      chunks: [{ name: "home.js", sources: ["turbopack:///[project]/ui/app/page.tsx"] }],
+      routes: [{ route: "/", chunks: ["home.js"], rawBytes: 2_000 }],
+    })
+    return evaluate({ uiDir, config: { routes: { "/": { firstLoadJsGzip: null } } } }).rows[0].measured
+  }
+
+  it("passe quand la mesure est pile au seuil, dépasse à un octet près", () => {
+    const measured = buildAtSize()
+
+    expect(evaluate({ uiDir, config: { routes: { "/": { firstLoadJsGzip: measured } } } }).violations).toEqual([])
+    expect(evaluate({ uiDir, config: { routes: { "/": { firstLoadJsGzip: measured - 1 } } } }).violations).toEqual(["JS first-load /"])
+  })
+
+  it("n'échoue pas en --report-only mais échoue en mode strict", () => {
+    const measured = buildAtSize()
+    const config = { routes: { "/": { firstLoadJsGzip: measured - 1 } } }
+
+    expect(run(config, ["--report-only"])).toBe(0)
+    expect(run(config)).toBe(1)
+  })
+
+  it("signale un seuil non renseigné, et échoue en mode strict", () => {
+    buildAtSize()
+    const config = { routes: { "/": { firstLoadJsGzip: null } } }
+
+    expect(run(config, ["--report-only"])).toBe(0)
+    expect(run(config)).toBe(1)
+  })
+
+  it("retient la route la plus lourde pour le plafond global", () => {
+    makeBuild({
+      chunks: [
+        { name: "home.js", sources: ["turbopack:///[project]/ui/app/page.tsx"] },
+        { name: "lourd.js", sources: ["turbopack:///[project]/ui/app/lourd/page.tsx"] },
+      ],
+      routes: [
+        { route: "/", chunks: ["home.js"], rawBytes: 1_000 },
+        { route: "/lourd", chunks: ["lourd.js"], rawBytes: 9_000 },
+      ],
+    })
+
+    const report = evaluate({ uiDir, config: { routes: {}, globalMaxFirstLoadJsRaw: 8_999 } })
+    const global = report.rows.find((row) => row.kind === "global")
+
+    expect(global.route).toBe("/lourd")
+    expect(global.measured).toBe(9_000)
+    expect(report.violations).toEqual(["JS first-load max (toutes routes, brut)"])
+  })
+})


### PR DESCRIPTION
Closes #5191

## Contexte

Le chantier perf (CSS DSFR −36 %, JS home −51 ko) n'avait aucun garde-fou : un import barrel `shared` mal placé ou un composant DSFR ajouté regrossit le bundle sans que personne ne le voie.

Aucune action GitHub du marché ne convient ici, et c'est structurel : le build sort en **Turbopack**.

| Outil évalué | Verdict | Raison vérifiée |
|---|---|---|
| `hashicorp/nextjs-bundle-analysis` | inopérant | lit `build-manifest.json.pages`, qui vaut `{"/_app": []}` sur ce repo → zéro route |
| `transferwise/actions-next-bundle-analyzer` | inopérant | même manifest + `react-loadable-manifest.json`, absent sous Turbopack |
| RelativeCI / Codecov bundle plugin / `webpack-bundle-analyzer` | inopérant | reposent sur des stats webpack, qui ne sont plus produites |
| `preactjs/compressed-size-action` | inadapté | apparie les fichiers par nom ; les noms Turbopack sont des hashs intégraux qui changent à chaque build |
| `size-limit` / `bundlewatch` | partiel | globs uniquement, n'expriment pas « first-load de la route / » |

En revanche Next 16.3 écrit lui-même `.next/diagnostics/route-bundle-stats.json` (`writeRouteBundleStats`, appelé sans condition par `next build`) : c'est exactement la métrique demandée, en source machine. D'où un script maison sans dépendance plutôt qu'un outil tiers.

## Changements

- `ui/scripts/perf-budget.mjs` : mesure le JS et le CSS du first-load, gzip niveau 9, et vérifie l'absence de packages interdits sur le first-load de la home via les sourcemaps.
- `ui/perf-budget.json` : seuils versionnés, avec les mesures de référence qui ont servi à les fixer.
- `.github/workflows/perf_budget.yml` : build UI + mesure + commentaire de PR, sur `pull_request` filtré (`ui/**`, `shared/**`, `yarn.lock`) et sur `merge_group`.
- `ui/scripts/perf-budget.test.ts` : 18 tests, cas de faux positifs en premier.

Mesures sur un build de production de `23457dcc1` :

| | Métrique | Mesure | Budget | Marge |
|---|---|---|---|---|
| ✅ | JS first-load `/` | 491,9 ko | 512,0 ko | 3,9 % |
| ✅ | CSS first-load `/` | 63,5 ko | 66,0 ko | 3,7 % |
| ✅ | JS first-load `/recherche` | 591,0 ko | 610,0 ko | 3,1 % |
| ✅ | JS max toutes routes (brut) | 2400,1 ko | 2500,0 ko | 4,0 % |
| ✅ | `libphonenumber-js` absent de `/` | — | — | — |

Le script mesure le CSS de la home à 63,5 ko, contre 63,6 ko trouvés indépendamment lors du chantier CSS DSFR : deux méthodes distinctes, même résultat.

## Choix à discuter

- **Mode informatif d'abord** : un dépassement de seuil affiche un ⚠️ mais ne bloque pas. Basculer en bloquant = retirer `--report-only` dans le workflow, et cocher le check requis côté réglages du repo. Le mode strict passe déjà, donc la bascule ne cassera rien.
- **Une erreur de mesure échoue toujours**, même en mode informatif (fichier de stats absent, route inconnue, sourcemap non résolue). Sinon un run vert serait indiscernable d'un run qui n'a rien mesuré.
- **Pas de diff vs `main`** : cela demanderait un second build. Le commentaire affiche mesure / seuil / marge.
- `zod` n'est pas encore dans `forbiddenOnFirstLoad` : à ajouter quand il aura quitté le first-load de la home.
- `/postuler` (591 ko, à égalité avec `/recherche`) n'est pas dans les routes nommées — à ajouter si vous le jugez utile.

## Deux pièges Turbopack, neutralisés dans le script

- Les sourcemaps portent **un hash différent du chunk** (`0u6odem8truz3.js` → `0p4wlissmmxc7.js.map`) : un `chunk + ".map"` naïf ne résout rien et conclut à tort « package absent ». Le script lit le commentaire `sourceMappingURL`.
- Les sourcemaps sont **indexées** : `sources` est vide à la racine, le contenu réel vit dans `sections[].map.sources`. Lire `sources` seul donne un tableau vide, donc un faux négatif silencieux.

Les deux cas sont couverts par des tests qui échouent si on réintroduit le bug.

## Plan de test

- [ ] Le workflow « Budget de performance » tourne sur cette PR et poste un commentaire avec le tableau des mesures.
- [ ] Les mesures du runner Linux sont proches de celles ci-dessus (les marges de 3-4 % doivent absorber l'écart de plateforme) — sinon réajuster les seuils.
- [ ] `yarn vitest run --project ui ui/scripts/perf-budget.test.ts` → 18 tests passent.
- [ ] `node ui/scripts/perf-budget.mjs` après un `yarn workspace ui build` local → sortie identique au tableau, exit 0.
- [ ] Vérifier que le job est bien ignoré sur une PR qui ne touche ni `ui/**` ni `shared/**`.