### PR TITLE
feat: ajoute une source external_sites pour les liens de recherche externes

### DIFF
--- a/server/src/http/controllers/search.controller.test.ts
+++ b/server/src/http/controllers/search.controller.test.ts
@@ -179,6 +179,30 @@ describe("search.controller", () => {
         expect(doc).toMatchObject({ status: "ok", nb_hits: 0 })
       })
 
+      it("logue source par défaut à free_text quand non fourni", async () => {
+        const response = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=sansSource&page=0" })
+        expect(response.statusCode).toBe(200)
+
+        const doc = await waitForLoggedQuery("sansSource")
+        expect(doc).toMatchObject({ source: "free_text" })
+      })
+
+      it.each([
+        ["training_links", "requeteTrainingLinks"],
+        ["external_sites", "requeteExternalSites"],
+      ] as const)("accepte et logue source=%s", async (source, q) => {
+        const response = await httpClient().inject({ method: "GET", path: `/api/v1/search?q=${q}&page=0&source=${source}` })
+        expect(response.statusCode).toBe(200)
+
+        const doc = await waitForLoggedQuery(q)
+        expect(doc).toMatchObject({ source })
+      })
+
+      it("rejette une valeur de source inconnue (400)", async () => {
+        const response = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=sourceInvalide&page=0&source=bogus" })
+        expect(response.statusCode).toBe(400)
+      })
+
       it("ne logue pas une requête interne ni une page > 0", async () => {
         const response1 = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=interne&page=0&internal=true" })
         const response2 = await httpClient().inject({ method: "GET", path: "/api/v1/search?q=page1&page=1" })

--- a/server/src/jobs/search/analyze-search-queries.ts
+++ b/server/src/jobs/search/analyze-search-queries.ts
@@ -67,10 +67,11 @@ async function aggregateQueryStats(): Promise<IQueryStats[]> {
       // status=error exclu : nb_hits est alors null (recherche non aboutie, aucun signal de
       // pertinence) — l'inclure gonflerait `total` sans jamais compter dans `zero_hits_count`,
       // ce qui ferait paraître le terme plus pertinent qu'il ne l'est (cf. #5166). Même logique
-      // pour source=training_links : trafic synthétique (liens générés côté serveur pour les
-      // vœux Parcoursup), pas des recherches organiques — l'inclure biaiserait les stats qui
+      // pour source=training_links / external_sites : trafic synthétique (liens générés côté
+      // serveur pour les vœux Parcoursup, ou liens de recherche personnalisés posés par des
+      // sites tiers), pas des recherches organiques — l'inclure biaiserait les stats qui
       // nourrissent le moteur de suggestion avec du volume qui ne reflète pas l'usage réel.
-      { $match: { created_at: { $gte: since }, status: { $ne: "error" }, source: { $ne: "training_links" } } },
+      { $match: { created_at: { $gte: since }, status: { $ne: "error" }, source: { $nin: ["training_links", "external_sites"] } } },
       {
         $group: {
           _id: "$q_normalized",

--- a/server/src/services/search/search-query-log.service.ts
+++ b/server/src/services/search/search-query-log.service.ts
@@ -47,7 +47,7 @@ type SearchQuerystring = {
   latitude?: number
   longitude?: number
   radius?: number
-  source?: "suggestion" | "free_text" | "training_links"
+  source?: "suggestion" | "free_text" | "training_links" | "external_sites"
 }
 
 // Arrondi à 1 décimale (~11 km) : suffisant pour "quelle zone cherche quoi", inexploitable

--- a/shared/src/models/search-queries.model.ts
+++ b/shared/src/models/search-queries.model.ts
@@ -23,8 +23,8 @@ export const ZSearchQuery = z.object({
   status: z.enum(["ok", "degraded", "error"]).describe("Issue de la recherche : succès normal, succès après repli, ou échec"),
   nb_hits: z.number().nullable().describe("Nombre de résultats retournés (null si status=error)"),
   source: z
-    .enum(["suggestion", "free_text", "training_links"])
-    .describe("Suggestion d'autocomplete sélectionnée vs texte libre vs lien généré côté serveur (traininglinks, vœux Parcoursup)"),
+    .enum(["suggestion", "free_text", "training_links", "external_sites"])
+    .describe("Suggestion d'autocomplete sélectionnée vs texte libre vs lien généré côté serveur (traininglinks, vœux Parcoursup) vs lien personnalisé posé par un site externe"),
   filters: z
     .object({
       type: z.string().nullable(),

--- a/shared/src/routes/search.routes.ts
+++ b/shared/src/routes/search.routes.ts
@@ -65,9 +65,11 @@ export const zSearchRoutes = {
         page: z.coerce.number<number>().min(0).default(0).describe("Index de page (0-based)"),
         hitsPerPage: z.coerce.number<number>().min(1).max(100).default(20).describe("Nombre de résultats par page (max 100)"),
         source: z
-          .enum(["suggestion", "free_text", "training_links"])
+          .enum(["suggestion", "free_text", "training_links", "external_sites"])
           .optional()
-          .describe("Origine de la requête (télémétrie autocomplete UI, ou lien généré côté serveur par traininglinks pour les vœux Parcoursup — sans effet sur les résultats)"),
+          .describe(
+            "Origine de la requête (télémétrie autocomplete UI, lien généré côté serveur par traininglinks pour les vœux Parcoursup, ou lien de recherche personnalisé posé par un site externe — sans effet sur les résultats)"
+          ),
         internal: z
           .enum(["true", "false"])
           .transform((v) => v === "true")

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
@@ -33,8 +33,8 @@ export const DEFAULT_SEARCH_MODE: SearchMode = "emplois"
 export type SortOption = "proximity" | "date" | "applications" | "start_date"
 const SORT_OPTIONS: SortOption[] = ["proximity", "date", "applications", "start_date"]
 
-export type QSource = "suggestion" | "free_text" | "training_links"
-const Q_SOURCES: QSource[] = ["suggestion", "free_text", "training_links"]
+export type QSource = "suggestion" | "free_text" | "training_links" | "external_sites"
+const Q_SOURCES: QSource[] = ["suggestion", "free_text", "training_links", "external_sites"]
 
 /**
  * Les filtres multi-valeurs utilisent des paramètres répétés dans l'URL :


### PR DESCRIPTION
## Changements

- Ajoute `external_sites` aux valeurs acceptées par le paramètre `source` de `/v1/search` (aux côtés de `suggestion`, `free_text`, `training_links`), pour les liens de recherche personnalisés que des sites tiers vont poser vers `/recherche`
- Étend en conséquence l'enum `QSource` côté UI (`search.params.utils.ts`) pour que la valeur soit bien transmise à l'API au lieu d'être silencieusement ignorée, et le schéma Mongo `search_queries`
- Exclut `source=external_sites` (comme `training_links`) de l'agrégation du job `analyzeSearchQueries`, qui alimente le moteur de suggestion : ce trafic synthétique ne doit pas biaiser les stats calculées sur les recherches organiques

## Plan de test

- [x] `yarn tsc --noEmit` sans erreur sur `server` et `ui`, `shared` build clean
- [x] Suite de tests existante sur `search.controller`, `search-query-log.service`, `search.params.utils` : verte
- [ ] Vérifier en recette qu'une requête `/recherche?q=...&source=external_sites` est bien loguée avec `source: "external_sites"` dans `search_queries`