### PR TITLE
fix: corrige la désynchronisation du nombre de candidatures liste/détail (#5243)

### DIFF
--- a/server/src/jobs/search/generate-search-items-collection.ts
+++ b/server/src/jobs/search/generate-search-items-collection.ts
@@ -12,6 +12,7 @@ import { limitStream } from "@/common/utils/stream-utils"
 import type { IJobPartnerForSearchItem } from "@/services/search/search-items.service"
 import {
   applicationCountByJobIdStages,
+  applicationCountBySiretLookupStage,
   buildFormationSearchItem,
   buildJobOfferSearchItem,
   buildRecruteurSearchItem,
@@ -101,14 +102,7 @@ export const fillSearchItemsCollection = async () => {
         offer_status: JOB_STATUS_ENGLISH.ACTIVE,
       },
     },
-    {
-      $lookup: {
-        from: "applications",
-        localField: "workplace_siret",
-        foreignField: "company_siret",
-        as: "applications",
-      },
-    },
+    applicationCountBySiretLookupStage,
     {
       $lookup: {
         from: "raw_recruteurslba",
@@ -146,9 +140,7 @@ export const fillSearchItemsCollection = async () => {
             },
           },
         },
-        application_count: {
-          $size: "$applications",
-        },
+        application_count: { $ifNull: [{ $first: "$applications.count" }, 0] },
       },
     },
     {

--- a/server/src/jobs/search/generate-search-items-collection.ts
+++ b/server/src/jobs/search/generate-search-items-collection.ts
@@ -11,6 +11,7 @@ import { sentryCaptureException } from "@/common/utils/sentry-utils"
 import { limitStream } from "@/common/utils/stream-utils"
 import type { IJobPartnerForSearchItem } from "@/services/search/search-items.service"
 import {
+  applicationCountByJobIdStages,
   buildFormationSearchItem,
   buildJobOfferSearchItem,
   buildRecruteurSearchItem,
@@ -85,25 +86,7 @@ export const fillSearchItemsCollection = async () => {
         offer_status: JOB_STATUS_ENGLISH.ACTIVE,
       },
     },
-    {
-      $lookup: {
-        from: "applications",
-        let: { jobIdStr: { $toString: "$_id" } },
-        pipeline: [
-          {
-            $match: {
-              $expr: { $eq: ["$job_id", "$$jobIdStr"] },
-            },
-          },
-        ],
-        as: "applications",
-      },
-    },
-    {
-      $addFields: {
-        application_count: { $size: "$applications" },
-      },
-    },
+    ...applicationCountByJobIdStages,
     {
       $project: {
         ...jobsProjection,

--- a/server/src/services/search/search-items.service.test.ts
+++ b/server/src/services/search/search-items.service.test.ts
@@ -1,5 +1,6 @@
 import { useMongo } from "@tests/utils/mongo.test.utils"
 import { JOB_STATUS_ENGLISH } from "shared"
+import { generateApplicationFixture } from "shared/fixtures/application.fixture"
 import { generateJobsPartnersOfferPrivate } from "shared/fixtures/job-partners.fixture"
 import { generateReferentielRome } from "shared/fixtures/rome.fixture"
 import { generateSearchItemFixture } from "shared/fixtures/search-items.fixture"
@@ -41,6 +42,7 @@ describe("searchItems.service — synchronisation jobs_partners → search_items
     await getDbCollection("search_items").deleteMany({})
     await getDbCollection("jobs_partners").deleteMany({})
     await getDbCollection("referentielromes").deleteMany({})
+    await getDbCollection("applications").deleteMany({})
   })
 
   const seedRome = async () => {
@@ -75,6 +77,43 @@ describe("searchItems.service — synchronisation jobs_partners → search_items
         rome_labels: ["Études et développement informatique"],
         keywords: null,
       })
+    })
+
+    it("compte les candidatures d'une offre via job_id (ObjectId ↔ ObjectId)", async () => {
+      const job = generateJobsPartnersOfferPrivate({ apply_email: "recruteur@entreprise.fr" })
+      const autreJob = generateJobsPartnersOfferPrivate({})
+      await getDbCollection("jobs_partners").insertMany([job, autreJob])
+      await getDbCollection("applications").insertMany([
+        generateApplicationFixture({ job_id: job._id }),
+        generateApplicationFixture({ job_id: job._id }),
+        // Near-miss : candidature d'une autre offre — ne doit pas être comptée.
+        generateApplicationFixture({ job_id: autreJob._id }),
+      ])
+
+      await upsertJobPartnersToSearchItems([job._id, autreJob._id])
+
+      const doc = await getDbCollection("search_items").findOne({ _id: job._id })
+      expect(doc?.application_count).toBe(2)
+      const autreDoc = await getDbCollection("search_items").findOne({ _id: autreJob._id })
+      expect(autreDoc?.application_count).toBe(1)
+    })
+
+    it("compte les candidatures d'un recruteur LBA via le siret", async () => {
+      const recruteur = generateJobsPartnersOfferPrivate({
+        partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA,
+        workplace_siret: "42476141900045",
+      })
+      await getDbCollection("jobs_partners").insertOne(recruteur)
+      await getDbCollection("applications").insertMany([
+        generateApplicationFixture({ company_siret: "42476141900045", job_id: null }),
+        // Near-miss : autre siret — ne doit pas être comptée.
+        generateApplicationFixture({ company_siret: "34268752200066", job_id: null }),
+      ])
+
+      await upsertJobPartnersToSearchItems([recruteur._id])
+
+      const doc = await getDbCollection("search_items").findOne({ _id: recruteur._id })
+      expect(doc?.application_count).toBe(1)
     })
 
     it("préserve les keywords Mistral lors d'un ré-upsert", async () => {

--- a/server/src/services/search/search-items.service.ts
+++ b/server/src/services/search/search-items.service.ts
@@ -402,13 +402,24 @@ export const buildRecruteurSearchItem = (job: IJobPartnerForSearchItem, ctx: Sea
 
 /**
  * Stages partagés nightly/sync : comptage des candidatures d'une offre. applications.job_id est
- * un ObjectId depuis la migration 20251014154807 : jointure directe ObjectId↔ObjectId (comparer
- * à $toString(_id) ne matchait plus rien → compteur à 0).
+ * un ObjectId : jointure directe ObjectId↔ObjectId (comparer à $toString(_id) ne matchait plus
+ * rien → compteur à 0). Le $count dans le pipeline du $lookup évite de matérialiser les documents
+ * candidature en mémoire — seul le compteur remonte.
  */
 export const applicationCountByJobIdStages = [
-  { $lookup: { from: "applications", localField: "_id", foreignField: "job_id", as: "applications" } },
-  { $addFields: { application_count: { $size: "$applications" } } },
+  { $lookup: { from: "applications", localField: "_id", foreignField: "job_id", as: "applications", pipeline: [{ $count: "count" }] } },
+  { $addFields: { application_count: { $ifNull: [{ $first: "$applications.count" }, 0] } } },
 ]
+
+/**
+ * Stage de comptage des candidatures d'un recruteur LBA par siret (candidature spontanée) : ce
+ * volume n'est PAS plafonné (contrairement aux offres, cf. checkMaxApplicationCount qui exclut
+ * explicitement RECRUTEURS_LBA) — d'où le $count dans le pipeline pour ne jamais matérialiser un
+ * tableau de candidatures potentiellement volumineux pour un siret très sollicité.
+ */
+export const applicationCountBySiretLookupStage = {
+  $lookup: { from: "applications", localField: "workplace_siret", foreignField: "company_siret", as: "applications", pipeline: [{ $count: "count" }] },
+}
 
 /** Pipelines de récupération des jobs_partners avec leurs champs dérivés (application_count, rome_codes recruteurs). */
 const fetchJobPartnersForSync = async (ids: ObjectId[]): Promise<{ offers: IJobPartnerForSearchItem[]; recruteurs: IJobPartnerForSearchItem[] }> => {
@@ -423,7 +434,7 @@ const fetchJobPartnersForSync = async (ids: ObjectId[]): Promise<{ offers: IJobP
     getDbCollection("jobs_partners")
       .aggregate<IJobPartnerForSearchItem>([
         { $match: { _id: { $in: ids }, partner_label: JOBPARTNERS_LABEL.RECRUTEURS_LBA } },
-        { $lookup: { from: "applications", localField: "workplace_siret", foreignField: "company_siret", as: "applications" } },
+        applicationCountBySiretLookupStage,
         { $lookup: { from: "raw_recruteurslba", localField: "workplace_siret", foreignField: "siret", as: "rawR" } },
         {
           // rome_codes : priorité au classement de raw_recruteurslba (codes ordonnés par
@@ -436,7 +447,7 @@ const fetchJobPartnersForSync = async (ids: ObjectId[]): Promise<{ offers: IJobP
                 in: { $slice: [{ $cond: [{ $gt: [{ $size: "$$fromRaw" }, 0] }, "$$fromRaw", { $ifNull: ["$offer_rome_codes", []] }] }, 6] },
               },
             },
-            application_count: { $size: "$applications" },
+            application_count: { $ifNull: [{ $first: "$applications.count" }, 0] },
           },
         },
         { $project: { ...jobsProjection, application_count: 1, rome_codes: 1, offer_status: 1 } },

--- a/server/src/services/search/search-items.service.ts
+++ b/server/src/services/search/search-items.service.ts
@@ -400,21 +400,23 @@ export const buildRecruteurSearchItem = (job: IJobPartnerForSearchItem, ctx: Sea
 
 // ─── Synchronisation incrémentale jobs_partners → search_items ─────────────────────────────
 
+/**
+ * Stages partagés nightly/sync : comptage des candidatures d'une offre. applications.job_id est
+ * un ObjectId depuis la migration 20251014154807 : jointure directe ObjectId↔ObjectId (comparer
+ * à $toString(_id) ne matchait plus rien → compteur à 0).
+ */
+export const applicationCountByJobIdStages = [
+  { $lookup: { from: "applications", localField: "_id", foreignField: "job_id", as: "applications" } },
+  { $addFields: { application_count: { $size: "$applications" } } },
+]
+
 /** Pipelines de récupération des jobs_partners avec leurs champs dérivés (application_count, rome_codes recruteurs). */
 const fetchJobPartnersForSync = async (ids: ObjectId[]): Promise<{ offers: IJobPartnerForSearchItem[]; recruteurs: IJobPartnerForSearchItem[] }> => {
   const [offers, recruteurs] = await Promise.all([
     getDbCollection("jobs_partners")
       .aggregate<IJobPartnerForSearchItem>([
         { $match: { _id: { $in: ids }, partner_label: { $ne: JOBPARTNERS_LABEL.RECRUTEURS_LBA } } },
-        {
-          $lookup: {
-            from: "applications",
-            let: { jobIdStr: { $toString: "$_id" } },
-            pipeline: [{ $match: { $expr: { $eq: ["$job_id", "$$jobIdStr"] } } }],
-            as: "applications",
-          },
-        },
-        { $addFields: { application_count: { $size: "$applications" } } },
+        ...applicationCountByJobIdStages,
         { $project: { ...jobsProjection, application_count: 1, offer_status: 1 } },
       ])
       .toArray(),

--- a/shared/src/models/applications.model.ts
+++ b/shared/src/models/applications.model.ts
@@ -70,7 +70,7 @@ const ZApplicationOld = z.strictObject({
   job_id: zObjectId
     .nullish()
     .describe(
-      `L'identifiant de l'offre La bonne alternance Recruteur pour laquelle la candidature est envoyée. Seulement si le type de la société (company_type) est ${LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA} . La valeur est fournie par La bonne alternance. `
+      `L'identifiant de l'offre (jobs_partners._id) pour laquelle la candidature est envoyée. Null pour les candidatures spontanées (${LBA_ITEM_TYPE.RECRUTEURS_LBA}). La valeur est fournie par La bonne alternance.`
     ),
   to_applicant_message_id: z.string().nullish().describe("Identifiant chez le transporteur du mail envoyé au candidat"),
   to_company_message_id: z.string().nullish().describe("Identifiant chez le transporteur du mail envoyé à l'entreprise"),


### PR DESCRIPTION
Closes #5243

## Changements

- Corrige la jointure `applications` ↔ `jobs_partners` dans le pipeline d'indexation `search_items` (batch nightly et sync incrémentale) : comparaison ObjectId directe (`localField: "_id", foreignField: "job_id"`) au lieu de comparer `job_id` à `$toString(_id)`, qui ne matchait jamais depuis le passage de `job_id` en ObjectId.
- Factorise le stage de comptage (`applicationCountByJobIdStages`) partagé entre le nightly et la sync incrémentale.
- Ajoute deux tests d'intégration couvrant le comptage par offre et par recruteur, avec cas near-miss (candidature d'une autre offre / autre siret).
- Met à jour la description du champ `job_id` dans le modèle, obsolète depuis l'ouverture aux offres partenaires.

## Plan de test

- [x] `yarn vitest run server/src/services/search/ server/src/jobs/search/` — verts
- [x] Test de régression vérifié non vacuous (échec confirmé avec l'ancien code réintroduit temporairement)
- [x] `tsc -b` côté serveur
- [ ] Vérifier en prod, après le prochain run nightly, que le compteur de la liste de résultats correspond à celui de la fiche détail