### PR TITLE
fix: fiabilise les erreurs transitoires mongot, mistral 429 et le logging géoloc (#5206)

### DIFF
--- a/server/src/services/geolocation.service.ts
+++ b/server/src/services/geolocation.service.ts
@@ -6,6 +6,7 @@ import { ZPointFeature, ZPointGeometry } from "shared/models/index"
 import { joinNonNullStrings } from "shared/utils/index"
 import z from "zod"
 import getApiClient from "@/common/apis/client"
+import { logger } from "@/common/logger"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
 import { getGeolocationFromCache, saveGeolocationInCache } from "./cache-geolocation.service"
 
@@ -103,6 +104,8 @@ export const getGeolocation = async (rawAddress: string): Promise<IPointFeature 
     if (!parseResult.success) {
       // sentryCaptureException et non console.error : la capture console sérialisait l'objet en
       // "[object Object]" (Sentry LBA-SERVER-5J7KF4ZZZT824) et perdait la cause réelle.
+      // logger.error en complément : garde le canal des logs locaux (stdout/Loki des jobs).
+      logger.error({ address: rawAddress, err: parseResult.error.message }, "error parsing geolocation api response")
       sentryCaptureException(parseResult.error, { extra: { cause: "error parsing geolocation api response", address: rawAddress } })
       return null
     }
@@ -131,6 +134,8 @@ export const getGeolocation = async (rawAddress: string): Promise<IPointFeature 
   } catch (error) {
     // sentryCaptureException et non console.error : la capture console sérialisait l'objet en
     // "[object Object]" (Sentry LBA-SERVER-P8YDWKZZZE60) — l'AxiosError (statut, URL) était perdue.
+    // logger.error en complément : garde le canal des logs locaux (stdout/Loki des jobs).
+    logger.error({ address: rawAddress, err: error instanceof Error ? error.message : String(error) }, "Error fetching or processing geolocation data")
     sentryCaptureException(error, { extra: { cause: "Error fetching or processing geolocation data", address: rawAddress } })
     return null
   }

--- a/server/src/services/geolocation.service.ts
+++ b/server/src/services/geolocation.service.ts
@@ -101,7 +101,9 @@ export const getGeolocation = async (rawAddress: string): Promise<IPointFeature 
 
     const parseResult = ZApiGeolocationResponse.safeParse(response)
     if (!parseResult.success) {
-      console.error("error parsing geolocation api response", { address: rawAddress, error: parseResult.error })
+      // sentryCaptureException et non console.error : la capture console sérialisait l'objet en
+      // "[object Object]" (Sentry LBA-SERVER-5J7KF4ZZZT824) et perdait la cause réelle.
+      sentryCaptureException(parseResult.error, { extra: { cause: "error parsing geolocation api response", address: rawAddress } })
       return null
     }
 
@@ -127,7 +129,9 @@ export const getGeolocation = async (rawAddress: string): Promise<IPointFeature 
 
     return firstFeature
   } catch (error) {
-    console.error("Error fetching or processing geolocation data:", { address: rawAddress, error })
+    // sentryCaptureException et non console.error : la capture console sérialisait l'objet en
+    // "[object Object]" (Sentry LBA-SERVER-P8YDWKZZZE60) — l'AxiosError (statut, URL) était perdue.
+    sentryCaptureException(error, { extra: { cause: "Error fetching or processing geolocation data", address: rawAddress } })
     return null
   }
 }

--- a/server/src/services/mistralai/mistralai.service.test.ts
+++ b/server/src/services/mistralai/mistralai.service.test.ts
@@ -46,6 +46,12 @@ describe("sendMistralMessages — backoff sur 429", () => {
     expect(vi.mocked(sleep).mock.calls.map(([ms]) => ms)).toEqual([7_000])
   })
 
+  it("caps an aberrant Retry-After at 120s", async () => {
+    completeMock.mockRejectedValueOnce(rateLimitError({ "retry-after": "3600" })).mockResolvedValueOnce(successResponse)
+    await expect(sendMistralMessages({ messages: [...MESSAGES] })).resolves.toBe('{"pong":true}')
+    expect(vi.mocked(sleep).mock.calls.map(([ms]) => ms)).toEqual([120_000])
+  })
+
   it("falls back to the fixed delays on a non-numeric Retry-After (near-miss: HTTP date)", async () => {
     completeMock.mockRejectedValueOnce(rateLimitError({ "retry-after": "Wed, 21 Aug 2026 09:00:00 GMT" })).mockResolvedValueOnce(successResponse)
     await expect(sendMistralMessages({ messages: [...MESSAGES] })).resolves.toBe('{"pong":true}')

--- a/server/src/services/mistralai/mistralai.service.test.ts
+++ b/server/src/services/mistralai/mistralai.service.test.ts
@@ -1,0 +1,77 @@
+import { setTimeout as sleep } from "node:timers/promises"
+
+import { describe, expect, it, vi } from "vitest"
+
+import { sentryCaptureException } from "@/common/utils/sentry-utils"
+import { sendMistralMessages } from "@/services/mistralai/mistralai.service"
+
+const { completeMock } = vi.hoisted(() => ({ completeMock: vi.fn() }))
+
+vi.mock("@mistralai/mistralai", () => ({
+  Mistral: class {
+    chat = { complete: completeMock }
+  },
+}))
+vi.mock("node:timers/promises", () => ({ setTimeout: vi.fn().mockResolvedValue(undefined) }))
+vi.mock("@/common/utils/sentry-utils")
+vi.mock("@/common/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
+vi.mock("@/config", () => ({ default: { mistralai: { apiKey: "test-key" } } }))
+
+const MESSAGES = [{ role: "user", content: "ping" }] as const
+
+const rateLimitError = (headers?: Record<string, string>) =>
+  Object.assign(new Error("API error occurred: Status 429"), { statusCode: 429, ...(headers ? { headers: new Headers(headers) } : {}) })
+const successResponse = { choices: [{ message: { content: '{"pong":true}' } }] }
+
+describe("sendMistralMessages — backoff sur 429", () => {
+  it("returns the content directly on success (no sleep, no capture)", async () => {
+    completeMock.mockResolvedValue(successResponse)
+    await expect(sendMistralMessages({ messages: [...MESSAGES] })).resolves.toBe('{"pong":true}')
+    expect(completeMock).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+    expect(sentryCaptureException).not.toHaveBeenCalled()
+  })
+
+  it("retries with backoff on 429 then succeeds, without capturing", async () => {
+    completeMock.mockRejectedValueOnce(rateLimitError()).mockRejectedValueOnce(rateLimitError()).mockResolvedValueOnce(successResponse)
+    await expect(sendMistralMessages({ messages: [...MESSAGES] })).resolves.toBe('{"pong":true}')
+    expect(completeMock).toHaveBeenCalledTimes(3)
+    expect(vi.mocked(sleep).mock.calls.map(([ms]) => ms)).toEqual([2_000, 10_000])
+    expect(sentryCaptureException).not.toHaveBeenCalled()
+  })
+
+  it("honors a numeric Retry-After header over the fixed delays", async () => {
+    completeMock.mockRejectedValueOnce(rateLimitError({ "retry-after": "7" })).mockResolvedValueOnce(successResponse)
+    await expect(sendMistralMessages({ messages: [...MESSAGES] })).resolves.toBe('{"pong":true}')
+    expect(vi.mocked(sleep).mock.calls.map(([ms]) => ms)).toEqual([7_000])
+  })
+
+  it("falls back to the fixed delays on a non-numeric Retry-After (near-miss: HTTP date)", async () => {
+    completeMock.mockRejectedValueOnce(rateLimitError({ "retry-after": "Wed, 21 Aug 2026 09:00:00 GMT" })).mockResolvedValueOnce(successResponse)
+    await expect(sendMistralMessages({ messages: [...MESSAGES] })).resolves.toBe('{"pong":true}')
+    expect(vi.mocked(sleep).mock.calls.map(([ms]) => ms)).toEqual([2_000])
+  })
+
+  it("gives up after exhausting retries on persistent 429: null + single capture", async () => {
+    completeMock.mockRejectedValue(rateLimitError())
+    await expect(sendMistralMessages({ messages: [...MESSAGES] })).resolves.toBeNull()
+    expect(completeMock).toHaveBeenCalledTimes(4)
+    expect(sleep).toHaveBeenCalledTimes(3)
+    expect(sentryCaptureException).toHaveBeenCalledTimes(1)
+  })
+
+  it("does NOT retry a non-429 error (near-miss: statusCode 500)", async () => {
+    completeMock.mockRejectedValue(Object.assign(new Error("API error occurred: Status 500"), { statusCode: 500 }))
+    await expect(sendMistralMessages({ messages: [...MESSAGES] })).resolves.toBeNull()
+    expect(completeMock).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+    expect(sentryCaptureException).toHaveBeenCalledTimes(1)
+  })
+
+  it("does NOT retry a thrown non-Error carrying statusCode 429 (near-miss)", async () => {
+    completeMock.mockRejectedValue({ statusCode: 429 })
+    await expect(sendMistralMessages({ messages: [...MESSAGES] })).resolves.toBeNull()
+    expect(completeMock).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+})

--- a/server/src/services/mistralai/mistralai.service.ts
+++ b/server/src/services/mistralai/mistralai.service.ts
@@ -12,6 +12,25 @@ const mistral = new Mistral({
 
 export type Message = { role: "system"; content: string } | { role: "user"; content: string } | { role: "assistant"; content: string } | { role: "tool"; content: string }
 
+// 429 Mistral (rate limit) : transitoire par nature — la capture immédiate générait ~100 events/jour
+// de pur bruit Sentry (LBA-SERVER-5J7KF4ZZZT9JV) alors qu'un backoff suffit. Les quotas sont des
+// fenêtres À LA MINUTE (vérifié empiriquement sur /v1/chat/completions : en-têtes
+// x-ratelimit-{limit,remaining}-{tokens,req}-minute ; pas de X-RateLimit-Remaining global,
+// contrairement à ce que suggère la doc) : on honore Retry-After s'il est présent sur le 429,
+// sinon paliers fixes dont le dernier (60s) garantit une fenêtre de quota fraîche. Tous les
+// appelants sont des jobs de fond : la latence ajoutée est sans enjeu. La capture Sentry ne part
+// qu'une fois les retries épuisés — la dégradation (retour null) reste observable.
+const RATE_LIMIT_RETRY_DELAYS_MS = [2_000, 10_000, 60_000]
+
+const isMistralRateLimitError = (error: unknown): error is Error & { headers?: Headers } => error instanceof Error && (error as { statusCode?: unknown }).statusCode === 429
+
+const getRateLimitRetryDelayMs = (error: Error & { headers?: Headers }, attempt: number): number => {
+  // Retry-After numérique uniquement (une date HTTP → NaN → paliers fixes).
+  const retryAfterSeconds = Number(error.headers?.get?.("retry-after"))
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) return retryAfterSeconds * 1_000
+  return RATE_LIMIT_RETRY_DELAYS_MS[attempt]
+}
+
 export const sendMistralMessages = async ({
   messages,
   randomSeed,
@@ -25,29 +44,45 @@ export const sendMistralMessages = async ({
   maxTokens?: number
   responseFormat?: { type: "text" | "json_object" }
 }): Promise<string | null> => {
-  try {
-    const response = await mistral.chat.complete({
-      model,
-      messages,
-      maxTokens,
-      ...(randomSeed ? { randomSeed } : {}),
-      responseFormat,
-    })
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const response = await mistral.chat.complete({
+        model,
+        messages,
+        maxTokens,
+        ...(randomSeed ? { randomSeed } : {}),
+        responseFormat,
+      })
 
-    if (!response.choices?.length || !response.choices[0].message) {
-      logger.info({ response }, "No response from Mistral")
+      if (!response.choices?.length || !response.choices[0].message) {
+        logger.info({ response }, "No response from Mistral")
+        return null
+      }
+      const message = response.choices[0].message.content as string
+      if (!message) {
+        logger.info({ response }, "No content from Mistral")
+        return null
+      }
+      return message
+    } catch (error) {
+      if (isMistralRateLimitError(error) && attempt < RATE_LIMIT_RETRY_DELAYS_MS.length) {
+        const delayMs = getRateLimitRetryDelayMs(error, attempt)
+        logger.warn(
+          {
+            attempt,
+            delayMs,
+            remainingTokensMinute: error.headers?.get?.("x-ratelimit-remaining-tokens-minute") ?? null,
+            remainingReqMinute: error.headers?.get?.("x-ratelimit-remaining-req-minute") ?? null,
+          },
+          "Mistral 429 — retry après backoff"
+        )
+        await sleep(delayMs)
+        continue
+      }
+      sentryCaptureException(error)
+      console.error(error)
       return null
     }
-    const message = response.choices[0].message.content as string
-    if (!message) {
-      logger.info({ response }, "No content from Mistral")
-      return null
-    }
-    return message
-  } catch (error) {
-    sentryCaptureException(error)
-    console.error(error)
-    return null
   }
 }
 

--- a/server/src/services/mistralai/mistralai.service.ts
+++ b/server/src/services/mistralai/mistralai.service.ts
@@ -25,9 +25,10 @@ const RATE_LIMIT_RETRY_DELAYS_MS = [2_000, 10_000, 60_000]
 const isMistralRateLimitError = (error: unknown): error is Error & { headers?: Headers } => error instanceof Error && (error as { statusCode?: unknown }).statusCode === 429
 
 const getRateLimitRetryDelayMs = (error: Error & { headers?: Headers }, attempt: number): number => {
-  // Retry-After numérique uniquement (une date HTTP → NaN → paliers fixes).
+  // Retry-After numérique uniquement (une date HTTP → NaN → paliers fixes), plafonné à 120s :
+  // un header aberrant ne doit pas endormir un job une heure par tentative.
   const retryAfterSeconds = Number(error.headers?.get?.("retry-after"))
-  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) return retryAfterSeconds * 1_000
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) return Math.min(retryAfterSeconds * 1_000, 120_000)
   return RATE_LIMIT_RETRY_DELAYS_MS[attempt]
 }
 

--- a/server/src/services/search/search-transient-retry.test.ts
+++ b/server/src/services/search/search-transient-retry.test.ts
@@ -1,0 +1,54 @@
+import { MongoServerError } from "mongodb"
+import { describe, expect, it, vi } from "vitest"
+
+import { sentryCaptureException } from "@/common/utils/sentry-utils"
+import { isTransientSearchCancellation, retryOnTransientSearchCancellation } from "@/services/search/search-transient-retry"
+
+vi.mock("@/common/utils/sentry-utils")
+
+const callbackCanceledError = () => new MongoServerError({ ok: 0, errmsg: "Callback canceled", code: 90, codeName: "CallbackCanceled" })
+
+describe("isTransientSearchCancellation", () => {
+  it("matches a MongoServerError CallbackCanceled (code 90)", () => {
+    expect(isTransientSearchCancellation(callbackCanceledError())).toBe(true)
+  })
+
+  it("does NOT match another MongoServerError (near-miss)", () => {
+    const other = new MongoServerError({ ok: 0, errmsg: "Remote error from mongot", code: 6, codeName: "HostUnreachable" })
+    expect(isTransientSearchCancellation(other)).toBe(false)
+  })
+
+  it("does NOT match a plain Error mentioning cancellation (near-miss)", () => {
+    expect(isTransientSearchCancellation(new Error("Callback canceled"))).toBe(false)
+  })
+})
+
+describe("retryOnTransientSearchCancellation", () => {
+  it("returns the result without retry nor capture on success", async () => {
+    const run = vi.fn().mockResolvedValue("ok")
+    await expect(retryOnTransientSearchCancellation(run, { q: "boulanger" })).resolves.toBe("ok")
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(sentryCaptureException).not.toHaveBeenCalled()
+  })
+
+  it("retries once on CallbackCanceled and captures a warning", async () => {
+    const run = vi.fn().mockRejectedValueOnce(callbackCanceledError()).mockResolvedValueOnce("ok")
+    await expect(retryOnTransientSearchCancellation(run, { q: "boulanger" })).resolves.toBe("ok")
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(sentryCaptureException).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(sentryCaptureException).mock.calls[0][1]).toMatchObject({ level: "warning", extra: { q: "boulanger", fallback: "search-transient-retry" } })
+  })
+
+  it("propagates the second error when the retry fails too", async () => {
+    const run = vi.fn().mockRejectedValue(callbackCanceledError())
+    await expect(retryOnTransientSearchCancellation(run, { q: "boulanger" })).rejects.toThrow("Callback canceled")
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it("does NOT retry a non-transient error (thrown as-is, no capture)", async () => {
+    const run = vi.fn().mockRejectedValue(new Error("maxClauseCount is set to 1024"))
+    await expect(retryOnTransientSearchCancellation(run, { q: "boulanger" })).rejects.toThrow("maxClauseCount")
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(sentryCaptureException).not.toHaveBeenCalled()
+  })
+})

--- a/server/src/services/search/search-transient-retry.ts
+++ b/server/src/services/search/search-transient-retry.ts
@@ -1,0 +1,23 @@
+import { MongoServerError } from "mongodb"
+
+import { sentryCaptureException } from "@/common/utils/sentry-utils"
+
+// mongot peut annuler ponctuellement une requête $search/$searchMeta : RPC mongod→mongot
+// interrompue (redémarrage/coupure du sidecar) → MongoServerError code 90 "CallbackCanceled"
+// (Sentry LBA-SERVER-5J7KF4ZZZT961 : ~150 requêtes/jour finissaient en 500 sur /api/v1/search).
+// L'erreur est transitoire : la requête suivante repart sur une connexion saine, un unique
+// retry suffit donc à éviter le 500 utilisateur. La capture en warning garde la fréquence du
+// repli observable, et l'échec du retry est propagé tel quel (500 + capture Sentry standard).
+export function isTransientSearchCancellation(err: unknown): boolean {
+  return err instanceof MongoServerError && (err.codeName === "CallbackCanceled" || err.code === 90)
+}
+
+export async function retryOnTransientSearchCancellation<T>(run: () => Promise<T>, extra: Record<string, unknown>): Promise<T> {
+  try {
+    return await run()
+  } catch (err) {
+    if (!isTransientSearchCancellation(err)) throw err
+    sentryCaptureException(err, { level: "warning", extra: { ...extra, fallback: "search-transient-retry" } })
+    return run()
+  }
+}

--- a/server/src/services/search/search.service.ts
+++ b/server/src/services/search/search.service.ts
@@ -5,6 +5,7 @@ import { JOB_START_TYPE } from "shared/models/job.model"
 import { getDistanceInKm } from "@/common/utils/geolib"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
+import { retryOnTransientSearchCancellation } from "@/services/search/search-transient-retry"
 
 const HIGHLIGHT_MAX_PASSAGES = 5
 const HIGHLIGHT_MAX_CHARS = 300
@@ -672,76 +673,82 @@ async function runSearchAggregations(params: ISearchFilters, simplifyQuery: bool
   const chipCountCompounds = buildChipCountCompounds(params, simplifyQuery)
   const chipCountKeys = Object.keys(chipCountCompounds) as (keyof typeof chipCountCompounds)[]
 
-  const [rows, chipCountArrays, ...metaArrays] = await Promise.all([
-    getDbCollection("search_items")
-      .aggregate<SearchRow>(
-        [
-          {
-            $search: {
-              index: "search_items_index",
-              compound,
-              sort: buildSortStage(params),
-              highlight: {
-                // rome_labels inclus : les recruteurs n'ont pas de description → preview via les intitulés métier.
-                path: ["title", "description", "rome_labels"],
-                maxNumPassages: HIGHLIGHT_MAX_PASSAGES,
-              },
-              count: { type: "total" },
-            },
-          },
-          {
-            $addFields: {
-              highlights: { $meta: "searchHighlights" },
-              _meta: "$$SEARCH_META",
-            },
-          },
-          { $skip: page * hitsPerPage },
-          { $limit: hitsPerPage },
-        ],
-        SEARCH_AGGREGATE_OPTIONS
-      )
-      .toArray(),
-
-    // Compteurs des chips booléennes (handi, urgent, candidature simplifiée) — un $searchMeta chacun.
-    Promise.all(
-      chipCountKeys.map((key) =>
+  // Retry unique si mongot annule une des requêtes (transitoire — cf. search-transient-retry.ts) ;
+  // relancer l'ensemble est sans risque, ce ne sont que des lectures.
+  const [rows, chipCountArrays, ...metaArrays] = await retryOnTransientSearchCancellation(
+    () =>
+      Promise.all([
         getDbCollection("search_items")
-          .aggregate<{ count?: { total?: number } }>(
+          .aggregate<SearchRow>(
             [
               {
-                $searchMeta: {
+                $search: {
                   index: "search_items_index",
-                  compound: chipCountCompounds[key],
+                  compound,
+                  sort: buildSortStage(params),
+                  highlight: {
+                    // rome_labels inclus : les recruteurs n'ont pas de description → preview via les intitulés métier.
+                    path: ["title", "description", "rome_labels"],
+                    maxNumPassages: HIGHLIGHT_MAX_PASSAGES,
+                  },
                   count: { type: "total" },
                 },
               },
+              {
+                $addFields: {
+                  highlights: { $meta: "searchHighlights" },
+                  _meta: "$$SEARCH_META",
+                },
+              },
+              { $skip: page * hitsPerPage },
+              { $limit: hitsPerPage },
             ],
             SEARCH_AGGREGATE_OPTIONS
           )
-          .toArray()
-      )
-    ),
+          .toArray(),
 
-    // Une requête $searchMeta par groupe de facettes (faceting disjonctif).
-    ...facetGroups.map((group) =>
-      getDbCollection("search_items")
-        .aggregate<FacetMetaRow>(
-          [
-            {
-              $searchMeta: {
-                index: "search_items_index",
-                facet: {
-                  operator: { compound: group.compound },
-                  facets: Object.fromEntries(group.keys.map((key) => [key, FACET_FIELD_DEFS[key]])),
+        // Compteurs des chips booléennes (handi, urgent, candidature simplifiée) — un $searchMeta chacun.
+        Promise.all(
+          chipCountKeys.map((key) =>
+            getDbCollection("search_items")
+              .aggregate<{ count?: { total?: number } }>(
+                [
+                  {
+                    $searchMeta: {
+                      index: "search_items_index",
+                      compound: chipCountCompounds[key],
+                      count: { type: "total" },
+                    },
+                  },
+                ],
+                SEARCH_AGGREGATE_OPTIONS
+              )
+              .toArray()
+          )
+        ),
+
+        // Une requête $searchMeta par groupe de facettes (faceting disjonctif).
+        ...facetGroups.map((group) =>
+          getDbCollection("search_items")
+            .aggregate<FacetMetaRow>(
+              [
+                {
+                  $searchMeta: {
+                    index: "search_items_index",
+                    facet: {
+                      operator: { compound: group.compound },
+                      facets: Object.fromEntries(group.keys.map((key) => [key, FACET_FIELD_DEFS[key]])),
+                    },
+                  },
                 },
-              },
-            },
-          ],
-          SEARCH_AGGREGATE_OPTIONS
-        )
-        .toArray()
-    ),
-  ])
+              ],
+              SEARCH_AGGREGATE_OPTIONS
+            )
+            .toArray()
+        ),
+      ]),
+    { q: params.q }
+  )
 
   return { rows, chipCountArrays, metaArrays, facetGroups, chipCountKeys }
 }
@@ -823,27 +830,32 @@ export async function searchItems(params: ISearchFilters): Promise<{
 
 // Autocomplétion sur le contenu indexé (title + rome_labels, edgeGram).
 async function suggestFromItems(q: string, limit: number): Promise<string[]> {
-  const rows = await getDbCollection("search_items")
-    .aggregate<{ title: string; rome_labels: string[] | null }>(
-      [
-        {
-          $search: {
-            index: "search_items_index",
-            compound: {
-              should: [
-                { autocomplete: { query: q, path: "title", fuzzy: { maxEdits: 1 }, score: { boost: { value: 2 } } } },
-                { autocomplete: { query: q, path: "rome_labels", fuzzy: { maxEdits: 1 } } },
-              ],
-              minimumShouldMatch: 1,
+  // Même retry anti-annulation mongot que la recherche principale (cf. search-transient-retry.ts).
+  const rows = await retryOnTransientSearchCancellation(
+    () =>
+      getDbCollection("search_items")
+        .aggregate<{ title: string; rome_labels: string[] | null }>(
+          [
+            {
+              $search: {
+                index: "search_items_index",
+                compound: {
+                  should: [
+                    { autocomplete: { query: q, path: "title", fuzzy: { maxEdits: 1 }, score: { boost: { value: 2 } } } },
+                    { autocomplete: { query: q, path: "rome_labels", fuzzy: { maxEdits: 1 } } },
+                  ],
+                  minimumShouldMatch: 1,
+                },
+              },
             },
-          },
-        },
-        { $limit: limit * 5 },
-        { $project: { _id: 0, title: 1, rome_labels: 1 } },
-      ],
-      SEARCH_AGGREGATE_OPTIONS
-    )
-    .toArray()
+            { $limit: limit * 5 },
+            { $project: { _id: 0, title: 1, rome_labels: 1 } },
+          ],
+          SEARCH_AGGREGATE_OPTIONS
+        )
+        .toArray(),
+    { q, source: "suggest" }
+  )
   return rows.flatMap((row) => [row.title, ...(row.rome_labels ?? [])])
 }
 

--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -28,6 +28,12 @@ init({
     reportingObserverIntegration({ types: ["crash"] }),
   ],
   sendDefaultPii: true,
+  denyUrls: [
+    // Scripts injectés par des extensions/WebViews tiers, jamais servis par LBA (aucun
+    // "executors" dans le code ni le build Next — frames type app:///executors/200.js,
+    // ex. TypeError "reading 'M_ID'", Sentry LBA-UI-5CVZZZZZZG4T4, ~2 300 events/7j).
+    /\/executors\/\d+\.js/,
+  ],
   ignoreErrors: [
     "AbortError",
     // Erreurs provenant d'extensions navigateur tierces (MetaMask, gestionnaires d'onglets…),


### PR DESCRIPTION
Closes #5206

## Changements

- **Recherche / mongot** : nouveau module `search-transient-retry.ts` — retry unique quand mongot annule une requête `$search`/`$searchMeta` (MongoServerError code 90 `CallbackCanceled`, transitoire pendant un redémarrage du sidecar). Appliqué à la recherche principale et à l'autocomplétion. Chaque repli est capturé en warning Sentry (observable), l'échec du retry reste propagé en 500. Supprime ~150 erreurs 500/jour sur la recherche.
- **Mistral 429** : backoff dans `sendMistralMessages` — `Retry-After` honoré s'il est présent, sinon paliers 2s/10s/60s (quotas Mistral à la minute, vérifié empiriquement via les en-têtes `x-ratelimit-*-minute` ; le dernier palier garantit une fenêtre fraîche). Capture Sentry uniquement après épuisement des retries ; log des quotas restants sur chaque 429. Appelants = jobs de fond uniquement.
- **Géolocalisation** : remplacement des `console.error` sérialisés en `[object Object]` par `sentryCaptureException` structuré — l'AxiosError réelle (statut, URL) et l'adresse redeviennent visibles dans Sentry.
- **UI / bruit Sentry** : `denyUrls` sur les frames `app:///executors/NNN.js` (scripts injectés par extensions/WebViews tiers, ~2 550 events/7j, aucun code LBA concerné — vérifié par deux recherches distinctes dans le repo).

## Plan de test

- [ ] `yarn vitest run --project server src/services/search/search-transient-retry.test.ts src/services/mistralai/mistralai.service.test.ts` — 14 tests (retry mongot + backoff 429, incluant near-miss : autre code Mongo, statusCode 500, Retry-After en date HTTP)
- [ ] `SEARCH_RELEVANCE_TESTS=true yarn vitest run --project server src/services/search/search-result.test.ts src/services/search/search.service.test.ts` — non-régression pertinence (59 + 3 tests, nécessite la stack Docker mongot)
- [ ] Vérifier post-déploiement dans Sentry : baisse des events LBA-SERVER-5J7KF4ZZZT961 (Callback canceled), LBA-SERVER-5J7KF4ZZZT9JV (429), disparition des nouveaux events LBA-UI-5CVZZZZZZG4T4 (M_ID)