### PR TITLE
fix: corrige la modale de recherche mobile (pop-in au retour accueil, suggestions sous le clavier)

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { fr } from "@codegouvfr/react-dsfr"
+import type { PopperProps } from "@mui/material"
 import { Box, TextField } from "@mui/material"
 import Autocomplete from "@mui/material/Autocomplete"
 import { useQuery } from "@tanstack/react-query"
@@ -52,6 +53,30 @@ const fieldSx = (error?: boolean) => ({
 
 // Panneau flottant des autocompletes (ombre + radius du design).
 const POPPER_PAPER_SX = { mt: "4px", borderRadius: "4px", py: "8px", boxShadow: "0 6px 18px rgba(0,0,18,0.16)" }
+
+// Mode « écran de saisie » (inlineSuggestions) : même design de liste que le dropdown
+// (radius, ombre, padding, rendu des options), mais le paper se borne à l'espace restant
+// sous le champ (le calc retranche son mt) et la liste scrolle à l'intérieur — le cap
+// 40vh de MUI saute, la hauteur vient du flex de l'écran de saisie.
+const INLINE_PAPER_SX = { ...POPPER_PAPER_SX, maxHeight: "calc(100% - 4px)", display: "flex", flexDirection: "column" } as const
+// overscroll contain : arrivé en butée, le scroll de la liste ne doit pas chaîner vers la
+// page derrière la modale (surtout iOS).
+const INLINE_LISTBOX_SX = { maxHeight: "none", minHeight: 0, overflowY: "auto", overscrollBehavior: "contain" } as const
+
+/**
+ * Slot popper du mode inlineSuggestions : à la place de la couche flottante popper.js, MUI
+ * rend ce conteneur DANS le flux, juste sous le champ — il occupe l'espace restant de
+ * l'écran de saisie (flex) et le clavier virtuel ne peut plus recouvrir la liste. Les props
+ * de positionnement (anchorEl, placement, style de largeur…) sont volontairement ignorées.
+ */
+function InlineSuggestionsContainer({ open, children, className }: PopperProps) {
+  if (!open) return null
+  return (
+    <Box className={className} sx={{ flex: "1 1 auto", minHeight: 0, width: "100%" }}>
+      {typeof children === "function" ? children({ placement: "bottom-start" }) : children}
+    </Box>
+  )
+}
 
 /**
  * Cap la hauteur de la liste de suggestions à l'espace visible SOUS le champ : sur mobile,
@@ -141,6 +166,15 @@ interface SearchBarProps {
   onQChange?: (q: string) => void
   /** "row" : barre desktop ; "column" : panneau mobile ; "responsive" : colonne en xs, rangée en md+ (home). */
   layout?: "row" | "column" | "responsive"
+  /**
+   * Modales mobiles plein écran : au focus d'un champ, la barre passe en « écran de saisie » —
+   * le champ actif reste seul affiché et ses suggestions sont rendues dans le flux dessous
+   * (plus de Popper flottant), donc jamais masquées par le clavier virtuel. Suppose un parent
+   * en flex column avec une hauteur bornée au viewport visible (SearchMobilePanel).
+   */
+  inlineSuggestions?: boolean
+  /** Champ en cours de saisie (mode inlineSuggestions) — permet au parent de masquer le reste du formulaire. */
+  onActiveFieldChange?: (field: "metier" | "lieu" | null) => void
   /** Message d'erreur DSFR sous le champ métier (label + stroke passent en rouge). */
   qError?: string
   /** Message d'erreur DSFR sous le champ lieu. */
@@ -179,7 +213,18 @@ function FieldError({ children, id }: { children: ReactNode; id?: string }) {
   )
 }
 
-export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuChange, onQChange, layout = "row", qError, lieuError }: SearchBarProps) {
+export function SearchBar({
+  initialQ = "",
+  initialLieuLabel,
+  onSubmit,
+  onLieuChange,
+  onQChange,
+  layout = "row",
+  inlineSuggestions = false,
+  onActiveFieldChange,
+  qError,
+  lieuError,
+}: SearchBarProps) {
   const metierLabelId = useId()
   const lieuLabelId = useId()
   const metierErrorId = useId()
@@ -211,6 +256,16 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
   const metierListbox = useListboxMaxHeight()
   const lieuListbox = useListboxMaxHeight()
 
+  // Champ en cours de saisie de l'écran de saisie mobile — piloté par focus/blur des
+  // Autocomplete (les clics sur les options ne blurent pas : MUI garde le focus dans
+  // l'input, et blurOnSelect le rend après sélection → retour à la vue formulaire).
+  const [activeField, setActiveField] = useState<"metier" | "lieu" | null>(null)
+  const changeActiveField = (field: "metier" | "lieu" | null) => {
+    if (!inlineSuggestions) return
+    setActiveField(field)
+    onActiveFieldChange?.(field)
+  }
+
   const isColumn = layout === "column"
   // Valeurs sx par layout : "responsive" = colonne en xs, rangée en md+ (formulaire home).
   const responsive = layout === "responsive"
@@ -222,6 +277,13 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
     lieuFlex: isColumn ? "none" : responsive ? { xs: "none", md: "0 0 320px" } : "0 0 320px",
     fieldWidth: isColumn ? "100%" : responsive ? { xs: "100%", md: "auto" } : undefined,
   } as const
+
+  // Écran de saisie : le wrapper du champ actif devient LA colonne flex qui contient label,
+  // champ et suggestions inline (rendues par MUI juste après le champ) ; l'autre champ est
+  // masqué mais reste monté (il garde son state). Hors écran de saisie, wrappers inchangés.
+  const activeWrapperSx = { flex: "1 1 auto", minHeight: 0, minWidth: 0, width: "100%", display: "flex", flexDirection: "column" } as const
+  const metierWrapperSx = activeField === "metier" ? activeWrapperSx : { flex: rowSx.metierFlex, width: rowSx.fieldWidth, display: activeField === "lieu" ? "none" : undefined }
+  const lieuWrapperSx = activeField === "lieu" ? activeWrapperSx : { flex: rowSx.lieuFlex, width: rowSx.fieldWidth, display: activeField === "metier" ? "none" : undefined }
 
   // Suggestions pour le champ métier — autocomplétion par préfixe (endpoint dédié, min 3 caractères)
   const { data: suggestionData } = useQuery({
@@ -292,10 +354,13 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
         flexDirection: rowSx.direction,
         gap: rowSx.gap,
         alignItems: rowSx.align,
+        // Écran de saisie : la barre s'étire sur tout l'espace restant du panneau — c'est
+        // cette hauteur que les suggestions inline remplissent.
+        ...(activeField ? { flex: "1 1 auto", minHeight: 0 } : null),
       }}
     >
       {/* Champ métier */}
-      <Box sx={{ flex: rowSx.metierFlex, width: rowSx.fieldWidth }}>
+      <Box sx={metierWrapperSx}>
         <FieldLabel id={metierLabelId} error={Boolean(qError)}>
           Que recherchez-vous ?
         </FieldLabel>
@@ -303,6 +368,10 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
           freeSolo
           options={metierOptions}
           getOptionLabel={(o) => (typeof o === "string" ? o : o.value)}
+          slots={inlineSuggestions ? { popper: InlineSuggestionsContainer } : undefined}
+          blurOnSelect={inlineSuggestions}
+          onFocus={() => changeActiveField("metier")}
+          onBlur={() => changeActiveField(null)}
           onOpen={metierListbox.onOpen}
           onClose={metierListbox.onClose}
           inputValue={inputValue}
@@ -373,7 +442,10 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
               </Box>
             </Box>
           )}
-          slotProps={{ paper: { sx: POPPER_PAPER_SX }, listbox: { sx: { maxHeight: metierListbox.maxHeight } } }}
+          slotProps={{
+            paper: { sx: inlineSuggestions ? INLINE_PAPER_SX : POPPER_PAPER_SX },
+            listbox: { sx: inlineSuggestions ? INLINE_LISTBOX_SX : { maxHeight: metierListbox.maxHeight } },
+          }}
           renderInput={(params) => (
             <TextField
               {...params}
@@ -394,7 +466,12 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
                 },
               }}
               onKeyDown={(e) => {
-                if (e.key === "Enter") handleSubmit(inputValue, "free_text")
+                if (e.key === "Enter") {
+                  handleSubmit(inputValue, "free_text")
+                  // Écran de saisie : Entrée vaut validation du champ — ferme le clavier
+                  // virtuel et revient à la vue formulaire (via le blur → changeActiveField).
+                  if (inlineSuggestions) (e.target as HTMLElement).blur()
+                }
               }}
             />
           )}
@@ -405,7 +482,7 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
       </Box>
 
       {/* Champ lieu */}
-      <Box sx={{ flex: rowSx.lieuFlex, width: rowSx.fieldWidth }}>
+      <Box sx={lieuWrapperSx}>
         <Box sx={{ mb: fr.spacing("1v") }}>
           <FieldLabel id={lieuLabelId} error={Boolean(lieuError)}>
             Lieu
@@ -427,11 +504,17 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
             if ("kind" in o) return false
             return typeof v === "string" ? o.label === v : !("kind" in v) && o.label === v.label
           }}
+          slots={inlineSuggestions ? { popper: InlineSuggestionsContainer } : undefined}
+          blurOnSelect={inlineSuggestions}
           onOpen={lieuListbox.onOpen}
           onClose={lieuListbox.onClose}
           inputValue={lieuInput}
           value={lieuValue}
-          onBlur={handleLieuBlur}
+          onFocus={() => changeActiveField("lieu")}
+          onBlur={() => {
+            changeActiveField(null)
+            handleLieuBlur()
+          }}
           onInputChange={(_e, value, reason) => {
             setLieuInput(value)
             // "clear" = clic sur la croix MUI — on retire le lieu des params
@@ -470,7 +553,10 @@ export function SearchBar({ initialQ = "", initialLieuLabel, onSubmit, onLieuCha
               </Box>
             )
           }
-          slotProps={{ paper: { sx: POPPER_PAPER_SX }, listbox: { sx: { maxHeight: lieuListbox.maxHeight } } }}
+          slotProps={{
+            paper: { sx: inlineSuggestions ? INLINE_PAPER_SX : POPPER_PAPER_SX },
+            listbox: { sx: inlineSuggestions ? INLINE_LISTBOX_SX : { maxHeight: lieuListbox.maxHeight } },
+          }}
           renderInput={(params) => (
             <TextField
               {...params}

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
@@ -372,8 +372,11 @@ export function SearchBar({
           blurOnSelect={inlineSuggestions}
           onFocus={() => changeActiveField("metier")}
           onBlur={() => changeActiveField(null)}
-          onOpen={metierListbox.onOpen}
-          onClose={metierListbox.onClose}
+          // Mode inline : le cap de hauteur du listbox ne sert plus (la hauteur vient du
+          // flex de l'écran de saisie) — ne pas armer le hook (listeners visualViewport +
+          // setState à chaque resize/scroll pendant l'animation du clavier).
+          onOpen={inlineSuggestions ? undefined : metierListbox.onOpen}
+          onClose={inlineSuggestions ? undefined : metierListbox.onClose}
           inputValue={inputValue}
           onInputChange={(_e, value, reason) => {
             // "reset" est déclenché par la sélection d'une option — ne pas écraser la saisie
@@ -506,8 +509,9 @@ export function SearchBar({
           }}
           slots={inlineSuggestions ? { popper: InlineSuggestionsContainer } : undefined}
           blurOnSelect={inlineSuggestions}
-          onOpen={lieuListbox.onOpen}
-          onClose={lieuListbox.onClose}
+          // Mode inline : cap listbox inutile — hook non armé (cf. champ métier).
+          onOpen={inlineSuggestions ? undefined : lieuListbox.onOpen}
+          onClose={inlineSuggestions ? undefined : lieuListbox.onClose}
           inputValue={lieuInput}
           value={lieuValue}
           onFocus={() => changeActiveField("lieu")}

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
@@ -79,12 +79,22 @@ export function SearchHomeForm() {
   const [lieu, setLieu] = useState<Lieu | null>(null)
   const [mode, setMode] = useState<SearchMode>(DEFAULT_SEARCH_MODE)
   const [mobilePanelOpen, setMobilePanelOpen] = useState(false)
+  // Champ (métier/lieu) en cours de saisie dans la modale : SearchBar passe en « écran de
+  // saisie » (suggestions inline plein écran) — le reste du formulaire est masqué.
+  const [mobileFieldActive, setMobileFieldActive] = useState(false)
+
+  const closeMobilePanel = () => {
+    setMobilePanelOpen(false)
+    // La modale peut se fermer pendant une saisie (croix, Escape) : sans reset, la
+    // prochaine ouverture masquerait type de recherche et bouton.
+    setMobileFieldActive(false)
+  }
 
   const launchSearch = (query: string, source: QSource) => {
     // cacheComponents (<Activity>) garde cette instance montée — pas démontée — pendant la
     // navigation : sans fermeture explicite, la modale serait encore ouverte en revenant
     // sur l'accueil (logo LBA, bouton retour).
-    setMobilePanelOpen(false)
+    closeMobilePanel()
     // Même événement que le formulaire home legacy, enrichi de search_engine.
     pushMatomoEvent({
       event: MATOMO_EVENTS.SEARCH_LAUNCHED,
@@ -184,22 +194,38 @@ export function SearchHomeForm() {
       {/* Même design que la modale de la page de résultats (SearchPageClient, panel "search") ;
           seul le comportement diffère : ici le bouton lance la recherche (application différée). */}
       {mobilePanelOpen && (
-        <SearchMobilePanel title="Votre recherche" onClose={() => setMobilePanelOpen(false)}>
-          <Box sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("4v") }}>
-            <SearchBar layout="column" initialQ={q} initialLieuLabel={lieu?.label} onSubmit={fillQ} onQChange={handleQChange} onLieuChange={setLieu} />
-            <RadioButtons
-              legend="Type de recherche"
-              options={SEARCH_MODE_OPTIONS.map((option) => ({
-                label: option.label,
-                hintText: option.hint,
-                nativeInputProps: { checked: mode === option.value, onChange: () => handleModeChange(option.value) },
-              }))}
+        <SearchMobilePanel title="Votre recherche" hideHeader={mobileFieldActive} onClose={closeMobilePanel}>
+          {/* height 100% pendant la saisie : les suggestions inline de SearchBar remplissent
+              l'espace du panneau (borné au viewport visible, donc au-dessus du clavier). */}
+          <Box sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("4v"), height: mobileFieldActive ? "100%" : undefined }}>
+            <SearchBar
+              layout="column"
+              inlineSuggestions
+              onActiveFieldChange={(field) => setMobileFieldActive(field !== null)}
+              initialQ={q}
+              initialLieuLabel={lieu?.label}
+              onSubmit={fillQ}
+              onQChange={handleQChange}
+              onLieuChange={setLieu}
             />
-            <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: fr.spacing("4v") }}>
-              <Button priority="primary" iconId="fr-icon-search-line" onClick={() => launchSearch(q, qSource)} style={{ width: "100%", justifyContent: "center" }}>
-                Rechercher
-              </Button>
-            </Box>
+            {/* Masqués pendant la saisie : l'écran est réservé au champ actif + suggestions. */}
+            {!mobileFieldActive && (
+              <>
+                <RadioButtons
+                  legend="Type de recherche"
+                  options={SEARCH_MODE_OPTIONS.map((option) => ({
+                    label: option.label,
+                    hintText: option.hint,
+                    nativeInputProps: { checked: mode === option.value, onChange: () => handleModeChange(option.value) },
+                  }))}
+                />
+                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: fr.spacing("4v") }}>
+                  <Button priority="primary" iconId="fr-icon-search-line" onClick={() => launchSearch(q, qSource)} style={{ width: "100%", justifyContent: "center" }}>
+                    Rechercher
+                  </Button>
+                </Box>
+              </>
+            )}
           </Box>
         </SearchMobilePanel>
       )}

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
@@ -81,6 +81,10 @@ export function SearchHomeForm() {
   const [mobilePanelOpen, setMobilePanelOpen] = useState(false)
 
   const launchSearch = (query: string, source: QSource) => {
+    // cacheComponents (<Activity>) garde cette instance montée — pas démontée — pendant la
+    // navigation : sans fermeture explicite, la modale serait encore ouverte en revenant
+    // sur l'accueil (logo LBA, bouton retour).
+    setMobilePanelOpen(false)
     // Même événement que le formulaire home legacy, enrichi de search_engine.
     pushMatomoEvent({
       event: MATOMO_EVENTS.SEARCH_LAUNCHED,

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchMobilePanel.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchMobilePanel.tsx
@@ -7,12 +7,19 @@ import type { ReactNode } from "react"
 
 import { useDialogA11y } from "../_hooks/use-dialog-a11y"
 import { useLockBodyScroll } from "../_hooks/use-lock-body-scroll"
+import { useVisualViewportSize } from "../_hooks/use-visual-viewport-size"
 
 interface SearchMobilePanelProps {
   /** Sans titre : header réduit au bouton « Fermer » aligné à droite (modale de la home). */
   title?: string
   /** Libellé accessibilité quand `title` est absent. */
   ariaLabel?: string
+  /**
+   * Masque le header (titre + Fermer) — écran de saisie : le champ focus doit être tout en
+   * haut pour maximiser l'espace des suggestions au-dessus du clavier. `display: none`
+   * (pas de démontage) : le focus trap ignore déjà les éléments non visibles.
+   */
+  hideHeader?: boolean
   onClose: () => void
   children: ReactNode
   footer?: ReactNode
@@ -22,9 +29,10 @@ interface SearchMobilePanelProps {
  * Panneau mobile plein écran (recherche / filtres). Remplace le `Drawer`
  * unique du POC. Head titre + croix, body scrollable, footer sticky optionnel.
  */
-export function SearchMobilePanel({ title, ariaLabel, onClose, children, footer }: SearchMobilePanelProps) {
+export function SearchMobilePanel({ title, ariaLabel, hideHeader = false, onClose, children, footer }: SearchMobilePanelProps) {
   useLockBodyScroll()
   const dialogRef = useDialogA11y(onClose)
+  const viewport = useVisualViewportSize()
 
   return (
     <Box
@@ -34,7 +42,15 @@ export function SearchMobilePanel({ title, ariaLabel, onClose, children, footer 
       aria-label={title ?? ariaLabel}
       sx={{
         position: "fixed",
-        inset: 0,
+        top: 0,
+        left: 0,
+        right: 0,
+        // Hauteur bornée au viewport VISUEL, pas `bottom: 0` : le clavier virtuel recouvre
+        // le bas du layout viewport — un panneau pleine hauteur y laisserait la liste de
+        // suggestions et le footer masqués. translateY : iOS décale le viewport visuel
+        // (offsetTop) pour amener le champ focus en vue.
+        height: viewport.height !== null ? `${viewport.height}px` : "100%",
+        transform: viewport.offsetTop ? `translateY(${viewport.offsetTop}px)` : undefined,
         // Sous le niveau "modal" (1300) pour que les dropdowns des Autocomplete
         // (MUI Popper) et de l'autocomplete Entreprise (downshift) passent devant.
         zIndex: 1250,
@@ -50,7 +66,7 @@ export function SearchMobilePanel({ title, ariaLabel, onClose, children, footer 
       <Box
         sx={{
           flex: "0 0 auto",
-          display: "flex",
+          display: hideHeader ? "none" : "flex",
           alignItems: "center",
           justifyContent: title ? "space-between" : "flex-end",
           px: fr.spacing("4v"),

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchMobilePanel.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchMobilePanel.tsx
@@ -42,15 +42,15 @@ export function SearchMobilePanel({ title, ariaLabel, hideHeader = false, onClos
       aria-label={title ?? ariaLabel}
       sx={{
         position: "fixed",
-        top: 0,
+        // Suivi du viewport VISUEL, pas `inset: 0` : le clavier virtuel recouvre le bas du
+        // layout viewport — un panneau pleine hauteur y laisserait la liste de suggestions
+        // et le footer masqués. top : iOS décale le viewport visuel (offsetTop) pour amener
+        // le champ focus en vue — décalage via `top` et non `transform`, déjà utilisé par
+        // l'animation d'ouverture (conflit pendant sa lecture).
+        top: viewport.offsetTop ? `${viewport.offsetTop}px` : 0,
         left: 0,
         right: 0,
-        // Hauteur bornée au viewport VISUEL, pas `bottom: 0` : le clavier virtuel recouvre
-        // le bas du layout viewport — un panneau pleine hauteur y laisserait la liste de
-        // suggestions et le footer masqués. translateY : iOS décale le viewport visuel
-        // (offsetTop) pour amener le champ focus en vue.
         height: viewport.height !== null ? `${viewport.height}px` : "100%",
-        transform: viewport.offsetTop ? `translateY(${viewport.offsetTop}px)` : undefined,
         // Sous le niveau "modal" (1300) pour que les dropdowns des Autocomplete
         // (MUI Popper) et de l'autocomplete Entreprise (downshift) passent devant.
         zIndex: 1250,

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
@@ -70,6 +70,15 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
   }, [pendingScrollHitId, result.data])
 
   const [panel, setPanel] = useState<MobilePanel>(null)
+  // Champ en cours de saisie dans la modale « Modifier la recherche » : SearchBar passe en
+  // « écran de saisie » (suggestions inline plein écran) — le reste du formulaire est masqué.
+  const [searchFieldActive, setSearchFieldActive] = useState(false)
+  const closeSearchPanel = () => {
+    setPanel(null)
+    // Fermeture possible pendant une saisie (croix, Escape) : sans reset, la prochaine
+    // ouverture masquerait type de recherche et bouton.
+    setSearchFieldActive(false)
+  }
 
   // Bandeau desktop collé ou non : sentinelle observée juste au-dessus du sticky — dès
   // qu'elle sort du viewport par le haut, le bandeau est collé (fond blanc pleine largeur).
@@ -347,22 +356,37 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
         </Box>
 
         {panel === "search" && (
-          <SearchMobilePanel title="Modifier la recherche" onClose={() => setPanel(null)}>
-            <Box sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("4v") }}>
-              <SearchBar layout="column" initialQ={params.q} initialLieuLabel={params.lieu_label} onSubmit={handleSearch} onLieuChange={handleLieuChange} />
-              <RadioButtons
-                legend="Type de recherche"
-                options={SEARCH_MODE_OPTIONS.map((option) => ({
-                  label: option.label,
-                  hintText: option.hint,
-                  nativeInputProps: { checked: params.mode === option.value, onChange: () => handleModeChange(option.value) },
-                }))}
+          <SearchMobilePanel title="Modifier la recherche" hideHeader={searchFieldActive} onClose={closeSearchPanel}>
+            {/* height 100% pendant la saisie : les suggestions inline de SearchBar remplissent
+                l'espace du panneau (borné au viewport visible, donc au-dessus du clavier). */}
+            <Box sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("4v"), height: searchFieldActive ? "100%" : undefined }}>
+              <SearchBar
+                layout="column"
+                inlineSuggestions
+                onActiveFieldChange={(field) => setSearchFieldActive(field !== null)}
+                initialQ={params.q}
+                initialLieuLabel={params.lieu_label}
+                onSubmit={handleSearch}
+                onLieuChange={handleLieuChange}
               />
-              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: fr.spacing("4v") }}>
-                <Button priority="primary" iconId="fr-icon-search-line" onClick={() => setPanel(null)} style={{ width: "100%", justifyContent: "center" }}>
-                  Rechercher
-                </Button>
-              </Box>
+              {/* Masqués pendant la saisie : l'écran est réservé au champ actif + suggestions. */}
+              {!searchFieldActive && (
+                <>
+                  <RadioButtons
+                    legend="Type de recherche"
+                    options={SEARCH_MODE_OPTIONS.map((option) => ({
+                      label: option.label,
+                      hintText: option.hint,
+                      nativeInputProps: { checked: params.mode === option.value, onChange: () => handleModeChange(option.value) },
+                    }))}
+                  />
+                  <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: fr.spacing("4v") }}>
+                    <Button priority="primary" iconId="fr-icon-search-line" onClick={closeSearchPanel} style={{ width: "100%", justifyContent: "center" }}>
+                      Rechercher
+                    </Button>
+                  </Box>
+                </>
+              )}
             </Box>
           </SearchMobilePanel>
         )}

--- a/ui/app/(candidat)/(recherche)/recherche/_hooks/use-visual-viewport-size.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_hooks/use-visual-viewport-size.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react"
+
+interface VisualViewportSize {
+  /** Hauteur visible en px CSS — null tant que non mesurée (SSR, navigateur sans visualViewport). */
+  height: number | null
+  offsetTop: number
+}
+
+/**
+ * Suit la taille du viewport VISUEL : sur mobile, le clavier virtuel réduit le visualViewport
+ * sans toucher au layout viewport — un panneau `position: fixed; inset: 0` garde donc sa
+ * hauteur pleine page et son bas (liste de suggestions, footer) passe sous le clavier.
+ * `offsetTop` : iOS fait défiler le viewport visuel (pas le document) pour amener le champ
+ * focus en vue — le panneau doit suivre ce décalage. Écoute resize ET scroll : l'ouverture
+ * du clavier s'anime après le focus et ne déclenche parfois que l'un des deux.
+ */
+export function useVisualViewportSize(): VisualViewportSize {
+  const [size, setSize] = useState<VisualViewportSize>({ height: null, offsetTop: 0 })
+
+  useEffect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+    const update = () => setSize({ height: Math.round(vv.height), offsetTop: Math.round(vv.offsetTop) })
+    update()
+    vv.addEventListener("resize", update)
+    vv.addEventListener("scroll", update)
+    return () => {
+      vv.removeEventListener("resize", update)
+      vv.removeEventListener("scroll", update)
+    }
+  }, [])
+
+  return size
+}

--- a/ui/app/(candidat)/(recherche)/recherche/_hooks/use-visual-viewport-size.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_hooks/use-visual-viewport-size.ts
@@ -22,8 +22,8 @@ export function useVisualViewportSize(): VisualViewportSize {
     if (!vv) return
     const update = () => setSize({ height: Math.round(vv.height), offsetTop: Math.round(vv.offsetTop) })
     update()
-    vv.addEventListener("resize", update)
-    vv.addEventListener("scroll", update)
+    vv.addEventListener("resize", update, { passive: true })
+    vv.addEventListener("scroll", update, { passive: true })
     return () => {
       vv.removeEventListener("resize", update)
       vv.removeEventListener("scroll", update)

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -265,9 +265,14 @@ const sentryConfig = {
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
 
-  // Automatically annotate React components to show their full name in breadcrumbs and session replay
-  reactComponentAnnotation: {
-    enabled: true,
+  // Formes non dépréciées depuis Sentry 10.x : reactComponentAnnotation et le tree-shaking
+  // du logger (ex-disableLogger) vivent sous `webpack`. hideSourceMaps a été retiré du SDK
+  // (la rétention des sourcemaps est pilotée par `sourcemaps` ci-dessous).
+  webpack: {
+    // Automatically annotate React components to show their full name in breadcrumbs and session replay
+    reactComponentAnnotation: { enabled: true },
+    // Automatically tree-shake Sentry logger statements to reduce bundle size
+    treeshake: { removeDebugLogging: true },
   },
 
   // Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
@@ -275,12 +280,6 @@ const sentryConfig = {
   // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
   // side errors will fail.
   // tunnelRoute: "/monitoring",
-
-  // Hides source maps from generated client bundles
-  hideSourceMaps: false,
-
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
 
   sourcemaps: {
     disable: false,


### PR DESCRIPTION
## Changements

- **Pop-in fantôme** : la modale de recherche de l'accueil se ferme désormais au lancement d'une recherche — avec `cacheComponents`, l'instance de la page restait montée (`<Activity>`) et la modale réapparaissait en revenant sur l'accueil (logo LBA, bouton retour).
- **Écran de saisie mobile** : au focus d'un champ (métier ou lieu) dans les modales de recherche (accueil et page résultats), le champ passe seul à l'écran, tout en haut — header de la modale, autre champ, type de recherche et bouton Rechercher sont masqués pendant la saisie.
- **Suggestions inline** : les suggestions sont rendues dans le flux sous le champ (plus de Popper flottant) avec le même design que le dropdown — elles ne sont plus masquées par le clavier virtuel.
- **Panneau borné au viewport visible** : `SearchMobilePanel` suit `visualViewport` (hauteur + offsetTop) via un nouveau hook — le bas du panneau s'arrête au-dessus du clavier, la liste scrolle en interne (`overscroll-behavior: contain`).
- **Sentry** : migration des options dépréciées de `next.config.mjs` vers leur forme actuelle (`webpack.reactComponentAnnotation`, `webpack.treeshake.removeDebugLogging`) et retrait de `hideSourceMaps`, supprimé du SDK.

## Plan de test

- [ ] Mobile, accueil : taper sur le module de recherche → la modale s'ouvre ; taper sur le champ métier → le clavier s'ouvre, le champ est en haut de l'écran et les suggestions s'affichent dessous, au-dessus du clavier
- [ ] Sélectionner une suggestion → le clavier se ferme, retour à la vue formulaire avec le champ rempli
- [ ] Même comportement sur le champ lieu (option « France entière » proposée au focus)
- [ ] Lancer une recherche puis revenir à l'accueil via le logo LBA → pas de pop-in
- [ ] Page résultats : ouvrir « Modifier la recherche » → mêmes comportements de saisie
- [ ] Desktop : comportement des autocompletes inchangé (dropdown flottant)

## Notes

- Un warning React « unique key » préexistant sur les listes de suggestions (présent aussi sur le dropdown desktop avant cette PR) sera traité séparément.