### PR TITLE
fix: allège Sentry client et contient la surface MUI (#5186)

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -7,3 +7,53 @@ This version has breaking changes — APIs, conventions, and file structure may 
 This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
 
 <!-- END:nextjs-agent-rules -->
+
+# Surface MUI (issue #5188)
+
+MUI (material + system + utils + Emotion + Popper) pèse ~99 ko gzip sur le first-load des pages
+publiques. C'est structurel — `MuiDsfrThemeProvider` (react-dsfr) est la colle du design system —
+mais la surface ne doit pas grossir. Règles :
+
+- **Pages publiques** (tout ce qui n'est pas sous `app/(espace-pro)`) : seuls les imports de
+  `@mui/material` (core) sont autorisés. Aucun module de l'écosystème étendu :
+  `@mui/x-data-grid`, `@mui/x-date-pickers`, `@mui/x-charts`, `@mui/icons-material`, `@mui/lab`…
+- **`@mui/x-data-grid`** n'est jamais importé directement dans ce repo : c'est une peer dependency
+  de `job-processor`, dont le composant React n'est monté que sur la page admin
+  `espace-pro/administration/processeur`. Ne pas l'importer ailleurs ; s'il faut un tableau côté
+  public, utiliser le composant Table du DSFR ou un tableau maison.
+- **Garde-fou CI** : `perf-budget.json` → `forbiddenOnFirstLoad` interdit `@mui/x-data-grid` et
+  `job-processor` sur le first-load de `/` et `/recherche` (vérifié par analyse des sourcemaps
+  dans `scripts/perf-budget.mjs`, workflow `perf_budget.yml`). Si un nouveau module lourd entre
+  dans le projet pour l'espace pro, l'ajouter à cette liste.
+- **Imports barrel OK** : `import { Box } from "@mui/material"` est déjà tree-shaké par Next
+  (`@mui/material` est dans la liste par défaut d'`optimizePackageImports`). Ne pas réécrire les
+  imports en chemins profonds (`@mui/material/Box`), ça n'apporte rien au bundle de prod.
+
+## optimizePackageImports : rien à ajouter (testé 2026-08, issue #5188)
+
+Ne pas ajouter d'entrée à `experimental.optimizePackageImports` sans nouvelle mesure. Inventaire
+des barrels du code ui et résultat :
+
+- `@mui/material` (~350 imports) et `lodash-es` : déjà dans la liste par défaut de Next.
+- `@codegouvfr/react-dsfr` (263 imports racine) : faux barrel — le root du package pointe sur
+  `fr/index.js` (le helper de tokens `fr`, seul export consommé) ; les composants sont déjà
+  importés en subpath (`…/Button`). Rien à optimiser.
+- `shared` (115 imports barrel d'un vrai `export *`) : testé en ajoutant
+  `optimizePackageImports: ["shared"]` puis build de prod — mesures du perf-budget strictement
+  identiques (425,3 / 63,5 / 591,5 / 2398,3 ko, mêmes décomptes de sources). Le tree-shaking de
+  Turbopack couvre déjà ce cas (ou l'option est inerte sur un package workspace transpilé) :
+  aucun gain, l'option n'a pas été gardée.
+
+## Pigment CSS : piste écartée (évaluée 2026-08, issue #5188)
+
+`@pigment-css/react` (CSS-in-JS zéro-runtime de MUI) permettrait en théorie de supprimer le
+runtime Emotion du first-load. Conclusion : **non viable actuellement**, à ne pas relancer sans
+changement chez MUI ou react-dsfr.
+
+1. Le projet est **en pause chez MUI** : toujours en alpha, développement gelé sans timeline
+   (https://github.com/mui/pigment-css/discussions/249, https://mui.com/blog/2026-and-beyond/).
+2. `MuiDsfrThemeProvider` de react-dsfr repose sur le thème runtime Emotion de `@mui/material` ;
+   basculer sur `@mui/material-pigment-css` casserait l'intégration DSFR↔MUI sans support amont.
+
+Réévaluer seulement si MUI relance le projet (ou équivalent zéro-runtime) **et** que react-dsfr
+le supporte.

--- a/ui/app/_components/ErrorComponent.tsx
+++ b/ui/app/_components/ErrorComponent.tsx
@@ -2,7 +2,7 @@
 
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Container, Typography } from "@mui/material"
-import * as Sentry from "@sentry/nextjs"
+import { captureException, type FallbackRender, ErrorBoundary as SentryErrorBoundary } from "@sentry/nextjs"
 import Image from "next/image"
 import type { PropsWithChildren } from "react"
 import { useEffect } from "react"
@@ -47,7 +47,7 @@ export function ErrorComponent({ error }: ErrorProps) {
       window.location.reload()
       return
     }
-    Sentry.captureException(error)
+    captureException(error)
     console.error(error)
   }, [error])
 
@@ -114,7 +114,7 @@ export function ErrorComponent({ error }: ErrorProps) {
   )
 }
 
-const fallbackRender: Sentry.FallbackRender = ({ error }) => {
+const fallbackRender: FallbackRender = ({ error }) => {
   return (
     <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
       <ErrorComponent error={error} />
@@ -123,5 +123,5 @@ const fallbackRender: Sentry.FallbackRender = ({ error }) => {
 }
 
 export function ErrorBoundary({ children }: PropsWithChildren) {
-  return <Sentry.ErrorBoundary fallback={fallbackRender}>{children}</Sentry.ErrorBoundary>
+  return <SentryErrorBoundary fallback={fallbackRender}>{children}</SentryErrorBoundary>
 }

--- a/ui/app/global-error.tsx
+++ b/ui/app/global-error.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import * as Sentry from "@sentry/nextjs"
+import { captureException } from "@sentry/nextjs"
 import Image from "next/image"
 import { useEffect } from "react"
 
@@ -10,7 +10,7 @@ import "./global-error.css"
 
 export default function GlobalError({ error }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error)
+    captureException(error)
     console.error(error)
   }, [error])
 

--- a/ui/components/ItemDetail/CandidatureLba/CandidatureLbaFileDropzone.tsx
+++ b/ui/components/ItemDetail/CandidatureLba/CandidatureLbaFileDropzone.tsx
@@ -1,6 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Button, CircularProgress, Typography } from "@mui/material"
-import * as Sentry from "@sentry/nextjs"
+import { captureMessage, setTag } from "@sentry/nextjs"
 import { useState } from "react"
 import type { DropzoneOptions } from "react-dropzone"
 import { useDropzone } from "react-dropzone"
@@ -68,26 +68,26 @@ export const CandidatureLbaFileDropzone = ({ setFileValue, formik }) => {
       const { errors, file } = fileRejection ?? {}
       const [error] = errors
       const { message } = error ?? {}
-      Sentry.setTag("errorType", "envoi_PJ_candidature")
+      setTag("errorType", "envoi_PJ_candidature")
       if (errors.some((error) => error.code === "file-invalid-type")) {
         const fileExtension = getFileExtension(file.name)
-        Sentry.setTag("file-extension", fileExtension)
+        setTag("file-extension", fileExtension)
       }
       if (errors.some((error) => error.code === "file-too-large")) {
         const sizeInMo = Math.round(file.size / 1024 / 1024)
-        Sentry.setTag("file-size-in-mo", sizeInMo)
+        setTag("file-size-in-mo", sizeInMo)
       }
       if (fileRejections.length > 1) {
-        Sentry.setTag("multiple-files", "true")
+        setTag("multiple-files", "true")
       }
       // Rejet de fichier (taille, type, nombre) : validation attendue du dropzone déclenchée par
       // le choix de l'utilisateur, pas un défaut applicatif — captureMessage/info conserve la
       // télémétrie (tags ci-dessus) sans polluer le triage des erreurs.
-      Sentry.captureMessage(message, "info")
-      Sentry.setTag("errorType", undefined)
-      Sentry.setTag("file-extension", undefined)
-      Sentry.setTag("file-size-in-mo", undefined)
-      Sentry.setTag("multiple-files", undefined)
+      captureMessage(message, "info")
+      setTag("errorType", undefined)
+      setTag("file-extension", undefined)
+      setTag("file-size-in-mo", undefined)
+      setTag("multiple-files", undefined)
     },
   })
 

--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -2,16 +2,19 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import { captureConsoleIntegration, captureRouterTransitionStart, extraErrorDataIntegration, httpClientIntegration, init, reportingObserverIntegration } from "@sentry/nextjs"
+import { extraErrorDataIntegration, httpClientIntegration, init, reportingObserverIntegration } from "@sentry/nextjs"
 
 import { shouldReloadOnce } from "@/utils/reload-guard.utils"
 
 import { publicConfig } from "./config.public"
 
+// Pas de tracing client (issue #5186, décision d'équipe 2026-08) : à 0,1 % de sample il
+// n'apportait presque rien, et son retrait permet le tree-shaking du module tracing via le flag
+// __SENTRY_TRACING__ (voir compiler.define dans next.config.mjs). Conséquences assumées : plus de
+// transactions pageload/navigation client, plus de propagation des trace headers vers l'API.
+// Le tracing serveur (sentry.server.config.ts / lba-server) est inchangé.
 init({
   dsn: publicConfig.sentry_dsn,
-  tracesSampleRate: publicConfig.env === "production" ? 0.001 : 1.0,
-  tracePropagationTargets: [/^https:\/\/[^/]*\.apprentissage\.beta\.gouv\.fr/, publicConfig.baseUrl, publicConfig.apiEndpoint, /^\//],
   environment: publicConfig.env,
   enabled: !publicConfig.sentryDisabled,
   release: publicConfig.version,
@@ -19,7 +22,8 @@ init({
   // replaysOnErrorSampleRate: 1.0,
   // replaysSessionSampleRate: 0.1,
   integrations: [
-    captureConsoleIntegration({ levels: ["error"] }),
+    // captureConsoleIntegration retirée (issue #5186) : 2 issues / 14 événements / 0 utilisateur
+    // en 90 jours de prod, et le seul cas capté était un TypeError mieux traité en vraie exception.
     extraErrorDataIntegration({ depth: 8 }),
     httpClientIntegration({}),
     // "deprecation"/"intervention" ne rapportent que des avertissements passifs du navigateur
@@ -54,8 +58,6 @@ init({
     return event
   },
 })
-
-export const onRouterTransitionStart = captureRouterTransitionStart
 
 // Pendant un déploiement (rolling update Docker Swarm), un onglet resté ouvert peut garder en
 // mémoire des chunks JS de l'ancien build : le routeur y navigue ensuite vers des modules qui

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -241,6 +241,11 @@ const sentryConfig = {
   project: "lba-ui",
   sentryUrl: "https://sentry.apprentissage.beta.gouv.fr/",
 
+  // Le tracing client est volontairement retiré (issue #5186) : sans ce flag, chaque build
+  // afficherait « ACTION REQUIRED » en demandant de réexporter onRouterTransitionStart depuis
+  // instrumentation-client.ts — soit exactement ce que la décision d'équipe a supprimé.
+  suppressOnRouterTransitionStartWarning: true,
+
   // Only print logs for uploading source maps in CI
   silent: false,
 

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -78,6 +78,14 @@ const nextConfig = {
   bundlePagesRouterDependencies: true,
   serverExternalPackages: ["react-pdf"],
   poweredByHeader: false,
+  compiler: {
+    // Text-replacé (JSON.stringify → il faut le booléen, la chaîne "false" serait truthy) dans le
+    // bundle : @sentry/nextjs n'enregistre browserTracingIntegration que si ce flag n'est pas
+    // remplacé par false — le module tracing est alors tree-shaké (issue #5186). Le flag n'existe
+    // que dans le build client du SDK (vérifié : absent de @sentry/node et @sentry/vercel-edge),
+    // le tracing serveur/edge (sentry.server.config.ts, sentry.edge.config.ts) n'est pas affecté.
+    define: { __SENTRY_TRACING__: false },
+  },
   cacheComponents: true,
   partialPrefetching: true,
   experimental: {

--- a/ui/perf-budget.json
+++ b/ui/perf-budget.json
@@ -1,27 +1,34 @@
 {
   "$comment": "Budgets du first-load, contrôlés par ui/scripts/perf-budget.mjs (issue #5191). Seuils en octets gzip (niveau ci-dessous), sauf globalMaxFirstLoadJsRaw en octets non compressés. null = budget non renseigné : la mesure est affichée mais rien n'est contrôlé. Pour relever un seuil, reporter la mesure affichée par le job et justifier la hausse en description de PR.",
   "$measured": {
-    "$comment": "Mesures de référence ayant servi à fixer les seuils (build de production, NEXT_PUBLIC_ENV=production, NEXT_PUBLIC_VERSION constante). Le script les re-dérive à chaque exécution : un écart se lit dans la colonne Marge.",
-    "commit": "23457dcc1",
-    "/ firstLoadJsGzip": 503681,
-    "/ firstLoadCssGzip": 65059,
-    "/recherche firstLoadJsGzip": 605176,
-    "globalMaxFirstLoadJsRaw": 2457682
+    "$comment": "Mesures de référence ayant servi à fixer les seuils (build de production, NEXT_PUBLIC_ENV=production, NEXT_PUBLIC_VERSION constante). Le script les re-dérive à chaque exécution : un écart se lit dans la colonne Marge. Seuils JS abaissés après l'allègement Sentry client (issue #5186 : retrait tracing + captureConsole, −19 ko gzip sur la home), même marge ~4 % qu'à l'origine (#5191).",
+    "commit": "8e7027163",
+    "/ firstLoadJsGzip": 415868,
+    "/ firstLoadCssGzip": 64977,
+    "/recherche firstLoadJsGzip": 586449,
+    "globalMaxFirstLoadJsRaw": 2395764
   },
   "gzipLevel": 9,
   "routes": {
     "/": {
-      "firstLoadJsGzip": 524288,
+      "firstLoadJsGzip": 432128,
       "firstLoadCssGzip": 67584
     },
     "/recherche": {
-      "firstLoadJsGzip": 624640
+      "firstLoadJsGzip": 609280
     }
   },
-  "globalMaxFirstLoadJsRaw": 2560000,
+  "globalMaxFirstLoadJsRaw": 2490368,
+  "$commentForbidden": "forbiddenOnFirstLoad — @mui/x-data-grid et job-processor : réservés à l'espace pro/admin (page processeur), issue #5188. libphonenumber-js : issue #5191.",
   "forbiddenOnFirstLoad": {
     "/": [
-      "libphonenumber-js"
+      "libphonenumber-js",
+      "@mui/x-data-grid",
+      "job-processor"
+    ],
+    "/recherche": [
+      "@mui/x-data-grid",
+      "job-processor"
     ]
   }
 }


### PR DESCRIPTION
Closes #5186
Closes #5188

## Changements

**Allègement Sentry client** (−19,2 ko gzip sur la home : 425,3 → 406,1 ko ; −18,8 ko sur /recherche)

- Retrait du tracing client (`tracesSampleRate` 0,1 %, `tracePropagationTargets`, export `onRouterTransitionStart`) — décision d'équipe, le tracing serveur/edge est inchangé
- Tree-shaking du module tracing via `compiler.define { __SENTRY_TRACING__: false }` (booléen obligatoire : les valeurs passent par `JSON.stringify`, la chaîne `"false"` serait truthy ; le flag n'existe que dans le build client du SDK, vérifié)
- Retrait de `captureConsoleIntegration` : 2 issues / 14 événements / 0 utilisateur en 90 jours de prod
- Conversion de 3 imports namespace `* as Sentry` en imports nommés
- Limite connue : ~10 ko gzip de modules tracing restent embarqués à cause d'une constante du SDK colocalisée avec l'instrumentation router (`INCOMPLETE_APP_ROUTER_INSTRUMENTATION_TRANSACTION_NAME`) — irréductible sans correctif amont, signalé upstream : https://github.com/getsentry/sentry-javascript/issues/23482

**Contention de la surface MUI**

- Vérifié sur build de prod (scan des sourcemaps) : `@mui/x-data-grid` et `job-processor` absents du first-load public — `@mui/x-data-grid` n'est importé qu'indirectement via `job-processor` sur la page admin processeur (peer dependency, le finding knip est un faux positif)
- Garde-fou CI : ajout des deux packages au `forbiddenOnFirstLoad` de `/` et `/recherche` (test anti-vacuité fait : un package présent est bien détecté et fait échouer le contrôle)
- Règle documentée dans `ui/AGENTS.md` : material core uniquement côté public ; imports barrel OK (`@mui/material` est dans la liste par défaut d'`optimizePackageImports` de Next) ; `optimizePackageImports` évalué sur `shared` → gain nul mesuré, non retenu ; piste Pigment CSS écartée (projet en pause chez MUI + `MuiDsfrThemeProvider` repose sur le moteur Emotion)

**Verrouillage du gain**

- Seuils du perf-budget abaissés avec la même marge ~4 % qu'à l'origine : JS home 512 → 422 ko, /recherche 610 → 595 ko, global brut 2 500 → 2 432 ko

## Plan de test

- [ ] Le job Performance budget est vert et affiche des marges ~4 % sur les lignes JS
- [ ] En prod/recette : les erreurs client remontent toujours dans Sentry (lba-ui), sans nouvelles transactions pageload/navigation
- [ ] Aucune régression sur l'envoi de PJ candidature (tags Sentry du dropzone) et les pages d'erreur (ErrorBoundary, global-error)
