### PR TITLE
fix: déduplique le first-load et sort les métadonnées SEO des bundles client (#5214)

### DIFF
--- a/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 import { ApiError, apiGet } from "@/utils/api.utils"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import DetailRendezVousRendererClient from "./DetailRendezVousRendererClient"
 export const metadata: Metadata = {
-  title: PAGES.static.detailRendezVousApprentissage.getMetadata().title,
+  title: METADATA.static.detailRendezVousApprentissage().title,
 }
 
 export default async function DetailRendezVousPage({ params, searchParams }: { params: Promise<{ id: string }>; searchParams: Promise<{ token: string }> }) {

--- a/ui/app/(candidat)/postuler/page.tsx
+++ b/ui/app/(candidat)/postuler/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import PostulerPage from "./PostulerPage"
 export const metadata: Metadata = {
-  title: PAGES.static.postuler.getMetadata().title,
+  title: METADATA.static.postuler().title,
 }
 
 const Page = async () => {

--- a/ui/app/(editorial)/_components/LayoutArticle.tsx
+++ b/ui/app/(editorial)/_components/LayoutArticle.tsx
@@ -1,5 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Divider, Grid, Typography } from "@mui/material"
+import type { Metadata } from "next"
 import type { ReactNode } from "react"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
@@ -19,6 +20,7 @@ export const LayoutArticle = ({
   sourceAllerPlusLoin,
   parentPage,
   page,
+  metadata,
 }: {
   pages: IPage[]
   title: ReactNode
@@ -37,12 +39,15 @@ export const LayoutArticle = ({
   sourceAllerPlusLoin?: string
   parentPage?: IPage
   page: IPage
+  // metadata de la page (celle exportée pour Next) : IPage ne porte plus les métadonnées SEO,
+  // qui vivent dans le registre METADATA server-only (issue #5214)
+  metadata: Metadata
 }) => (
   <>
     <SchemaOrg
       type="Article"
-      title={page.getMetadata().title as string}
-      description={page.getMetadata().description}
+      title={metadata.title as string}
+      description={metadata.description}
       url={page.getPath()}
       breadcrumbs={[
         { name: PAGES.static.home.title, url: PAGES.static.home.getPath() },

--- a/ui/app/(editorial)/a-propos/page.tsx
+++ b/ui/app/(editorial)/a-propos/page.tsx
@@ -46,10 +46,11 @@ import tbd from "@/public/images/logosPartenaires/partenaire-tdb.webp"
 import toulouseMetropole from "@/public/images/logosPartenaires/partenaire-toulouse-metropole.webp"
 import veritone from "@/public/images/logosPartenaires/partenaire-veritone.webp"
 
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.aPropos.getMetadata().title,
-  description: PAGES.static.aPropos.getMetadata().description,
+  title: METADATA.static.aPropos().title,
+  description: METADATA.static.aPropos().description,
 }
 
 export default function APropos() {

--- a/ui/app/(editorial)/alternance/diplomes/page.tsx
+++ b/ui/app/(editorial)/alternance/diplomes/page.tsx
@@ -14,10 +14,11 @@ import { SectionTitle } from "@/app/(editorial)/alternance/_components/SectionTi
 import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.alternanceDiplomes.getMetadata().title,
-  description: PAGES.static.alternanceDiplomes.getMetadata().description,
+  title: METADATA.static.alternanceDiplomes().title,
+  description: METADATA.static.alternanceDiplomes().description,
 }
 
 const faqItems = [
@@ -55,7 +56,7 @@ const faqItems = [
 
 export default function AlternanceDiplomes() {
   const url = PAGES.static.alternanceDiplomes.getPath()
-  const meta = PAGES.static.alternanceDiplomes.getMetadata?.() ?? { title: PAGES.static.alternanceDiplomes.title, description: "" }
+  const meta = METADATA.static.alternanceDiplomes()
   const metaTitle = typeof meta.title === "string" ? meta.title : PAGES.static.alternanceDiplomes.title
   const metaDescription = typeof meta.description === "string" ? meta.description : ""
   const breadcrumbs = [

--- a/ui/app/(editorial)/alternance/metiers/page.tsx
+++ b/ui/app/(editorial)/alternance/metiers/page.tsx
@@ -14,10 +14,11 @@ import { SectionTitle } from "@/app/(editorial)/alternance/_components/SectionTi
 import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.alternanceMetiers.getMetadata().title,
-  description: PAGES.static.alternanceMetiers.getMetadata().description,
+  title: METADATA.static.alternanceMetiers().title,
+  description: METADATA.static.alternanceMetiers().description,
 }
 
 const faqItems = [
@@ -50,7 +51,7 @@ const faqItems = [
 
 export default function AlternanceMetiers() {
   const url = PAGES.static.alternanceMetiers.getPath()
-  const meta = PAGES.static.alternanceMetiers.getMetadata?.() ?? { title: PAGES.static.alternanceMetiers.title, description: "" }
+  const meta = METADATA.static.alternanceMetiers()
   const breadcrumbs = [
     { name: "Accueil", url: "/" },
     { name: "Métiers en alternance", url },

--- a/ui/app/(editorial)/alternance/villes/page.tsx
+++ b/ui/app/(editorial)/alternance/villes/page.tsx
@@ -14,10 +14,11 @@ import { SectionTitle } from "@/app/(editorial)/alternance/_components/SectionTi
 import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { ArrowRightLine } from "@/theme/components/icons"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.alternanceVilles.getMetadata().title,
-  description: PAGES.static.alternanceVilles.getMetadata().description,
+  title: METADATA.static.alternanceVilles().title,
+  description: METADATA.static.alternanceVilles().description,
 }
 
 const faqItems = [
@@ -55,7 +56,7 @@ const faqItems = [
 
 export default function AlternanceVilles() {
   const url = PAGES.static.alternanceVilles.getPath()
-  const meta = PAGES.static.alternanceVilles.getMetadata?.() ?? { title: PAGES.static.alternanceVilles.title, description: "" }
+  const meta = METADATA.static.alternanceVilles()
   const breadcrumbs = [
     { name: "Accueil", url: "/" },
     { name: "Alternance dans les grandes villes", url },

--- a/ui/app/(editorial)/barometre/page.tsx
+++ b/ui/app/(editorial)/barometre/page.tsx
@@ -7,6 +7,7 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
 import { BarChartHorizontal } from "./_components/BarChartHorizontal"
@@ -32,7 +33,7 @@ import {
   topSecteursSpontanees,
 } from "./_data/t1-2026"
 export const metadata: Metadata = {
-  ...PAGES.static.barometre.getMetadata(),
+  ...METADATA.static.barometre(),
   alternates: {
     canonical: PAGES.static.barometre.getPath(),
   },
@@ -76,8 +77,8 @@ export default function BarometrePage() {
     <Box>
       <SchemaOrg
         type="Article"
-        title={PAGES.static.barometre.getMetadata().title as string}
-        description={PAGES.static.barometre.getMetadata().description as string}
+        title={METADATA.static.barometre().title as string}
+        description={METADATA.static.barometre().description as string}
         url={PAGES.static.barometre.getPath()}
         breadcrumbs={[
           { name: "Accueil", url: PAGES.static.home.getPath() },

--- a/ui/app/(editorial)/contact/page.tsx
+++ b/ui/app/(editorial)/contact/page.tsx
@@ -7,10 +7,11 @@ import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { publicConfig } from "@/config.public"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.contact.getMetadata().title,
-  description: PAGES.static.contact.getMetadata().description,
+  title: METADATA.static.contact().title,
+  description: METADATA.static.contact().description,
 }
 
 export default function Contact() {

--- a/ui/app/(editorial)/desinscription/page.tsx
+++ b/ui/app/(editorial)/desinscription/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
 import { DepotSimplifieStyling } from "@/components/espace_pro/common/components/DepotSimplifieLayout"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { DesinscriptionRecruteur } from "./Desinscription"
 export const metadata: Metadata = {
-  title: PAGES.static.desinscription.getMetadata().title,
-  description: PAGES.static.desinscription.getMetadata().description,
+  title: METADATA.static.desinscription().title,
+  description: METADATA.static.desinscription().description,
 }
 
 export default function PageDesinscription() {

--- a/ui/app/(editorial)/espace-developpeurs/page.tsx
+++ b/ui/app/(editorial)/espace-developpeurs/page.tsx
@@ -6,10 +6,11 @@ import type { Metadata } from "next"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.EspaceDeveloppeurs.getMetadata().title,
-  description: PAGES.static.EspaceDeveloppeurs.getMetadata().description,
+  title: METADATA.static.EspaceDeveloppeurs().title,
+  description: METADATA.static.EspaceDeveloppeurs().description,
 }
 
 export default function EspaceDeveloppeurs() {

--- a/ui/app/(editorial)/guide-alternant/a-propos-des-formations/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/a-propos-des-formations/page.tsx
@@ -12,8 +12,9 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideAlternantAProposDesFormations.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternantAProposDesFormations()
 
 const AProposDesFormationsPage = () => {
   const pages = [PAGES.static.guideAlternant, PAGES.static.guideAlternantAProposDesFormations]
@@ -30,6 +31,7 @@ const AProposDesFormationsPage = () => {
       allerPlusLoinItems={[ARTICLES_PARTAGES["decouvrir-l-alternance"], ARTICLES["conseils-et-astuces-pour-trouver-un-employeur"], ARTICLES["se-faire-accompagner"]]}
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantAProposDesFormations}
+      metadata={metadata}
     >
       <Section title="Vérifiez les résultats de l'établissement">
         <ParagraphList

--- a/ui/app/(editorial)/guide-alternant/comment-signer-un-contrat-en-alternance/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/comment-signer-un-contrat-en-alternance/page.tsx
@@ -11,8 +11,9 @@ import { Section } from "@/app/(editorial)/_components/Section"
 import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideAlternantCommentSignerUnContratEnAlternance.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternantCommentSignerUnContratEnAlternance()
 
 const CommentSignerUnContratEnAlternancePage = () => {
   const pages = [PAGES.static.guideAlternant, PAGES.static.guideAlternantCommentSignerUnContratEnAlternance]
@@ -31,6 +32,7 @@ const CommentSignerUnContratEnAlternancePage = () => {
       allerPlusLoinItems={[ARTICLES["role-et-missions-du-maitre-d-apprentissage-ou-tuteur"], ARTICLES["la-rupture-de-contrat"], ARTICLES["se-faire-accompagner"]]}
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantCommentSignerUnContratEnAlternance}
+      metadata={metadata}
     >
       <Section title="Pour un contrat d'apprentissage">
         <Paragraph>

--- a/ui/app/(editorial)/guide-alternant/comprendre-la-remuneration/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/comprendre-la-remuneration/page.tsx
@@ -12,11 +12,12 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
 const remunerationPage = PAGES.static.guideAlternantComprendreLaRemuneration
 
-export const metadata: Metadata = remunerationPage.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternantComprendreLaRemuneration()
 
 // Miroir texte brut de la FAQ visible ci-dessous, pour le JSON-LD FAQPage (aide à obtenir les rich results / PAA).
 const FAQ_ITEMS = [
@@ -291,11 +292,12 @@ const ComprendreLaRemunerationPage = () => {
       ]}
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantComprendreLaRemuneration}
+      metadata={metadata}
     >
       <SchemaOrg
         type="FAQPage"
         title={remunerationPage.title}
-        description={remunerationPage.getMetadata().description ?? ""}
+        description={metadata.description ?? ""}
         url={remunerationPage.getPath()}
         breadcrumbs={[]}
         omitBreadcrumb

--- a/ui/app/(editorial)/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur/page.tsx
@@ -12,8 +12,9 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideAlternantConseilsEtAstucesPourTrouverUnEmployeur.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternantConseilsEtAstucesPourTrouverUnEmployeur()
 
 const ConseilsEtAstucesPourTrouverUnEmployeurPage = () => {
   const pages = [PAGES.static.guideAlternant, PAGES.static.guideAlternantConseilsEtAstucesPourTrouverUnEmployeur]
@@ -34,6 +35,7 @@ const ConseilsEtAstucesPourTrouverUnEmployeurPage = () => {
       ]}
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantConseilsEtAstucesPourTrouverUnEmployeur}
+      metadata={metadata}
     >
       <Section title="Où trouver des entreprises qui recrutent ?">
         <Paragraph>

--- a/ui/app/(editorial)/guide-alternant/const.ts
+++ b/ui/app/(editorial)/guide-alternant/const.ts
@@ -1,3 +1,4 @@
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
 export const IMAGE_BASE_PATH = "/images/guides/guide-alternant/"
@@ -6,7 +7,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["preparer-son-projet-en-alternance"]: {
     id: "preparer-son-projet-en-alternance",
     title: PAGES.static.guideAlternantPreparerSonProjetEnAlternance.title,
-    description: PAGES.static.guideAlternantPreparerSonProjetEnAlternance.getMetadata().description,
+    description: METADATA.static.guideAlternantPreparerSonProjetEnAlternance().description,
     imageUrl: `${IMAGE_BASE_PATH}preparer-son-projet-en-alternance.svg`,
     path: PAGES.static.guideAlternantPreparerSonProjetEnAlternance.getPath(),
     updatedAt: "26/03/2026",
@@ -14,7 +15,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["se-faire-accompagner"]: {
     id: "se-faire-accompagner",
     title: PAGES.static.guideAlternantSeFaireAccompagner.title,
-    description: PAGES.static.guideAlternantSeFaireAccompagner.getMetadata().description,
+    description: METADATA.static.guideAlternantSeFaireAccompagner().description,
     imageUrl: `${IMAGE_BASE_PATH}se-faire-accompagner.svg`,
     path: PAGES.static.guideAlternantSeFaireAccompagner.getPath(),
     updatedAt: "20/07/2026",
@@ -22,7 +23,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["la-rupture-de-contrat"]: {
     id: "la-rupture-de-contrat",
     title: PAGES.static.guideAlternantLaRuptureDeContrat.title,
-    description: PAGES.static.guideAlternantLaRuptureDeContrat.getMetadata().description,
+    description: METADATA.static.guideAlternantLaRuptureDeContrat().description,
     imageUrl: `${IMAGE_BASE_PATH}la-rupture-de-contrat.svg`,
     path: PAGES.static.guideAlternantLaRuptureDeContrat.getPath(),
     updatedAt: "20/07/2026",
@@ -30,7 +31,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["comprendre-la-remuneration"]: {
     id: "comprendre-la-remuneration",
     title: PAGES.static.guideAlternantComprendreLaRemuneration.title,
-    description: PAGES.static.guideAlternantComprendreLaRemuneration.getMetadata().description,
+    description: METADATA.static.guideAlternantComprendreLaRemuneration().description,
     imageUrl: `${IMAGE_BASE_PATH}comprendre-la-remuneration.svg`,
     path: PAGES.static.guideAlternantComprendreLaRemuneration.getPath(),
     updatedAt: "12/08/2026",
@@ -38,7 +39,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["comment-signer-un-contrat-en-alternance"]: {
     id: "comment-signer-un-contrat-en-alternance",
     title: PAGES.static.guideAlternantCommentSignerUnContratEnAlternance.title,
-    description: PAGES.static.guideAlternantCommentSignerUnContratEnAlternance.getMetadata().description,
+    description: METADATA.static.guideAlternantCommentSignerUnContratEnAlternance().description,
     imageUrl: `${IMAGE_BASE_PATH}comment-signer-un-contrat-en-alternance.svg`,
     path: PAGES.static.guideAlternantCommentSignerUnContratEnAlternance.getPath(),
     updatedAt: "26/03/2026",
@@ -46,7 +47,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["role-et-missions-du-maitre-d-apprentissage-ou-tuteur"]: {
     id: "role-et-missions-du-maitre-d-apprentissage-ou-tuteur",
     title: PAGES.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur.title,
-    description: PAGES.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur.getMetadata().description,
+    description: METADATA.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur().description,
     imageUrl: `${IMAGE_BASE_PATH}role-et-missions-du-maitre-d-apprentissage-ou-tuteur.svg`,
     path: PAGES.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur.getPath(),
     updatedAt: "26/03/2026",

--- a/ui/app/(editorial)/guide-alternant/la-rupture-de-contrat/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/la-rupture-de-contrat/page.tsx
@@ -10,8 +10,9 @@ import { TableArticle } from "@/app/(editorial)/_components/TableArticle"
 import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideAlternantLaRuptureDeContrat.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternantLaRuptureDeContrat()
 
 const LaRuptureDeContratPage = () => {
   const pages = [PAGES.static.guideAlternant, PAGES.static.guideAlternantLaRuptureDeContrat]
@@ -34,6 +35,7 @@ const LaRuptureDeContratPage = () => {
       ]}
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantLaRuptureDeContrat}
+      metadata={metadata}
     >
       <Section title="Peut-on rompre un contrat d'apprentissage ?">
         <Paragraph>

--- a/ui/app/(editorial)/guide-alternant/les-aides-financieres-et-materielles/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/les-aides-financieres-et-materielles/page.tsx
@@ -9,8 +9,9 @@ import { Section } from "@/app/(editorial)/_components/Section"
 import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideAlternantLesAidesFinancieresEtMaterielles.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternantLesAidesFinancieresEtMaterielles()
 
 const LesAidesFinancieresEtMateriellesPage = () => {
   const pages = [PAGES.static.guideAlternant, PAGES.static.guideAlternantLesAidesFinancieresEtMaterielles]
@@ -29,6 +30,7 @@ const LesAidesFinancieresEtMateriellesPage = () => {
       allerPlusLoinItems={[ARTICLES["comprendre-la-remuneration"], ARTICLES["preparer-son-projet-en-alternance"], ARTICLES["se-faire-accompagner"]]}
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantLesAidesFinancieresEtMaterielles}
+      metadata={metadata}
     >
       <Section title="Vous cherchez un logement pour votre alternance ?">
         <Paragraph>Plusieurs solutions et aides existent :</Paragraph>

--- a/ui/app/(editorial)/guide-alternant/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/page.tsx
@@ -14,9 +14,10 @@ import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { DsfrIcon } from "@/components/DsfrIcon"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { ARTICLES } from "./const"
-export const metadata: Metadata = PAGES.static.guideAlternant.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternant()
 
 const GuideAlternantPage = () => {
   return (
@@ -27,8 +28,8 @@ const GuideAlternantPage = () => {
     >
       <SchemaOrg
         type="WebPage"
-        title={PAGES.static.guideAlternant.getMetadata().title}
-        description={PAGES.static.guideAlternant.getMetadata().description}
+        title={METADATA.static.guideAlternant().title}
+        description={METADATA.static.guideAlternant().description}
         url={PAGES.static.guideAlternant.getPath()}
         breadcrumbs={[
           { name: PAGES.static.home.title, url: PAGES.static.home.getPath() },

--- a/ui/app/(editorial)/guide-alternant/preparer-son-projet-en-alternance/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/preparer-son-projet-en-alternance/page.tsx
@@ -11,8 +11,9 @@ import { Section } from "@/app/(editorial)/_components/Section"
 import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideAlternantPreparerSonProjetEnAlternance.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternantPreparerSonProjetEnAlternance()
 
 const PreparerSonProjetEnAlternancePage = () => {
   const pages = [PAGES.static.guideAlternant, PAGES.static.guideAlternantPreparerSonProjetEnAlternance]
@@ -31,6 +32,7 @@ const PreparerSonProjetEnAlternancePage = () => {
       allerPlusLoinItems={[ARTICLES["role-et-missions-du-maitre-d-apprentissage-ou-tuteur"], ARTICLES["comment-signer-un-contrat-en-alternance"], ARTICLES["se-faire-accompagner"]]}
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantPreparerSonProjetEnAlternance}
+      metadata={metadata}
     >
       <Section>
         <Paragraph bold>Les étapes clés :</Paragraph>

--- a/ui/app/(editorial)/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur/page.tsx
@@ -9,8 +9,9 @@ import { Section } from "@/app/(editorial)/_components/Section"
 import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur()
 
 const RoleEtMissionsDuMaitreDApprentissageOuTuteurPage = () => {
   const pages = [PAGES.static.guideAlternant, PAGES.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur]
@@ -29,6 +30,7 @@ const RoleEtMissionsDuMaitreDApprentissageOuTuteurPage = () => {
       allerPlusLoinItems={[ARTICLES["comprendre-la-remuneration"], ARTICLES["la-rupture-de-contrat"], ARTICLES["se-faire-accompagner"]]}
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur}
+      metadata={metadata}
     >
       <Section>
         <Paragraph>

--- a/ui/app/(editorial)/guide-alternant/se-faire-accompagner/page.tsx
+++ b/ui/app/(editorial)/guide-alternant/se-faire-accompagner/page.tsx
@@ -10,8 +10,9 @@ import { Section } from "@/app/(editorial)/_components/Section"
 import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection"
 import { ARTICLES } from "@/app/(editorial)/guide-alternant/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideAlternantSeFaireAccompagner.getMetadata()
+export const metadata: Metadata = METADATA.static.guideAlternantSeFaireAccompagner()
 
 const SeFaireAccompagnerPage = () => {
   const pages = [PAGES.static.guideAlternant, PAGES.static.guideAlternantSeFaireAccompagner]
@@ -34,6 +35,7 @@ const SeFaireAccompagnerPage = () => {
       ]}
       parentPage={PAGES.static.guideAlternant}
       page={PAGES.static.guideAlternantSeFaireAccompagner}
+      metadata={metadata}
     >
       <Section title="Pourquoi se faire accompagner ?">
         <Paragraph>

--- a/ui/app/(editorial)/guide-cfa/accompagner-vos-alternants/page.tsx
+++ b/ui/app/(editorial)/guide-cfa/accompagner-vos-alternants/page.tsx
@@ -12,8 +12,9 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-cfa/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideCfaAccompagnerVosAlternants.getMetadata()
+export const metadata: Metadata = METADATA.static.guideCfaAccompagnerVosAlternants()
 
 const AccompagnerVosAlternantsPage = async () => {
   const pages = [PAGES.static.guideCfa, PAGES.static.guideCfaAccompagnerVosAlternants]
@@ -35,6 +36,7 @@ const AccompagnerVosAlternantsPage = async () => {
       parentPage={PAGES.static.guideCfa}
       redirectionInterne={<RedirectionInterne source="guide-cfa" />}
       page={PAGES.static.guideCfaAccompagnerVosAlternants}
+      metadata={metadata}
     >
       <Section title="Comment La bonne alternance identifie ces entreprises auprès desquelles adresser des candidatures spontanées">
         <Paragraph>

--- a/ui/app/(editorial)/guide-cfa/const.ts
+++ b/ui/app/(editorial)/guide-cfa/const.ts
@@ -1,3 +1,4 @@
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
 export const IMAGE_BASE_PATH = "/images/guides/guide-cfa/"
@@ -6,7 +7,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["la-carte-etudiant-des-metiers"]: {
     id: "la-carte-etudiant-des-metiers",
     title: PAGES.static.guideCfaLaCarteEtudiantDesMetiers.title,
-    description: PAGES.static.guideCfaLaCarteEtudiantDesMetiers.getMetadata().description,
+    description: METADATA.static.guideCfaLaCarteEtudiantDesMetiers().description,
     imageUrl: `${IMAGE_BASE_PATH}la-carte-etudiant-des-metiers.svg`,
     path: PAGES.static.guideCfaLaCarteEtudiantDesMetiers.getPath(),
     updatedAt: "26/03/2026",
@@ -14,7 +15,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["accompagner-vos-alternants"]: {
     id: "accompagner-vos-alternants",
     title: PAGES.static.guideCfaAccompagnerVosAlternants.title,
-    description: PAGES.static.guideCfaAccompagnerVosAlternants.getMetadata().description,
+    description: METADATA.static.guideCfaAccompagnerVosAlternants().description,
     imageUrl: `${IMAGE_BASE_PATH}accompagner-vos-alternants.svg`,
     path: PAGES.static.guideCfaAccompagnerVosAlternants.getPath(),
     updatedAt: "20/07/2026",

--- a/ui/app/(editorial)/guide-cfa/la-carte-etudiant-des-metiers/page.tsx
+++ b/ui/app/(editorial)/guide-cfa/la-carte-etudiant-des-metiers/page.tsx
@@ -9,10 +9,11 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES } from "@/app/(editorial)/guide-cfa/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { getSession } from "@/utils/get-session"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { BandeauAuthentificationCfa } from "../BandeauAuthentificationCfa"
 
-export const metadata: Metadata = PAGES.static.guideCfaLaCarteEtudiantDesMetiers.getMetadata()
+export const metadata: Metadata = METADATA.static.guideCfaLaCarteEtudiantDesMetiers()
 
 const LaCarteEtudiantDesMetiersPage = () => {
   return (
@@ -44,6 +45,7 @@ const LaCarteEtudiantDesMetiersContent = async () => {
       allerPlusLoinItems={[]}
       parentPage={PAGES.static.guideCfa}
       page={PAGES.static.guideCfaLaCarteEtudiantDesMetiers}
+      metadata={metadata}
     >
       <Section>
         <Paragraph>

--- a/ui/app/(editorial)/guide-cfa/page.tsx
+++ b/ui/app/(editorial)/guide-cfa/page.tsx
@@ -11,10 +11,11 @@ import { GuideHeaderIllustration } from "@/app/(editorial)/_components/GuideHead
 import { DsfrIcon } from "@/components/DsfrIcon"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { ARTICLES as ARTICLES_PARTAGES } from "../guide/const"
 import { ARTICLES } from "./const"
-export const metadata: Metadata = PAGES.static.guideCfa.getMetadata()
+export const metadata: Metadata = METADATA.static.guideCfa()
 
 const guideCfaPage = () => {
   return (
@@ -25,8 +26,8 @@ const guideCfaPage = () => {
     >
       <SchemaOrg
         type="WebPage"
-        title={PAGES.static.guideCfa.getMetadata().title}
-        description={PAGES.static.guideCfa.getMetadata().description}
+        title={METADATA.static.guideCfa().title}
+        description={METADATA.static.guideCfa().description}
         url={PAGES.static.guideCfa.getPath()}
         breadcrumbs={[
           { name: PAGES.static.home.title, url: PAGES.static.home.getPath() },

--- a/ui/app/(editorial)/guide-recruteur/cerfa-apprentissage-et-professionnalisation/page.tsx
+++ b/ui/app/(editorial)/guide-recruteur/cerfa-apprentissage-et-professionnalisation/page.tsx
@@ -13,8 +13,9 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideRecruteurCerfaApprentissageEtProfessionnalisation.getMetadata()
+export const metadata: Metadata = METADATA.static.guideRecruteurCerfaApprentissageEtProfessionnalisation()
 
 const CerfaApprentissageEtProfessionnalisationPage = () => {
   const pages = [PAGES.static.guideRecruteur, PAGES.static.guideRecruteurCerfaApprentissageEtProfessionnalisation]
@@ -38,6 +39,7 @@ const CerfaApprentissageEtProfessionnalisationPage = () => {
       sourceAllerPlusLoin="guide-recruteur"
       parentPage={PAGES.static.guideRecruteur}
       page={PAGES.static.guideRecruteurCerfaApprentissageEtProfessionnalisation}
+      metadata={metadata}
     >
       <Section title="Les deux formulaires Cerfa">
         <ParagraphList

--- a/ui/app/(editorial)/guide-recruteur/const.ts
+++ b/ui/app/(editorial)/guide-recruteur/const.ts
@@ -1,3 +1,4 @@
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
 export const IMAGE_BASE_PATH = "/images/guides/guide-recruteur/"
@@ -6,7 +7,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["je-suis-employeur-public"]: {
     id: "je-suis-employeur-public",
     title: PAGES.static.guideRecruteurJeSuisEmployeurPublic.title,
-    description: PAGES.static.guideRecruteurJeSuisEmployeurPublic.getMetadata().description,
+    description: METADATA.static.guideRecruteurJeSuisEmployeurPublic().description,
     imageUrl: `${IMAGE_BASE_PATH}je-suis-employeur-public.svg`,
     path: PAGES.static.guideRecruteurJeSuisEmployeurPublic.getPath(),
     updatedAt: "26/03/2026",
@@ -14,7 +15,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["cerfa-apprentissage-et-professionnalisation"]: {
     id: "cerfa-apprentissage-et-professionnalisation",
     title: PAGES.static.guideRecruteurCerfaApprentissageEtProfessionnalisation.title,
-    description: PAGES.static.guideRecruteurCerfaApprentissageEtProfessionnalisation.getMetadata().description,
+    description: METADATA.static.guideRecruteurCerfaApprentissageEtProfessionnalisation().description,
     imageUrl: `${IMAGE_BASE_PATH}cerfa-apprentissage-et-professionnalisation.svg`,
     path: PAGES.static.guideRecruteurCerfaApprentissageEtProfessionnalisation.getPath(),
     updatedAt: "26/03/2026",

--- a/ui/app/(editorial)/guide-recruteur/je-suis-employeur-public/page.tsx
+++ b/ui/app/(editorial)/guide-recruteur/je-suis-employeur-public/page.tsx
@@ -9,8 +9,9 @@ import { UpdatedAtSection } from "@/app/(editorial)/_components/UpdatedAtSection
 import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { ARTICLES } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.guideRecruteurJeSuisEmployeurPublic.getMetadata()
+export const metadata: Metadata = METADATA.static.guideRecruteurJeSuisEmployeurPublic()
 
 const JeSuisEmployeurPublicPage = () => {
   const pages = [PAGES.static.guideRecruteur, PAGES.static.guideRecruteurJeSuisEmployeurPublic]
@@ -42,6 +43,7 @@ const JeSuisEmployeurPublicPage = () => {
       sourceAllerPlusLoin="guide-recruteur"
       parentPage={PAGES.static.guideRecruteur}
       page={PAGES.static.guideRecruteurJeSuisEmployeurPublic}
+      metadata={metadata}
     >
       <Section title="Démarches à suivre">
         <Paragraph>

--- a/ui/app/(editorial)/guide-recruteur/page.tsx
+++ b/ui/app/(editorial)/guide-recruteur/page.tsx
@@ -13,9 +13,10 @@ import { ARTICLES as ARTICLES_PARTAGES } from "@/app/(editorial)/guide/const"
 import { DsfrIcon } from "@/components/DsfrIcon"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { ARTICLES } from "./const"
-export const metadata: Metadata = PAGES.static.guideRecruteur.getMetadata()
+export const metadata: Metadata = METADATA.static.guideRecruteur()
 
 const GuideRecruteurPage = () => {
   return (
@@ -26,8 +27,8 @@ const GuideRecruteurPage = () => {
     >
       <SchemaOrg
         type="WebPage"
-        title={PAGES.static.guideRecruteur.getMetadata().title}
-        description={PAGES.static.guideRecruteur.getMetadata().description}
+        title={METADATA.static.guideRecruteur().title}
+        description={METADATA.static.guideRecruteur().description}
         url={PAGES.static.guideRecruteur.getPath()}
         breadcrumbs={[
           { name: PAGES.static.home.title, url: PAGES.static.home.getPath() },

--- a/ui/app/(editorial)/guide/apprentissage-et-handicap/page.tsx
+++ b/ui/app/(editorial)/guide/apprentissage-et-handicap/page.tsx
@@ -15,9 +15,10 @@ import { ARTICLES as ARTICLES_ALTERNANT } from "@/app/(editorial)/guide-alternan
 import { ARTICLES as ARTICLES_CFA } from "@/app/(editorial)/guide-cfa/const"
 import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  ...PAGES.static.guideApprentissageEtHandicap.getMetadata(),
+  ...METADATA.static.guideApprentissageEtHandicap(),
   alternates: { canonical: PAGES.static.guideApprentissageEtHandicap.getPath() },
 }
 
@@ -68,6 +69,7 @@ const ApprentissageEtHandicapPage = async ({ searchParams }: { searchParams: Pro
       redirectionInterne={<RedirectionInterne source={source} />}
       allerPlusLoinItems={getAllerPlusLoinItems(source)}
       page={PAGES.static.guideApprentissageEtHandicap}
+      metadata={metadata}
     >
       <InfoSection>
         <Box>

--- a/ui/app/(editorial)/guide/const.ts
+++ b/ui/app/(editorial)/guide/const.ts
@@ -1,3 +1,4 @@
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
 export const IMAGE_BASE_PATH = "/images/guides/"
@@ -6,7 +7,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["decouvrir-l-alternance"]: {
     id: "decouvrir-l-alternance",
     title: PAGES.static.guideDecouvrirLAlternance.title,
-    description: PAGES.static.guideDecouvrirLAlternance.getMetadata().description,
+    description: METADATA.static.guideDecouvrirLAlternance().description,
     imageUrl: `${IMAGE_BASE_PATH}decouvrir-l-alternance.svg`,
     path: PAGES.static.guideDecouvrirLAlternance.getPath(),
     updatedAt: "26/03/2026",
@@ -14,7 +15,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["apprentissage-et-handicap"]: {
     id: "apprentissage-et-handicap",
     title: PAGES.static.guideApprentissageEtHandicap.title,
-    description: PAGES.static.guideApprentissageEtHandicap.getMetadata().description,
+    description: METADATA.static.guideApprentissageEtHandicap().description,
     imageUrl: `${IMAGE_BASE_PATH}apprentissage-et-handicap.svg`,
     path: PAGES.static.guideApprentissageEtHandicap.getPath(),
     updatedAt: "01/04/2026",
@@ -22,7 +23,7 @@ export const ARTICLES: Record<string, { id: string; title: string; description: 
   ["prevention-des-risques-professionnels-pour-les-apprentis"]: {
     id: "prevention-des-risques-professionnels-pour-les-apprentis",
     title: PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.title,
-    description: PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getMetadata().description,
+    description: METADATA.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis().description,
     imageUrl: `${IMAGE_BASE_PATH}prevention-des-risques-professionnels-pour-les-apprentis.svg`,
     path: PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getPath(),
     updatedAt: "26/03/2026",

--- a/ui/app/(editorial)/guide/decouvrir-l-alternance/page.tsx
+++ b/ui/app/(editorial)/guide/decouvrir-l-alternance/page.tsx
@@ -13,9 +13,10 @@ import { ARTICLES as ARTICLES_ALTERNANT } from "@/app/(editorial)/guide-alternan
 import { ARTICLES as ARTICLES_CFA } from "@/app/(editorial)/guide-cfa/const"
 import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteur/const"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  ...PAGES.static.guideDecouvrirLAlternance.getMetadata(),
+  ...METADATA.static.guideDecouvrirLAlternance(),
   alternates: { canonical: PAGES.static.guideDecouvrirLAlternance.getPath() },
 }
 
@@ -66,6 +67,7 @@ const DecouvrirLAlternancePage = async ({ searchParams }: { searchParams: Promis
       allerPlusLoinItems={getAllerPlusLoinItems(source)}
       redirectionInterne={<RedirectionInterne source={source} />}
       page={PAGES.static.guideDecouvrirLAlternance}
+      metadata={metadata}
     >
       <Section title="Qui peut être alternant ?">
         <Paragraph>Les conditions pour être alternant diffèrent selon le type de contrat choisi.</Paragraph>

--- a/ui/app/(editorial)/guide/prevention-des-risques-professionnels-pour-les-apprentis/page.tsx
+++ b/ui/app/(editorial)/guide/prevention-des-risques-professionnels-pour-les-apprentis/page.tsx
@@ -10,9 +10,10 @@ import { ARTICLES } from "@/app/(editorial)/guide/const"
 import { ARTICLES as ARTICLES_ALTERNANT } from "@/app/(editorial)/guide-alternant/const"
 import { ARTICLES as ARTICLES_CFA } from "@/app/(editorial)/guide-cfa/const"
 import { ARTICLES as ARTICLES_RECRUTEUR } from "@/app/(editorial)/guide-recruteur/const"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  ...PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getMetadata(),
+  ...METADATA.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis(),
   alternates: { canonical: PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis.getPath() },
 }
 
@@ -58,6 +59,7 @@ const PreventionDesRisquesProfessionnelsPourLesApprentisPage = async ({ searchPa
       allerPlusLoinItems={getAllerPlusLoinItems(source)}
       parentPage={PAGES.static.guideRecruteur}
       page={PAGES.static.guidePreventionDesRisquesProfessionnelsPourLesApprentis}
+      metadata={metadata}
     >
       <Section title="Obligations des employeurs d’apprentis">
         <Paragraph>L’employeur a une obligation légale de sécurité envers tous ses salariés, y compris les apprentis. À ce titre, il doit :</Paragraph>

--- a/ui/app/(editorial)/metiers/[slug]/page.tsx
+++ b/ui/app/(editorial)/metiers/[slug]/page.tsx
@@ -9,6 +9,7 @@ import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import type { IStaticMetiers, IStaticVilles } from "@/utils/get-static-data"
 import { getStaticMetiers, getStaticVilles } from "@/utils/get-static-data"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
 const getTowns = () => {
@@ -33,7 +34,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   if (!metier) {
     return { title: "Métier introuvable - La bonne alternance" }
   }
-  return PAGES.dynamic.metierJobById(metier.name).getMetadata()
+  return METADATA.dynamic.metierJobById(metier.name)
 }
 
 export default async function MetiersByJobId({ params }: { params: Promise<{ slug: string }> }) {

--- a/ui/app/(editorial)/metiers/page.tsx
+++ b/ui/app/(editorial)/metiers/page.tsx
@@ -7,10 +7,11 @@ import path from "path"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { getStaticMetiers } from "@/utils/get-static-data"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.metiers.getMetadata().title,
-  description: PAGES.static.metiers.getMetadata().description,
+  title: METADATA.static.metiers().title,
+  description: METADATA.static.metiers().description,
 }
 
 export default async function Metiers() {

--- a/ui/app/(editorial)/plan-du-site/page.tsx
+++ b/ui/app/(editorial)/plan-du-site/page.tsx
@@ -9,10 +9,11 @@ import { metierData } from "@/app/(editorial)/alternance/_components/metier_data
 import { villeData } from "@/app/(editorial)/alternance/_components/ville_data"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { publicConfig } from "@/config.public"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.planDuSite.getMetadata().title,
-  description: PAGES.static.planDuSite.getMetadata().description,
+  title: METADATA.static.planDuSite().title,
+  description: METADATA.static.planDuSite().description,
 }
 
 export default function PlanDuSite() {

--- a/ui/app/(editorial)/statistiques/page.tsx
+++ b/ui/app/(editorial)/statistiques/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import StatistiquesClient from "./StatistiquesClient"
 export const metadata: Metadata = {
-  title: PAGES.static.statistiques.getMetadata().title,
-  description: PAGES.static.statistiques.getMetadata().description,
+  title: METADATA.static.statistiques().title,
+  description: METADATA.static.statistiques().description,
 }
 
 export default function Statistiques() {

--- a/ui/app/(editorial-with-notion)/accessibilite/page.tsx
+++ b/ui/app/(editorial-with-notion)/accessibilite/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next"
 import { fetchNotionPage } from "@/services/fetch-notion-page"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { AccessibilitePage } from "./AccessibilitePage"
 
 export const metadata: Metadata = {
-  title: PAGES.static.accessibilite.getMetadata().title,
-  description: PAGES.static.accessibilite.getMetadata().description,
+  title: METADATA.static.accessibilite().title,
+  description: METADATA.static.accessibilite().description,
 }
 
 const Page = async () => {

--- a/ui/app/(editorial-with-notion)/conditions-generales-utilisation/page.tsx
+++ b/ui/app/(editorial-with-notion)/conditions-generales-utilisation/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next"
 import { fetchNotionPage } from "@/services/fetch-notion-page"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import CGURendererClient from "./CGURendererClient"
 
 export const metadata: Metadata = {
-  title: PAGES.static.cgu.getMetadata().title,
-  description: PAGES.static.cgu.getMetadata().description,
+  title: METADATA.static.cgu().title,
+  description: METADATA.static.cgu().description,
 }
 
 export default async function CGU() {

--- a/ui/app/(editorial-with-notion)/faq/page.tsx
+++ b/ui/app/(editorial-with-notion)/faq/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next"
 import { fetchNotionPage } from "@/services/fetch-notion-page"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import FAQRendererClient from "./FAQRendererClient"
 
 export const metadata: Metadata = {
-  title: PAGES.static.faq.getMetadata().title,
-  description: PAGES.static.faq.getMetadata().description,
+  title: METADATA.static.faq().title,
+  description: METADATA.static.faq().description,
 }
 
 export default async function FAQ({ searchParams }: { searchParams: Promise<Record<string, string>> }) {

--- a/ui/app/(editorial-with-notion)/mentions-legales/page.tsx
+++ b/ui/app/(editorial-with-notion)/mentions-legales/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next"
 import { fetchNotionPage } from "@/services/fetch-notion-page"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import MentionLegalesRendererClient from "./MentionLegalesRendererClient"
 
 export const metadata: Metadata = {
-  title: PAGES.static.mentionsLegales.getMetadata().title,
-  description: PAGES.static.mentionsLegales.getMetadata().description,
+  title: METADATA.static.mentionsLegales().title,
+  description: METADATA.static.mentionsLegales().description,
 }
 
 export default async function MentionsLegales() {

--- a/ui/app/(editorial-with-notion)/politique-de-confidentialite/page.tsx
+++ b/ui/app/(editorial-with-notion)/politique-de-confidentialite/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next"
 import { fetchNotionPage } from "@/services/fetch-notion-page"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import PolitiqueDeConfidentialiteRendererClient from "./PDCRendererClient"
 
 export const metadata: Metadata = {
-  title: PAGES.static.politiqueConfidentialite.getMetadata().title,
-  description: PAGES.static.politiqueConfidentialite.getMetadata().description,
+  title: METADATA.static.politiqueConfidentialite().title,
+  description: METADATA.static.politiqueConfidentialite().description,
 }
 
 export default async function PolitiqueDeConfidentialite() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/compte/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from "next"
 import { ADMIN } from "shared/constants/recruteur"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.dynamic.compte({ userType: ADMIN }).getMetadata().title,
+  title: METADATA.dynamic.compte({ userType: ADMIN }).title,
 }
 
 export default function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import GestionDesAdministrateurs from "./gestionDesAdministrateurs"
 export const metadata: Metadata = {
-  title: PAGES.static.backAdminGestionDesAdministrateurs.getMetadata().title,
+  title: METADATA.static.backAdminGestionDesAdministrateurs().title,
 }
 
 export default async function AdministrationGestionAdministrateurs() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/user/[userId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-administrateurs/user/[userId]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import EditAdministrateur from "./editAdministrateur"
 export async function generateMetadata({ params }: { params: Promise<{ userId: string }> }): Promise<Metadata> {
   const { userId } = await params
   return {
-    title: PAGES.dynamic.backEditAdministrator({ userId }).getMetadata().title,
+    title: METADATA.dynamic.backEditAdministrator({ userId }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-entreprises/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/gestion-des-entreprises/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import GestionEntreprises from "./gestionEntreprises"
 export const metadata: Metadata = {
-  title: PAGES.static.backAdminGestionDesEntreprises.getMetadata().title,
+  title: METADATA.static.backAdminGestionDesEntreprises().title,
 }
 
 export default async function AdministrationGestionEntreprises() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/offres-partenaires/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { OffresPartenairesList } from "./OffresPartenairesList"
 export const metadata: Metadata = {
-  title: PAGES.static.backAdminGestionDesOffresPartenaires.getMetadata().title,
+  title: METADATA.static.backAdminGestionDesOffresPartenaires().title,
 }
 
 export default async function GestionDesOffresPartenaires() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/[id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/[id]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import ProcesseurCronTaskPage from "./ProcesseurCronTaskPage"
 export async function generateMetadata({ params }: { params: Promise<{ name: string; id: string }> }): Promise<Metadata> {
   const { name, id } = await params
   return {
-    title: PAGES.dynamic.adminProcessorCronTask({ name, id }).getMetadata().title,
+    title: METADATA.dynamic.adminProcessorCronTask({ name, id }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/cron/[name]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import ProcesseurCronPage from "./ProcesseurCronPage"
 export async function generateMetadata({ params }: { params: Promise<{ name: string }> }): Promise<Metadata> {
   const { name } = await params
   return {
-    title: PAGES.dynamic.adminProcessorCron(name).getMetadata().title,
+    title: METADATA.dynamic.adminProcessorCron(name).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/[id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/[id]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import ProcesseurJobInstancePage from "./ProcesseurJobInstancePage"
 export async function generateMetadata({ params }: { params: Promise<{ name: string; id: string }> }): Promise<Metadata> {
   const { name, id } = await params
   return {
-    title: PAGES.dynamic.adminProcessorJobInstance({ name, id }).getMetadata().title,
+    title: METADATA.dynamic.adminProcessorJobInstance({ name, id }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/job/[name]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import ProcesseurJobPage from "./ProcesseurJobPage"
 export async function generateMetadata({ params }: { params: Promise<{ name: string }> }): Promise<Metadata> {
   const { name } = await params
   return {
-    title: PAGES.dynamic.adminProcessorJob(name).getMetadata().title,
+    title: METADATA.dynamic.adminProcessorJob(name).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/processeur/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import ProcesseurPage from "./ProcesseurPage"
 export const metadata: Metadata = {
-  title: PAGES.static.adminProcessor.getMetadata().title,
+  title: METADATA.static.adminProcessor().title,
 }
 
 export default async function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/recruteurs/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/recruteurs/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { RecruteursList } from "./RecruteursList"
 export const metadata: Metadata = {
-  title: PAGES.static.backAdminGestionDesRecruteurs.getMetadata().title,
+  title: METADATA.static.backAdminGestionDesRecruteurs().title,
 }
 
 export default async function GestionDesRecruteurs() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/[siret]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/[siret]/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next"
 import LoadingEmptySpace from "@/app/(espace-pro)/_components/LoadingEmptySpace"
 import { getEligibleTrainingsForAppointments, getEtablissement } from "@/utils/api"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import RendezVousApprentissageDetailRendererClient from "./RendezVousApprentissageDetailRendererClient"
 export async function generateMetadata({ params }: { params: Promise<{ siret: string }> }): Promise<Metadata> {
   const { siret } = await params
   return {
-    title: PAGES.dynamic.rendezVousApprentissageDetail({ siret }).getMetadata().title,
+    title: METADATA.dynamic.rendezVousApprentissageDetail({ siret }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/rendez-vous-apprentissage/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import RendezVousApprentissagePage from "./RendezVousApprentissagePage"
 export const metadata: Metadata = {
-  title: PAGES.static.rendezVousApprentissageRecherche.getMetadata().title,
+  title: METADATA.static.rendezVousApprentissageRecherche().title,
 }
 
 export default async function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/cfa/[establishment_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/cfa/[establishment_id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import AdminUserCfaEntreprisePage from "./AdminUserCfaEntreprisePage"
 export async function generateMetadata({ params }: { params: { userId: string; establishment_id: string } }): Promise<Metadata> {
   const { userId, establishment_id } = params
-  return { title: PAGES.dynamic.backAdminUserCfaEntreprise({ user_id: userId, establishment_id }).getMetadata().title }
+  return { title: METADATA.dynamic.backAdminUserCfaEntreprise({ user_id: userId, establishment_id }).title }
 }
 
 export default async function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/entreprise/[establishment_id]/offre/[job_id]/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next"
 import { ADMIN } from "shared/constants/recruteur"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import AdminOffrePage from "./AdminOffrePage"
 export async function generateMetadata({ params }: { params: Promise<{ job_id: string; establishment_id: string; userId: string }> }): Promise<Metadata> {
   const { job_id, establishment_id, userId } = await params
   return {
-    title: PAGES.dynamic.offreUpsert({ establishment_id, offerId: job_id, userType: ADMIN, userId }).getMetadata().title,
+    title: METADATA.dynamic.offreUpsert({ establishment_id, offerId: job_id, userType: ADMIN, userId }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/[userId]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import User from "./User"
 export async function generateMetadata({ params }: { params: Promise<{ userId: string }> }): Promise<Metadata> {
   const { userId } = await params
   return {
-    title: PAGES.dynamic.backAdminRecruteurOffres({ user_id: userId }).getMetadata().title,
+    title: METADATA.dynamic.backAdminRecruteurOffres({ user_id: userId }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/administration/users/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { UsersList } from "./UsersList"
 export const metadata: Metadata = {
-  title: PAGES.static.backAdminHome.getMetadata().title,
+  title: METADATA.static.backAdminHome().title,
 }
 
 export default async function AccueilAdministration() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/carte-d-etudiant-des-metiers/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/carte-d-etudiant-des-metiers/page.tsx
@@ -6,8 +6,9 @@ import Image from "next/image"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
 import { DsfrIcon } from "@/components/DsfrIcon"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
-export const metadata: Metadata = PAGES.static.espaceProCfaCarteDEtudiantDesMetiers.getMetadata()
+export const metadata: Metadata = METADATA.static.espaceProCfaCarteDEtudiantDesMetiers()
 
 const CarteDEtudiantDesMetiersPage = () => (
   <Box

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/compte/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from "next"
 import { CFA } from "shared/constants/recruteur"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.dynamic.compte({ userType: CFA }).getMetadata().title,
+  title: METADATA.dynamic.compte({ userType: CFA }).title,
 }
 
 export default function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/[siret]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/[siret]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import CreationEntrepriseDetailPage from "./CreationEntrepriseDetailPage"
 export async function generateMetadata({ params }: { params: Promise<{ siret: string }> }): Promise<Metadata> {
   const { siret } = await params
   return {
-    title: PAGES.dynamic.backCfaEntrepriseCreationDetail(siret).getMetadata().title,
+    title: METADATA.dynamic.backCfaEntrepriseCreationDetail(siret).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/creation-entreprise/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import CreationEntreprisePage from "./CreationEntreprisePage"
 export const metadata: Metadata = {
-  title: PAGES.static.backCfaCreationEntreprise.getMetadata().title,
+  title: METADATA.static.backCfaCreationEntreprise().title,
 }
 
 export default async function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/creation-offre/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/creation-offre/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import CfaCreationOffrePage from "./CfaCreationOffrePage"
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string }> }): Promise<Metadata> {
   const { establishment_id } = await params
   return {
-    title: PAGES.dynamic.backCfaEntrepriseCreationOffre(establishment_id).getMetadata().title,
+    title: METADATA.dynamic.backCfaEntrepriseCreationOffre(establishment_id).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/informations/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/informations/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next"
 import { getSession } from "@/utils/get-session"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { EntrepriseInformationsPage } from "./EntrepriseInformationsPage"
 
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string }> }): Promise<Metadata> {
   const { establishment_id } = await params
   return {
-    title: PAGES.dynamic.backCfaPageInformations(establishment_id).getMetadata().title,
+    title: METADATA.dynamic.backCfaPageInformations(establishment_id).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/offre/[jobId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/offre/[jobId]/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next"
 import { CFA } from "shared/constants/recruteur"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import CfaOffrePage from "./CfaOffrePage"
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string; jobId: string }> }): Promise<Metadata> {
   const { establishment_id, jobId } = await params
   return {
-    title: PAGES.dynamic.offreUpsert({ establishment_id, offerId: jobId, userType: CFA }).getMetadata().title,
+    title: METADATA.dynamic.offreUpsert({ establishment_id, offerId: jobId, userType: CFA }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/entreprise/[establishment_id]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import CfaEntreprisePage from "./CfaEntreprisePage"
 export async function generateMetadata({ params }: { params: Promise<{ establishment_id: string }> }): Promise<Metadata> {
   const { establishment_id } = await params
   return {
-    title: PAGES.dynamic.backCfaPageEntreprise(establishment_id).getMetadata().title,
+    title: METADATA.dynamic.backCfaPageEntreprise(establishment_id).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/cfa/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/cfa/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next"
 import CfaHome from "@/app/(espace-pro)/espace-pro/(connected)/_components/CfaHome"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.backCfaHome.getMetadata().title,
+  title: METADATA.static.backCfaHome().title,
 }
 
 export default function CfaPage() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/compte/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from "next"
 import { ENTREPRISE } from "shared/constants/recruteur"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.dynamic.compte({ userType: ENTREPRISE }).getMetadata().title,
+  title: METADATA.dynamic.compte({ userType: ENTREPRISE }).title,
 }
 
 export default function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/creation-offre/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/creation-offre/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
 import { BackEntrepriseUpsertOffre } from "@/app/(espace-pro)/espace-pro/(connected)/_components/BackEntrepriseUpsertOffre"
 import { getSession } from "@/utils/get-session"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 
 export const metadata: Metadata = {
-  title: PAGES.static.backEntrepriseCreationOffre.getMetadata().title,
+  title: METADATA.static.backEntrepriseCreationOffre().title,
 }
 
 export default async function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/mise-en-relation/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/mise-en-relation/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next"
 import MiseEnRelation from "@/app/(espace-pro)/_components/MiseEnRelation"
 import { getSession } from "@/utils/get-session"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 
 export async function generateMetadata({ params }: { params: Promise<{ job_id: string }> }): Promise<Metadata> {
   const { job_id } = await params
   return {
-    title: PAGES.dynamic.backEntrepriseMiseEnRelation({ job_id }).getMetadata().title,
+    title: METADATA.dynamic.backEntrepriseMiseEnRelation({ job_id }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/offre/[job_id]/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next"
 import { getSession } from "@/utils/get-session"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PageWithParams } from "./PageWithParams"
 
 export async function generateMetadata({ params }: { params: Promise<{ job_id: string }> }): Promise<Metadata> {
   const { job_id } = await params
   return {
-    title: PAGES.dynamic.backEntrepriseEditionOffre({ job_id }).getMetadata().title,
+    title: METADATA.dynamic.backEntrepriseEditionOffre({ job_id }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/entreprise/page.tsx
@@ -2,10 +2,11 @@ import type { Metadata } from "next"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import ListeOffres from "@/app/(espace-pro)/espace-pro/(connected)/_components/ListeOffres"
 import { getSession } from "@/utils/get-session"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
 export const metadata: Metadata = {
-  title: PAGES.static.backHomeEntreprise.getMetadata().title,
+  title: METADATA.static.backHomeEntreprise().title,
 }
 
 export default async function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/compte/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/compte/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from "next"
 import { OPCO } from "shared/constants/recruteur"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import CompteRenderer from "@/app/(espace-pro)/espace-pro/(connected)/_components/CompteRenderer"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 export const metadata: Metadata = {
-  title: PAGES.dynamic.compte({ userType: OPCO }).getMetadata().title,
+  title: METADATA.dynamic.compte({ userType: OPCO }).title,
 }
 
 export default function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import OpcoPage from "./OpcoPage"
 export const metadata: Metadata = {
-  title: PAGES.static.backOpcoHome.getMetadata().title,
+  title: METADATA.static.backOpcoHome().title,
 }
 
 export default async function Page() {

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/entreprise/[establishment_id]/offre/[jobId]/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next"
 import { OPCO } from "shared/constants/recruteur"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import OpcoOffrePage from "./OpcoOffrePage"
 export async function generateMetadata({ params }: { params: Promise<{ jobId: string; establishment_id: string; userId: string }> }): Promise<Metadata> {
   const { jobId, establishment_id, userId } = await params
   return {
-    title: PAGES.dynamic.offreUpsert({ establishment_id, offerId: jobId, userType: OPCO, userId }).getMetadata().title,
+    title: METADATA.dynamic.offreUpsert({ establishment_id, offerId: jobId, userType: OPCO, userId }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/opco/users/[userId]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import User from "./User"
 export async function generateMetadata({ params }: { params: Promise<{ userId: string }> }): Promise<Metadata> {
   const { userId } = await params
   return {
-    title: PAGES.dynamic.backOpcoInformationEntreprise({ user_id: userId }).getMetadata().title,
+    title: METADATA.dynamic.backOpcoInformationEntreprise({ user_id: userId }).title,
   }
 }
 

--- a/ui/app/(espace-pro)/espace-pro/authentification/confirmation/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/confirmation/page.tsx
@@ -2,9 +2,9 @@ import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Typography } from "@mui/material"
 import type { Metadata } from "next"
 import { publicConfig } from "@/config.public"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 export const metadata: Metadata = {
-  title: PAGES.dynamic.backCreateCFAConfirmation({ email: "" }).getMetadata().title,
+  title: METADATA.dynamic.backCreateCFAConfirmation({ email: "" }).title,
 }
 
 export default function ConfirmationCreationCompte() {

--- a/ui/app/(espace-pro)/espace-pro/authentification/en-attente/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/en-attente/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import CompteEnAttente from "./CompteEnAttente"
 export const metadata: Metadata = {
-  title: PAGES.static.backCreateCFAEnAttente.getMetadata().title,
+  title: METADATA.static.backCreateCFAEnAttente().title,
 }
 
 export default function PageCompteEnAttente() {

--- a/ui/app/(espace-pro)/espace-pro/authentification/page.tsx
+++ b/ui/app/(espace-pro)/espace-pro/authentification/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import AuthentificationPage from "./AuthentificationPage"
 export const metadata: Metadata = {
-  title: PAGES.static.authentification.getMetadata().title,
-  description: PAGES.static.authentification.getMetadata().description,
+  title: METADATA.static.authentification().title,
+  description: METADATA.static.authentification().description,
 }
 
 const Page = async () => {

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/[origin]/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/[origin]/page.tsx
@@ -2,10 +2,10 @@ import type { Metadata } from "next"
 import { Suspense } from "react"
 import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.espaceProCreationCfa.getMetadata().title,
-  description: PAGES.static.espaceProCreationCfa.getMetadata().description,
+  title: METADATA.static.espaceProCreationCfa().title,
+  description: METADATA.static.espaceProCreationCfa().description,
 }
 
 export default async function Page({ params }) {

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/cfa/page.tsx
@@ -2,10 +2,10 @@ import type { Metadata } from "next"
 import { Suspense } from "react"
 import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.espaceProCreationCfa.getMetadata().title,
-  description: PAGES.static.espaceProCreationCfa.getMetadata().description,
+  title: METADATA.static.espaceProCreationCfa().title,
+  description: METADATA.static.espaceProCreationCfa().description,
 }
 
 export default function Page() {

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/[origin]/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/[origin]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import CreationWithOriginPage from "./CreationWithOriginPage"
 export const metadata: Metadata = {
-  title: PAGES.static.espaceProCreationEntreprise.getMetadata().title,
-  description: PAGES.static.espaceProCreationEntreprise.getMetadata().description,
+  title: METADATA.static.espaceProCreationEntreprise().title,
+  description: METADATA.static.espaceProCreationEntreprise().description,
 }
 
 const Page = async () => {

--- a/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/page.tsx
+++ b/ui/app/(espace-pro-creation-compte)/espace-pro/creation/entreprise/page.tsx
@@ -2,10 +2,10 @@ import type { Metadata } from "next"
 import { Suspense } from "react"
 import { AUTHTYPE } from "@/common/contants"
 import CreationCompte from "@/components/espace_pro/Authentification/CreationCompte"
-import { PAGES } from "@/utils/routes.utils"
+import { METADATA } from "@/utils/routes.metadata.utils"
 export const metadata: Metadata = {
-  title: PAGES.static.espaceProCreationEntreprise.getMetadata().title,
-  description: PAGES.static.espaceProCreationEntreprise.getMetadata().description,
+  title: METADATA.static.espaceProCreationEntreprise().title,
+  description: METADATA.static.espaceProCreationEntreprise().description,
 }
 
 export default function CreationEntreprise() {

--- a/ui/app/(home)/page.tsx
+++ b/ui/app/(home)/page.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from "next"
 import { AppreciationUsagers } from "@/app/(home)/_components/AppreciationUsagers"
 import { GrandsGroupesCandidat } from "@/app/(home)/_components/GrandsGroupesCandidat"
 import { SchemaOrg } from "@/components/SchemaOrg"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { AlgoHome } from "./_components/AlgoHome"
 import { CalculRemuneration } from "./_components/CalculRemuneration"
@@ -14,8 +15,8 @@ import { HowTo } from "./_components/HowTo"
 import { InformationsAlternance } from "./_components/InformationsAlternance"
 
 export const metadata: Metadata = {
-  title: PAGES.static.home.getMetadata().title,
-  description: PAGES.static.home.getMetadata().description,
+  title: METADATA.static.home().title,
+  description: METADATA.static.home().description,
 }
 
 export default function HomePage() {
@@ -23,8 +24,8 @@ export default function HomePage() {
     <>
       <SchemaOrg
         type="WebPage"
-        title={PAGES.static.home.getMetadata().title}
-        description={PAGES.static.home.getMetadata().description}
+        title={METADATA.static.home().title}
+        description={METADATA.static.home().description}
         url={PAGES.static.home.getPath()}
         breadcrumbs={[{ name: PAGES.static.home.title, url: PAGES.static.home.getPath() }]}
       />

--- a/ui/app/(landing-pages)/je-suis-cfa/page.tsx
+++ b/ui/app/(landing-pages)/je-suis-cfa/page.tsx
@@ -14,9 +14,10 @@ import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { getDepotCtaHref } from "@/services/get-depot-cta-href"
 import { getSession } from "@/utils/get-session"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
-export const metadata: Metadata = PAGES.static.jeSuisCFA.getMetadata()
+export const metadata: Metadata = METADATA.static.jeSuisCFA()
 
 async function DepotCtaButtons() {
   const { user } = await getSession()
@@ -76,8 +77,8 @@ const JeSuisCFAPage = () => {
     >
       <SchemaOrg
         type="WebPage"
-        title={PAGES.static.jeSuisCFA.getMetadata().title}
-        description={PAGES.static.jeSuisCFA.getMetadata().description}
+        title={METADATA.static.jeSuisCFA().title}
+        description={METADATA.static.jeSuisCFA().description}
         url={PAGES.static.jeSuisCFA.getPath()}
         breadcrumbs={[
           { name: PAGES.static.home.title, url: PAGES.static.home.getPath() },

--- a/ui/app/(landing-pages)/je-suis-recruteur/page.tsx
+++ b/ui/app/(landing-pages)/je-suis-recruteur/page.tsx
@@ -14,6 +14,7 @@ import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { SchemaOrg } from "@/components/SchemaOrg"
 import { getDepotCtaHref } from "@/services/get-depot-cta-href"
 import { getSession } from "@/utils/get-session"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 
 export const cardSx = {
@@ -24,7 +25,7 @@ export const cardSx = {
   textAlign: "center",
 }
 
-export const metadata: Metadata = PAGES.static.jeSuisRecruteur.getMetadata()
+export const metadata: Metadata = METADATA.static.jeSuisRecruteur()
 
 async function DepotCtaButtons() {
   const { user } = await getSession()
@@ -52,8 +53,8 @@ const JeSuisRecruteurPage = () => {
       >
         <SchemaOrg
           type="WebPage"
-          title={PAGES.static.jeSuisRecruteur.getMetadata().title}
-          description={PAGES.static.jeSuisRecruteur.getMetadata().description}
+          title={METADATA.static.jeSuisRecruteur().title}
+          description={METADATA.static.jeSuisRecruteur().description}
           url={PAGES.static.jeSuisRecruteur.getPath()}
           breadcrumbs={[
             { name: PAGES.static.home.title, url: PAGES.static.home.getPath() },

--- a/ui/app/(landing-pages)/salaire-alternant/page.tsx
+++ b/ui/app/(landing-pages)/salaire-alternant/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next"
 import { Breadcrumb } from "@/app/_components/Breadcrumb"
 import DefaultContainer from "@/app/_components/Layout/DefaultContainer"
+import { METADATA } from "@/utils/routes.metadata.utils"
 import { PAGES } from "@/utils/routes.utils"
 import { SimulateurRemuneration } from "./_components/SimulateurRemuneration"
 export const metadata: Metadata = {
-  title: PAGES.static.salaireAlternant.getMetadata().title,
-  description: PAGES.static.salaireAlternant.getMetadata().description,
+  title: METADATA.static.salaireAlternant().title,
+  description: METADATA.static.salaireAlternant().description,
 }
 
 export default async function Simulateur() {

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -95,6 +95,16 @@ const nextConfig = {
     },
     // Uniquement pour les tests Playwright instant() en local/CI, jamais en production réelle.
     exposeTestingApiInProductionBuild: process.env.PLAYWRIGHT_TEST_MODE === "1",
+    // Abaisse le seuil sous lequel Turbopack fusionne un chunk avec ses voisins (défaut 50 ko).
+    // À 50 ko, un même groupe de modules partagé entre deux chunk groups clients (ex. error.tsx
+    // et le groupe page) est fusionné différemment de chaque côté → deux chunks au contenu
+    // différent → pas de partage par hash → double téléchargement (~37,6 ko bruts sur la home,
+    // issue #5214). À 20 ko, le groupe reste un chunk autonome identique des deux côtés.
+    // Réglage sensible et non monotone : 30_000 est PIRE que le défaut (+10 ko gzip sur /).
+    // Toute modification doit être validée par le job Performance budget.
+    turbopackChunking: {
+      minChunkSize: 20_000,
+    },
   },
   output: "standalone",
   compress: false, // disable default gzip compression by nextJS, done by Nginx

--- a/ui/package.json
+++ b/ui/package.json
@@ -55,6 +55,7 @@
     "react-qr-code": "^2.0.18",
     "react-swipeable": "7.0.2",
     "react-table": "^7.8.0",
+    "server-only": "^0.0.1",
     "shared": "workspace:*",
     "yup": "^1.7.1",
     "zod": "^4.4.3",

--- a/ui/perf-budget.json
+++ b/ui/perf-budget.json
@@ -1,24 +1,24 @@
 {
   "$comment": "Budgets du first-load, contrôlés par ui/scripts/perf-budget.mjs (issue #5191). Seuils en octets gzip (niveau ci-dessous), sauf globalMaxFirstLoadJsRaw en octets non compressés. null = budget non renseigné : la mesure est affichée mais rien n'est contrôlé. Pour relever un seuil, reporter la mesure affichée par le job et justifier la hausse en description de PR.",
   "$measured": {
-    "$comment": "Mesures de référence ayant servi à fixer les seuils (build de production, NEXT_PUBLIC_ENV=production, NEXT_PUBLIC_VERSION constante). Le script les re-dérive à chaque exécution : un écart se lit dans la colonne Marge. Seuils JS abaissés après l'allègement Sentry client (issue #5186 : retrait tracing + captureConsole, −19 ko gzip sur la home), même marge ~4 % qu'à l'origine (#5191).",
-    "commit": "8e7027163",
-    "/ firstLoadJsGzip": 415868,
+    "$comment": "Mesures de référence ayant servi à fixer les seuils (build de production, NEXT_PUBLIC_ENV=production, NEXT_PUBLIC_VERSION constante). Le script les re-dérive à chaque exécution : un écart se lit dans la colonne Marge. Seuils JS abaissés après la déduplication inter-chunks (turbopackChunking.minChunkSize) et le découpage server-only des métadonnées de routes.utils (issue #5214 : −21 ko gzip sur la home), même marge ~4 % qu'à l'origine (#5191).",
+    "commit": "branche issue #5214 (PR de dédup first-load)",
+    "/ firstLoadJsGzip": 395785,
     "/ firstLoadCssGzip": 64977,
-    "/recherche firstLoadJsGzip": 586449,
-    "globalMaxFirstLoadJsRaw": 2395764
+    "/recherche firstLoadJsGzip": 580882,
+    "globalMaxFirstLoadJsRaw": 2282393
   },
   "gzipLevel": 9,
   "routes": {
     "/": {
-      "firstLoadJsGzip": 432128,
+      "firstLoadJsGzip": 411648,
       "firstLoadCssGzip": 67584
     },
     "/recherche": {
-      "firstLoadJsGzip": 609280
+      "firstLoadJsGzip": 604160
     }
   },
-  "globalMaxFirstLoadJsRaw": 2490368,
+  "globalMaxFirstLoadJsRaw": 2373632,
   "$commentForbidden": "forbiddenOnFirstLoad — @mui/x-data-grid et job-processor : réservés à l'espace pro/admin (page processeur), issue #5188. libphonenumber-js : issue #5191.",
   "forbiddenOnFirstLoad": {
     "/": [

--- a/ui/utils/routes.metadata.utils.ts
+++ b/ui/utils/routes.metadata.utils.ts
@@ -1,0 +1,381 @@
+import "server-only"
+import type { Metadata } from "next"
+import type { CFA, ENTREPRISE, ETAT_UTILISATEUR, OPCOS_LABEL } from "shared/constants/index"
+import { buildRechercheMetadata } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils_LEGACY"
+import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
+import type { PAGES } from "@/utils/routes.utils"
+
+// Registre des métadonnées SEO des pages, séparé de PAGES (routes.utils.ts) et server-only :
+// PAGES est importé par de nombreux composants client (header, footer, error boundary) et ces
+// littéraux titre/description représentaient ~la moitié de ses octets émis dans les bundles
+// client, dupliqués entre chunks (issue #5214). Les clés reflètent celles de PAGES — le
+// `satisfies` en fin de fichier casse le typecheck si une clé de PAGES est renommée ou supprimée.
+export const METADATA = {
+  static: {
+    home: () => ({
+      title: "La bonne alternance | Trouvez votre alternance, formation et emploi",
+      description:
+        "Trouvez votre alternance parmi des milliers d’offres d’emploi et de formations. Recherchez par métier et par ville, candidatez en ligne ou en spontané. Service public gratuit.",
+    }),
+    authentification: () => ({
+      title: "Authentification - La bonne alternance",
+      description: "Connectez-vous à votre compte La bonne alternance pour accéder à vos offres d’alternance.",
+    }),
+    aPropos: () => ({
+      title: "À propos de La bonne alternance - Notre mission et engagement",
+      description: "Apprenez-en plus sur La bonne alternance, notre mission et notre engagement pour faciliter votre recherche d’alternance.",
+    }),
+    cgu: () => ({
+      title: "Conditions générales d'utilisation - La bonne alternance",
+      description: "Consultez les conditions générales d’utilisation de La bonne alternance pour comprendre nos règles et engagements.",
+    }),
+    faq: () => ({
+      title: "FAQ - Réponses à vos questions sur l'alternance",
+      description: "Trouvez des réponses aux questions fréquentes sur l’alternance, nos services et le fonctionnement du site.",
+    }),
+    mentionsLegales: () => ({
+      title: "Mentions légales - La bonne alternance",
+      description: "Consultez les mentions légales de La bonne alternance pour en savoir plus sur nos obligations légales et notre responsabilité.",
+    }),
+    politiqueConfidentialite: () => ({
+      title: "Politique de confidentialité - Protection de vos données",
+      description: "Découvrez comment nous protégeons vos données personnelles et respectons votre vie privée sur La bonne alternance.",
+    }),
+    // Le « 77 » correspond au nombre de secteurs listés dans ui/config/metiers.txt (compteur en dur, cf. note ci-dessous).
+    metiers: () => ({
+      title: "Métiers en alternance : 77 secteurs | La bonne alternance",
+      description: "La liste des 77 secteurs qui recrutent en alternance : RH, communication, vente, BTP, santé, informatique… Offres d'emploi et formations du CAP au Master.",
+    }),
+    // Note : les compteurs des meta ci-dessous sont en dur volontairement (importer les tableaux
+    // _data juste pour un .length alourdirait le graphe serveur pour rien). À mettre à jour lors
+    // d'un changement de palier (30/30/10 → 100). Les pages hub affichent, elles, le décompte
+    // dynamique via {data.length}.
+    alternanceMetiers: () => ({
+      title: "30 métiers en alternance qui recrutent | La bonne alternance",
+      description: "Découvrez 30 métiers accessibles en alternance avec offres, salaires moyens et formations. Tertiaire, numérique, médico-social, artisanat.",
+    }),
+    alternanceVilles: () => ({
+      title: "Alternance dans 30 grandes villes | La bonne alternance",
+      description: "Trouvez votre alternance dans 30 grandes villes françaises. Offres, entreprises qui recrutent, logement, transports et vie d'alternant.",
+    }),
+    alternanceDiplomes: () => ({
+      title: "Diplômes en alternance : BTS, BUT, Licence Pro | LBA",
+      description: "Explorez 10 diplômes accessibles en alternance (BTS, BUT, Licence Pro, CAP, Titres Pro). Programme, durée, salaire et débouchés.",
+    }),
+    codeSources: () => ({
+      title: "Nos sources de données - La bonne alternance",
+      description: "Découvrez les sources de données que nous utilisons pour vous proposer les meilleures offres d’alternance.",
+    }),
+    blog: () => ({
+      title: "Blog - Conseils et actualités sur l'alternance",
+      description: "Lisez nos articles sur l’alternance, les conseils de carrière et les tendances du marché pour optimiser votre recherche.",
+    }),
+    ressources: () => ({
+      title: "Ressources pour réussir votre alternance - La bonne alternance",
+      description: "Accédez à des guides et outils pratiques pour maximiser vos chances de trouver une alternance et réussir votre parcours.",
+    }),
+    guideDecouvrirLAlternance: () => ({
+      title: "Découvrir l'alternance | Contrats, conditions et durée",
+      description: "Apprentissage ou professionnalisation : conditions d'accès, durée, rythme, coût de la formation et conditions de travail. Tout comprendre en 5 min.",
+    }),
+    guideApprentissageEtHandicap: () => ({
+      title: "Apprentissage et handicap | Droits, aides et aménagements",
+      description: "Alternance et situation de handicap : conditions d'accès, aménagements de formation, rémunération et aides spécifiques (AGEFIPH, FIPHFP). Guide 2026.",
+    }),
+    guidePreventionDesRisquesProfessionnelsPourLesApprentis: () => ({
+      title: "La prévention des risques professionnels | Guide pour les apprentis, les CFA et les recruteurs",
+      description: "Obligations des employeurs, accueil en entreprise et rôle des CFA dans la prévention des risques professionnels pour les apprentis.",
+    }),
+    guideAlternant: () => ({
+      title: "Guide de l'alternant 2026 | Tout savoir sur l'alternance",
+      description: "Informations, conseils et outils pour réussir votre alternance : contrats, rémunération, aides, formation et recherche d'employeur. Guide complet.",
+    }),
+    guideAlternantPreparerSonProjetEnAlternance: () => ({
+      title: "Préparer son projet en alternance | Les 5 étapes clés",
+      description: "Les 5 étapes pour réussir votre entrée en alternance : choix du métier, du contrat, recherche d’entreprise, de formation et aides disponibles.",
+    }),
+    guideAlternantSeFaireAccompagner: () => ({
+      title: "Accompagnement alternance | Missions locales et mentorat",
+      description: "Missions locales, cellules régionales, mentorat, 1jeune1solution : tous les dispositifs gratuits pour vous aider à trouver votre alternance.",
+    }),
+    guideAlternantLaRuptureDeContrat: () => ({
+      title: "Rupture de contrat en alternance | Guide complet 2026",
+      description: "Comment rompre un contrat d'apprentissage ou de professionnalisation ? Procédures, délais, droits et obligations. Guide pratique pour les alternants.",
+    }),
+    guideAlternantComprendreLaRemuneration: () => ({
+      title: "Salaire en alternance 2026 : grille et barèmes officiels",
+      description:
+        "Grille de salaire en alternance 2026 : de 27 % à 100 % du SMIC selon l'âge et l'année de contrat. Apprentissage et professionnalisation, calcul brut/net et exonérations.",
+    }),
+    guideAlternantCommentSignerUnContratEnAlternance: () => ({
+      title: "Signer un contrat en alternance | Démarches et Cerfa",
+      description: "Guide complet pour signer votre contrat d'apprentissage ou de professionnalisation : formulaires Cerfa, informations requises et étapes clés.",
+    }),
+    guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur: () => ({
+      title: "Maître d'apprentissage et tuteur | Rôle et missions",
+      description: "Quel est le rôle du maître d'apprentissage ou tuteur en alternance ? Conditions, missions d'accompagnement et recours en cas de difficulté.",
+    }),
+    guideAlternantAProposDesFormations: () => ({
+      title: "Bien choisir sa formation en alternance | Conseils pratiques",
+      description: "Taux de réussite, insertion professionnelle, certification Qualiopi : les critères clés pour choisir votre formation en alternance.",
+    }),
+    guideAlternantConseilsEtAstucesPourTrouverUnEmployeur: () => ({
+      title: "Trouver un employeur en alternance | Conseils et astuces",
+      description: "Salons, candidatures spontanées, CV, préparation aux entretiens : nos conseils pratiques pour décrocher votre contrat en alternance.",
+    }),
+    guideAlternantLesAidesFinancieresEtMaterielles: () => ({
+      title: "Aides alternant 2026 | Logement, transport et aides financières",
+      description: "APL, Mobili-Jeune, Avance Loca-Pass, aides transport : toutes les aides financières et matérielles pour les alternants. Simulateur inclus.",
+    }),
+    jeSuisCFA: () => ({
+      title: "CFA et organismes de formation | La bonne alternance",
+      description: "Diffusez gratuitement les offres de vos entreprises partenaires, recevez des candidatures et gérez la carte étudiant des métiers. Service public.",
+    }),
+    guideCfa: () => ({
+      title: "Guide CFA | Ressources organismes de formation en alternance",
+      description: "Outils, liens utiles et documents pour les CFA : catalogue des formations, Vade-mecum, Cerfa, guides handicap et aides aux contrats.",
+    }),
+    guideCfaLaCarteEtudiantDesMetiers: () => ({
+      title: "Carte étudiant des métiers | Délivrance et avantages",
+      description: "Délivrance de la carte d'étudiant des métiers par les CFA : obligations, délais (30 jours), avantages et réductions pour les alternants.",
+    }),
+    guideCfaAccompagnerVosAlternants: () => ({
+      title: "Guide CFA | Accompagner vos alternants",
+      description: "Comment les candidatures spontanées augmentent les chances de trouver son futur employeur.",
+    }),
+    jeSuisRecruteur: () => ({
+      title: "Recruteur alternance | Publiez vos offres gratuitement",
+      description: "Diffusez gratuitement vos offres d'alternance sur La bonne alternance, 1jeune1solution et Parcoursup. Recevez des candidatures en quelques clics.",
+    }),
+    guideRecruteur: () => ({
+      title: "Guide recruteur alternance 2026 | Ressources employeurs",
+      description: "Informations et outils pour recruter en alternance : contrats, Cerfa, aides à l'embauche, OPCO et prévention des risques. Guide complet employeur.",
+    }),
+    guideRecruteurJeSuisEmployeurPublic: () => ({
+      title: "Apprentissage dans la fonction publique | Guide employeur public",
+      description: "Recrutement d'apprentis dans le secteur public : financement, démarches administratives spécifiques et dispositifs de titularisation.",
+    }),
+    guideRecruteurCerfaApprentissageEtProfessionnalisation: () => ({
+      title: "Cerfa apprentissage et professionnalisation | Guide complet 2026",
+      description: "Comment remplir le Cerfa d'apprentissage ou de professionnalisation ? Formulaires, délais OPCO et documents requis. Guide employeur.",
+    }),
+    guideRecruteurAidesALEmbaucheEnAlternance: () => ({
+      title: "Aides à l'embauche en alternance 2026 | Jusqu'à 6 000 €",
+      description: "Aide unique, aide exceptionnelle jusqu'à 6 000 €, exonérations : toutes les aides financières pour recruter un alternant en 2026.",
+    }),
+    salaireAlternant: () => ({
+      title: "Simulateur salaire alternance 2026 | Calcul gratuit brut et net",
+      description:
+        "Calculez votre salaire net en alternance en 2 clics. Indiquez votre âge, type de contrat et durée : le simulateur affiche votre rémunération mensuelle brut et net.",
+    }),
+    EspaceDeveloppeurs: () => ({
+      title: "Espace développeurs - Transparence et qualité des offres - La bonne alternance",
+      description: "En savoir plus sur notre API et nos données pour développer vos propres outils et services d’alternance.",
+    }),
+    contact: () => ({
+      title: "Contactez-nous - La bonne alternance",
+      description: "Besoin d’aide ou d’informations ? Contactez notre équipe pour toute question relative à votre recherche d’alternance.",
+    }),
+    statistiques: () => ({
+      title: "Statistiques - La bonne alternance",
+      description: "Consultez nos statistiques et analyses sur le marché de l’alternance en France.",
+    }),
+    barometre: () => ({
+      title: "Baromètre de l’alternance T1 2026 - La bonne alternance",
+      description:
+        "Baromètre T1 2026 de l’alternance : offres, candidatures, métiers les plus recherchés, secteurs qui recrutent, tensions par région. Données La bonne alternance.",
+      keywords: [
+        "baromètre alternance",
+        "marché de l’alternance",
+        "alternance T1 2026",
+        "candidatures alternance",
+        "offres apprentissage",
+        "métiers en alternance",
+        "secteurs qui recrutent en alternance",
+        "tensions alternance par région",
+        "La bonne alternance",
+      ],
+      openGraph: {
+        title: "Baromètre de l’alternance T1 2026 - La bonne alternance",
+        description:
+          "Baromètre T1 2026 de l’alternance : offres, candidatures, métiers les plus recherchés, secteurs qui recrutent, tensions par région. Données La bonne alternance.",
+        url: `/barometre`,
+        siteName: "La bonne alternance",
+        locale: "fr_FR",
+        type: "article",
+        images: [
+          {
+            url: "/favicon/android-chrome-512x512.png",
+            width: 512,
+            height: 512,
+            alt: "La bonne alternance",
+          },
+        ],
+      },
+    }),
+    accesRecruteur: () => ({
+      title: "Accès recruteur - La bonne alternance",
+      description: "Diffusez simplement et gratuitement vos offres en alternance.",
+    }),
+    organismeDeFormation: () => ({
+      title: "Accès Organisme de formation - La bonne alternance",
+      description: "Diffusez simplement et gratuitement vos offres en alternance.",
+    }),
+    espaceProCreationEntreprise: () => ({
+      title: "Créer un compte recruteur - La bonne alternance",
+      description: "Créer un compte recruteur pour diffuser simplement et gratuitement vos offres en alternance.",
+    }),
+    espaceProCreationCfa: () => ({
+      title: "Créer un compte d'organisme de formation - La bonne alternance",
+      description: "Créer un compte d'organisme de formation pour diffuser simplement et gratuitement les offres en alternance de vos entreprises partenaires.",
+    }),
+    backCfaHome: () => ({
+      title: "Accueil espace CFA - La bonne alternance",
+    }),
+    espaceProCfaCarteDEtudiantDesMetiers: () => ({
+      title: "Carte d'étudiant des métiers - La bonne alternance",
+      description: "Téléchargez la carte d'étudiant des métiers",
+    }),
+    backCfaCreationEntreprise: () => ({
+      title: "Création d'entreprise partenaire - La bonne alternance",
+    }),
+    backAdminHome: () => ({
+      title: "Accueil espace administration - La bonne alternance",
+    }),
+    backAdminGestionDesEntreprises: () => ({
+      title: "Gestion des entreprises - La bonne alternance",
+    }),
+    backAdminGestionDesAdministrateurs: () => ({
+      title: "Gestion des administrateurs - La bonne alternance",
+    }),
+    backAdminGestionDesRecruteurs: () => ({
+      title: "Gestion des recruteurs - La bonne alternance",
+    }),
+    backAdminGestionDesOffresPartenaires: () => ({
+      title: "Offres partenaires - La bonne alternance",
+    }),
+    backOpcoHome: () => ({
+      title: "Accueil espace OPCO - La bonne alternance",
+    }),
+    backHomeEntreprise: () => ({
+      title: "Accueil espace recruteur - La bonne alternance",
+    }),
+    backEntrepriseCreationOffre: () => ({
+      title: "Nouvelle offre - La bonne alternance",
+    }),
+    rendezVousApprentissageRecherche: () => ({
+      title: "Recherche etablissement rendez-vous apprentissage - La bonne alternance",
+    }),
+    backCreateCFAEnAttente: () => ({
+      title: "Création de compte CFA en attente - La bonne alternance",
+    }),
+    desinscription: () => ({
+      title: "Désinscription candidatures spontanées - La bonne alternance",
+      description: "Désinscrivez vous de l'envoi de candidatures spontanées.",
+    }),
+    accessibilite: () => ({
+      title: "Déclaration d'accessibilité - La bonne alternance",
+      description: "Politique de confidentialité, traitement des données à caractère personnel sur le site de La bonne alternance.",
+    }),
+    planDuSite: () => ({
+      title: "Plan du site - La bonne alternance",
+      description: "Découvrez l'ensemble des pages et services disponibles sur La bonne alternance.",
+    }),
+    adminProcessor: () => ({
+      title: "Statut du processeur - La bonne alternance",
+    }),
+    postuler: () => ({
+      title: "Postuler à l'offre - La bonne alternance",
+    }),
+    detailRendezVousApprentissage: () => ({
+      title: "Détail du rendez-vous d'apprentissage - La bonne alternance",
+    }),
+  },
+  dynamic: {
+    compte: ({ userType }: { userType: "CFA" | "ENTREPRISE" | "OPCO" | "ADMIN" }): Metadata => ({ title: "Informations de contact - La bonne alternance" }),
+    metierJobById: (metier: string): Metadata => ({
+      title: `${metier} en alternance - Découvrez les opportunités`,
+      description: `Explorez les différents métiers accessibles en ${metier} en alternance et trouvez celui qui correspond à votre projet professionnel.`,
+    }),
+    modificationEntreprise: (userType: string, establishment_id?: string): Metadata => ({ title: "Modification entreprise - La bonne alternance" }),
+    offreUpsert: ({
+      offerId,
+      establishment_id,
+      userType,
+      userId,
+      raison_sociale,
+    }: {
+      offerId: string
+      establishment_id: string
+      userType: string
+      userId?: string
+      raison_sociale?: string
+    }): Metadata => ({ title: `${offerId === "creation" ? "Création d'une offre" : "Edition d'une offre"} - La bonne alternance` }),
+    successEditionOffre: ({
+      userType,
+      establishment_id,
+      user_id,
+    }: {
+      userType: "OPCO" | "ENTREPRISE" | "CFA" | "ADMIN"
+      establishment_id?: string
+      user_id?: string
+    }): Metadata => ({}),
+    recherche: (rechercheParams: Partial<IRecherchePageParams> | null): Metadata => buildRechercheMetadata(rechercheParams, "default"),
+    rechercheFormation: (rechercheParams: Partial<IRecherchePageParams> | null): Metadata => buildRechercheMetadata(rechercheParams, "formation"),
+    rechercheEmploi: (rechercheParams: Partial<IRecherchePageParams> | null): Metadata => buildRechercheMetadata(rechercheParams, "emploi"),
+    backCfaEntrepriseCreationDetail: (siret: string): Metadata => ({
+      title: `Création entreprise ${siret} - La bonne alternance`,
+    }),
+    backCfaPageEntreprise: (establishment_id: string, establishmentLabel?: string): Metadata => ({
+      title: `${establishmentLabel ?? "Entreprise"} - La bonne alternance`,
+    }),
+    backCfaPageInformations: (establishment_id: string): Metadata => ({
+      title: "Informations de contact entreprise - La bonne alternance",
+    }),
+    backCfaEntrepriseCreationOffre: (establishment_id: string): Metadata => ({
+      title: "Création d'une offre - La bonne alternance",
+    }),
+    backAdminRecruteursATraiter: (props: { status?: ETAT_UTILISATEUR; accountType?: typeof CFA | typeof ENTREPRISE; opco?: OPCOS_LABEL; page?: string }): Metadata => ({
+      title: "Gestion des recruteurs - La bonne alternance",
+    }),
+    backAdminRecruteurOffres: ({ user_id, user_label }: { user_id: string; user_label?: string }): Metadata => ({
+      title: `${user_label ?? "Entreprise"} - La bonne alternance`,
+    }),
+    backAdminUserCfaEntreprise: ({ user_id, establishment_id, user_label }: { user_id: string; establishment_id: string; user_label?: string }): Metadata => ({
+      title: `${user_label ?? "Entreprise"} - La bonne alternance`,
+    }),
+    backEntrepriseEditionOffre: ({ job_id }: { job_id: string }): Metadata => ({
+      title: `${job_id ? "Edition d'une offre" : "Création d'une offre"} - La bonne alternance`,
+    }),
+    backEntrepriseMiseEnRelation: ({ job_id }: { job_id: string }): Metadata => ({
+      title: "Mise en relation avec des organismes de formation - La bonne alternance",
+    }),
+    backOpcoInformationEntreprise: ({ user_id, user_label }: { user_id: string; user_label?: string }): Metadata => ({
+      title: `${user_label ?? "Entreprise"} - La bonne alternance`,
+    }),
+    backEditAdministrator: ({ userId }: { userId: string }): Metadata => ({
+      title: "Modification d'administrateur - La bonne alternance",
+    }),
+    backCreateCFAConfirmation: ({ email }: { email: string }): Metadata => ({
+      title: "Confirmation de création de compte - La bonne alternance",
+    }),
+    rendezVousApprentissageDetail: ({ siret }: { siret: string }): Metadata => ({
+      title: `Détail etablissement ${siret} - La bonne alternance`,
+    }),
+    adminProcessorJob: (name: string): Metadata => ({
+      title: `Job ${name} - La bonne alternance`,
+    }),
+    adminProcessorJobInstance: (props: { name: string; id: string }): Metadata => ({
+      title: `Tâche Job ${props.id} - La bonne alternance`,
+    }),
+    adminProcessorCron: (name: string): Metadata => ({
+      title: `CRON ${name} - La bonne alternance`,
+    }),
+    adminProcessorCronTask: (props: { name: string; id: string }): Metadata => ({
+      title: `Tâche CRON ${props.id} - La bonne alternance`,
+    }),
+  },
+} as const satisfies {
+  static: Partial<Record<keyof typeof PAGES.static, () => Metadata>>
+  dynamic: Partial<Record<keyof typeof PAGES.dynamic, (...args: never[]) => Metadata>>
+}

--- a/ui/utils/routes.metadata.utils.ts
+++ b/ui/utils/routes.metadata.utils.ts
@@ -1,8 +1,6 @@
 import "server-only"
 import type { Metadata } from "next"
 import type { CFA, ENTREPRISE, ETAT_UTILISATEUR, OPCOS_LABEL } from "shared/constants/index"
-import { buildRechercheMetadata } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils_LEGACY"
-import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import type { PAGES } from "@/utils/routes.utils"
 
 // Registre des métadonnées SEO des pages, séparé de PAGES (routes.utils.ts) et server-only :
@@ -311,18 +309,6 @@ export const METADATA = {
       userId?: string
       raison_sociale?: string
     }): Metadata => ({ title: `${offerId === "creation" ? "Création d'une offre" : "Edition d'une offre"} - La bonne alternance` }),
-    successEditionOffre: ({
-      userType,
-      establishment_id,
-      user_id,
-    }: {
-      userType: "OPCO" | "ENTREPRISE" | "CFA" | "ADMIN"
-      establishment_id?: string
-      user_id?: string
-    }): Metadata => ({}),
-    recherche: (rechercheParams: Partial<IRecherchePageParams> | null): Metadata => buildRechercheMetadata(rechercheParams, "default"),
-    rechercheFormation: (rechercheParams: Partial<IRecherchePageParams> | null): Metadata => buildRechercheMetadata(rechercheParams, "formation"),
-    rechercheEmploi: (rechercheParams: Partial<IRecherchePageParams> | null): Metadata => buildRechercheMetadata(rechercheParams, "emploi"),
     backCfaEntrepriseCreationDetail: (siret: string): Metadata => ({
       title: `Création entreprise ${siret} - La bonne alternance`,
     }),

--- a/ui/utils/routes.utils.ts
+++ b/ui/utils/routes.utils.ts
@@ -1,18 +1,18 @@
-import type { Metadata } from "next"
 import { assertUnreachable, removeUndefinedFields, toKebabCase } from "shared"
 import type { ETAT_UTILISATEUR, OPCOS_LABEL } from "shared/constants/index"
 import { ADMIN, CFA, ENTREPRISE, OPCO } from "shared/constants/index"
 import type { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import { generateUri } from "shared/helpers/generate-uri"
-import { buildRechercheMetadata } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.metadata.utils_LEGACY"
 import type { IRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { buildRecherchePageParams, IRechercheMode } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 
+// Ce module est embarqué dans les bundles client (header, footer, error boundary…) : ne rien
+// y ajouter qui ne serve qu'au serveur. Les métadonnées SEO (title/description) vivent dans
+// routes.metadata.utils.ts (registre METADATA, server-only) — issue #5214.
 export interface IPage {
   getPath: (args?: any) => string
   title: string
   index?: boolean
-  getMetadata?: (args?: any) => Metadata
 }
 
 interface INotionPage extends IPage {
@@ -32,586 +32,307 @@ export const PAGES = {
       getPath: () => `/` as string,
       title: "Accueil",
       index: true,
-      getMetadata: () => ({
-        title: "La bonne alternance | Trouvez votre alternance, formation et emploi",
-        description:
-          "Trouvez votre alternance parmi des milliers d’offres d’emploi et de formations. Recherchez par métier et par ville, candidatez en ligne ou en spontané. Service public gratuit.",
-      }),
     },
     authentification: {
       getPath: () => `/espace-pro/authentification` as string,
       title: "Authentification",
       index: false,
-      getMetadata: () => ({
-        title: "Authentification - La bonne alternance",
-        description: "Connectez-vous à votre compte La bonne alternance pour accéder à vos offres d’alternance.",
-      }),
     },
     aPropos: {
       getPath: () => `/a-propos` as string,
       title: "À propos",
       index: false,
-      getMetadata: () => ({
-        title: "À propos de La bonne alternance - Notre mission et engagement",
-        description: "Apprenez-en plus sur La bonne alternance, notre mission et notre engagement pour faciliter votre recherche d’alternance.",
-      }),
     },
     cgu: {
       getPath: () => `/conditions-generales-utilisation` as string,
       title: "Conditions générales d'utilisation",
       index: false,
-      getMetadata: () => ({
-        title: "Conditions générales d'utilisation - La bonne alternance",
-        description: "Consultez les conditions générales d’utilisation de La bonne alternance pour comprendre nos règles et engagements.",
-      }),
     },
     faq: {
       getPath: () => `/faq` as string,
       title: "FAQ",
       index: false,
-      getMetadata: () => ({
-        title: "FAQ - Réponses à vos questions sur l'alternance",
-        description: "Trouvez des réponses aux questions fréquentes sur l’alternance, nos services et le fonctionnement du site.",
-      }),
     },
     mentionsLegales: {
       getPath: () => `/mentions-legales` as string,
       title: "Mentions légales",
       index: false,
-      getMetadata: () => ({
-        title: "Mentions légales - La bonne alternance",
-        description: "Consultez les mentions légales de La bonne alternance pour en savoir plus sur nos obligations légales et notre responsabilité.",
-      }),
     },
     politiqueConfidentialite: {
       getPath: () => `/politique-de-confidentialite` as string,
       title: "Politique de confidentialité - La bonne alternance",
       index: false,
-      getMetadata: () => ({
-        title: "Politique de confidentialité - Protection de vos données",
-        description: "Découvrez comment nous protégeons vos données personnelles et respectons votre vie privée sur La bonne alternance.",
-      }),
     },
     metiers: {
       getPath: () => `/metiers` as string,
       title: "Métiers",
       index: false,
-      // Le « 77 » correspond au nombre de secteurs listés dans ui/config/metiers.txt (compteur en dur, cf. note ci-dessous).
-      getMetadata: () => ({
-        title: "Métiers en alternance : 77 secteurs | La bonne alternance",
-        description: "La liste des 77 secteurs qui recrutent en alternance : RH, communication, vente, BTP, santé, informatique… Offres d'emploi et formations du CAP au Master.",
-      }),
     },
-    // Note : les compteurs des meta ci-dessous sont en dur volontairement.
-    // routes.utils est importé par de nombreux composants client ; importer les
-    // tableaux _data juste pour un .length les embarquerait dans les bundles client.
-    // À mettre à jour lors d'un changement de palier (30/30/10 → 100). Les pages hub
-    // (Server Components) affichent, elles, le décompte dynamique via {data.length}.
     alternanceMetiers: {
       getPath: () => `/alternance/metiers` as string,
       title: "Métiers en alternance",
       index: true,
-      getMetadata: () => ({
-        title: "30 métiers en alternance qui recrutent | La bonne alternance",
-        description: "Découvrez 30 métiers accessibles en alternance avec offres, salaires moyens et formations. Tertiaire, numérique, médico-social, artisanat.",
-      }),
     },
     alternanceVilles: {
       getPath: () => `/alternance/villes` as string,
       title: "Alternance dans les grandes villes",
       index: true,
-      getMetadata: () => ({
-        title: "Alternance dans 30 grandes villes | La bonne alternance",
-        description: "Trouvez votre alternance dans 30 grandes villes françaises. Offres, entreprises qui recrutent, logement, transports et vie d'alternant.",
-      }),
     },
     alternanceDiplomes: {
       getPath: () => `/alternance/diplomes` as string,
       title: "Diplômes en alternance",
       index: true,
-      getMetadata: () => ({
-        title: "Diplômes en alternance : BTS, BUT, Licence Pro | LBA",
-        description: "Explorez 10 diplômes accessibles en alternance (BTS, BUT, Licence Pro, CAP, Titres Pro). Programme, durée, salaire et débouchés.",
-      }),
     },
     codeSources: {
       getPath: () => `https://github.com/mission-apprentissage/labonnealternance` as string,
       title: "Sources",
       index: false,
-      getMetadata: () => ({
-        title: "Nos sources de données - La bonne alternance",
-        description: "Découvrez les sources de données que nous utilisons pour vous proposer les meilleures offres d’alternance.",
-      }),
     },
     blog: {
       getPath: () => `https://labonnealternance.sites.beta.gouv.fr/?utm_source=lba&utm_medium=website&utm_campaign=lba_footer` as string,
       title: "Blog",
       index: false,
-      getMetadata: () => ({
-        title: "Blog - Conseils et actualités sur l'alternance",
-        description: "Lisez nos articles sur l’alternance, les conseils de carrière et les tendances du marché pour optimiser votre recherche.",
-      }),
     },
     ressources: {
       getPath: () => `/ressources` as string,
       title: "Ressources",
       index: false,
-      getMetadata: () => ({
-        title: "Ressources pour réussir votre alternance - La bonne alternance",
-        description: "Accédez à des guides et outils pratiques pour maximiser vos chances de trouver une alternance et réussir votre parcours.",
-      }),
     },
     guideDecouvrirLAlternance: {
       getPath: () => `/guide/decouvrir-l-alternance` as string,
       title: "Découvrir l'alternance",
       index: true,
-      getMetadata: () => ({
-        title: "Découvrir l'alternance | Contrats, conditions et durée",
-        description: "Apprentissage ou professionnalisation : conditions d'accès, durée, rythme, coût de la formation et conditions de travail. Tout comprendre en 5 min.",
-      }),
     },
     guideApprentissageEtHandicap: {
       getPath: () => `/guide/apprentissage-et-handicap` as string,
       title: "Apprentissage & handicap",
       index: true,
-      getMetadata: () => ({
-        title: "Apprentissage et handicap | Droits, aides et aménagements",
-        description: "Alternance et situation de handicap : conditions d'accès, aménagements de formation, rémunération et aides spécifiques (AGEFIPH, FIPHFP). Guide 2026.",
-      }),
     },
     guidePreventionDesRisquesProfessionnelsPourLesApprentis: {
       getPath: () => `/guide/prevention-des-risques-professionnels-pour-les-apprentis` as string,
       title: "La prévention des risques professionnels pour les apprentis",
       index: true,
-      getMetadata: () => ({
-        title: "La prévention des risques professionnels | Guide pour les apprentis, les CFA et les recruteurs",
-        description: "Obligations des employeurs, accueil en entreprise et rôle des CFA dans la prévention des risques professionnels pour les apprentis.",
-      }),
     },
     guideAlternant: {
       getPath: () => `/guide-alternant` as string,
       title: "Je m'informe sur l'alternance",
       index: true,
-      getMetadata: () => ({
-        title: "Guide de l'alternant 2026 | Tout savoir sur l'alternance",
-        description: "Informations, conseils et outils pour réussir votre alternance : contrats, rémunération, aides, formation et recherche d'employeur. Guide complet.",
-      }),
     },
     guideAlternantPreparerSonProjetEnAlternance: {
       getPath: () => `/guide-alternant/preparer-son-projet-en-alternance` as string,
       title: "Préparer son projet en alternance",
       index: true,
-      getMetadata: () => ({
-        title: "Préparer son projet en alternance | Les 5 étapes clés",
-        description: "Les 5 étapes pour réussir votre entrée en alternance : choix du métier, du contrat, recherche d’entreprise, de formation et aides disponibles.",
-      }),
     },
     guideAlternantSeFaireAccompagner: {
       getPath: () => `/guide-alternant/se-faire-accompagner` as string,
       title: "Des professionnels pour vous accompagner",
       index: true,
-      getMetadata: () => ({
-        title: "Accompagnement alternance | Missions locales et mentorat",
-        description: "Missions locales, cellules régionales, mentorat, 1jeune1solution : tous les dispositifs gratuits pour vous aider à trouver votre alternance.",
-      }),
     },
     guideAlternantLaRuptureDeContrat: {
       getPath: () => `/guide-alternant/la-rupture-de-contrat` as string,
       title: "Rupture d'un contrat d'alternance : guide complet",
       index: true,
-      getMetadata: () => ({
-        title: "Rupture de contrat en alternance | Guide complet 2026",
-        description: "Comment rompre un contrat d'apprentissage ou de professionnalisation ? Procédures, délais, droits et obligations. Guide pratique pour les alternants.",
-      }),
     },
     guideAlternantComprendreLaRemuneration: {
       getPath: () => `/guide-alternant/comprendre-la-remuneration` as string,
       title: "Comprendre la rémunération en alternance",
       index: true,
-      getMetadata: () => ({
-        title: "Salaire en alternance 2026 : grille et barèmes officiels",
-        description:
-          "Grille de salaire en alternance 2026 : de 27 % à 100 % du SMIC selon l'âge et l'année de contrat. Apprentissage et professionnalisation, calcul brut/net et exonérations.",
-      }),
     },
     guideAlternantCommentSignerUnContratEnAlternance: {
       getPath: () => `/guide-alternant/comment-signer-un-contrat-en-alternance` as string,
       title: "Comment signer un contrat en alternance ?",
       index: true,
-      getMetadata: () => ({
-        title: "Signer un contrat en alternance | Démarches et Cerfa",
-        description: "Guide complet pour signer votre contrat d'apprentissage ou de professionnalisation : formulaires Cerfa, informations requises et étapes clés.",
-      }),
     },
     guideAlternantRoleEtMissionsDuMaitreDApprentissageOuTuteur: {
       getPath: () => `/guide-alternant/role-et-missions-du-maitre-d-apprentissage-ou-tuteur` as string,
       title: "Le rôle et les missions du maître d'apprentissage ou tuteur",
       index: true,
-      getMetadata: () => ({
-        title: "Maître d'apprentissage et tuteur | Rôle et missions",
-        description: "Quel est le rôle du maître d'apprentissage ou tuteur en alternance ? Conditions, missions d'accompagnement et recours en cas de difficulté.",
-      }),
     },
     guideAlternantAProposDesFormations: {
       getPath: () => `/guide-alternant/a-propos-des-formations` as string,
       title: "À propos des formations",
       index: true,
-      getMetadata: () => ({
-        title: "Bien choisir sa formation en alternance | Conseils pratiques",
-        description: "Taux de réussite, insertion professionnelle, certification Qualiopi : les critères clés pour choisir votre formation en alternance.",
-      }),
     },
     guideAlternantConseilsEtAstucesPourTrouverUnEmployeur: {
       getPath: () => `/guide-alternant/conseils-et-astuces-pour-trouver-un-employeur` as string,
       title: "Conseils et astuces pour trouver un employeur",
       index: true,
-      getMetadata: () => ({
-        title: "Trouver un employeur en alternance | Conseils et astuces",
-        description: "Salons, candidatures spontanées, CV, préparation aux entretiens : nos conseils pratiques pour décrocher votre contrat en alternance.",
-      }),
     },
     guideAlternantLesAidesFinancieresEtMaterielles: {
       getPath: () => `/guide-alternant/les-aides-financieres-et-materielles` as string,
       title: "Les aides financières et matérielles pour les alternants",
       index: true,
-      getMetadata: () => ({
-        title: "Aides alternant 2026 | Logement, transport et aides financières",
-        description: "APL, Mobili-Jeune, Avance Loca-Pass, aides transport : toutes les aides financières et matérielles pour les alternants. Simulateur inclus.",
-      }),
     },
     jeSuisCFA: {
       getPath: () => `/je-suis-cfa` as string,
       title: "Je suis CFA",
       index: true,
-      getMetadata: () => ({
-        title: "CFA et organismes de formation | La bonne alternance",
-        description: "Diffusez gratuitement les offres de vos entreprises partenaires, recevez des candidatures et gérez la carte étudiant des métiers. Service public.",
-      }),
     },
     guideCfa: {
       getPath: () => `/guide-cfa` as string,
       title: "Je m'informe sur l'alternance",
       index: true,
-      getMetadata: () => ({
-        title: "Guide CFA | Ressources organismes de formation en alternance",
-        description: "Outils, liens utiles et documents pour les CFA : catalogue des formations, Vade-mecum, Cerfa, guides handicap et aides aux contrats.",
-      }),
     },
     guideCfaLaCarteEtudiantDesMetiers: {
       getPath: () => `/guide-cfa/la-carte-etudiant-des-metiers` as string,
       title: "Téléchargement de la carte d'étudiant des métiers",
       index: true,
-      getMetadata: () => ({
-        title: "Carte étudiant des métiers | Délivrance et avantages",
-        description: "Délivrance de la carte d'étudiant des métiers par les CFA : obligations, délais (30 jours), avantages et réductions pour les alternants.",
-      }),
     },
     guideCfaAccompagnerVosAlternants: {
       getPath: () => `/guide-cfa/accompagner-vos-alternants` as string,
       title: "Accompagner vos alternants dans leurs démarches de candidatures",
       index: true,
-      getMetadata: () => ({
-        title: "Guide CFA | Accompagner vos alternants",
-        description: "Comment les candidatures spontanées augmentent les chances de trouver son futur employeur.",
-      }),
     },
     jeSuisRecruteur: {
       getPath: () => `/je-suis-recruteur` as string,
       title: "Je suis recruteur",
       index: true,
-      getMetadata: () => ({
-        title: "Recruteur alternance | Publiez vos offres gratuitement",
-        description: "Diffusez gratuitement vos offres d'alternance sur La bonne alternance, 1jeune1solution et Parcoursup. Recevez des candidatures en quelques clics.",
-      }),
     },
     guideRecruteur: {
       getPath: () => `/guide-recruteur` as string,
       title: "Je m'informe sur l'alternance",
       index: true,
-      getMetadata: () => ({
-        title: "Guide recruteur alternance 2026 | Ressources employeurs",
-        description: "Informations et outils pour recruter en alternance : contrats, Cerfa, aides à l'embauche, OPCO et prévention des risques. Guide complet employeur.",
-      }),
     },
     guideRecruteurJeSuisEmployeurPublic: {
       getPath: () => `/guide-recruteur/je-suis-employeur-public` as string,
       title: "Je suis employeur public",
       index: true,
-      getMetadata: () => ({
-        title: "Apprentissage dans la fonction publique | Guide employeur public",
-        description: "Recrutement d'apprentis dans le secteur public : financement, démarches administratives spécifiques et dispositifs de titularisation.",
-      }),
     },
     guideRecruteurCerfaApprentissageEtProfessionnalisation: {
       getPath: () => `/guide-recruteur/cerfa-apprentissage-et-professionnalisation` as string,
       title: "Cerfa apprentissage et professionnalisation : le guide complet",
       index: true,
-      getMetadata: () => ({
-        title: "Cerfa apprentissage et professionnalisation | Guide complet 2026",
-        description: "Comment remplir le Cerfa d'apprentissage ou de professionnalisation ? Formulaires, délais OPCO et documents requis. Guide employeur.",
-      }),
     },
     guideRecruteurAidesALEmbaucheEnAlternance: {
       getPath: () => `/guide-recruteur/aides-a-l-embauche-en-alternance` as string,
       title: "Aides à l'embauche en alternance",
       index: true,
-      getMetadata: () => ({
-        title: "Aides à l'embauche en alternance 2026 | Jusqu'à 6 000 €",
-        description: "Aide unique, aide exceptionnelle jusqu'à 6 000 €, exonérations : toutes les aides financières pour recruter un alternant en 2026.",
-      }),
     },
     salaireAlternant: {
       getPath: () => `/salaire-alternant` as string,
       title: "Salaire alternant",
       index: true,
-      getMetadata: () => ({
-        title: "Simulateur salaire alternance 2026 | Calcul gratuit brut et net",
-        description:
-          "Calculez votre salaire net en alternance en 2 clics. Indiquez votre âge, type de contrat et durée : le simulateur affiche votre rémunération mensuelle brut et net.",
-      }),
     },
     EspaceDeveloppeurs: {
       getPath: () => `/espace-developpeurs` as string,
       title: "Espace développeurs",
       index: false,
-      getMetadata: () => ({
-        title: "Espace développeurs - Transparence et qualité des offres - La bonne alternance",
-        description: "En savoir plus sur notre API et nos données pour développer vos propres outils et services d’alternance.",
-      }),
     },
     contact: {
       getPath: () => `/contact` as string,
       title: "Contact",
       index: false,
-      getMetadata: () => ({
-        title: "Contactez-nous - La bonne alternance",
-        description: "Besoin d’aide ou d’informations ? Contactez notre équipe pour toute question relative à votre recherche d’alternance.",
-      }),
     },
     statistiques: {
       getPath: () => `/statistiques` as string,
       title: "Statistiques",
       index: false,
-      getMetadata: () => ({
-        title: "Statistiques - La bonne alternance",
-        description: "Consultez nos statistiques et analyses sur le marché de l’alternance en France.",
-      }),
     },
     barometre: {
       getPath: () => `/barometre` as string,
       title: "Baromètre de l’alternance",
       index: true,
-      getMetadata: () => ({
-        title: "Baromètre de l’alternance T1 2026 - La bonne alternance",
-        description:
-          "Baromètre T1 2026 de l’alternance : offres, candidatures, métiers les plus recherchés, secteurs qui recrutent, tensions par région. Données La bonne alternance.",
-        keywords: [
-          "baromètre alternance",
-          "marché de l’alternance",
-          "alternance T1 2026",
-          "candidatures alternance",
-          "offres apprentissage",
-          "métiers en alternance",
-          "secteurs qui recrutent en alternance",
-          "tensions alternance par région",
-          "La bonne alternance",
-        ],
-        openGraph: {
-          title: "Baromètre de l’alternance T1 2026 - La bonne alternance",
-          description:
-            "Baromètre T1 2026 de l’alternance : offres, candidatures, métiers les plus recherchés, secteurs qui recrutent, tensions par région. Données La bonne alternance.",
-          url: `/barometre`,
-          siteName: "La bonne alternance",
-          locale: "fr_FR",
-          type: "article",
-          images: [
-            {
-              url: "/favicon/android-chrome-512x512.png",
-              width: 512,
-              height: 512,
-              alt: "La bonne alternance",
-            },
-          ],
-        },
-      }),
     },
     accesRecruteur: {
       getPath: () => `/acces-recruteur` as string,
       title: "Recruteur",
       index: false,
-      getMetadata: () => ({
-        title: "Accès recruteur - La bonne alternance",
-        description: "Diffusez simplement et gratuitement vos offres en alternance.",
-      }),
     },
     organismeDeFormation: {
       getPath: () => `/organisme-de-formation` as string,
       title: "Organisme de formation",
       index: false,
-      getMetadata: () => ({
-        title: "Accès Organisme de formation - La bonne alternance",
-        description: "Diffusez simplement et gratuitement vos offres en alternance.",
-      }),
     },
     espaceProCreationEntreprise: {
       getPath: () => `/espace-pro/creation/entreprise` as string,
       title: "Créer un compte entreprise",
-      getMetadata: () => ({
-        title: "Créer un compte recruteur - La bonne alternance",
-        description: "Créer un compte recruteur pour diffuser simplement et gratuitement vos offres en alternance.",
-      }),
     },
     espaceProCreationCfa: {
       getPath: () => `/espace-pro/creation/cfa` as string,
       title: "Créer un compte d'organisme de formation",
-      getMetadata: () => ({
-        title: "Créer un compte d'organisme de formation - La bonne alternance",
-        description: "Créer un compte d'organisme de formation pour diffuser simplement et gratuitement les offres en alternance de vos entreprises partenaires.",
-      }),
     },
     backCfaHome: {
       getPath: () => `/espace-pro/cfa` as string,
       title: "Accueil CFA",
-      getMetadata: () => ({
-        title: "Accueil espace CFA - La bonne alternance",
-      }),
     },
     espaceProCfaCarteDEtudiantDesMetiers: {
       getPath: () => `/espace-pro/cfa/carte-d-etudiant-des-metiers` as string,
       title: "Carte d'étudiant des métiers",
       index: true,
-      getMetadata: () => ({
-        title: "Carte d'étudiant des métiers - La bonne alternance",
-        description: "Téléchargez la carte d'étudiant des métiers",
-      }),
     },
     backCfaCreationEntreprise: {
       getPath: () => `/espace-pro/cfa/creation-entreprise` as string,
       title: "Création d'entreprise",
-      getMetadata: () => ({
-        title: "Création d'entreprise partenaire - La bonne alternance",
-      }),
     },
     backAdminHome: {
       getPath: () => `/espace-pro/administration/users` as string,
       title: "Accueil administration",
-      getMetadata: () => ({
-        title: "Accueil espace administration - La bonne alternance",
-      }),
     },
     backAdminGestionDesEntreprises: {
       getPath: () => `/espace-pro/administration/gestion-des-entreprises` as string,
       title: "Gestion des entreprises",
-      getMetadata: () => ({
-        title: "Gestion des entreprises - La bonne alternance",
-      }),
     },
     backAdminGestionDesAdministrateurs: {
       getPath: () => `/espace-pro/administration/gestion-des-administrateurs` as string,
       title: "Gestion des administrateurs",
-      getMetadata: () => ({
-        title: "Gestion des administrateurs - La bonne alternance",
-      }),
     },
     backAdminGestionDesRecruteurs: {
       getPath: () => `/espace-pro/administration/recruteurs` as string,
       title: "Gestion des recruteurs",
-      getMetadata: () => ({
-        title: "Gestion des recruteurs - La bonne alternance",
-      }),
     },
     backAdminGestionDesOffresPartenaires: {
       getPath: () => `/espace-pro/administration/offres-partenaires` as string,
       title: "Offres partenaires",
-      getMetadata: () => ({
-        title: "Offres partenaires - La bonne alternance",
-      }),
     },
     backOpcoHome: {
       getPath: () => `/espace-pro/opco` as string,
       title: "Accueil OPCO",
-      getMetadata: () => ({
-        title: "Accueil espace OPCO - La bonne alternance",
-      }),
     },
     backHomeEntreprise: {
       getPath: () => `/espace-pro/entreprise` as string,
       title: "Accueil entreprise",
-      getMetadata: () => ({
-        title: "Accueil espace recruteur - La bonne alternance",
-      }),
     },
     backEntrepriseCreationOffre: {
       getPath: () => `/espace-pro/entreprise/creation-offre` as string,
       title: "Nouvelle offre",
-      getMetadata: () => ({
-        title: "Nouvelle offre - La bonne alternance",
-      }),
     },
     rendezVousApprentissageRecherche: {
       getPath: () => `/espace-pro/administration/rendez-vous-apprentissage` as string,
       title: "Recherche etablissement rendez-vous apprentissage",
-      getMetadata: () => ({
-        title: "Recherche etablissement rendez-vous apprentissage - La bonne alternance",
-      }),
     },
     backCreateCFAEnAttente: {
       getPath: () => "/espace-pro/authentification/en-attente" as string,
       title: "Création de compte CFA en attente",
-      getMetadata: () => ({
-        title: "Création de compte CFA en attente - La bonne alternance",
-      }),
     },
     desinscription: {
       getPath: () => `/desinscription` as string,
       title: "Désinscription candidatures spontanées",
       index: false,
-      getMetadata: () => ({
-        title: "Désinscription candidatures spontanées - La bonne alternance",
-        description: "Désinscrivez vous de l'envoi de candidatures spontanées.",
-      }),
     },
     accessibilite: {
       getPath: () => `/accessibilite` as string,
       title: "Déclaration d'accessibilité",
       index: true,
-      getMetadata: () => ({
-        title: "Déclaration d'accessibilité - La bonne alternance",
-        description: "Politique de confidentialité, traitement des données à caractère personnel sur le site de La bonne alternance.",
-      }),
     },
     planDuSite: {
       getPath: () => `/plan-du-site` as string,
       title: "Plan du site",
       index: false,
-      getMetadata: () => ({
-        title: "Plan du site - La bonne alternance",
-        description: "Découvrez l'ensemble des pages et services disponibles sur La bonne alternance.",
-      }),
     },
     adminProcessor: {
       getPath: () => `/espace-pro/administration/processeur` as string,
       index: false,
       title: "Statut du processeur",
-      getMetadata: () => ({
-        title: "Statut du processeur - La bonne alternance",
-      }),
     },
     postuler: {
       getPath: () => `/postuler` as string,
       title: "Postuler",
       index: false,
-      getMetadata: () => ({
-        title: "Postuler à l'offre - La bonne alternance",
-      }),
     },
     detailRendezVousApprentissage: {
       title: "Détail du rendez-vous d'apprentissage",
       getPath: () => `/detail-rendez-vous` as string,
       index: false,
-      getMetadata: () => ({
-        title: "Détail du rendez-vous d'apprentissage - La bonne alternance",
-      }),
     },
   },
   dynamic: {
@@ -631,22 +352,16 @@ export const PAGES = {
         }
       },
       index: false,
-      getMetadata: () => ({ title: "Informations de contact - La bonne alternance" }),
       title: "Informations de contact",
     }),
     metierJobById: (metier: string): IPage => ({
       getPath: () => `/metiers/${metier}` as string,
       index: false,
-      getMetadata: () => ({
-        title: `${metier} en alternance - Découvrez les opportunités`,
-        description: `Explorez les différents métiers accessibles en ${metier} en alternance et trouvez celui qui correspond à votre projet professionnel.`,
-      }),
       title: metier,
     }),
     modificationEntreprise: (userType: string, establishment_id?: string): IPage => ({
       getPath: () => (userType === "CFA" ? `/espace-pro/cfa/entreprise/${establishment_id}/informations` : "/espace-pro/entreprise/compte"),
       index: false,
-      getMetadata: () => ({ title: "Modification entreprise - La bonne alternance" }),
       title: "Modification entreprise",
     }),
     offreUpsert: ({
@@ -680,7 +395,6 @@ export const PAGES = {
           }
         },
         index: false,
-        getMetadata: () => ({ title: `${isCreation ? "Création d'une offre" : "Edition d'une offre"} - La bonne alternance` }),
         title: isCreation ? "Création d'une offre" : "Edition d'une offre",
       }
     },
@@ -707,7 +421,6 @@ export const PAGES = {
         getPath: () => path,
         title: "Success édition offre",
         index: false,
-        getMetadata: () => ({}),
       }
     },
     espaceProCreationDetail: (props: { siret: string; email?: string; type: "CFA" | "ENTREPRISE"; origin: string; isWidget: boolean }): IPage => ({
@@ -775,7 +488,6 @@ export const PAGES = {
       return {
         getPath: () => `/recherche${search ? `?${search}` : ""}` as string,
         index: false,
-        getMetadata: () => buildRechercheMetadata(rechercheParams, "default"),
         title: "Offres en alternance",
       }
     },
@@ -785,7 +497,6 @@ export const PAGES = {
       return {
         getPath: () => `/recherche-formation${search ? `?${search}` : ""}` as string,
         index: false,
-        getMetadata: () => buildRechercheMetadata(rechercheParams, "formation"),
         title: "Formations en alternance",
       }
     },
@@ -795,7 +506,6 @@ export const PAGES = {
       return {
         getPath: () => `/recherche-emploi${search ? `?${search}` : ""}` as string,
         index: false,
-        getMetadata: () => buildRechercheMetadata(rechercheParams, "emploi"),
         title: "Offres en alternance",
       }
     },
@@ -820,30 +530,18 @@ export const PAGES = {
     backCfaEntrepriseCreationDetail: (siret: string): IPage => ({
       getPath: () => `/espace-pro/cfa/creation-entreprise/${siret}` as string,
       title: siret,
-      getMetadata: () => ({
-        title: `Création entreprise ${siret} - La bonne alternance`,
-      }),
     }),
     backCfaPageEntreprise: (establishment_id: string, establishmentLabel?: string): IPage => ({
       getPath: () => `/espace-pro/cfa/entreprise/${establishment_id}` as string,
       title: establishmentLabel ?? "Entreprise",
-      getMetadata: () => ({
-        title: `${establishmentLabel ?? "Entreprise"} - La bonne alternance`,
-      }),
     }),
     backCfaPageInformations: (establishment_id: string): IPage => ({
       getPath: () => `/espace-pro/cfa/entreprise/${establishment_id}/informations` as string,
       title: "Informations de contact",
-      getMetadata: () => ({
-        title: "Informations de contact entreprise - La bonne alternance",
-      }),
     }),
     backCfaEntrepriseCreationOffre: (establishment_id: string): IPage => ({
       getPath: () => `/espace-pro/cfa/entreprise/${establishment_id}/creation-offre` as string,
       title: "Création d'une offre",
-      getMetadata: () => ({
-        title: "Création d'une offre - La bonne alternance",
-      }),
     }),
     backAdminRecruteursATraiter: (props: { status?: ETAT_UTILISATEUR; accountType?: typeof CFA | typeof ENTREPRISE; opco?: OPCOS_LABEL; page?: string }): IPage => {
       const searchParams = new URLSearchParams()
@@ -855,59 +553,35 @@ export const PAGES = {
       return {
         getPath: () => `/espace-pro/administration/users?${searchParams}` as string,
         title: "Gestion des recruteurs",
-        getMetadata: () => ({
-          title: "Gestion des recruteurs - La bonne alternance",
-        }),
       }
     },
     backAdminRecruteurOffres: ({ user_id, user_label }: { user_id: string; user_label?: string }): IPage => ({
       getPath: () => `/espace-pro/administration/users/${user_id}` as string,
       title: user_label ?? "Entreprise",
-      getMetadata: () => ({
-        title: `${user_label ?? "Entreprise"} - La bonne alternance`,
-      }),
     }),
     backAdminUserCfaEntreprise: ({ user_id, establishment_id, user_label }: { user_id: string; establishment_id: string; user_label?: string }): IPage => ({
       getPath: () => `/espace-pro/administration/users/${user_id}/cfa/${establishment_id}` as string,
       title: user_label ?? "Entreprise",
-      getMetadata: () => ({
-        title: `${user_label ?? "Entreprise"} - La bonne alternance`,
-      }),
     }),
     backEntrepriseEditionOffre: ({ job_id }: { job_id: string }): IPage => ({
       getPath: () => `/espace-pro/entreprise/offre/${job_id}` as string,
       title: job_id ? "Edition d'une offre" : "Création d'une offre",
-      getMetadata: () => ({
-        title: `${job_id ? "Edition d'une offre" : "Création d'une offre"} - La bonne alternance`,
-      }),
     }),
     backEntrepriseMiseEnRelation: ({ job_id }: { job_id: string }): IPage => ({
       getPath: () => `/espace-pro/entreprise/offre/${job_id}/mise-en-relation` as string,
       title: "Mise en relation avec des organismes de formation",
-      getMetadata: () => ({
-        title: "Mise en relation avec des organismes de formation - La bonne alternance",
-      }),
     }),
     backOpcoInformationEntreprise: ({ user_id, user_label }: { user_id: string; user_label?: string }): IPage => ({
       getPath: () => `/espace-pro/opco/users/${user_id}` as string,
       title: user_label ?? "Entreprise",
-      getMetadata: () => ({
-        title: `${user_label ?? "Entreprise"} - La bonne alternance`,
-      }),
     }),
     backEditAdministrator: ({ userId }: { userId: string }): IPage => ({
       getPath: () => `/espace-pro/administration/gestion-des-administrateurs/user/${userId}` as string,
       title: "Modification d'administrateur",
-      getMetadata: () => ({
-        title: "Modification d'administrateur - La bonne alternance",
-      }),
     }),
     backCreateCFAConfirmation: ({ email }: { email: string }): IPage => ({
       getPath: () => `/espace-pro/authentification/confirmation?email=${email}` as string,
       title: "Confirmation de création de compte",
-      getMetadata: () => ({
-        title: "Confirmation de création de compte - La bonne alternance",
-      }),
     }),
     backHome: ({ userType }: { userType: "CFA" | "ENTREPRISE" | "ADMIN" | "OPCO" }): IPage => {
       switch (userType) {
@@ -926,9 +600,6 @@ export const PAGES = {
     rendezVousApprentissageDetail: ({ siret }: { siret: string }): IPage => ({
       getPath: () => `/espace-pro/administration/rendez-vous-apprentissage/${siret}` as string,
       title: `Détail etablissement ${siret}`,
-      getMetadata: () => ({
-        title: `Détail etablissement ${siret} - La bonne alternance`,
-      }),
     }),
     prdvUnsubscribeOptout: ({ id }: { id: string }): IPage => ({
       getPath: () => `/optout/unsubscribe/${id}` as string,
@@ -938,33 +609,21 @@ export const PAGES = {
       getPath: () => `/espace-pro/administration/processeur/job/${name}`,
       index: false,
       title: `Job ${name}`,
-      getMetadata: () => ({
-        title: `Job ${name} - La bonne alternance`,
-      }),
     }),
     adminProcessorJobInstance: (props: { name: string; id: string }): IPage => ({
       getPath: () => `/espace-pro/administration/processeur/job/${props.name}/${props.id}`,
       index: false,
       title: `Tâche Job ${props.id}`,
-      getMetadata: () => ({
-        title: `Tâche Job ${props.id} - La bonne alternance`,
-      }),
     }),
     adminProcessorCron: (name: string): IPage => ({
       getPath: () => `/espace-pro/administration/processeur/cron/${name}`,
       index: false,
       title: `CRON ${name}`,
-      getMetadata: () => ({
-        title: `CRON ${name} - La bonne alternance`,
-      }),
     }),
     adminProcessorCronTask: (props: { name: string; id: string }): IPage => ({
       getPath: () => `/espace-pro/administration/processeur/cron/${props.name}/${props.id}`,
       index: false,
       title: `Tâche CRON ${props.id}`,
-      getMetadata: () => ({
-        title: `Tâche CRON ${props.id} - La bonne alternance`,
-      }),
     }),
     seoVille: (villeSlug: string, villeLabel?: string): IPage => ({
       getPath: () => `/alternance/ville/${villeSlug}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17643,6 +17643,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"server-only@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "server-only@npm:0.0.1"
+  checksum: c432348956641ea3f460af8dc3765f3a1bdbcf7a1e0205b0756d868e6e6fe8934cdee6bff68401a1dd49ba4a831c75916517a877446d54b334f7de36fa273e53
+  languageName: node
+  linkType: hard
+
 "server@workspace:server":
   version: 0.0.0-use.local
   resolution: "server@workspace:server"
@@ -19439,6 +19446,7 @@ __metadata:
     react-swipeable: 7.0.2
     react-table: ^7.8.0
     sass: ^1.93.3
+    server-only: ^0.0.1
     shared: "workspace:*"
     type-fest: ^5.2.0
     typescript: ^7.0.2


### PR DESCRIPTION
Closes #5214

## Changements

Deux correctifs complémentaires contre la duplication inter-chunks du first-load :

- **Config Turbopack** : `experimental.turbopackChunking.minChunkSize: 20_000` dans `ui/next.config.mjs`. Turbopack ne partage un chunk entre chunk groups que si son contenu est identique (nom = hash de contenu). Avec le défaut (50 ko), le groupe de modules `routes.utils` (37,6 ko bruts), tiré à la fois par `error.tsx` (error boundary racine, présente sur toutes les routes via header/footer) et par le groupe des composants clients de la page, était fusionné différemment de chaque côté → deux chunks différents → double téléchargement. À 20 ko, le groupe reste un chunk autonome identique des deux côtés. Réglage sensible et non monotone (30 ko est *pire* que le défaut, +10 ko gzip) — commenté dans la config, gardé par le job Performance budget.
- **Découpage server-only des métadonnées** : les 89 blocs `getMetadata` de `PAGES` (51 % des octets émis de `routes.utils.ts`, littéraux SEO inutiles côté client) déménagent dans un registre `METADATA` (`ui/utils/routes.metadata.utils.ts`), gardé par `import "server-only"` et verrouillé par `satisfies` sur `keyof typeof PAGES`. `IPage` perd `getMetadata` ; ~90 pages migrées (`PAGES.x.getMetadata()` → `METADATA.x()`) ; `LayoutArticle` reçoit les metadata en prop. Extraction des blocs par codemod AST — zéro retranscription manuelle des littéraux.
- **Budgets resserrés** dans `ui/perf-budget.json` pour verrouiller le gain (marge ~3,9 %, même convention que l'origine).

## Mesures avant/après

Build de production, mêmes variables d'env que le job Performance budget, reproduites sur deux builds :

| Métrique | Avant | Après |
|---|---|---|
| JS first-load `/` (gzip) | 407,7 ko | **386,5 ko (−5,2 %)** |
| JS first-load `/recherche` (gzip) | 579,9 ko | **567,3 ko** |
| JS max toutes routes (brut) | 2332,2 ko | **2228,9 ko** |
| Somme gzip des scripts du HTML prérendu home | 457,0 ko | **433,5 ko** |
| Octets dupliqués entre chunks du first-load home | 111 049 o | **17 350 o** |
| Chunk du groupe `routes.utils` | 38 050 o **×2** | **20 946 o ×1** |

## Non-régression SEO

Diff automatisé des `<title>`, meta description, `og:title`, canonical et robots extraits des **123 pages prérendues**, entre un build de `main` et un build de cette branche : **zéro écart**.

## Plan de test

- [ ] Job Performance budget vert (386,5 ko / budget 402 ko sur la home)
- [ ] `yarn typecheck` et tests unitaires ui verts (205 tests)
- [ ] Vérifier title/description en preview sur : home, un guide (`/guide-alternant/comprendre-la-remuneration`), `/barometre` (openGraph), `/metiers/[slug]` (metadata dynamique)
- [ ] Vérifier que la page d'erreur (error boundary) s'affiche normalement avec header/footer