### PR TITLE
fix: aligne la largeur des blocs des fiches détail offre et formation

### DIFF
--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
@@ -250,7 +250,6 @@ function JobDetail({ selectedItem, rechercheParams }: { rechercheParams: IRecher
             ref={headerRef}
             sx={{
               filter: "drop-shadow(0px 4px 4px rgba(213, 213, 213, 0.25))",
-              borderRadius: { xs: 0, lg: fr.spacing("2v") },
               boxShadow: { xs: "unset", lg: "0 4px 12px 0 rgba(0, 0, 18, 0.16)" },
               padding: "10px 20px 0px 20px",
               backgroundColor: "white",
@@ -331,7 +330,7 @@ function JobDetail({ selectedItem, rechercheParams }: { rechercheParams: IRecher
           </Box>
 
           <Box id="detail-content-container" />
-          <Box sx={{ mx: { md: 0, lg: fr.spacing("6v") } }}>
+          <Box>
             {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && isMandataire && <LbaJobCfaDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}
             {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && (isCfaEntreprise || isGeiq) && <GeiqJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}
             {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && !isMandataire && !isCfaEntreprise && <LbaJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}

--- a/ui/app/(candidat)/formation/[id]/[intitule-formation]/TrainingDetailRendererClient.tsx
+++ b/ui/app/(candidat)/formation/[id]/[intitule-formation]/TrainingDetailRendererClient.tsx
@@ -189,7 +189,6 @@ function TrainingDetailPage({
             ref={headerRef}
             sx={{
               filter: "drop-shadow(0px 4px 4px rgba(213, 213, 213, 0.25))",
-              borderRadius: { xs: 0, lg: fr.spacing("2v") },
               boxShadow: { xs: "unset", lg: "0 4px 12px 0 rgba(0, 0, 18, 0.16)" },
               padding: "10px 20px 0px 20px",
               backgroundColor: "white",
@@ -243,7 +242,7 @@ function TrainingDetailPage({
               </Box>
             </Box>
           </Box>
-          <Box sx={{ mx: { md: 0, lg: fr.spacing("6v") } }}>
+          <Box>
             <TrainingDetail training={selectedItem} />
             <AideApprentissage />
           </Box>


### PR DESCRIPTION
## Changements

- Retire la marge horizontale (`mx` 24px en desktop) du wrapper des blocs de contenu sous la carte header, sur les fiches détail offre et formation : tous les blocs sont désormais alignés sur la même largeur, conformément à la maquette Figma
- Retire le `border-radius` de la carte header sur les deux fiches

## Plan de test

- [ ] Ouvrir une fiche offre en desktop : la carte header et les blocs (Contrat, Présentation de l'entreprise, Description…) ont la même largeur, sans coins arrondis
- [ ] Idem sur une fiche formation
- [ ] Vérifier le rendu mobile (pas de régression, les marges mobiles étaient déjà à 0)