### PR TITLE
feat: parallélise le traitement des vœux dans getTrainingLinks (#5204)

### DIFF
--- a/server/src/services/training-links.service.test.ts
+++ b/server/src/services/training-links.service.test.ts
@@ -188,4 +188,32 @@ describe("getTrainingLinks", () => {
     const w4Url = new URL(w4.lien_lba)
     expect(w4Url.pathname).toBe("/")
   })
+
+  it("returns one result per wish, in input order, across parallel groups", async () => {
+    await saveRome("D1102", "Boulangerie - viennoiserie")
+    await saveFormation({
+      cle_ministere_educatif: "CLE1",
+      intitule_long: "Bac Pro Boulanger",
+      rome_codes: ["D1102"],
+      localite: "Paris 6e",
+      lieu_formation_geopoint: { type: "Point", coordinates: [2.35, 48.86] },
+    })
+
+    // Plus que la taille d'un groupe parallèle (10), en alternant vœux résolus (durée variable :
+    // lookups formation + rome) et vœux vides (immédiats) pour désynchroniser les complétions
+    const wishes = Array.from({ length: 25 }, (_, i) => (i % 2 === 0 ? { id: `w${i}`, cle_ministere_educatif: "CLE1" } : { id: `w${i}` }))
+
+    const results = await getTrainingLinks(wishes)
+
+    expect(results.map((r) => r.id)).toEqual(wishes.map((w) => w.id))
+
+    for (const [i, result] of results.entries()) {
+      const url = new URL(result.lien_lba)
+      if (i % 2 === 0) {
+        expect(url.searchParams.get("q")).toBe("Boulangerie - viennoiserie")
+      } else {
+        expect(url.pathname).toBe("/")
+      }
+    }
+  })
 })

--- a/server/src/services/training-links.service.ts
+++ b/server/src/services/training-links.service.ts
@@ -1,7 +1,7 @@
 import { getDistance } from "geolib"
 import type { IFormationCatalogue } from "shared/models/index"
 import { URL } from "url"
-import { asyncForEach } from "@/common/utils/async-utils"
+import { asyncForEachGrouped } from "@/common/utils/async-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import config from "@/config.js"
 import { getCommuneByCodeInsee, getCommuneByCodePostal } from "./referentiel/commune/commune.referentiel.service"
@@ -256,10 +256,12 @@ export const getTrainingLinks = async (params: IWish[]): Promise<ILinks[]> => {
     formationsByCle.get(cle)!.push(formation)
   }
 
-  const results: ILinks[] = []
-  await asyncForEach(params, async (training) => {
+  // Traitement par groupes parallèles : chaque vœu ne fait que des lectures Mongo et les
+  // structures partagées sont en lecture seule. L'écriture indexée préserve l'ordre d'entrée.
+  const results: ILinks[] = new Array(params.length)
+  await asyncForEachGrouped(params, 10, async (training, index) => {
     const [lien_prdv, lien_lba] = await Promise.all([getPrdvLink(training, eligibleCles), getLBALink(training, formationsByCle, romeLabelByCode)])
-    results.push({ id: training.id, lien_prdv, lien_lba })
+    results[index] = { id: training.id, lien_prdv, lien_lba }
   })
 
   return results


### PR DESCRIPTION
Closes #5204

## Changements

- `getTrainingLinks` traite désormais les vœux par groupes de 10 en parallèle (`asyncForEachGrouped`, utilitaire existant) au lieu d'une boucle strictement séquentielle (`asyncForEach`)
- L'ordre des résultats est préservé par écriture indexée (`results[index]`), indépendamment de l'ordre de complétion au sein d'un groupe
- Sans risque de concurrence identifié : le chemin par vœu ne fait que des lectures Mongo (formations, communes du référentiel local — aucune API externe), et les structures partagées (`eligibleCles`, `formationsByCle`, `romeLabelByCode`) sont préchargées en lecture seule
- Test ajouté : 25 vœux (plus de 2 groupes parallèles) alternant vœux résolus et vœux vides aux durées désynchronisées — un résultat par vœu, dans l'ordre d'entrée

## Contexte

Pour un chunk de 100 vœux, la latence était ≈ 100 × le coût unitaire (plusieurs lookups Mongo par vœu). C'est le principal facteur de latence pour les consommateurs batch de `/api/traininglinks`, notamment la génération des listes de diffusion BAL (une liste de 357K lignes = 3 570 appels de 100 vœux, ~30 h de génération constatées en production). Latence attendue divisée par ~10 sur ce poste.

## Plan de test

- [ ] `yarn typecheck` et tests `training-links.service.test.ts` verts (vérifié en local : 9 tests dont le nouveau)
- [ ] En recette, appeler `POST /api/traininglinks` avec 100 vœux réels et comparer la latence avant/après
- [ ] Vérifier que les liens retournés sont identiques à l'existant sur un même payload (l'ordre et le contenu ne doivent pas changer)