### PR TITLE
fix: filtre les erreurs Sentry removeChild liées aux extensions navigateur

### DIFF
--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -47,19 +47,28 @@ init({
     /SCDynimacBridge/,
     "No Listener: tabs:outgoing.message.ready",
     "Invalid call to runtime.sendMessage",
-    // Une extension navigateur (traducteur, gestionnaire de mots de passe…) mute le DOM en
-    // parallèle du commit React, qui perd ensuite la référence du nœud pendant son cleanup.
-    // Stack 100 % interne à react-dom-client.production.js (commitMutationEffectsOnFiber /
-    // commitDeletionEffectsOnFiber), aucune frame applicative. Chronique depuis fin juin/début
-    // juillet 2026, sans lien avec un déploiement (Sentry LBA-UI-5CVZZZZZZG3V9 ~1350 events,
-    // LBA-UI-5CVZZZZZZG3XY ~320 events, vérifié 2026-08-25).
-    "The object can not be found here.",
-    "Cannot read properties of null (reading 'removeChild')",
   ],
   beforeSend(event) {
     // Hydratation error comes from DSFR
     if (event.extra?.arguments && Array.isArray(event.extra?.arguments) && event.extra?.arguments?.includes("https://react.dev/link/hydration-mismatch")) {
       return null
+    }
+
+    // Une extension navigateur (traducteur, gestionnaire de mots de passe…) mute le DOM en
+    // parallèle du commit React, qui perd ensuite la référence du nœud pendant son cleanup.
+    // On ne filtre que si TOUTES les frames sont internes à react-dom-client.production.js
+    // (aucune frame applicative) : un `ignoreErrors` sur le seul texte matcherait aussi
+    // "The object can not be found here." (message générique WebKit pour n'importe quelle
+    // NotFoundError, pas seulement removeChild) ou un futur vrai bug applicatif qui produirait
+    // le même message par coïncidence. Chronique depuis fin juin/début juillet 2026, sans lien
+    // avec un déploiement (Sentry LBA-UI-5CVZZZZZZG3V9 ~1350 events, LBA-UI-5CVZZZZZZG3XY
+    // ~320 events, vérifié 2026-08-25).
+    const exception = event.exception?.values?.[0]
+    const isRemoveChildMessage = exception?.value === "The object can not be found here." || exception?.value?.includes("reading 'removeChild'")
+    if (isRemoveChildMessage) {
+      const frames = exception?.stacktrace?.frames ?? []
+      const hasNoApplicationFrame = frames.every((frame) => !frame.filename || frame.filename === "[native code]" || /react-dom-client\.production\.js$/.test(frame.filename))
+      if (hasNoApplicationFrame) return null
     }
 
     console.info(event)

--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -47,6 +47,14 @@ init({
     /SCDynimacBridge/,
     "No Listener: tabs:outgoing.message.ready",
     "Invalid call to runtime.sendMessage",
+    // Une extension navigateur (traducteur, gestionnaire de mots de passe…) mute le DOM en
+    // parallèle du commit React, qui perd ensuite la référence du nœud pendant son cleanup.
+    // Stack 100 % interne à react-dom-client.production.js (commitMutationEffectsOnFiber /
+    // commitDeletionEffectsOnFiber), aucune frame applicative. Chronique depuis fin juin/début
+    // juillet 2026, sans lien avec un déploiement (Sentry LBA-UI-5CVZZZZZZG3V9 ~1350 events,
+    // LBA-UI-5CVZZZZZZG3XY ~320 events, vérifié 2026-08-25).
+    "The object can not be found here.",
+    "Cannot read properties of null (reading 'removeChild')",
   ],
   beforeSend(event) {
     // Hydratation error comes from DSFR


### PR DESCRIPTION
## Changements

- Ajoute deux entrées `ignoreErrors` dans `ui/instrumentation-client.ts` : `The object can not be found here.` et `Cannot read properties of null (reading 'removeChild')`
- Ces erreurs proviennent d'un conflit DOM entre une extension navigateur (traducteur, gestionnaire de mots de passe...) qui mute le DOM en parallèle du commit React, et le reconciler qui perd ensuite la référence du nœud pendant son cleanup
- Stack trace 100 % interne à `react-dom-client.production.js` (`commitMutationEffectsOnFiber` / `commitDeletionEffectsOnFiber`), aucune frame applicative — non actionnable côté code
- Chronique depuis fin juin/début juillet 2026 (~1670 events cumulés sur deux issues Sentry LBA-UI-5CVZZZZZZG3V9 et LBA-UI-5CVZZZZZZG3XY), sans lien avec un déploiement récent

## Plan de test

- [ ] Vérifier en prod après déploiement que ces deux issues Sentry n'accumulent plus de nouveaux événements
- [ ] Vérifier qu'aucune vraie régression applicative ne matche accidentellement ces deux messages d'erreur