### PR TITLE
chore: répare yarn knip, cassé par TypeScript 7 (#5199)

### DIFF
--- a/docs/developpement/knip.md
+++ b/docs/developpement/knip.md
@@ -1,0 +1,221 @@
+# knip — détection de code mort et de dépendances orphelines
+
+`yarn knip` analyse les 3 workspaces (`server`, `shared`, `ui`) et signale : fichiers non
+atteignables, dépendances déclarées mais non utilisées, dépendances utilisées mais non déclarées,
+exports jamais consommés. Configuration : [`knip.json`](../../knip.json).
+
+```bash
+yarn knip
+```
+
+## Pourquoi knip était cassé (et ne l'était pas visiblement)
+
+Le repo est passé à **TypeScript 7** (le paquet du compilateur natif). knip 5 déclarait
+`peerDependencies: { "typescript": ">=5.0.4 <7" }` et appelait l'API du compilateur JS legacy.
+Sous TS 7 cette API n'existe plus :
+
+```
+$ node -e "const ts=require('typescript'); console.log(typeof ts.getDefaultLibFilePath)"
+undefined
+
+$ yarn knip
+TypeError: ts.getDefaultLibFilePath is not a function
+    at node_modules/knip/dist/typescript/create-hosts.js:6:37
+```
+
+`yarn knip` plantait donc **immédiatement**, sur toutes les branches. Comme le script n'était pas
+branché en CI, personne ne le voyait : `knip.json` avait l'air d'un garde-fou actif alors qu'aucune
+exécution ne pouvait aboutir.
+
+**Correctif : knip 6.** knip 6 a supprimé toute dépendance au compilateur TypeScript ; il parse et
+résout avec `oxc-parser` / `oxc-resolver` / `get-tsconfig`, et n'a plus de `peerDependencies` du
+tout. Il tourne donc sous TS 7 sans adaptation, en **827 ms** sur ce repo (`yarn knip -u`). Le
+schéma de configuration est inchangé : le `knip.json` existant est accepté tel quel par knip 6
+(vérifié — knip 6 rejette les clés inconnues, donc l'absence d'erreur vaut validation).
+
+Il n'existe **pas** de mécanisme de baseline natif dans knip 6.32.2 : `--save-baseline` et
+`--baseline` (mentionnés par certains articles) ne sont pas des options de knip — `yarn knip
+--save-baseline` répond `Unknown option`. D'où ce fichier, qui tient lieu de baseline.
+
+### Ce que la panne a coûté
+
+Sur la PR 5192, la suppression de 48 fichiers legacy a laissé 6 fichiers orphelins
+(`ui/components/InfoTooltipOrModal.tsx`, `ui/components/index.ts`, `ui/components/ErrorMessage/*`,
+`ResultListsLoading.tsx`, `rechercheCDDCDI.tsx`) et la dépendance `mersenne-twister` derrière elle,
+détectés à la main. Vérification faite sur le commit `23457dcc1` (avant que le nettoyage
+n'atterrisse) : **les 6 fichiers et `mersenne-twister` figuraient tous dans la sortie de knip 6**.
+La détection manuelle était intégralement reproductible par l'outil.
+
+## Corrections de configuration appliquées au passage
+
+knip 6 a fait apparaître des dégâts de configuration qui produisaient des findings faux. Chaque
+correctif ci-dessous a été mesuré isolément, en diffant la sortie complète avec et sans.
+
+| Symptôme | Cause | Correctif | Effet mesuré |
+| --- | --- | --- | --- |
+| hint `src/dev.ts  server  Refine entry pattern (no matches)` | entry pointant sur un fichier supprimé ; le vrai point d'entrée (`src/index.ts`, cf. `tsup.config.ts` et `server/package.json#scripts.cli`) n'était pas déclaré, ni le `globalSetup` vitest | `entry: ["src/index.ts!", "src/migrations/*.ts!", "tests/utils/globalSetup.ts"]` | −2 faux « unused files » (`server/src/index.ts`, `server/tests/utils/globalSetup.ts`), −1 faux « unused export » (`initSentry`), hint levé |
+| 15 fausses « unlisted dependencies » (`@yarnpkg/core`, `clipanion`, `semver`…) | knip lit les plugins Yarn déclarés dans `.yarnrc.yml` et analyse les bundles `.yarn/plugins/*.cjs` | `".": { "ignore": [".yarn/**"] }` | unlisted 28 → 13 |
+| hints `.scss` / `.sass  ui  Compiled extension excluded by project` | les patterns `project` de `ui` ne couvraient que `ts,tsx` | `project: ["./**/*.{ts,tsx,scss,sass}", …]` | 2 hints levés |
+
+Total : 459 → **441 findings**, et **3 → 0 configuration hints**.
+
+Les suffixes `!` (fichiers de production) sont conservés : `yarn knip -p` reste utilisable pour
+l'analyse en mode production stricte.
+
+> Piste écartée : ajouter `**/*.test.ts` à l'`entry` de `server` (l'`entry` explicite écrase les
+> patterns par défaut de knip, qui incluent les fichiers de test). Mesuré sur cette base : sortie
+> **strictement identique**, donc no-op — non retenu.
+
+## Baseline sur `main` (knip 6.32.2)
+
+441 findings, `exit 1`. Répartition :
+
+| Catégorie | Total | `server` | `shared` | `ui` | racine |
+| --- | --- | --- | --- | --- | --- |
+| Unused files | 15 | 4 | 0 | 11 | 0 |
+| Unused dependencies | 8 | 3 | 2 | 3 | 0 |
+| Unused devDependencies | 14 | 2 | 0 | 3 | 9 |
+| Unlisted dependencies | 13 | 1 | 1 | 11 | 0 |
+| Unlisted binaries | 7 | 1 | 0 | 0 | 6 |
+| Unresolved imports | 3 | 0 | 0 | 0 | 3 |
+| Unused exports | 250 | 118 | 97 | 35 | 0 |
+| Unused exported types | 118 | 32 | 77 | 9 | 0 |
+| Unused exported enum members | 8 | 0 | 8 | 0 | 0 |
+| Duplicate exports | 5 | 2 | 1 | 2 | 0 |
+
+### Unused files (15)
+
+- `server/src/common/utils/log-message.ts`
+- `server/src/jobs/domaines-metiers/domaine-metiers-fix-romes.ts`
+- `server/src/jobs/one-time-job/resync-lba-jobs-partners-stats.ts`
+- `server/src/services/ftjob.service.ts`
+- `ui/app/_components/ClientOnly.tsx`
+- `ui/app/_components/FormComponents/AutocompleteAsync.tsx`
+- `ui/app/_components/FormComponents/InputFormField.tsx`
+- `ui/app/_components/FormComponents/SelectFormField.tsx`
+- `ui/app/(espace-pro)/_components/ConnectionActions.tsx`
+- `ui/app/(espace-pro)/_components/promoRessources.tsx`
+- `ui/app/(home)/_components/AmeliorerLBA.tsx`
+- `ui/components/ItemDetail/DidYouKnow.tsx`
+- `ui/components/MailCard.tsx`
+- `ui/services/fetch-lba-company-details.ts`
+- `ui/utils/get-item-id.ts`
+
+### Unused dependencies (8) et devDependencies (14)
+
+Les 22 findings ont été vérifiés un par un au `grep` sur les sources. Classement :
+
+**Réellement mortes — supprimables** (12) : aucune occurrence hors `package.json`.
+`bunyan`, `memoizee`, `openai` (seule trace : une clé de config `config.openai`, aucun import),
+`i18next`, `@mui/x-data-grid`, `cross-env`, `vite-tsconfig-paths`,
+`zod-fixture` (remplacé par le shim maison `server/tests/utils/zodFixtureCompat.ts`),
+`@testing-library/react` et `@testing-library/dom` (aucun test `ui` ne les importe),
+`@semantic-release/changelog` et `@semantic-release/git` (ni l'un ni l'autre n'est dans les
+`plugins` de `release.config.js` — attention au faux positif de `grep` sur
+`@semantic-release/github`).
+
+**Mortes par ricochet d'un fichier mort** (3) — à supprimer avec le fichier :
+`@uidotdev/usehooks`, `autosuggest-highlight` et `@types/autosuggest-highlight`, importés
+uniquement par `ui/app/_components/FormComponents/AutocompleteAsync.tsx`, lui-même non atteignable.
+
+**Mal placées** (4) — utilisées, mais déclarées dans le mauvais workspace :
+`zod-mongodb-schema` (déclaré dans `shared`, importé dans
+`server/src/common/utils/mongodb-utils.ts`), `stream-json`, `type-fest`, `dotenv` (déclarés à la
+racine, utilisés dans `server` / `ui`, qui déclarent d'ailleurs leur propre `dotenv`).
+
+**Faux positifs** (3) :
+- `gitleaks-secret-scanner` — appelé par `yarn run gitleaks-secret-scanner` depuis
+  `.bin/scripts/gitleaks-check.sh` ; knip n'analyse pas les scripts shell.
+- `sharp` — backend d'optimisation d'images de Next en production ; `next/image` est importé dans
+  68 fichiers `ui`. Aucune référence directe dans les sources, donc invisible pour knip : ne pas
+  supprimer sans valider un build de production.
+- `nock` — **bug knip 6**. `nock` est importé dans 32 fichiers `server`. Vérifié : même en ajoutant
+  `import nock from "nock"` en tête de `server/src/index.ts` (fichier entry), knip continue de le
+  déclarer non utilisé. Non reproductible sur un projet isolé (`package.json` + `index.ts`
+  important `nock`, `zod-fixture` et `picocolors`, mêmes `node_modules`, avec et sans
+  `tsconfig.json` en `moduleResolution: bundler`) → le faux positif est spécifique au monorepo,
+  cause non élucidée. À remonter en amont.
+
+À noter également : `sass` est déclaré dans `ui/devDependencies` alors qu'il ne reste **aucun**
+fichier `.scss` dans le repo. knip ne le signale pas (son plugin `sass` le considère utilisé
+implicitement) — candidat à la suppression, à confirmer côté build Next.
+
+### Unlisted dependencies (13)
+
+- `dayjs` — `server/src/global.d.ts` l'importe sans que `server` ne le déclare. À déclarer.
+- `notion-types` × 5 (pages éditoriales `ui`) — transitive de `notion-client` / `react-notion-x`
+  (tous deux déclarés dans `ui/package.json`), importée directement pour ses types. À déclarer.
+- `job-processor/dist/core.js` × 1 et `job-processor/dist/react` × 6 — imports profonds dans un
+  paquet déclaré, non couverts par sa `exports` map. Soit passer par un sous-chemin exporté, soit
+  ajouter à `ignoreDependencies`.
+
+### Unlisted binaries (7)
+
+- `mna` × 6 (`package.json` + 5 workflows) — script local `.bin/mna`, que knip ne modélise pas.
+  Faux positif ; candidat à `ignoreBinaries`.
+- `dotenv` × 1 (`server/package.json`, script `seed:reference`) — **finding réel** : le paquet
+  `dotenv` ne fournit pas de binaire `dotenv` (c'est `dotenv-cli`). `yarn workspace server
+  seed:reference` est donc cassé.
+
+### Unresolved imports (3)
+
+```
+./tests/utils/setup.ts        vitest.config.ts
+./tests/utils/globalSetup.ts  vitest.config.ts
+./tests/setup.ts              vitest.config.ts
+```
+
+Limitation knip : dans un `vitest.config.ts` utilisant `test.projects`, knip résout `setupFiles` /
+`globalSetup` par rapport au fichier de config (la racine) au lieu du `root` de chaque projet
+(`./server`, `./ui`). Les 3 chemins sont corrects côté vitest. Faux positifs.
+
+### Unused exports (250), types (118), enum members (8), duplicate exports (5)
+
+Backlog à traiter par workspace, hors périmètre de ce correctif. Deux remarques :
+
+- `shared` est configuré avec `includeEntryExports: true` et tous ses fichiers en `entry` : ses 97
+  exports + 77 types signalés sont des exports d'un paquet interne consommés par personne — c'est
+  le comportement voulu, pas un artefact.
+- Les 5 `duplicate exports` sont des fichiers qui exportent la même valeur en nommé **et** en
+  `default` — correction mécanique.
+
+Liste complète : `yarn knip --exports`.
+
+## Ajout en CI — évaluation
+
+Le job `tests` de `.github/workflows/ci.yml` fait `typecheck` + `biome ci` + `vitest`. Aucun des
+trois ne voit un fichier non importé ni une dépendance orpheline : c'est bien un angle mort.
+
+**En l'état, `yarn knip` ne peut pas être ajouté en gate bloquant** : 441 findings, `exit 1`
+immédiat. Et knip 6 n'a pas de baseline native (cf. plus haut), donc pas de moyen de ne faire
+échouer que sur les *nouveaux* findings sans écrire un script maison.
+
+Trois options, par ordre de préférence :
+
+1. **Nettoyer puis brancher (recommandé).** Le volume actionnable est faible : 12 dépendances
+   réellement mortes + 3 mortes par ricochet (1 PR), 15 fichiers orphelins (1 PR), 4 dépendances à
+   déplacer et 6 à déclarer (1 PR). Restent les ~380 exports/types, à traiter par workspace. Une
+   fois à zéro, le step ci-dessous devient un gate honnête.
+
+2. **Brancher tout de suite mais scopé aux catégories nettoyées au fur et à mesure**, en
+   élargissant `--include` PR après PR. Premier palier possible dès que les fichiers orphelins et
+   les dépendances mortes sont traités :
+
+   ```yaml
+         - name: dead code & unused dependencies
+           run: yarn knip --include files,dependencies,unlisted,binaries --treat-config-hints-as-errors
+   ```
+
+   `--treat-config-hints-as-errors` est important : sans lui, une config qui pourrit (entry
+   pointant sur un fichier supprimé, comme `src/dev.ts` ci-dessus) dégrade silencieusement
+   l'analyse sans faire échouer le job.
+
+3. **Ne pas brancher.** À écarter : c'est l'état actuel, et il a déjà coûté une détection manuelle
+   sur la PR 5192.
+
+Ce qu'il ne faut **pas** faire : ajouter le step avec `--no-exit-code`. Un job vert qui affiche des
+warnings est indiscernable d'un job vert propre, et personne ne lira la sortie.
+
+Le coût est négligeable : knip 6 s'appuie sur `oxc` et non plus sur le compilateur TypeScript —
+827 ms, sans service à démarrer. Le step se place naturellement après `lint & format`, avant le
+démarrage de MongoDB.

--- a/knip.json
+++ b/knip.json
@@ -2,9 +2,9 @@
   "workspaces": {
     "server": {
       "entry": [
-        "src/main.ts!",
-        "src/dev.ts",
-        "src/migrations/*.ts!"
+        "src/index.ts!",
+        "src/migrations/*.ts!",
+        "tests/utils/globalSetup.ts"
       ],
       "project": [
         "src/**/*.ts!",
@@ -25,7 +25,7 @@
     },
     "ui": {
       "project": [
-        "./**/*.{ts,tsx}",
+        "./**/*.{ts,tsx,scss,sass}",
         "!.next"
       ],
       "paths": {
@@ -43,6 +43,9 @@
       "commitlint": true,
       "project": [
         "!.husky/commitlint.config.js"
+      ],
+      "ignore": [
+        ".yarn/**"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^17.2.3",
     "gitleaks-secret-scanner": "^2.1.1",
     "husky": "^9.1.7",
-    "knip": "^5.67.1",
+    "knip": "^6.32.2",
     "lint-staged": "^16.2.6",
     "semantic-release": "^25.0.1",
     "semantic-release-slack-bot": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,12 +1783,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.11.2":
+  version: 1.11.2
+  resolution: "@emnapi/core@npm:1.11.2"
+  dependencies:
+    "@emnapi/wasi-threads": 1.2.2
+    tslib: ^2.4.0
+  checksum: 714cd078cb4f13629c4375632975780e5053a1fd0fce7bcb763af53981ffed46e01e74a8af8be863a26c7084eed57429422db0f67e484a7863a9a9dcabf81c69
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.11.1":
   version: 1.11.1
   resolution: "@emnapi/runtime@npm:1.11.1"
   dependencies:
     tslib: ^2.4.0
   checksum: d00f25faca4d30ab09e64a8674bd44adec3805b3c99fe7de45d9f1ecd7dcbdec4a8e0d19d06cfa837a6f3f383eb92186106fa67ef13a1b8951a7f898718e7bf2
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.11.2":
+  version: 1.11.2
+  resolution: "@emnapi/runtime@npm:1.11.2"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: dc88233176be74958b1609620e0e90c9ce6fc1aba4648c56fb89f6b242e0b192e0f3422c4f65861f94479cb5052247a12b99e9ecae3eeb0209024b356a5d3336
   languageName: node
   linkType: hard
 
@@ -3371,7 +3390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.0.7, @napi-rs/wasm-runtime@npm:^1.1.6":
+"@napi-rs/wasm-runtime@npm:^1.1.6":
   version: 1.1.6
   resolution: "@napi-rs/wasm-runtime@npm:1.1.6"
   dependencies:
@@ -3477,14 +3496,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodelib/fs.stat@npm:2.0.5, @nodelib/fs.stat@npm:^2.0.2":
+"@nodelib/fs.stat@npm:2.0.5":
   version: 2.0.5
   resolution: "@nodelib/fs.stat@npm:2.0.5"
   checksum: 012480b5ca9d97bff9261571dbbec7bbc6033f69cc92908bc1ecfad0792361a5a1994bc48674b9ef76419d056a03efadfce5a6cf6dbc0a36559571a7a483f6f0
   languageName: node
   linkType: hard
 
-"@nodelib/fs.walk@npm:^1.2.3, @nodelib/fs.walk@npm:^1.2.8":
+"@nodelib/fs.walk@npm:^1.2.8":
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
@@ -4658,6 +4677,139 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-parser/binding-android-arm-eabi@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-android-arm-eabi@npm:0.143.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-android-arm64@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-android-arm64@npm:0.143.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-darwin-arm64@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-darwin-arm64@npm:0.143.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-darwin-x64@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-darwin-x64@npm:0.143.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-freebsd-x64@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-freebsd-x64@npm:0.143.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm-gnueabihf@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-arm-gnueabihf@npm:0.143.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm-musleabihf@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-arm-musleabihf@npm:0.143.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm64-gnu@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-arm64-gnu@npm:0.143.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm64-musl@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-arm64-musl@npm:0.143.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-ppc64-gnu@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-ppc64-gnu@npm:0.143.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-riscv64-gnu@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-riscv64-gnu@npm:0.143.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-riscv64-musl@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-riscv64-musl@npm:0.143.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-s390x-gnu@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-s390x-gnu@npm:0.143.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-x64-gnu@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-x64-gnu@npm:0.143.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-x64-musl@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-linux-x64-musl@npm:0.143.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-openharmony-arm64@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-openharmony-arm64@npm:0.143.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-win32-arm64-msvc@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-win32-arm64-msvc@npm:0.143.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-win32-ia32-msvc@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-win32-ia32-msvc@npm:0.143.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-win32-x64-msvc@npm:0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-parser/binding-win32-x64-msvc@npm:0.143.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@oxc-project/types@npm:=0.139.0":
   version: 0.139.0
   resolution: "@oxc-project/types@npm:0.139.0"
@@ -4665,137 +4817,146 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-android-arm-eabi@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.13.0"
+"@oxc-project/types@npm:^0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-project/types@npm:0.143.0"
+  checksum: fe1ddda89c900222021756e6d8f0ffda574e65716e5e5446b2fb110ad9a1f8749399f783e02e950e1c4bf11f7040db5195db3d4b45a27f1567f059b1a97abae0
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm-eabi@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.24.2"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-android-arm64@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-android-arm64@npm:11.13.0"
+"@oxc-resolver/binding-android-arm64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-android-arm64@npm:11.24.2"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-darwin-arm64@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.13.0"
+"@oxc-resolver/binding-darwin-arm64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.24.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-darwin-x64@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.13.0"
+"@oxc-resolver/binding-darwin-x64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.24.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-freebsd-x64@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.13.0"
+"@oxc-resolver/binding-freebsd-x64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.24.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.13.0"
+"@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.24.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-arm-musleabihf@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.13.0"
+"@oxc-resolver/binding-linux-arm-musleabihf@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.24.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-arm64-gnu@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.13.0"
+"@oxc-resolver/binding-linux-arm64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.24.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-arm64-musl@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.13.0"
+"@oxc-resolver/binding-linux-arm64-musl@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.24.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-ppc64-gnu@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.13.0"
+"@oxc-resolver/binding-linux-ppc64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.24.2"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-riscv64-gnu@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.13.0"
+"@oxc-resolver/binding-linux-riscv64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.24.2"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-riscv64-musl@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.13.0"
+"@oxc-resolver/binding-linux-riscv64-musl@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.24.2"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-s390x-gnu@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.13.0"
+"@oxc-resolver/binding-linux-s390x-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.24.2"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-x64-gnu@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.13.0"
+"@oxc-resolver/binding-linux-x64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.24.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-x64-musl@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.13.0"
+"@oxc-resolver/binding-linux-x64-musl@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.24.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-wasm32-wasi@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.13.0"
+"@oxc-resolver/binding-openharmony-arm64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-openharmony-arm64@npm:11.24.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-wasm32-wasi@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.24.2"
   dependencies:
-    "@napi-rs/wasm-runtime": ^1.0.7
+    "@emnapi/core": 1.11.2
+    "@emnapi/runtime": 1.11.2
+    "@napi-rs/wasm-runtime": ^1.1.6
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-win32-arm64-msvc@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.13.0"
+"@oxc-resolver/binding-win32-arm64-msvc@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.24.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-win32-ia32-msvc@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-win32-ia32-msvc@npm:11.13.0"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@oxc-resolver/binding-win32-x64-msvc@npm:11.13.0":
-  version: 11.13.0
-  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.13.0"
+"@oxc-resolver/binding-win32-x64-msvc@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.24.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -10305,19 +10466,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "fast-glob@npm:3.3.3"
-  dependencies:
-    "@nodelib/fs.stat": ^2.0.2
-    "@nodelib/fs.walk": ^1.2.3
-    glob-parent: ^5.1.2
-    merge2: ^1.3.0
-    micromatch: ^4.0.8
-  checksum: 0704d7b85c0305fd2cef37777337dfa26230fdd072dce9fb5c82a4b03156f3ffb8ed3e636033e65d45d2a5805a4e475825369a27404c0307f2db0c8eb3366fbd
-  languageName: node
-  linkType: hard
-
 "fast-json-stable-stringify@npm:^2.0.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
@@ -10957,6 +11105,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-tsconfig@npm:4.14.1":
+  version: 4.14.1
+  resolution: "get-tsconfig@npm:4.14.1"
+  dependencies:
+    resolve-pkg-maps: ^1.0.0
+  checksum: 65b56ad50bed11e001d6ea598212ff809126e83d3e94ed01949cb23539bbe81bcb84a0ee63512fbd4a1dbad7d2b4bc35bea00489458cec3c8a856fb153199344
+  languageName: node
+  linkType: hard
+
 "git-log-parser@npm:^1.2.0":
   version: 1.2.1
   resolution: "git-log-parser@npm:1.2.1"
@@ -11011,21 +11168,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
-  version: 5.1.2
-  resolution: "glob-parent@npm:5.1.2"
-  dependencies:
-    is-glob: ^4.0.1
-  checksum: f4f2bfe2425296e8a47e36864e4f42be38a996db40420fe434565e4480e3322f18eb37589617a98640c5dc8fdec1a387007ee18dbb1f3f5553409c34d17f425e
-  languageName: node
-  linkType: hard
-
 "glob-parent@npm:^6.0.2":
   version: 6.0.2
   resolution: "glob-parent@npm:6.0.2"
   dependencies:
     is-glob: ^4.0.3
   checksum: c13ee97978bef4f55106b71e66428eb1512e71a7466ba49025fc2aec59a5bfb0954d5abd58fc5ee6c9b076eef4e1f6d3375c2e964b88466ca390da4419a786a8
+  languageName: node
+  linkType: hard
+
+"glob-parent@npm:~5.1.2":
+  version: 5.1.2
+  resolution: "glob-parent@npm:5.1.2"
+  dependencies:
+    is-glob: ^4.0.1
+  checksum: f4f2bfe2425296e8a47e36864e4f42be38a996db40420fe434565e4480e3322f18eb37589617a98640c5dc8fdec1a387007ee18dbb1f3f5553409c34d17f425e
   languageName: node
   linkType: hard
 
@@ -12303,12 +12460,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^2.6.0, jiti@npm:^2.6.1":
-  version: 2.6.1
-  resolution: "jiti@npm:2.6.1"
+"jiti@npm:^2.6.1, jiti@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "jiti@npm:2.7.0"
   bin:
     jiti: lib/jiti-cli.mjs
-  checksum: 9394e29c5e40d1ca8267923160d8d86706173c9ff30c901097883434b0c4866de2c060427b6a9a5843bb3e42fa3a3c8b5b2228531d3dd4f4f10c5c6af355bb86
+  checksum: e43d0859988f1f709a9a6c69833219ebdfe041fd2f7355a2a2151254c0c42b5a74de400f24d6b5d3d6689112fedae8be1ed4df29fcc1b891e8aa0992d33f3b16
   languageName: node
   linkType: hard
 
@@ -12602,29 +12759,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"knip@npm:^5.67.1":
-  version: 5.67.1
-  resolution: "knip@npm:5.67.1"
+"knip@npm:^6.32.2":
+  version: 6.32.2
+  resolution: "knip@npm:6.32.2"
   dependencies:
-    "@nodelib/fs.walk": ^1.2.3
-    fast-glob: ^3.3.3
+    fdir: ^6.5.0
     formatly: ^0.3.0
-    jiti: ^2.6.0
-    js-yaml: ^4.1.0
-    minimist: ^1.2.8
-    oxc-resolver: ^11.12.0
-    picocolors: ^1.1.1
-    picomatch: ^4.0.1
-    smol-toml: ^1.4.1
-    strip-json-comments: 5.0.2
-    zod: ^4.1.11
-  peerDependencies:
-    "@types/node": ">=18"
-    typescript: ">=5.0.4 <7"
+    get-tsconfig: 4.14.1
+    jiti: ^2.7.0
+    oxc-parser: ^0.143.0
+    oxc-resolver: 11.24.2
+    picomatch: ^4.0.5
+    smol-toml: ^1.7.1
+    strip-json-comments: 5.0.3
+    tinyglobby: ^0.2.17
+    unbash: ^4.0.9
+    yaml: ^2.9.0
+    zod: ^4.4.3
   bin:
     knip: bin/knip.js
     knip-bun: bin/knip-bun.js
-  checksum: 73318fe1eb8859b37184b1458bcfa14d7cdffaebeaadec4de1d69fbeebab2946325bbd2e2b471d2e3665712ebab6dbc38b94b2b08ec60081791b1e085583b788
+  checksum: 99905703d6396a6e781b1f53ae7fd7b38c82b0a2a392463369b9011eabe4b58047ada41d5b057229bd869a42130b05b4feab41f5da4ffe181cfed4f6db6d0b27
   languageName: node
   linkType: hard
 
@@ -13531,13 +13686,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.3.0":
-  version: 1.4.1
-  resolution: "merge2@npm:1.4.1"
-  checksum: 7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
-  languageName: node
-  linkType: hard
-
 "mgrs@npm:1.0.0":
   version: 1.0.0
   resolution: "mgrs@npm:1.0.0"
@@ -14294,7 +14442,7 @@ __metadata:
     dotenv: ^17.2.3
     gitleaks-secret-scanner: ^2.1.1
     husky: ^9.1.7
-    knip: ^5.67.1
+    knip: ^6.32.2
     lint-staged: ^16.2.6
     semantic-release: ^25.0.1
     semantic-release-slack-bot: ^4.0.2
@@ -15297,29 +15445,96 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oxc-resolver@npm:^11.12.0":
-  version: 11.13.0
-  resolution: "oxc-resolver@npm:11.13.0"
+"oxc-parser@npm:^0.143.0":
+  version: 0.143.0
+  resolution: "oxc-parser@npm:0.143.0"
   dependencies:
-    "@oxc-resolver/binding-android-arm-eabi": 11.13.0
-    "@oxc-resolver/binding-android-arm64": 11.13.0
-    "@oxc-resolver/binding-darwin-arm64": 11.13.0
-    "@oxc-resolver/binding-darwin-x64": 11.13.0
-    "@oxc-resolver/binding-freebsd-x64": 11.13.0
-    "@oxc-resolver/binding-linux-arm-gnueabihf": 11.13.0
-    "@oxc-resolver/binding-linux-arm-musleabihf": 11.13.0
-    "@oxc-resolver/binding-linux-arm64-gnu": 11.13.0
-    "@oxc-resolver/binding-linux-arm64-musl": 11.13.0
-    "@oxc-resolver/binding-linux-ppc64-gnu": 11.13.0
-    "@oxc-resolver/binding-linux-riscv64-gnu": 11.13.0
-    "@oxc-resolver/binding-linux-riscv64-musl": 11.13.0
-    "@oxc-resolver/binding-linux-s390x-gnu": 11.13.0
-    "@oxc-resolver/binding-linux-x64-gnu": 11.13.0
-    "@oxc-resolver/binding-linux-x64-musl": 11.13.0
-    "@oxc-resolver/binding-wasm32-wasi": 11.13.0
-    "@oxc-resolver/binding-win32-arm64-msvc": 11.13.0
-    "@oxc-resolver/binding-win32-ia32-msvc": 11.13.0
-    "@oxc-resolver/binding-win32-x64-msvc": 11.13.0
+    "@oxc-parser/binding-android-arm-eabi": 0.143.0
+    "@oxc-parser/binding-android-arm64": 0.143.0
+    "@oxc-parser/binding-darwin-arm64": 0.143.0
+    "@oxc-parser/binding-darwin-x64": 0.143.0
+    "@oxc-parser/binding-freebsd-x64": 0.143.0
+    "@oxc-parser/binding-linux-arm-gnueabihf": 0.143.0
+    "@oxc-parser/binding-linux-arm-musleabihf": 0.143.0
+    "@oxc-parser/binding-linux-arm64-gnu": 0.143.0
+    "@oxc-parser/binding-linux-arm64-musl": 0.143.0
+    "@oxc-parser/binding-linux-ppc64-gnu": 0.143.0
+    "@oxc-parser/binding-linux-riscv64-gnu": 0.143.0
+    "@oxc-parser/binding-linux-riscv64-musl": 0.143.0
+    "@oxc-parser/binding-linux-s390x-gnu": 0.143.0
+    "@oxc-parser/binding-linux-x64-gnu": 0.143.0
+    "@oxc-parser/binding-linux-x64-musl": 0.143.0
+    "@oxc-parser/binding-openharmony-arm64": 0.143.0
+    "@oxc-parser/binding-win32-arm64-msvc": 0.143.0
+    "@oxc-parser/binding-win32-ia32-msvc": 0.143.0
+    "@oxc-parser/binding-win32-x64-msvc": 0.143.0
+    "@oxc-project/types": ^0.143.0
+  dependenciesMeta:
+    "@oxc-parser/binding-android-arm-eabi":
+      optional: true
+    "@oxc-parser/binding-android-arm64":
+      optional: true
+    "@oxc-parser/binding-darwin-arm64":
+      optional: true
+    "@oxc-parser/binding-darwin-x64":
+      optional: true
+    "@oxc-parser/binding-freebsd-x64":
+      optional: true
+    "@oxc-parser/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-parser/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxc-parser/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-parser/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-riscv64-musl":
+      optional: true
+    "@oxc-parser/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-x64-musl":
+      optional: true
+    "@oxc-parser/binding-openharmony-arm64":
+      optional: true
+    "@oxc-parser/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-parser/binding-win32-ia32-msvc":
+      optional: true
+    "@oxc-parser/binding-win32-x64-msvc":
+      optional: true
+  checksum: 048429ee3b462e286d1a5af093860ebd2080ddc5f49d53b27083d85ef9c589832713c3de98befac2bb836913f3f68f0cdb2807489cd42f15c47e8341c29378ab
+  languageName: node
+  linkType: hard
+
+"oxc-resolver@npm:11.24.2":
+  version: 11.24.2
+  resolution: "oxc-resolver@npm:11.24.2"
+  dependencies:
+    "@oxc-resolver/binding-android-arm-eabi": 11.24.2
+    "@oxc-resolver/binding-android-arm64": 11.24.2
+    "@oxc-resolver/binding-darwin-arm64": 11.24.2
+    "@oxc-resolver/binding-darwin-x64": 11.24.2
+    "@oxc-resolver/binding-freebsd-x64": 11.24.2
+    "@oxc-resolver/binding-linux-arm-gnueabihf": 11.24.2
+    "@oxc-resolver/binding-linux-arm-musleabihf": 11.24.2
+    "@oxc-resolver/binding-linux-arm64-gnu": 11.24.2
+    "@oxc-resolver/binding-linux-arm64-musl": 11.24.2
+    "@oxc-resolver/binding-linux-ppc64-gnu": 11.24.2
+    "@oxc-resolver/binding-linux-riscv64-gnu": 11.24.2
+    "@oxc-resolver/binding-linux-riscv64-musl": 11.24.2
+    "@oxc-resolver/binding-linux-s390x-gnu": 11.24.2
+    "@oxc-resolver/binding-linux-x64-gnu": 11.24.2
+    "@oxc-resolver/binding-linux-x64-musl": 11.24.2
+    "@oxc-resolver/binding-openharmony-arm64": 11.24.2
+    "@oxc-resolver/binding-wasm32-wasi": 11.24.2
+    "@oxc-resolver/binding-win32-arm64-msvc": 11.24.2
+    "@oxc-resolver/binding-win32-x64-msvc": 11.24.2
   dependenciesMeta:
     "@oxc-resolver/binding-android-arm-eabi":
       optional: true
@@ -15351,15 +15566,15 @@ __metadata:
       optional: true
     "@oxc-resolver/binding-linux-x64-musl":
       optional: true
+    "@oxc-resolver/binding-openharmony-arm64":
+      optional: true
     "@oxc-resolver/binding-wasm32-wasi":
       optional: true
     "@oxc-resolver/binding-win32-arm64-msvc":
       optional: true
-    "@oxc-resolver/binding-win32-ia32-msvc":
-      optional: true
     "@oxc-resolver/binding-win32-x64-msvc":
       optional: true
-  checksum: e992b35cb0cb101df63bff16ab5c8786eddc29a10e94cbc17846de5c40d3ca42f3a05b674f385769556abbf351a3a73558ce9e20a5cefbe07616ce5332ce0a57
+  checksum: d84df52af9e830db9bd9ddceb7a0f8f93cbebb96cfd8e99c90347924a1690af3d0443deba6c2a8adeb5cab07b863ffd4a1c3584de8633044183d7235ce19ab7e
   languageName: node
   linkType: hard
 
@@ -15811,7 +16026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.1, picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4, picomatch@npm:^4.0.5":
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4, picomatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "picomatch@npm:4.0.5"
   checksum: 44f305aa44f33c15d304f2e887409961d1c14eebd465b5553d8aefddcfe7b5e40d208148adef8c21a21183dda2fdba1e83c8a56918e3b5e5d3db6bcaba5b7e12
@@ -16928,6 +17143,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 1012afc566b3fdb190a6309cc37ef3b2dcc35dff5fa6683a9d00cd25c3247edfbc4691b91078c97adc82a29b77a2660c30d791d65dab4fc78bfc473f60289977
+  languageName: node
+  linkType: hard
+
 "resolve@npm:1.22.8":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
@@ -17942,10 +18164,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smol-toml@npm:^1.4.1":
-  version: 1.4.2
-  resolution: "smol-toml@npm:1.4.2"
-  checksum: f12d3fbc2d49396ec523170828a5c9a89bc7740eb7b205f8d8553af18629d936474c1ce55b70c7839aa239a11252e16fd1c3fc955b966b81c9dec00155df4f85
+"smol-toml@npm:^1.7.1":
+  version: 1.8.0
+  resolution: "smol-toml@npm:1.8.0"
+  checksum: eb465a145ab88c0c38a758a87eac19e6b25604718311415162cab87d6915e173d8dfdeec5a699c4bd1bf55c347e63a828a7e7cc73dc9b6138c874d7344eb5bd1
   languageName: node
   linkType: hard
 
@@ -18353,10 +18575,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:5.0.2":
-  version: 5.0.2
-  resolution: "strip-json-comments@npm:5.0.2"
-  checksum: 986064b73898edc77113cd6147b32f36e299869f3675ed81c3166492a6d8f02d918a492604d1982dab40ca727a86969cb91aa44d6632626f8d7c3c6ead1216bb
+"strip-json-comments@npm:5.0.3, strip-json-comments@npm:^5.0.2":
+  version: 5.0.3
+  resolution: "strip-json-comments@npm:5.0.3"
+  checksum: 3ccbf26f278220f785e4b71f8a719a6a063d72558cc63cb450924254af258a4f4c008b8c9b055373a680dc7bd525be9e543ad742c177f8a7667e0b726258e0e4
   languageName: node
   linkType: hard
 
@@ -18364,13 +18586,6 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
-  languageName: node
-  linkType: hard
-
-"strip-json-comments@npm:^5.0.2":
-  version: 5.0.3
-  resolution: "strip-json-comments@npm:5.0.3"
-  checksum: 3ccbf26f278220f785e4b71f8a719a6a063d72558cc63cb450924254af258a4f4c008b8c9b055373a680dc7bd525be9e543ad742c177f8a7667e0b726258e0e4
   languageName: node
   linkType: hard
 
@@ -19240,6 +19455,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unbash@npm:^4.0.9":
+  version: 4.0.10
+  resolution: "unbash@npm:4.0.10"
+  checksum: 400723c86258f22ce821319e67c017c859964a82d726aa01113eb4ebda14f43f868ff2416ddfb0a6a5ebaa26a7b73882220bb32779704cbec2accd2e41ad33ab
+  languageName: node
+  linkType: hard
+
 "unbox-primitive@npm:^1.1.0":
   version: 1.1.0
   resolution: "unbox-primitive@npm:1.1.0"
@@ -20061,12 +20283,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.8.0, yaml@npm:^2.8.1":
-  version: 2.8.1
-  resolution: "yaml@npm:2.8.1"
+"yaml@npm:^2.8.0, yaml@npm:^2.8.1, yaml@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
   bin:
     yaml: bin.mjs
-  checksum: 35b46150d48bc1da2fd5b1521a48a4fa36d68deaabe496f3c3fa9646d5796b6b974f3930a02c4b5aee6c85c860d7d7f79009416724465e835f40b87898c36de4
+  checksum: f0f74b349c126bb9acf649be1e7efaec5869b1567bdc047e43b176bcdd7730a9bc7ab8fc9c6b1c358e611fab0fe0a0d8933393f1af383a7dc0b4755a1d5f31f9
   languageName: node
   linkType: hard
 
@@ -20208,7 +20430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25.0 || ^4.0.0, zod@npm:^4.1.11, zod@npm:^4.4.3":
+"zod@npm:^3.25.0 || ^4.0.0, zod@npm:^4.4.3":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: bf236fdee7a5a5ec645eef5bfea3aad34e7df912931c2a23bc17e5b59882482751da42392916529da52ff9bc70f584797a5d496f1fb81f2d1a4c90fdd3922d2a


### PR DESCRIPTION
Closes #5199

## Changements

- `knip` 5.67.1 → **6.32.2**. knip 6 a supprimé toute dépendance au compilateur TypeScript (parsing et résolution via `oxc-parser` / `oxc-resolver` / `get-tsconfig`) et n'a plus de `peerDependencies`. Il tourne donc sous TS 7 sans adaptation, en **827 ms**. Schéma de configuration inchangé : le `knip.json` existant est accepté tel quel (knip 6 rejette les clés inconnues, donc l'absence d'erreur vaut validation).
- 3 correctifs `knip.json`, chacun mesuré isolément en diffant la sortie complète avec et sans :
  - l'`entry` de `server` pointait sur `src/dev.ts` (fichier supprimé) et ignorait le vrai point d'entrée `src/index.ts` (cf. `tsup.config.ts` et `server/package.json#scripts.cli`) ainsi que le `globalSetup` vitest → −2 faux « unused files », −1 faux « unused export » (`initSentry`), hint levé
  - `ignore: [".yarn/**"]` à la racine : knip analysait les bundles `.yarn/plugins/*.cjs`, d'où 15 fausses « unlisted dependencies » (`@yarnpkg/core`, `clipanion`, `semver`…) → unlisted 28 → 13
  - `project` de `ui` étendu à `scss,sass` → 2 hints d'extension compilée levés
- `yarn dedupe` : knip 6 remonte `jiti` et `yaml`, requis par le step `yarn dedupe --check` de la CI
- nouvelle doc `docs/developpement/knip.md` : cause de la panne, correctifs mesurés, baseline complète et évaluation de l'ajout en CI

Total : 459 → 441 findings, et 3 → 0 *configuration hints*.

Une quatrième piste a été écartée après mesure : ajouter `**/*.test.ts` à l'`entry` de `server` produit une sortie strictement identique sur cette base — no-op, donc non retenu.

## Baseline

441 findings, `exit 1`. Détail et classification dans la doc. Points saillants :

- 15 fichiers morts (4 `server`, 11 `ui`)
- 22 findings de dépendances, vérifiés un par un au `grep` : 12 réellement mortes, 3 mortes par ricochet d'un fichier mort, 4 mal placées (mauvais workspace), 3 faux positifs
- ~380 exports/types jamais consommés, dont 174 dans `shared` (attendu : `includeEntryExports: true` sur un paquet interne)

Validation de l'outil : sur le commit `23457dcc1`, avant que le nettoyage legacy n'atterrisse, les 6 fichiers orphelins et la dépendance `mersenne-twister` laissés par la PR 5192 figuraient **tous** dans la sortie de knip 6. La détection qui avait été faite à la main était intégralement reproductible par l'outil.

Trouvailles collatérales, hors périmètre : `sass` est déclaré dans `ui` alors qu'il ne reste aucun `.scss` dans le repo, et `yarn workspace server seed:reference` est cassé (`dotenv` ne fournit pas de binaire, c'est `dotenv-cli`).

Faux positif knip 6 à remonter en amont : `nock` (importé dans 32 fichiers `server`) reste « unused devDependency » même avec un `import nock` en tête de `server/src/index.ts`, et n'est pas reproductible sur un projet isolé.

## CI : évalué, pas branché

`ci.yml` n'est pas modifié. En l'état `yarn knip` sort en `exit 1` avec 441 findings : un gate bloquant rendrait la CI rouge en permanence, et knip 6 n'a pas de baseline native (`--save-baseline` / `--baseline` n'existent pas — `Unknown option`), donc pas de moyen de n'échouer que sur les nouveaux findings sans script maison.

Recommandation détaillée dans la doc : nettoyer d'abord (3 PR couvrent l'essentiel du volume actionnable), puis brancher `yarn knip --include files,dependencies,unlisted,binaries --treat-config-hints-as-errors` après `lint & format`. Coût négligeable (827 ms, aucun service). Pas `--no-exit-code` : un job vert avec warnings est indiscernable d'un job vert propre.

## Plan de test

- [ ] `yarn install --immutable` puis `yarn knip` : la commande aboutit (`exit 1` = findings, pas crash) et n'affiche aucun *configuration hint*
- [ ] contrôle de non-vacuité : créer un `.ts` exporté mais importé par personne → il apparaît dans « Unused files » (15 → 16) ; le supprimer → il disparaît
- [ ] CI verte : `yarn typecheck`, `yarn check:ci`, `yarn dedupe --check`, `yarn test:ci`