### PR TITLE
feat: corrige les liens traininglinks pour le nouveau moteur de recherche (#5197)

### DIFF
--- a/server/src/jobs/search/analyze-search-queries.ts
+++ b/server/src/jobs/search/analyze-search-queries.ts
@@ -66,8 +66,11 @@ async function aggregateQueryStats(): Promise<IQueryStats[]> {
     .aggregate<IQueryStats>([
       // status=error exclu : nb_hits est alors null (recherche non aboutie, aucun signal de
       // pertinence) — l'inclure gonflerait `total` sans jamais compter dans `zero_hits_count`,
-      // ce qui ferait paraître le terme plus pertinent qu'il ne l'est (cf. #5166).
-      { $match: { created_at: { $gte: since }, status: { $ne: "error" } } },
+      // ce qui ferait paraître le terme plus pertinent qu'il ne l'est (cf. #5166). Même logique
+      // pour source=training_links : trafic synthétique (liens générés côté serveur pour les
+      // vœux Parcoursup), pas des recherches organiques — l'inclure biaiserait les stats qui
+      // nourrissent le moteur de suggestion avec du volume qui ne reflète pas l'usage réel.
+      { $match: { created_at: { $gte: since }, status: { $ne: "error" }, source: { $ne: "training_links" } } },
       {
         $group: {
           _id: "$q_normalized",

--- a/server/src/services/referentiel/commune/commune.referentiel.service.ts
+++ b/server/src/services/referentiel/commune/commune.referentiel.service.ts
@@ -91,14 +91,12 @@ export async function getNearestCommuneByGeoPoint(geo: IGeoPoint): Promise<IRefe
   return commune
 }
 
-export async function getCommuneByCodeInsee(code: string): Promise<IReferentielCommune | null> {
-  return await getDbCollection("referentiel.communes").findOne({
-    code,
-  })
+type ICommuneCentreLabel = Pick<IReferentielCommune, "centre" | "nom">
+
+export async function getCommuneByCodeInsee(code: string): Promise<ICommuneCentreLabel | null> {
+  return await getDbCollection("referentiel.communes").findOne({ code }, { projection: { centre: 1, nom: 1 } })
 }
 
-export async function getCommuneByCodePostal(codePostal: string): Promise<IReferentielCommune | null> {
-  return await getDbCollection("referentiel.communes").findOne({
-    codesPostaux: codePostal,
-  })
+export async function getCommuneByCodePostal(codePostal: string): Promise<ICommuneCentreLabel | null> {
+  return await getDbCollection("referentiel.communes").findOne({ codesPostaux: codePostal }, { projection: { centre: 1, nom: 1 } })
 }

--- a/server/src/services/search/search-query-log.service.ts
+++ b/server/src/services/search/search-query-log.service.ts
@@ -47,7 +47,7 @@ type SearchQuerystring = {
   latitude?: number
   longitude?: number
   radius?: number
-  source?: "suggestion" | "free_text"
+  source?: "suggestion" | "free_text" | "training_links"
 }
 
 // Arrondi à 1 décimale (~11 km) : suffisant pour "quelle zone cherche quoi", inexploitable

--- a/server/src/services/training-links.service.test.ts
+++ b/server/src/services/training-links.service.test.ts
@@ -2,7 +2,7 @@ import { useMongo } from "@tests/utils/mongo.test.utils"
 import { saveDbEntity } from "@tests/utils/user.test.utils"
 import { ObjectId } from "bson"
 import { parisFixture } from "shared/fixtures/referentiel/commune.fixture"
-import { zFormationCatalogueSchema } from "shared/models/index"
+import { ZReferentielRome, zFormationCatalogueSchema } from "shared/models/index"
 import { describe, expect, it } from "vitest"
 import type { z } from "zod"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
@@ -13,16 +13,23 @@ useMongo()
 const saveFormation = (data: Partial<z.input<typeof zFormationCatalogueSchema>>) =>
   saveDbEntity(zFormationCatalogueSchema, (item) => getDbCollection("formationcatalogues").insertOne(item), data)
 
+const saveRome = (code_rome: string, intitule: string) =>
+  saveDbEntity(ZReferentielRome, (item) => getDbCollection("referentielromes").insertOne(item), {
+    rome: { code_rome, intitule, code_ogr: code_rome },
+  })
+
 const saveCommune = async () => {
   await getDbCollection("referentiel.communes").insertOne({ _id: new ObjectId(), ...parisFixture })
 }
 
 describe("getLBALink", () => {
-  it("uses the formation's intitule_long, localite and geopoint when a single formation matches", async () => {
+  it("prefers the ROME label over intitule_long as q when a rome code resolves", async () => {
+    await saveRome("D1102", "Boulangerie - viennoiserie")
     await saveFormation({
       cle_ministere_educatif: "CLE1",
       intitule_long: "Bac Pro Boulanger",
-      etablissement_formateur_localite: "Paris 6e",
+      rome_codes: ["D1102"],
+      localite: "Paris 6e",
       lieu_formation_geopoint: { type: "Point", coordinates: [2.35, 48.86] },
     })
 
@@ -31,15 +38,31 @@ describe("getLBALink", () => {
 
     expect(url.origin + url.pathname).toBe("http://localhost:3000/recherche")
     expect(url.searchParams.get("mode")).toBe("emplois")
-    expect(url.searchParams.get("q")).toBe("Bac Pro Boulanger")
+    expect(url.searchParams.get("q")).toBe("Boulangerie - viennoiserie")
     expect(url.searchParams.get("lieu_label")).toBe("Paris 6e")
     expect(url.searchParams.get("latitude")).toBe("48.86")
     expect(url.searchParams.get("longitude")).toBe("2.35")
     expect(url.searchParams.get("radius")).toBe("60")
+    expect(url.searchParams.get("source")).toBe("training_links")
     expect(url.searchParams.get("utm_source")).toBe("lba")
     expect(url.searchParams.has("romes")).toBe(false)
     expect(url.searchParams.has("lat")).toBe(false)
     expect(url.searchParams.has("lon")).toBe(false)
+  })
+
+  it("falls back to intitule_long as q when no rome code resolves to a label", async () => {
+    await saveFormation({
+      cle_ministere_educatif: "CLE2",
+      intitule_long: "Formation sans rome connu",
+      rome_codes: ["Z9999"],
+      localite: "Lyon",
+      lieu_formation_geopoint: { type: "Point", coordinates: [4.83, 45.75] },
+    })
+
+    const link = await getLBALink({ id: "w2", cle_ministere_educatif: "CLE2" })
+    const url = new URL(link)
+
+    expect(url.searchParams.get("q")).toBe("Formation sans rome connu")
   })
 
   it("picks the formation closest to the wish's commune when several formations match", async () => {
@@ -47,19 +70,21 @@ describe("getLBALink", () => {
       cle_ministere_educatif: "CLE_PARIS",
       etablissement_formateur_uai: "0751234A",
       intitule_long: "Formation Paris",
-      etablissement_formateur_localite: "Paris",
+      localite: "Paris",
       lieu_formation_geopoint: { type: "Point", coordinates: [2.35, 48.86] },
     })
     await saveFormation({
       cle_ministere_educatif: "CLE_MARSEILLE",
       etablissement_formateur_uai: "0751234A",
       intitule_long: "Formation Marseille",
-      etablissement_formateur_localite: "Marseille",
+      localite: "Marseille",
       lieu_formation_geopoint: { type: "Point", coordinates: [5.3806, 43.2803] },
     })
     await saveCommune()
 
-    const link = await getLBALink({ id: "w2", uai_formateur: "0751234A", code_postal: "75006" })
+    // "CLE_MARSEILLE" trie avant "CLE_PARIS" par ordre alphabétique : si la sélection par
+    // distance ne s'appliquait pas, le pick déterministe retiendrait Marseille à tort.
+    const link = await getLBALink({ id: "w3", uai_formateur: "0751234A", code_postal: "75006" })
     const url = new URL(link)
 
     expect(url.searchParams.get("q")).toBe("Formation Paris")
@@ -68,26 +93,70 @@ describe("getLBALink", () => {
     expect(url.searchParams.get("longitude")).toBe("2.35")
   })
 
+  it("picks a deterministic formation (lowest cle_ministere_educatif) when several match and no commune is known", async () => {
+    await saveFormation({
+      cle_ministere_educatif: "Z_LATER",
+      etablissement_formateur_uai: "0759999A",
+      intitule_long: "Formation Z",
+      localite: "Ville Z",
+      lieu_formation_geopoint: { type: "Point", coordinates: [1, 1] },
+    })
+    await saveFormation({
+      cle_ministere_educatif: "A_FIRST",
+      etablissement_formateur_uai: "0759999A",
+      intitule_long: "Formation A",
+      localite: "Ville A",
+      lieu_formation_geopoint: { type: "Point", coordinates: [2, 2] },
+    })
+
+    const link = await getLBALink({ id: "w4", uai_formateur: "0759999A" })
+    const url = new URL(link)
+
+    expect(url.searchParams.get("q")).toBe("Formation A")
+    expect(url.searchParams.get("lieu_label")).toBe("Ville A")
+  })
+
+  it("keeps lieu_label consistent with the commune when the matched formation has no geopoint", async () => {
+    await saveFormation({
+      cle_ministere_educatif: "CLE_NOGEO",
+      intitule_long: "Formation sans geopoint",
+      localite: "Lyon",
+      lieu_formation_geopoint: null,
+    })
+    await saveCommune()
+
+    const link = await getLBALink({ id: "w5", cle_ministere_educatif: "CLE_NOGEO", code_postal: "75006" })
+    const url = new URL(link)
+
+    // Les coordonnées viennent forcément de la commune (Paris) faute de geopoint sur la
+    // formation : le lieu affiché doit être celui de la commune, pas "Lyon".
+    expect(url.searchParams.get("latitude")).toBe("48.8589")
+    expect(url.searchParams.get("longitude")).toBe("2.347")
+    expect(url.searchParams.get("lieu_label")).toBe("Paris")
+  })
+
   it("falls back to a location-only search when no formation matches but the commune is known", async () => {
     await saveCommune()
 
-    const link = await getLBALink({ id: "w3", code_postal: "75006" })
+    const link = await getLBALink({ id: "w6", code_postal: "75006" })
     const url = new URL(link)
 
     expect(url.origin + url.pathname).toBe("http://localhost:3000/recherche")
     expect(url.searchParams.get("lieu_label")).toBe("Paris")
     expect(url.searchParams.get("latitude")).toBe("48.8589")
     expect(url.searchParams.get("longitude")).toBe("2.347")
+    expect(url.searchParams.get("source")).toBe("training_links")
     expect(url.searchParams.has("q")).toBe(false)
   })
 
   it("falls back to the homepage when no formation and no commune are found", async () => {
-    const link = await getLBALink({ id: "w4" })
+    const link = await getLBALink({ id: "w7" })
     const url = new URL(link)
 
     expect(url.origin).toBe("http://localhost:3000")
     expect(url.pathname).toBe("/")
     expect(url.searchParams.get("utm_source")).toBe("lba")
+    expect(url.searchParams.get("source")).toBe("training_links")
     expect(url.searchParams.has("mode")).toBe(false)
     expect(url.searchParams.has("q")).toBe(false)
     expect(url.searchParams.has("latitude")).toBe(false)
@@ -96,11 +165,13 @@ describe("getLBALink", () => {
 })
 
 describe("getTrainingLinks", () => {
-  it("builds a lien_lba per wish, batching formation lookups by cle_ministere_educatif", async () => {
+  it("builds a lien_lba per wish, batching formation and rome lookups", async () => {
+    await saveRome("D1102", "Boulangerie - viennoiserie")
     await saveFormation({
       cle_ministere_educatif: "CLE1",
       intitule_long: "Bac Pro Boulanger",
-      etablissement_formateur_localite: "Paris 6e",
+      rome_codes: ["D1102"],
+      localite: "Paris 6e",
       lieu_formation_geopoint: { type: "Point", coordinates: [2.35, 48.86] },
     })
 
@@ -111,7 +182,7 @@ describe("getTrainingLinks", () => {
     const w4 = results.find((r) => r.id === "w4")!
 
     const w1Url = new URL(w1.lien_lba)
-    expect(w1Url.searchParams.get("q")).toBe("Bac Pro Boulanger")
+    expect(w1Url.searchParams.get("q")).toBe("Boulangerie - viennoiserie")
     expect(w1Url.searchParams.get("latitude")).toBe("48.86")
 
     const w4Url = new URL(w4.lien_lba)

--- a/server/src/services/training-links.service.test.ts
+++ b/server/src/services/training-links.service.test.ts
@@ -1,0 +1,120 @@
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { saveDbEntity } from "@tests/utils/user.test.utils"
+import { ObjectId } from "bson"
+import { parisFixture } from "shared/fixtures/referentiel/commune.fixture"
+import { zFormationCatalogueSchema } from "shared/models/index"
+import { describe, expect, it } from "vitest"
+import type { z } from "zod"
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { getLBALink, getTrainingLinks } from "./training-links.service"
+
+useMongo()
+
+const saveFormation = (data: Partial<z.input<typeof zFormationCatalogueSchema>>) =>
+  saveDbEntity(zFormationCatalogueSchema, (item) => getDbCollection("formationcatalogues").insertOne(item), data)
+
+const saveCommune = async () => {
+  await getDbCollection("referentiel.communes").insertOne({ _id: new ObjectId(), ...parisFixture })
+}
+
+describe("getLBALink", () => {
+  it("uses the formation's intitule_long, localite and geopoint when a single formation matches", async () => {
+    await saveFormation({
+      cle_ministere_educatif: "CLE1",
+      intitule_long: "Bac Pro Boulanger",
+      etablissement_formateur_localite: "Paris 6e",
+      lieu_formation_geopoint: { type: "Point", coordinates: [2.35, 48.86] },
+    })
+
+    const link = await getLBALink({ id: "w1", cle_ministere_educatif: "CLE1" })
+    const url = new URL(link)
+
+    expect(url.origin + url.pathname).toBe("http://localhost:3000/recherche")
+    expect(url.searchParams.get("mode")).toBe("emplois")
+    expect(url.searchParams.get("q")).toBe("Bac Pro Boulanger")
+    expect(url.searchParams.get("lieu_label")).toBe("Paris 6e")
+    expect(url.searchParams.get("latitude")).toBe("48.86")
+    expect(url.searchParams.get("longitude")).toBe("2.35")
+    expect(url.searchParams.get("radius")).toBe("60")
+    expect(url.searchParams.get("utm_source")).toBe("lba")
+    expect(url.searchParams.has("romes")).toBe(false)
+    expect(url.searchParams.has("lat")).toBe(false)
+    expect(url.searchParams.has("lon")).toBe(false)
+  })
+
+  it("picks the formation closest to the wish's commune when several formations match", async () => {
+    await saveFormation({
+      cle_ministere_educatif: "CLE_PARIS",
+      etablissement_formateur_uai: "0751234A",
+      intitule_long: "Formation Paris",
+      etablissement_formateur_localite: "Paris",
+      lieu_formation_geopoint: { type: "Point", coordinates: [2.35, 48.86] },
+    })
+    await saveFormation({
+      cle_ministere_educatif: "CLE_MARSEILLE",
+      etablissement_formateur_uai: "0751234A",
+      intitule_long: "Formation Marseille",
+      etablissement_formateur_localite: "Marseille",
+      lieu_formation_geopoint: { type: "Point", coordinates: [5.3806, 43.2803] },
+    })
+    await saveCommune()
+
+    const link = await getLBALink({ id: "w2", uai_formateur: "0751234A", code_postal: "75006" })
+    const url = new URL(link)
+
+    expect(url.searchParams.get("q")).toBe("Formation Paris")
+    expect(url.searchParams.get("lieu_label")).toBe("Paris")
+    expect(url.searchParams.get("latitude")).toBe("48.86")
+    expect(url.searchParams.get("longitude")).toBe("2.35")
+  })
+
+  it("falls back to a location-only search when no formation matches but the commune is known", async () => {
+    await saveCommune()
+
+    const link = await getLBALink({ id: "w3", code_postal: "75006" })
+    const url = new URL(link)
+
+    expect(url.origin + url.pathname).toBe("http://localhost:3000/recherche")
+    expect(url.searchParams.get("lieu_label")).toBe("Paris")
+    expect(url.searchParams.get("latitude")).toBe("48.8589")
+    expect(url.searchParams.get("longitude")).toBe("2.347")
+    expect(url.searchParams.has("q")).toBe(false)
+  })
+
+  it("falls back to the homepage when no formation and no commune are found", async () => {
+    const link = await getLBALink({ id: "w4" })
+    const url = new URL(link)
+
+    expect(url.origin).toBe("http://localhost:3000")
+    expect(url.pathname).toBe("/")
+    expect(url.searchParams.get("utm_source")).toBe("lba")
+    expect(url.searchParams.has("mode")).toBe(false)
+    expect(url.searchParams.has("q")).toBe(false)
+    expect(url.searchParams.has("latitude")).toBe(false)
+    expect(url.searchParams.has("radius")).toBe(false)
+  })
+})
+
+describe("getTrainingLinks", () => {
+  it("builds a lien_lba per wish, batching formation lookups by cle_ministere_educatif", async () => {
+    await saveFormation({
+      cle_ministere_educatif: "CLE1",
+      intitule_long: "Bac Pro Boulanger",
+      etablissement_formateur_localite: "Paris 6e",
+      lieu_formation_geopoint: { type: "Point", coordinates: [2.35, 48.86] },
+    })
+
+    const results = await getTrainingLinks([{ id: "w1", cle_ministere_educatif: "CLE1" }, { id: "w4" }])
+
+    expect(results).toHaveLength(2)
+    const w1 = results.find((r) => r.id === "w1")!
+    const w4 = results.find((r) => r.id === "w4")!
+
+    const w1Url = new URL(w1.lien_lba)
+    expect(w1Url.searchParams.get("q")).toBe("Bac Pro Boulanger")
+    expect(w1Url.searchParams.get("latitude")).toBe("48.86")
+
+    const w4Url = new URL(w4.lien_lba)
+    expect(w4Url.pathname).toBe("/")
+  })
+})

--- a/server/src/services/training-links.service.ts
+++ b/server/src/services/training-links.service.ts
@@ -1,14 +1,10 @@
 import { getDistance } from "geolib"
-import { MAX_SEARCH_ROMES } from "shared"
 import type { IFormationCatalogue, IReferentielCommune } from "shared/models/index"
 import { URL } from "url"
 import { asyncForEach } from "@/common/utils/async-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import config from "@/config.js"
-import { getRomesFromRncp } from "./external/api-alternance/certification.service"
-import { filterWrongRomes } from "./formation.service"
 import { getCommuneByCodeInsee, getCommuneByCodePostal } from "./referentiel/commune/commune.referentiel.service"
-import { expandRomesV3toV4 } from "./rome.service"
 
 interface IWish {
   id: string
@@ -37,26 +33,32 @@ interface ILinks {
 
 const defaultUtmData = { utm_source: "lba", utm_medium: "email", utm_campaign: "promotion-emploi-jeunes-voeux" }
 
-const buildEmploiUrl = ({ baseUrl = `${config.publicUrl}/recherche-emploi`, params }: { baseUrl?: string; params: Record<string, string | string[] | null | undefined> }) => {
+const buildEmploiUrl = ({ baseUrl = `${config.publicUrl}/recherche?mode=emplois`, params }: { baseUrl?: string; params: Record<string, string | null | undefined> }) => {
   const url = new URL(baseUrl)
 
   Object.entries(params).forEach(([key, value]) => {
-    // @ts-expect-error
     if (value) url.searchParams.append(key, value)
   })
   return url.toString()
 }
 
+// lieu_formation_geopoint.coordinates is a GeoJSON Point: [longitude, latitude]
+const getFormationCoordinates = (formation: IFormationCatalogue): { latitude: string | null; longitude: string | null } => {
+  const coordinates = formation.lieu_formation_geopoint?.coordinates
+  if (!coordinates) return { latitude: null, longitude: null }
+  const [longitude, latitude] = coordinates
+  return { latitude: latitude.toString(), longitude: longitude.toString() }
+}
+
 const getFormations = (
   query: object,
   projection: object = {
-    lieu_formation_geo_coordonnees: 1,
-    rome_codes: 1,
+    etablissement_formateur_localite: 1,
+    intitule_long: 1,
+    lieu_formation_geopoint: 1,
     _id: 0,
   }
 ) => getDbCollection("formationcatalogues").find(query, { projection }).toArray()
-
-const limitSearchRomes = (romes: string[]) => romes.slice(0, MAX_SEARCH_ROMES)
 
 const getTrainingsFromParameters = async (wish: IWish, formationsByCle?: Map<string, IFormationCatalogue[]>): Promise<IFormationCatalogue[]> => {
   let formations
@@ -80,14 +82,6 @@ const getTrainingsFromParameters = async (wish: IWish, formationsByCle?: Map<str
     formations = formationsByCle ? (formationsByCle.get(wish.cle_ministere_educatif) ?? []) : await getFormations({ cle_ministere_educatif: wish.cle_ministere_educatif })
   }
 
-  // KBA 2024_07_29 : commenté en attendant la remonté du champ uai_formation dans le catalogue RCO
-  // if (!formations || !formations.length) {
-  //   // search by uai_lieu_formation
-  //   if (wish.uai_lieu_formation) {
-  //     formations = await getFormations({ $or: [{ cfd: wish.cfd }, { rncp_code: wish.rncp }, { "bcn_mefs_10.mef10": wish.mef }], uai_formation: wish.uai_lieu_formation })
-  //   }
-  // }
-
   if (!formations || !formations.length) {
     // search by uai_formateur
     if (wish.uai_formateur) {
@@ -102,50 +96,7 @@ const getTrainingsFromParameters = async (wish: IWish, formationsByCle?: Map<str
     }
   }
 
-  // extraction des codes romes erronés
-  if (formations?.length) {
-    formations = formations
-      .map((formation) => {
-        filterWrongRomes(formation)
-        return formation
-      })
-      .filter((formation) => formation.rome_codes.length > 0)
-  }
-
   return formations || []
-}
-
-type IRomesFormation = { rome_codes?: string[] | null; rncp_code?: string | null; cfd?: string | null; bcn_mefs_10?: Array<{ mef10?: string }> | null }
-type IRomesFormationsIndex = { byRncp: Map<string, IRomesFormation[]>; byCfd: Map<string, IRomesFormation[]>; byMef: Map<string, IRomesFormation[]> }
-
-const getRomesGlobaux = async ({ rncp, cfd, mef }: { rncp?: string | null; cfd?: string | null; mef?: string | null }, index?: IRomesFormationsIndex): Promise<string[]> => {
-  let romes = [] as string[]
-
-  if (index) {
-    const seen = new Set<IRomesFormation>()
-    if (rncp) for (const f of index.byRncp.get(rncp) ?? []) seen.add(f)
-    if (cfd) for (const f of index.byCfd.get(cfd) ?? []) seen.add(f)
-    if (mef) for (const f of index.byMef.get(mef) ?? []) seen.add(f)
-    const matching = [...seen].slice(0, 5)
-    if (matching.length) {
-      romes = [...new Set(matching.flatMap(({ rome_codes }) => rome_codes ?? []))] as string[]
-    }
-    return romes
-  }
-
-  const tmpFormations = await getDbCollection("formationcatalogues")
-    .find(
-      {
-        $or: [{ rncp_code: rncp }, { cfd: cfd ? cfd : undefined }, { "bcn_mefs_10.mef10": mef }],
-      },
-      { projection: { rome_codes: 1, _id: 0 } }
-    )
-    .limit(5)
-    .toArray()
-  if (tmpFormations.length) {
-    romes = [...new Set(tmpFormations.flatMap(({ rome_codes }) => rome_codes))] as string[]
-  }
-  return romes
 }
 
 const getPrdvLink = async (wish: IWish, eligibleCles?: Set<string>): Promise<string> => {
@@ -201,77 +152,58 @@ async function getWishCommune(wish: IWish): Promise<IReferentielCommune | null> 
   return null
 }
 
-export const getLBALink = async (wish: IWish, formationsByCle?: Map<string, IFormationCatalogue[]>, romesIndex?: IRomesFormationsIndex): Promise<string> => {
+export const getLBALink = async (wish: IWish, formationsByCle?: Map<string, IFormationCatalogue[]>): Promise<string> => {
   // Try getting formations first
   const formations = await getTrainingsFromParameters(wish, formationsByCle)
 
   const utmParams = wish.utm_data ? wish.utm_data : defaultUtmData
-
-  // Handle single formation case
-  if (formations?.length === 1) {
-    const { rome_codes, lieu_formation_geo_coordonnees } = formations[0]
-    const [latitude, longitude] = lieu_formation_geo_coordonnees!.split(",")
-    const romes = limitSearchRomes(await expandRomesV3toV4(rome_codes ?? []))
-    return buildEmploiUrl({ params: { romes, lat: latitude, lon: longitude, radius: "60", ...utmParams } })
-  }
 
   // Extract postcode and get coordinates if available
   const commune = await getWishCommune(wish)
   // GeoJSON coordinates are in [longitude, latitude] format
   const wLon: string | null = commune?.centre.coordinates[0].toString() ?? null
   const wLat: string | null = commune?.centre.coordinates[1].toString() ?? null
+  const wLieuLabel: string | null = commune?.nom ?? null
 
-  // Get romes based on rncp or training database
-  let romes = wish.rncp
-    ? (await getRomesFromRncp(wish.rncp)) || (await getRomesGlobaux({ rncp: wish.rncp, cfd: wish.cfd, mef: wish.mef }, romesIndex))
-    : await getRomesGlobaux({ rncp: wish.rncp, cfd: wish.cfd, mef: wish.mef }, romesIndex)
-
-  romes = romes.filter((rome_code) => rome_code.length === 5 && !rome_code.endsWith("00"))
-  romes = limitSearchRomes(await expandRomesV3toV4(romes))
-
-  // Build url based on formations and coordinates
-  if (formations?.length) {
-    let formation = formations[0]
-    let lat: string | null = null
-    let lon: string | null = null
-    if (formations.length > 1 && wLat && wLon) {
-      // Find closest formation if multiple and coordinates available
-      formation = formations.reduce(
-        (closest, current) => {
-          if (!current.lieu_formation_geo_coordonnees) return closest
-          const [fLat, fLon] = current.lieu_formation_geo_coordonnees.split(",")
-          const currentDist = getDistance({ latitude: wLat, longitude: wLon }, { latitude: fLat, longitude: fLon })
-          return currentDist < closest.distance! ? { ...current, distance: currentDist } : closest
-        },
-        { distance: 999999999, ...formation }
-      )
-      // Catalogue geo-coordinates are in [latitude, longitude] format
-      lat = formation.lieu_formation_geo_coordonnees?.split(",")[0] ?? null
-      lon = formation.lieu_formation_geo_coordonnees?.split(",")[1] ?? null
-    } else {
-      // Use formation coordinates or user coordinates
-      lat = formation.lieu_formation_geo_coordonnees?.split(",")[0] || wLat
-      lon = formation.lieu_formation_geo_coordonnees?.split(",")[1] || wLon
+  if (!formations?.length) {
+    // No formation found: fall back to a location-only search
+    if (wLat && wLon) {
+      return buildEmploiUrl({ params: { lieu_label: wLieuLabel, latitude: wLat, longitude: wLon, radius: "60", ...utmParams } })
     }
-    return buildEmploiUrl({ params: { ...(romes.length ? { romes } : {}), lat, lon, radius: "60", ...utmParams } })
-  } else {
-    // No formations found, use user coordinates if available
-    if (romes.length) {
-      return buildEmploiUrl({ params: { romes, lat: wLat, lon: wLon, radius: "60", ...utmParams } })
-    } else {
-      return buildEmploiUrl({ baseUrl: config.publicUrl, params: { ...utmParams } })
-    }
+    return buildEmploiUrl({ baseUrl: config.publicUrl, params: { ...utmParams } })
   }
+
+  // Pick the formation closest to the wish's location when several match
+  let formation = formations[0]
+  if (formations.length > 1 && wLat && wLon) {
+    formation = formations.reduce(
+      (closest, current) => {
+        const { latitude: cLat, longitude: cLon } = getFormationCoordinates(current)
+        if (!cLat || !cLon) return closest
+        const currentDist = getDistance({ latitude: wLat, longitude: wLon }, { latitude: cLat, longitude: cLon })
+        return currentDist < closest.distance! ? { ...current, distance: currentDist } : closest
+      },
+      { distance: Infinity, ...formation }
+    )
+  }
+
+  const { latitude, longitude } = getFormationCoordinates(formation)
+  return buildEmploiUrl({
+    params: {
+      q: formation.intitule_long,
+      lieu_label: formation.etablissement_formateur_localite,
+      latitude: latitude ?? wLat,
+      longitude: longitude ?? wLon,
+      radius: "60",
+      ...utmParams,
+    },
+  })
 }
 
 export const getTrainingLinks = async (params: IWish[]): Promise<ILinks[]> => {
   const cles = [...new Set(params.map((w) => w.cle_ministere_educatif).filter(Boolean) as string[])]
-  const allRncps = [...new Set(params.map((w) => w.rncp).filter(Boolean) as string[])]
-  const allCfds = [...new Set(params.map((w) => w.cfd).filter(Boolean) as string[])]
-  const allMefs = [...new Set(params.map((w) => w.mef).filter(Boolean) as string[])]
-  const hasRomesQuery = allRncps.length || allCfds.length || allMefs.length
 
-  const [eligibleTrainings, allFormations, romesFormations] = await Promise.all([
+  const [eligibleTrainings, allFormations] = await Promise.all([
     cles.length
       ? getDbCollection("eligible_trainings_for_appointments")
           .find({ cle_ministere_educatif: { $in: cles }, lieu_formation_email: { $ne: null, $exists: true, $not: /^$/ } }, { projection: { _id: 0, cle_ministere_educatif: 1 } })
@@ -279,24 +211,12 @@ export const getTrainingLinks = async (params: IWish[]): Promise<ILinks[]> => {
       : Promise.resolve([]),
     cles.length
       ? getDbCollection("formationcatalogues")
-          .find({ cle_ministere_educatif: { $in: cles } }, { projection: { lieu_formation_geo_coordonnees: 1, rome_codes: 1, cle_ministere_educatif: 1, _id: 0 } })
+          .find(
+            { cle_ministere_educatif: { $in: cles } },
+            { projection: { etablissement_formateur_localite: 1, intitule_long: 1, lieu_formation_geopoint: 1, cle_ministere_educatif: 1, _id: 0 } }
+          )
           .toArray()
       : Promise.resolve([]),
-    hasRomesQuery
-      ? (getDbCollection("formationcatalogues")
-          .find(
-            {
-              $or: [
-                ...(allRncps.length ? [{ rncp_code: { $in: allRncps } }] : []),
-                ...(allCfds.length ? [{ cfd: { $in: allCfds } }] : []),
-                ...(allMefs.length ? [{ "bcn_mefs_10.mef10": { $in: allMefs } }] : []),
-              ],
-            },
-            { projection: { rome_codes: 1, rncp_code: 1, cfd: 1, "bcn_mefs_10.mef10": 1, _id: 0 } }
-          )
-          .limit(500)
-          .toArray() as Promise<IRomesFormation[]>)
-      : Promise.resolve([] as IRomesFormation[]),
   ])
 
   const eligibleCles = new Set(eligibleTrainings.map((f) => f.cle_ministere_educatif as string))
@@ -308,27 +228,9 @@ export const getTrainingLinks = async (params: IWish[]): Promise<ILinks[]> => {
     formationsByCle.get(cle)!.push(formation)
   }
 
-  const romesIndex: IRomesFormationsIndex = { byRncp: new Map(), byCfd: new Map(), byMef: new Map() }
-  for (const f of romesFormations) {
-    if (f.rncp_code) {
-      if (!romesIndex.byRncp.has(f.rncp_code)) romesIndex.byRncp.set(f.rncp_code, [])
-      romesIndex.byRncp.get(f.rncp_code)!.push(f)
-    }
-    if (f.cfd) {
-      if (!romesIndex.byCfd.has(f.cfd)) romesIndex.byCfd.set(f.cfd, [])
-      romesIndex.byCfd.get(f.cfd)!.push(f)
-    }
-    for (const { mef10 } of f.bcn_mefs_10 ?? []) {
-      if (mef10) {
-        if (!romesIndex.byMef.has(mef10)) romesIndex.byMef.set(mef10, [])
-        romesIndex.byMef.get(mef10)!.push(f)
-      }
-    }
-  }
-
   const results: ILinks[] = []
   await asyncForEach(params, async (training) => {
-    const [lien_prdv, lien_lba] = await Promise.all([getPrdvLink(training, eligibleCles), getLBALink(training, formationsByCle, romesIndex)])
+    const [lien_prdv, lien_lba] = await Promise.all([getPrdvLink(training, eligibleCles), getLBALink(training, formationsByCle)])
     results.push({ id: training.id, lien_prdv, lien_lba })
   })
 

--- a/server/src/services/training-links.service.ts
+++ b/server/src/services/training-links.service.ts
@@ -1,10 +1,11 @@
 import { getDistance } from "geolib"
-import type { IFormationCatalogue, IReferentielCommune } from "shared/models/index"
+import type { IFormationCatalogue } from "shared/models/index"
 import { URL } from "url"
 import { asyncForEach } from "@/common/utils/async-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import config from "@/config.js"
 import { getCommuneByCodeInsee, getCommuneByCodePostal } from "./referentiel/commune/commune.referentiel.service"
+import { loadRomeLabelByCode, resolveRomeLabels } from "./search/search-items.service"
 
 interface IWish {
   id: string
@@ -50,12 +51,22 @@ const getFormationCoordinates = (formation: IFormationCatalogue): { latitude: st
   return { latitude: latitude.toString(), longitude: longitude.toString() }
 }
 
+// Préfère le libellé ROME (signal le plus boosté côté recherche, cf. rome_labels) et ne retombe
+// sur l'intitulé de formation que si aucun code ROME n'est résolu, pour éviter les 0 résultat
+// sur les intitulés longs (au-delà de 4 termes utiles, 75% de couverture est exigée).
+const getFormationSearchLabel = (formation: IFormationCatalogue, romeLabelByCode: Map<string, string>): string | null => {
+  const [romeLabel] = resolveRomeLabels(formation.rome_codes, romeLabelByCode)
+  return romeLabel ?? formation.intitule_long ?? null
+}
+
 const getFormations = (
   query: object,
   projection: object = {
-    etablissement_formateur_localite: 1,
+    localite: 1,
     intitule_long: 1,
     lieu_formation_geopoint: 1,
+    rome_codes: 1,
+    cle_ministere_educatif: 1,
     _id: 0,
   }
 ) => getDbCollection("formationcatalogues").find(query, { projection }).toArray()
@@ -128,82 +139,98 @@ const getPrdvLink = async (wish: IWish, eligibleCles?: Set<string>): Promise<str
   return ""
 }
 
-async function getWishCommune(wish: IWish): Promise<IReferentielCommune | null> {
-  if (wish.code_insee) {
-    const commune = await getCommuneByCodeInsee(wish.code_insee)
-    if (commune) return commune
+type ICommuneCoords = { latitude: string | null; longitude: string | null; lieuLabel: string | null }
+
+async function findWishCommune(wish: IWish): Promise<ICommuneCoords> {
+  const resolve = async (): Promise<{ centre: { coordinates: [number, number] }; nom: string } | null> => {
+    if (wish.code_insee) {
+      const commune = await getCommuneByCodeInsee(wish.code_insee)
+      if (commune) return commune
+    }
+
+    if (wish.code_postal) {
+      const commune = await getCommuneByCodePostal(wish.code_postal)
+      if (commune) return commune
+    }
+
+    const code = wish.code_insee || wish.code_postal
+
+    if (code) {
+      const generalPostCode = code.replace(/\d{3}$/, "000")
+      const byCodeInsee = await getCommuneByCodeInsee(generalPostCode)
+      if (byCodeInsee) return byCodeInsee
+      const byCodePostal = await getCommuneByCodePostal(generalPostCode)
+      if (byCodePostal) return byCodePostal
+    }
+
+    return null
   }
 
-  if (wish.code_postal) {
-    const commune = await getCommuneByCodePostal(wish.code_postal)
-    if (commune) return commune
-  }
-
-  const code = wish.code_insee || wish.code_postal
-
-  if (code) {
-    const generalPostCode = code.replace(/\d{3}$/, "000")
-    const byCodeInsee = await getCommuneByCodeInsee(generalPostCode)
-    if (byCodeInsee) return byCodeInsee
-    const byCodePostal = await getCommuneByCodePostal(generalPostCode)
-    if (byCodePostal) return byCodePostal
-  }
-
-  return null
+  const commune = await resolve()
+  if (!commune) return { latitude: null, longitude: null, lieuLabel: null }
+  // GeoJSON coordinates are in [longitude, latitude] format
+  return { latitude: commune.centre.coordinates[1].toString(), longitude: commune.centre.coordinates[0].toString(), lieuLabel: commune.nom }
 }
 
-export const getLBALink = async (wish: IWish, formationsByCle?: Map<string, IFormationCatalogue[]>): Promise<string> => {
-  // Try getting formations first
-  const formations = await getTrainingsFromParameters(wish, formationsByCle)
+// Ordre stable indépendant de l'ordre naturel Mongo : évite qu'un choix arbitraire entre
+// plusieurs formations candidates ne change silencieusement d'un run à l'autre.
+const sortFormationsDeterministically = (formations: IFormationCatalogue[]): IFormationCatalogue[] =>
+  [...formations].sort((a, b) => (a.cle_ministere_educatif ?? "").localeCompare(b.cle_ministere_educatif ?? ""))
 
+export const getLBALink = async (wish: IWish, formationsByCle?: Map<string, IFormationCatalogue[]>, romeLabelByCode?: Map<string, string>): Promise<string> => {
+  const formations = await getTrainingsFromParameters(wish, formationsByCle)
   const utmParams = wish.utm_data ? wish.utm_data : defaultUtmData
 
-  // Extract postcode and get coordinates if available
-  const commune = await getWishCommune(wish)
-  // GeoJSON coordinates are in [longitude, latitude] format
-  const wLon: string | null = commune?.centre.coordinates[0].toString() ?? null
-  const wLat: string | null = commune?.centre.coordinates[1].toString() ?? null
-  const wLieuLabel: string | null = commune?.nom ?? null
+  // Résolue au plus une fois par vœu, seulement si un des cas ci-dessous en a besoin.
+  let communePromise: Promise<ICommuneCoords> | null = null
+  const getWishCommune = () => (communePromise ??= findWishCommune(wish))
 
   if (!formations?.length) {
     // No formation found: fall back to a location-only search
-    if (wLat && wLon) {
-      return buildEmploiUrl({ params: { lieu_label: wLieuLabel, latitude: wLat, longitude: wLon, radius: "60", ...utmParams } })
+    const { latitude, longitude, lieuLabel } = await getWishCommune()
+    if (latitude && longitude) {
+      return buildEmploiUrl({ params: { lieu_label: lieuLabel, latitude, longitude, radius: "60", source: "training_links", ...utmParams } })
     }
-    return buildEmploiUrl({ baseUrl: config.publicUrl, params: { ...utmParams } })
+    return buildEmploiUrl({ baseUrl: config.publicUrl, params: { source: "training_links", ...utmParams } })
   }
+
+  const sortedFormations = sortFormationsDeterministically(formations)
+  let formation = sortedFormations[0]
 
   // Pick the formation closest to the wish's location when several match
-  let formation = formations[0]
-  if (formations.length > 1 && wLat && wLon) {
-    formation = formations.reduce(
-      (closest, current) => {
-        const { latitude: cLat, longitude: cLon } = getFormationCoordinates(current)
-        if (!cLat || !cLon) return closest
-        const currentDist = getDistance({ latitude: wLat, longitude: wLon }, { latitude: cLat, longitude: cLon })
-        return currentDist < closest.distance! ? { ...current, distance: currentDist } : closest
-      },
-      { distance: Infinity, ...formation }
-    )
+  if (sortedFormations.length > 1) {
+    const { latitude: wLat, longitude: wLon } = await getWishCommune()
+    if (wLat && wLon) {
+      formation = sortedFormations.reduce(
+        (closest, current) => {
+          const { latitude: cLat, longitude: cLon } = getFormationCoordinates(current)
+          if (!cLat || !cLon) return closest
+          const currentDist = getDistance({ latitude: wLat, longitude: wLon }, { latitude: cLat, longitude: cLon })
+          return currentDist < closest.distance! ? { ...current, distance: currentDist } : closest
+        },
+        { distance: Infinity, ...formation }
+      )
+    }
   }
 
-  const { latitude, longitude } = getFormationCoordinates(formation)
+  // latitude/longitude et lieu_label doivent toujours venir de la même source : soit la
+  // formation retenue (lieu_formation_geopoint + localite), soit la commune du vœu en repli —
+  // jamais un mélange qui afficherait un lieu différent de celui réellement recherché.
+  const formationCoords = getFormationCoordinates(formation)
+  const { latitude, longitude, lieuLabel } =
+    formationCoords.latitude && formationCoords.longitude ? { ...formationCoords, lieuLabel: formation.localite ?? null } : await getWishCommune()
+
+  const q = getFormationSearchLabel(formation, romeLabelByCode ?? (await loadRomeLabelByCode()))
+
   return buildEmploiUrl({
-    params: {
-      q: formation.intitule_long,
-      lieu_label: formation.etablissement_formateur_localite,
-      latitude: latitude ?? wLat,
-      longitude: longitude ?? wLon,
-      radius: "60",
-      ...utmParams,
-    },
+    params: { q, lieu_label: lieuLabel, latitude, longitude, radius: "60", source: "training_links", ...utmParams },
   })
 }
 
 export const getTrainingLinks = async (params: IWish[]): Promise<ILinks[]> => {
   const cles = [...new Set(params.map((w) => w.cle_ministere_educatif).filter(Boolean) as string[])]
 
-  const [eligibleTrainings, allFormations] = await Promise.all([
+  const [eligibleTrainings, allFormations, romeLabelByCode] = await Promise.all([
     cles.length
       ? getDbCollection("eligible_trainings_for_appointments")
           .find({ cle_ministere_educatif: { $in: cles }, lieu_formation_email: { $ne: null, $exists: true, $not: /^$/ } }, { projection: { _id: 0, cle_ministere_educatif: 1 } })
@@ -213,10 +240,11 @@ export const getTrainingLinks = async (params: IWish[]): Promise<ILinks[]> => {
       ? getDbCollection("formationcatalogues")
           .find(
             { cle_ministere_educatif: { $in: cles } },
-            { projection: { etablissement_formateur_localite: 1, intitule_long: 1, lieu_formation_geopoint: 1, cle_ministere_educatif: 1, _id: 0 } }
+            { projection: { localite: 1, intitule_long: 1, lieu_formation_geopoint: 1, rome_codes: 1, cle_ministere_educatif: 1, _id: 0 } }
           )
           .toArray()
       : Promise.resolve([]),
+    loadRomeLabelByCode(),
   ])
 
   const eligibleCles = new Set(eligibleTrainings.map((f) => f.cle_ministere_educatif as string))
@@ -230,7 +258,7 @@ export const getTrainingLinks = async (params: IWish[]): Promise<ILinks[]> => {
 
   const results: ILinks[] = []
   await asyncForEach(params, async (training) => {
-    const [lien_prdv, lien_lba] = await Promise.all([getPrdvLink(training, eligibleCles), getLBALink(training, formationsByCle)])
+    const [lien_prdv, lien_lba] = await Promise.all([getPrdvLink(training, eligibleCles), getLBALink(training, formationsByCle, romeLabelByCode)])
     results.push({ id: training.id, lien_prdv, lien_lba })
   })
 

--- a/shared/src/models/search-queries.model.ts
+++ b/shared/src/models/search-queries.model.ts
@@ -22,7 +22,9 @@ export const ZSearchQuery = z.object({
   // puisque ce log n'était appelé qu'après un succès — ce champ comble ce trou).
   status: z.enum(["ok", "degraded", "error"]).describe("Issue de la recherche : succès normal, succès après repli, ou échec"),
   nb_hits: z.number().nullable().describe("Nombre de résultats retournés (null si status=error)"),
-  source: z.enum(["suggestion", "free_text"]).describe("Suggestion d'autocomplete sélectionnée vs texte libre"),
+  source: z
+    .enum(["suggestion", "free_text", "training_links"])
+    .describe("Suggestion d'autocomplete sélectionnée vs texte libre vs lien généré côté serveur (traininglinks, vœux Parcoursup)"),
   filters: z
     .object({
       type: z.string().nullable(),

--- a/shared/src/routes/search.routes.ts
+++ b/shared/src/routes/search.routes.ts
@@ -64,7 +64,10 @@ export const zSearchRoutes = {
         radius: ZRadiusParam.pipe(z.number().min(0).max(200).optional()).default(30),
         page: z.coerce.number<number>().min(0).default(0).describe("Index de page (0-based)"),
         hitsPerPage: z.coerce.number<number>().min(1).max(100).default(20).describe("Nombre de résultats par page (max 100)"),
-        source: z.enum(["suggestion", "free_text"]).optional().describe("Origine de la requête côté UI (télémétrie autocomplete, sans effet sur les résultats)"),
+        source: z
+          .enum(["suggestion", "free_text", "training_links"])
+          .optional()
+          .describe("Origine de la requête (télémétrie autocomplete UI, ou lien généré côté serveur par traininglinks pour les vœux Parcoursup — sans effet sur les résultats)"),
         internal: z
           .enum(["true", "false"])
           .transform((v) => v === "true")

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
@@ -33,8 +33,8 @@ export const DEFAULT_SEARCH_MODE: SearchMode = "emplois"
 export type SortOption = "proximity" | "date" | "applications" | "start_date"
 const SORT_OPTIONS: SortOption[] = ["proximity", "date", "applications", "start_date"]
 
-export type QSource = "suggestion" | "free_text"
-const Q_SOURCES: QSource[] = ["suggestion", "free_text"]
+export type QSource = "suggestion" | "free_text" | "training_links"
+const Q_SOURCES: QSource[] = ["suggestion", "free_text", "training_links"]
 
 /**
  * Les filtres multi-valeurs utilisent des paramètres répétés dans l'URL :


### PR DESCRIPTION
Closes #5197

## Changements

- Aligne `getLBALink`/`getTrainingLinks` sur les paramètres du nouveau moteur de recherche : `q` (intitulé long de la formation), `lieu_label` (localité de l'établissement formateur), `latitude`/`longitude` (issus de `lieu_formation_geopoint`, géré au bon ordre GeoJSON)
- Supprime le code devenu mort suite à la bascule (recherche par codes ROME, index RNCP/CFD/MEF), plus lu par le frontend
- Fallback sans formation correspondante : recherche géolocalisée sur la commune du vœu, sans texte de recherche
- Ajoute les tests unitaires manquants pour `training-links.service.ts` (formation unique, formations multiples avec sélection de la plus proche, fallbacks)

## Plan de test

- [x] `yarn tsc --noEmit` sans erreur sur le workspace server
- [x] `yarn test --run server/src/services/training-links.service.test.ts` : 5 tests passent
- [ ] Vérifier en environnement de recette qu'une URL générée valorise bien les champs lieu & métier et filtre sur les résultats emploi