### PR TITLE
fix: améliore la lisibilité des noms des github actions (#5202)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   npm-packages-check:
+    name: NPM dependency check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
@@ -39,6 +40,7 @@ jobs:
         run: mna-npm-check/npm-check.sh -p .
 
   build:
+    name: Build & push image
     if: ${{ success() }}
     needs: ["npm-packages-check"]
     concurrency:

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -71,6 +71,7 @@ jobs:
           APP_VERSION: ${{ inputs.app_version }}
 
   npm-packages-check:
+    name: NPM dependency check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
 jobs:
   npm-packages-check:
+    name: NPM dependency check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project

--- a/.github/workflows/perf_budget.yml
+++ b/.github/workflows/perf_budget.yml
@@ -1,4 +1,4 @@
-name: Perf Budget
+name: Performance budget
 
 on:
   pull_request:

--- a/.github/workflows/perf_budget.yml
+++ b/.github/workflows/perf_budget.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   perf-budget:
-    name: Budget de performance
+    name: Performance budget
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/perf_budget.yml
+++ b/.github/workflows/perf_budget.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   perf-budget:
-    name: Performance budget
+    name: Measure bundle size
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,4 @@
-name: PR CI and Preview
+name: Pull Request Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, closed]
@@ -9,7 +9,7 @@ jobs:
     uses: "./.github/workflows/ci.yml"
 
   deploy_comment:
-    name: Add deploy comment
+    name: Preview instructions
     runs-on: ubuntu-latest
     steps:
       - name: Comment PR Preview

--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   cleanup:
-    name: Clean Previews
+    name: Delete expired previews
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
     uses: "./.github/workflows/ci.yml"
 
   npm-packages-check:
+    name: NPM dependency check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
@@ -26,6 +27,7 @@ jobs:
         run: mna-npm-check/npm-check.sh -p .
 
   release:
+    name: Bump & release version
     if: ${{ success() }}
     needs: ["npm-packages-check"]
     concurrency:
@@ -83,6 +85,7 @@ jobs:
         run: echo "VERSION=$(git describe --tags --abbrev=0 | cut -c2-)" >> "$GITHUB_OUTPUT"
 
   build-ui-recette:
+    name: Build UI image (recette)
     needs: ["release"]
     if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
     runs-on: ubuntu-latest
@@ -132,6 +135,7 @@ jobs:
           CI: true
 
   docker-scout-server:
+    name: Docker Scout scan (server)
     if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
     needs: ["release"]
     runs-on: ubuntu-latest
@@ -159,6 +163,7 @@ jobs:
           category: Docker Server
 
   docker-scout-ui:
+    name: Docker Scout scan (UI)
     if: needs.release.outputs.VERSION != needs.release.outputs.PREV_VERSION
     needs: ["release"]
     runs-on: ubuntu-latest
@@ -201,6 +206,7 @@ jobs:
       OPENPGP_PRIVATE_SUBKEY: ${{ secrets.OPENPGP_PRIVATE_SUBKEY }}
 
   sentry:
+    name: Upload sourcemaps to Sentry
     needs: ["release"]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Closes #5202

## Changements

- `preview.yml` : "PR CI and Preview" → "Pull Request Checks" (le workflow ne déploie pas de preview, il ne fait que lancer la CI et poster un commentaire d'instructions)
- `preview.yml` : job `deploy_comment` → "Preview instructions" pour éviter la confusion avec le vrai déploiement de preview
- `preview_cleanup.yml` : job `cleanup` "Clean Previews" → "Delete expired previews" (doublon avec le nom du workflow)
- `perf_budget.yml` : job `perf-budget` en français → "Performance budget" (cohérence de langue avec le reste des workflows)
- `_build.yml`, `_deploy.yml`, `ci.yml`, `release.yml` : ajout d'un `name:` lisible sur les jobs qui affichaient leur id brut dans l'UI GitHub (`npm-packages-check`, `build`, `release`, `build-ui-recette`, `docker-scout-server`, `docker-scout-ui`, `sentry`)

Aucun id de job ni `needs:`/`uses:` n'a été modifié. Le check requis sur `main` (`tests / Tests`) reste inchangé.

## Plan de test

- [ ] Vérifier dans l'onglet Actions que les nouveaux libellés s'affichent correctement sur un run de chaque workflow modifié
- [ ] Vérifier que le merge queue / la CI passent normalement (check `tests / Tests` toujours présent)