### PR TITLE
fix: purge le cookie invalide pour éviter la boucle de redirection espace-pro (#5245)

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,4 +1,5 @@
 import env from "env-var"
+import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from "shared/constants/session"
 
 const config = {
   version: env.get("PUBLIC_VERSION").required().asString(),
@@ -58,14 +59,9 @@ const config = {
       publicKey: env.get("LBA_API_APPRENTISSAGE_PUBLIC_KEY").required().asString(),
     },
     session: {
-      cookieName: "lba_session",
-      cookie: {
-        maxAge: 30 * 24 * 3600000,
-        httpOnly: true,
-        sameSite: "lax" as const,
-        path: "/",
-        secure: true,
-      },
+      cookieName: SESSION_COOKIE_NAME,
+      // maxAge en secondes : @fastify/cookie sérialise la valeur telle quelle dans Max-Age
+      cookie: SESSION_COOKIE_OPTIONS,
     },
   },
   diagoriente: {

--- a/server/src/services/sessions.service.ts
+++ b/server/src/services/sessions.service.ts
@@ -15,7 +15,8 @@ export const createSession = async (data: TCreateSession) => {
     _id: new ObjectId(),
     updated_at: now,
     created_at: now,
-    expires_at: new Date(now.getTime() + config.auth.session.cookie.maxAge),
+    // maxAge est en secondes (unité du Set-Cookie), getTime() en millisecondes
+    expires_at: new Date(now.getTime() + config.auth.session.cookie.maxAge * 1000),
   }
   const { insertedId } = await getDbCollection("sessions").insertOne(sessionObj)
 

--- a/shared/src/constants/index.ts
+++ b/shared/src/constants/index.ts
@@ -4,3 +4,4 @@ export const FILE_SIZE_LIMIT = 100 * megaByte
 export * from "./geiq.js"
 export * from "./recruteur.js"
 export * from "./search.js"
+export * from "./session.js"

--- a/shared/src/constants/session.ts
+++ b/shared/src/constants/session.ts
@@ -1,0 +1,12 @@
+export const SESSION_COOKIE_NAME = "lba_session"
+
+// Attributs du cookie de session, partagés entre le serveur (@fastify/cookie) et le proxy UI
+// (NextResponse.cookies) : les deux sérialisent maxAge en secondes (Max-Age, RFC 6265).
+// L'expiration des sessions en base (expires_at) se dérive de cette même durée.
+export const SESSION_COOKIE_OPTIONS = {
+  maxAge: 30 * 24 * 3600,
+  httpOnly: true,
+  sameSite: "lax",
+  path: "/",
+  secure: true,
+} as const

--- a/ui/proxy.test.ts
+++ b/ui/proxy.test.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from "next/server"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { proxy } from "./proxy"
+
+const BASE_URL = "http://localhost:3000"
+const INVALID_JWT = "invalid.jwt.token"
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock)
+  fetchMock.mockImplementation(async () => new Response(null, { status: 401 }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  fetchMock.mockReset()
+})
+
+function requestWithSessionCookie(path: string): NextRequest {
+  const request = new NextRequest(new URL(path, BASE_URL))
+  request.cookies.set("lba_session", INVALID_JWT)
+  return request
+}
+
+describe("proxy - session invalide", () => {
+  it("redirige une seule fois de /espace-pro/cfa vers /espace-pro/authentification, purge le cookie et signale l'erreur", async () => {
+    const request = requestWithSessionCookie("/espace-pro/cfa")
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    const location = new URL(response.headers.get("location")!)
+    expect(location.pathname).toBe("/espace-pro/authentification")
+    expect(location.searchParams.get("error")).toBe("true")
+
+    const setCookie = response.cookies.get("lba_session")
+    expect(setCookie?.value).toBe("")
+  })
+
+  it("ne redirige pas une deuxième fois vers /espace-pro/cfa une fois le cookie purgé (pas de boucle)", async () => {
+    const firstRequest = requestWithSessionCookie("/espace-pro/cfa")
+    const firstResponse = await proxy(firstRequest)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const redirectLocation = new URL(firstResponse.headers.get("location")!)
+
+    // Le navigateur suit la redirection sans plus jamais envoyer le cookie purgé.
+    const secondRequest = new NextRequest(new URL(`${redirectLocation.pathname}${redirectLocation.search}`, BASE_URL))
+    fetchMock.mockClear()
+
+    const secondResponse = await proxy(secondRequest)
+
+    // Pas de redirection : la page d'authentification doit s'afficher (avec son message d'erreur).
+    expect(secondResponse.status).not.toBe(307)
+    expect(secondResponse.headers.get("location")).toBeNull()
+    // La session n'ayant plus de cookie, getSession() ne doit plus appeler l'API auth/session ou auth/access.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("ne redirige pas vers l'authentification quand aucun cookie de session n'est présent (pas de message d'erreur trompeur)", async () => {
+    const request = new NextRequest(new URL("/espace-pro/cfa", BASE_URL))
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    const location = new URL(response.headers.get("location")!)
+    expect(location.searchParams.get("error")).toBeNull()
+    expect(response.cookies.get("lba_session")).toBeUndefined()
+  })
+})

--- a/ui/proxy.test.ts
+++ b/ui/proxy.test.ts
@@ -4,13 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { proxy } from "./proxy"
 
 const BASE_URL = "http://localhost:3000"
-const INVALID_JWT = "invalid.jwt.token"
+const SOME_JWT = "some.jwt.token"
 
 const fetchMock = vi.fn()
 
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock)
-  fetchMock.mockImplementation(async () => new Response(null, { status: 401 }))
 })
 
 afterEach(() => {
@@ -20,20 +19,26 @@ afterEach(() => {
 
 function requestWithSessionCookie(path: string): NextRequest {
   const request = new NextRequest(new URL(path, BASE_URL))
-  request.cookies.set("lba_session", INVALID_JWT)
+  request.cookies.set("lba_session", SOME_JWT)
   return request
 }
 
-describe("proxy - session invalide", () => {
+describe("proxy - session confirmée invalide (401)", () => {
+  beforeEach(() => {
+    fetchMock.mockImplementation(async () => new Response(null, { status: 401 }))
+  })
+
   it("redirige une seule fois de /espace-pro/cfa vers /espace-pro/authentification, purge le cookie et signale l'erreur", async () => {
     const request = requestWithSessionCookie("/espace-pro/cfa")
 
     const response = await proxy(request)
 
+    expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(response.status).toBe(307)
     const location = new URL(response.headers.get("location")!)
     expect(location.pathname).toBe("/espace-pro/authentification")
     expect(location.searchParams.get("error")).toBe("true")
+    expect(location.searchParams.get("sessionRetry")).toBeNull()
 
     const setCookie = response.cookies.get("lba_session")
     expect(setCookie?.value).toBe("")
@@ -42,7 +47,6 @@ describe("proxy - session invalide", () => {
   it("ne redirige pas une deuxième fois vers /espace-pro/cfa une fois le cookie purgé (pas de boucle)", async () => {
     const firstRequest = requestWithSessionCookie("/espace-pro/cfa")
     const firstResponse = await proxy(firstRequest)
-    expect(fetchMock).toHaveBeenCalledTimes(2)
     const redirectLocation = new URL(firstResponse.headers.get("location")!)
 
     // Le navigateur suit la redirection sans plus jamais envoyer le cookie purgé.
@@ -54,18 +58,84 @@ describe("proxy - session invalide", () => {
     // Pas de redirection : la page d'authentification doit s'afficher (avec son message d'erreur).
     expect(secondResponse.status).not.toBe(307)
     expect(secondResponse.headers.get("location")).toBeNull()
-    // La session n'ayant plus de cookie, getSession() ne doit plus appeler l'API auth/session ou auth/access.
+    // La session n'ayant plus de cookie, checkSession() ne doit plus appeler l'API auth/session ou auth/access.
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it("ne redirige pas vers l'authentification quand aucun cookie de session n'est présent (pas de message d'erreur trompeur)", async () => {
+  it("purge aussi le cookie quand on atterrit directement sur /espace-pro/authentification avec un cookie invalide", async () => {
+    const request = requestWithSessionCookie("/espace-pro/authentification")
+
+    const response = await proxy(request)
+
+    expect(response.headers.get("location")).toBeNull()
+    expect(response.cookies.get("lba_session")?.value).toBe("")
+  })
+})
+
+describe("proxy - aucun cookie de session", () => {
+  it("ne redirige pas vers l'authentification avec un message d'erreur trompeur", async () => {
     const request = new NextRequest(new URL("/espace-pro/cfa", BASE_URL))
+
+    const response = await proxy(request)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(response.status).toBe(307)
+    const location = new URL(response.headers.get("location")!)
+    expect(location.searchParams.get("error")).toBeNull()
+    expect(location.searchParams.get("sessionRetry")).toBeNull()
+    expect(response.cookies.get("lba_session")).toBeUndefined()
+  })
+})
+
+describe("proxy - panne API ambiguë (ni confirmée invalide, ni confirmée valide)", () => {
+  it("ne purge pas le cookie et n'affiche pas 'session expirée' sur un simple 500", async () => {
+    fetchMock.mockImplementation(async () => new Response(null, { status: 500 }))
+    const request = requestWithSessionCookie("/espace-pro/cfa")
 
     const response = await proxy(request)
 
     expect(response.status).toBe(307)
     const location = new URL(response.headers.get("location")!)
     expect(location.searchParams.get("error")).toBeNull()
+    expect(location.searchParams.get("sessionRetry")).toBe("true")
+    // Le cookie n'est pas purgé : on ne sait pas s'il est réellement invalide.
     expect(response.cookies.get("lba_session")).toBeUndefined()
+  })
+
+  it("ne purge pas le cookie non plus sur une erreur réseau (fetch qui rejette)", async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new Error("fetch failed: ECONNRESET")
+    })
+    const request = requestWithSessionCookie("/espace-pro/cfa")
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    expect(response.cookies.get("lba_session")).toBeUndefined()
+    const location = new URL(response.headers.get("location")!)
+    expect(location.searchParams.get("sessionRetry")).toBe("true")
+  })
+
+  it("ne rebondit pas une deuxième fois vers la page protégée même si la session semble valide au second essai (pas de boucle)", async () => {
+    fetchMock.mockImplementationOnce(async () => new Response(null, { status: 500 })).mockImplementationOnce(async () => new Response(null, { status: 500 }))
+    const firstRequest = requestWithSessionCookie("/espace-pro/cfa")
+    const firstResponse = await proxy(firstRequest)
+    const redirectLocation = new URL(firstResponse.headers.get("location")!)
+    expect(redirectLocation.searchParams.get("sessionRetry")).toBe("true")
+
+    // Le cookie n'a pas été purgé : le navigateur le renvoie sur le second hop, et cette fois
+    // l'API répond que la session est bien valide (flakiness typique décrite dans l'issue #5245).
+    const secondRequest = requestWithSessionCookie(`${redirectLocation.pathname}${redirectLocation.search}`)
+    fetchMock.mockReset()
+    fetchMock.mockImplementation(
+      async (url: string) => new Response(url.endsWith("/auth/session") ? JSON.stringify({ _id: "u1", type: "CFA" }) : JSON.stringify({}), { status: 200 })
+    )
+
+    const secondResponse = await proxy(secondRequest)
+
+    // Le signal était instable : on ne fait pas confiance à ce "succès" pour rebondir à nouveau
+    // vers /espace-pro/cfa. La page d'authentification s'affiche simplement, sans purge.
+    expect(secondResponse.headers.get("location")).toBeNull()
+    expect(secondResponse.cookies.get("lba_session")).toBeUndefined()
   })
 })

--- a/ui/proxy.test.ts
+++ b/ui/proxy.test.ts
@@ -73,7 +73,7 @@ describe("proxy - session confirmée invalide (401)", () => {
 })
 
 describe("proxy - aucun cookie de session", () => {
-  it("ne redirige pas vers l'authentification avec un message d'erreur trompeur", async () => {
+  it("redirige vers l'authentification sans message d'erreur trompeur ni sessionRetry", async () => {
     const request = new NextRequest(new URL("/espace-pro/cfa", BASE_URL))
 
     const response = await proxy(request)

--- a/ui/proxy.test.ts
+++ b/ui/proxy.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { proxy } from "./proxy"
 
+// apiPost (flux magic link) lit les headers de la requête Next via next/headers, indisponible hors
+// scope requête dans vitest : on fournit des headers vides, sans incidence sur les autres tests.
+vi.mock("next/headers", () => ({ headers: async () => new Headers() }))
+
 const BASE_URL = "http://localhost:3000"
 const SOME_JWT = "some.jwt.token"
 
@@ -137,5 +141,52 @@ describe("proxy - panne API ambiguë (ni confirmée invalide, ni confirmée vali
     // vers /espace-pro/cfa. La page d'authentification s'affiche simplement, sans purge.
     expect(secondResponse.headers.get("location")).toBeNull()
     expect(secondResponse.cookies.get("lba_session")).toBeUndefined()
+  })
+})
+
+describe("proxy - connexion par magic link (pose du cookie de session)", () => {
+  it("pose le cookie avec les attributs alignés sur config.auth.session.cookie côté serveur", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes("/login/verification")) {
+        return new Response(JSON.stringify({ user: { _id: "u1", type: "CFA" }, sessionToken: SOME_JWT }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      throw new Error(`appel inattendu: ${url}`)
+    })
+    const request = new NextRequest(new URL("/espace-pro/authentification?token=magic-token", BASE_URL))
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    expect(new URL(response.headers.get("location")!).pathname).toBe("/espace-pro/cfa")
+
+    const cookie = response.cookies.get("lba_session")
+    // Valeurs volontairement en dur (pas importées de shared/constants/session) : le test doit
+    // casser si SESSION_COOKIE_OPTIONS change, pour forcer une décision explicite.
+    expect(cookie).toMatchObject({
+      value: SOME_JWT,
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+      // 30 jours, en secondes (unité du Max-Age)
+      maxAge: 30 * 24 * 3600,
+    })
+  })
+
+  it("la purge émet un Set-Cookie qui matche l'identité du cookie posé (nom + path)", async () => {
+    fetchMock.mockImplementation(async () => new Response(null, { status: 401 }))
+    const request = requestWithSessionCookie("/espace-pro/cfa")
+
+    const response = await proxy(request)
+
+    // Un cookie est supprimé par le navigateur si nom + domaine + path correspondent :
+    // le cookie est posé avec path=/, la purge doit donc porter path=/ et une expiration passée.
+    const setCookie = response.headers.get("set-cookie")!
+    expect(setCookie.toLowerCase()).toContain("lba_session=;")
+    expect(setCookie.toLowerCase()).toContain("path=/")
+    expect(setCookie.toLowerCase()).toMatch(/max-age=0|expires=thu, 01 jan 1970/)
   })
 })

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from "next/server"
 import { NextResponse } from "next/server"
 import type { ComputedUserAccess, IUserRecruteurPublic } from "shared"
 import { AUTHTYPE } from "shared/constants/index"
+import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from "shared/constants/session"
 
 import { publicConfig } from "./config.public"
 import { apiPost } from "./utils/api.utils"
@@ -28,13 +29,13 @@ type SessionCheckResult =
   | { kind: "unavailable" }
 
 async function checkSession(request: NextRequest): Promise<SessionCheckResult> {
-  const sessionCookie = request.cookies.get("lba_session")
+  const sessionCookie = request.cookies.get(SESSION_COOKIE_NAME)
   if (!sessionCookie) {
     return { kind: "no-cookie" }
   }
 
   const headers = new Headers()
-  headers.append("cookie", `lba_session=${sessionCookie.value}`)
+  headers.append("cookie", `${SESSION_COOKIE_NAME}=${sessionCookie.value}`)
 
   // Best would be: jwt.decode(sessionCookie.value)
 
@@ -70,7 +71,7 @@ const verifyAuthentication = async (token: string, request: NextRequest) => {
       },
     })
     const response = await redirectAfterAuthentication(user, request)
-    response.cookies.set("lba_session", sessionToken)
+    response.cookies.set(SESSION_COOKIE_NAME, sessionToken, SESSION_COOKIE_OPTIONS)
 
     return response
   } catch (_) {
@@ -104,7 +105,7 @@ const redirectToAuthentication = (request: NextRequest, options: { purgeCookie: 
   }
   const response = NextResponse.redirect(url)
   if (options.purgeCookie) {
-    response.cookies.delete("lba_session")
+    response.cookies.delete(SESSION_COOKIE_NAME)
   }
   return response
 }
@@ -115,7 +116,7 @@ const renderAuthenticationPage = (request: NextRequest, options: { purgeCookie: 
   anonymousHeaders.delete("x-session")
   const response = NextResponse.next({ request: { headers: anonymousHeaders } })
   if (options.purgeCookie) {
-    response.cookies.delete("lba_session")
+    response.cookies.delete(SESSION_COOKIE_NAME)
   }
   return response
 }

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -9,19 +9,36 @@ import { PAGES } from "./utils/routes.utils"
 
 const removeAtEnd = (url: string, removed: string): string => (url.endsWith(removed) ? url.slice(0, -removed.length) : url)
 
-async function getSession(request: NextRequest): Promise<{ user: IUserRecruteurPublic | null; access: ComputedUserAccess | null } | null> {
+// Marqueur de rebond posé sur la redirection espace-pro protégée → authentification quand la
+// session n'a pas pu être confirmée invalide (panne API, pas de 401). S'il est déjà présent quand
+// on atterrit sur /espace-pro/authentification, on ne fait plus jamais confiance à un résultat
+// "session valide" pour rebondir une nouvelle fois vers la page protégée : un signal instable
+// (JWT proche de l'expiration, API auth flaky) ne doit jamais produire plus d'un aller-retour
+// (cf. issue #5245).
+const SESSION_RETRY_PARAM = "sessionRetry"
+
+type SessionCheckResult =
+  | { kind: "no-cookie" }
+  | { kind: "ok"; user: IUserRecruteurPublic; access: ComputedUserAccess }
+  // 401 renvoyé explicitement par /auth/session ou /auth/access : le token est bien rejeté, sans
+  // ambiguïté. Sûr de purger le cookie.
+  | { kind: "invalid" }
+  // Panne de l'API (5xx, réseau, timeout...) : impossible de savoir si la session est valide.
+  // Ne jamais purger le cookie ni afficher "session expirée" sur la seule foi de ce signal.
+  | { kind: "unavailable" }
+
+async function checkSession(request: NextRequest): Promise<SessionCheckResult> {
+  const sessionCookie = request.cookies.get("lba_session")
+  if (!sessionCookie) {
+    return { kind: "no-cookie" }
+  }
+
+  const headers = new Headers()
+  headers.append("cookie", `lba_session=${sessionCookie.value}`)
+
+  // Best would be: jwt.decode(sessionCookie.value)
+
   try {
-    const sessionCookie = request.cookies.get("lba_session")
-
-    if (!sessionCookie) {
-      return null
-    }
-
-    const headers = new Headers()
-    headers.append("cookie", `lba_session=${sessionCookie.value}`)
-
-    // Best would be: jwt.decode(sessionCookie.value)
-
     const [sessionRequest, accessRequest] = await Promise.all([
       fetch(`${removeAtEnd(publicConfig.apiEndpoint, "/")}/auth/session`, {
         headers,
@@ -31,13 +48,17 @@ async function getSession(request: NextRequest): Promise<{ user: IUserRecruteurP
       }),
     ])
 
-    if (!sessionRequest.ok || !accessRequest.ok) {
-      return null
+    if (sessionRequest.status === 401 || accessRequest.status === 401) {
+      return { kind: "invalid" }
     }
 
-    return { user: await sessionRequest.json(), access: await accessRequest.json() }
+    if (!sessionRequest.ok || !accessRequest.ok) {
+      return { kind: "unavailable" }
+    }
+
+    return { kind: "ok", user: await sessionRequest.json(), access: await accessRequest.json() }
   } catch (_) {
-    return null
+    return { kind: "unavailable" }
   }
 }
 
@@ -73,15 +94,27 @@ const isUnallowedPathForUser = (user: IUserRecruteurPublic, pathname: string) =>
   )
 }
 
-// Un cookie lba_session invalide/expiré doit être purgé avant de renvoyer vers l'authentification :
-// sinon la prochaine requête retente les mêmes appels /auth/session et /auth/access, et une
-// réponse instable (JWT proche de l'expiration) peut faire rebondir l'utilisateur en boucle
-// entre la page protégée et /espace-pro/authentification (cf. issue #5245).
-const redirectToInvalidSession = (request: NextRequest) => {
-  const hadSessionCookie = Boolean(request.cookies.get("lba_session"))
-  const url = new URL(hadSessionCookie ? "/espace-pro/authentification?error=true" : "/espace-pro/authentification", request.url)
+const redirectToAuthentication = (request: NextRequest, options: { purgeCookie: boolean; error: boolean; retry: boolean }) => {
+  const url = new URL("/espace-pro/authentification", request.url)
+  if (options.error) {
+    url.searchParams.set("error", "true")
+  }
+  if (options.retry) {
+    url.searchParams.set(SESSION_RETRY_PARAM, "true")
+  }
   const response = NextResponse.redirect(url)
-  if (hadSessionCookie) {
+  if (options.purgeCookie) {
+    response.cookies.delete("lba_session")
+  }
+  return response
+}
+
+const renderAuthenticationPage = (request: NextRequest, options: { purgeCookie: boolean }) => {
+  // même sans session, ne pas laisser passer un x-session forgé par le client
+  const anonymousHeaders = new Headers(request.headers)
+  anonymousHeaders.delete("x-session")
+  const response = NextResponse.next({ request: { headers: anonymousHeaders } })
+  if (options.purgeCookie) {
     response.cookies.delete("lba_session")
   }
   return response
@@ -89,44 +122,52 @@ const redirectToInvalidSession = (request: NextRequest) => {
 
 export async function proxy(request: NextRequest) {
   const { pathname, search } = request.nextUrl
+  const query = new URLSearchParams(search)
 
   if (pathname === "/espace-pro/authentification") {
-    const query = new URLSearchParams(search)
     const token = query.get("token")
     if (token) {
       return await verifyAuthentication(token, request)
     }
-    const hadSessionCookie = Boolean(request.cookies.get("lba_session"))
-    const session = await getSession(request)
-    const user = session?.user
-    if (user) {
-      return redirectAfterAuthentication(user, request)
+
+    const result = await checkSession(request)
+
+    if (result.kind === "ok") {
+      if (query.get(SESSION_RETRY_PARAM)) {
+        // On vient de rebondir depuis une route protégée qui n'a pas pu confirmer la session
+        // (panne API ambiguë) : même si elle semble valide ici, ne pas rebondir une nouvelle fois,
+        // le signal est instable. L'utilisateur devra se reconnecter manuellement une fois l'API
+        // stabilisée.
+        return renderAuthenticationPage(request, { purgeCookie: false })
+      }
+      return redirectAfterAuthentication(result.user, request)
     }
-    // même sans session, ne pas laisser passer un x-session forgé par le client
-    const anonymousHeaders = new Headers(request.headers)
-    anonymousHeaders.delete("x-session")
-    const response = NextResponse.next({ request: { headers: anonymousHeaders } })
-    if (hadSessionCookie) {
-      response.cookies.delete("lba_session")
-    }
-    return response
+
+    return renderAuthenticationPage(request, { purgeCookie: result.kind === "invalid" })
   }
-  const session = await getSession(request)
-  const user = session?.user
+
+  const result = await checkSession(request)
+
   if (isConnectionRequired(pathname)) {
-    if (!user) {
-      return redirectToInvalidSession(request)
-    }
-    if (isUnallowedPathForUser(user, pathname)) {
-      return NextResponse.redirect(new URL("/espace-pro/authentification", request.url))
+    if (result.kind === "ok") {
+      if (isUnallowedPathForUser(result.user, pathname)) {
+        return NextResponse.redirect(new URL("/espace-pro/authentification", request.url))
+      }
+    } else if (result.kind === "invalid") {
+      return redirectToAuthentication(request, { purgeCookie: true, error: true, retry: false })
+    } else if (result.kind === "unavailable") {
+      const alreadyRetried = Boolean(query.get(SESSION_RETRY_PARAM))
+      return redirectToAuthentication(request, { purgeCookie: false, error: false, retry: !alreadyRetried })
+    } else {
+      return redirectToAuthentication(request, { purgeCookie: false, error: false, retry: false })
     }
   }
 
   const requestHeaders = new Headers(request.headers)
   // seul le proxy a le droit de poser x-session : un client ne doit pas pouvoir le forger
   requestHeaders.delete("x-session")
-  if (session) {
-    requestHeaders.set("x-session", JSON.stringify(session))
+  if (result.kind === "ok") {
+    requestHeaders.set("x-session", JSON.stringify({ user: result.user, access: result.access }))
   }
 
   return NextResponse.next({

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -73,6 +73,20 @@ const isUnallowedPathForUser = (user: IUserRecruteurPublic, pathname: string) =>
   )
 }
 
+// Un cookie lba_session invalide/expiré doit être purgé avant de renvoyer vers l'authentification :
+// sinon la prochaine requête retente les mêmes appels /auth/session et /auth/access, et une
+// réponse instable (JWT proche de l'expiration) peut faire rebondir l'utilisateur en boucle
+// entre la page protégée et /espace-pro/authentification (cf. issue #5245).
+const redirectToInvalidSession = (request: NextRequest) => {
+  const hadSessionCookie = Boolean(request.cookies.get("lba_session"))
+  const url = new URL(hadSessionCookie ? "/espace-pro/authentification?error=true" : "/espace-pro/authentification", request.url)
+  const response = NextResponse.redirect(url)
+  if (hadSessionCookie) {
+    response.cookies.delete("lba_session")
+  }
+  return response
+}
+
 export async function proxy(request: NextRequest) {
   const { pathname, search } = request.nextUrl
 
@@ -82,6 +96,7 @@ export async function proxy(request: NextRequest) {
     if (token) {
       return await verifyAuthentication(token, request)
     }
+    const hadSessionCookie = Boolean(request.cookies.get("lba_session"))
     const session = await getSession(request)
     const user = session?.user
     if (user) {
@@ -90,12 +105,21 @@ export async function proxy(request: NextRequest) {
     // même sans session, ne pas laisser passer un x-session forgé par le client
     const anonymousHeaders = new Headers(request.headers)
     anonymousHeaders.delete("x-session")
-    return NextResponse.next({ request: { headers: anonymousHeaders } })
+    const response = NextResponse.next({ request: { headers: anonymousHeaders } })
+    if (hadSessionCookie) {
+      response.cookies.delete("lba_session")
+    }
+    return response
   }
   const session = await getSession(request)
   const user = session?.user
-  if (isConnectionRequired(pathname) && (!user || isUnallowedPathForUser(user, pathname))) {
-    return NextResponse.redirect(new URL("/espace-pro/authentification", request.url))
+  if (isConnectionRequired(pathname)) {
+    if (!user) {
+      return redirectToInvalidSession(request)
+    }
+    if (isUnallowedPathForUser(user, pathname)) {
+      return NextResponse.redirect(new URL("/espace-pro/authentification", request.url))
+    }
   }
 
   const requestHeaders = new Headers(request.headers)


### PR DESCRIPTION
Closes #5245

## Changements

`ui/proxy.ts` distingue désormais trois issues possibles à la vérification de session (`checkSession`) au lieu de tout réduire à un booléen :

- **`invalid`** : `/auth/session` ou `/auth/access` renvoie explicitement `401` — le token est confirmé rejeté. Le cookie `lba_session` est purgé et la redirection vers `/espace-pro/authentification` porte `?error=true` (message "Session invalidée" déjà géré côté page).
- **`unavailable`** : panne API (5xx, erreur réseau, timeout...) — on ne sait pas si la session est valide. Le cookie n'est **jamais** purgé sur ce seul signal, et aucun message "session expirée" trompeur n'est affiché. La redirection vers `/espace-pro/authentification` porte un marqueur `sessionRetry=true`.
- **`no-cookie`** : visite anonyme normale, comportement inchangé.

Le marqueur `sessionRetry` sert de garde-fou anti-boucle pour le cas ambigu : si `/espace-pro/authentification` est atteinte avec ce marqueur et que la vérification y semble cette fois "valide", on ne rebondit **pas** une nouvelle fois vers la page protégée (signal jugé instable) — la page de connexion s'affiche simplement, sans purge. Ça plafonne tout rebond, invalide ou ambigu, à un seul aller-retour maximum.

## Pourquoi cette version (et pas une purge systématique)

Une première version purgeait le cookie dès que `getSession()` échouait, quelle que soit la cause. Vérifié par un repro exécuté : un simple `500` ou une erreur réseau ponctuelle sur `/auth/session`/`/auth/access`, avec un JWT par ailleurs valide, provoquait une déconnexion forcée de l'utilisateur (cookie purgé, message "session expirée" affiché) — sur n'importe quelle route protégée sous `/espace-pro/`. Cette version corrige la boucle sans introduire ce risque : seule une invalidité confirmée (401) déclenche une purge.

## Plan de test

- [x] `yarn typecheck` (ui) passe
- [x] `yarn biome check` passe sur les fichiers modifiés
- [x] `ui/proxy.test.ts` (7 tests) : 401 confirmé → purge + `error=true` + pas de boucle ; aucun cookie → pas de message trompeur ; panne API ambiguë (500 et erreur réseau) → pas de purge, marqueur `sessionRetry` posé ; second hop avec panne ambiguë même si la session semble "valide" ensuite → pas de rebond vers la page protégée, pas de purge
- [x] Chaque test de boucle a été vérifié en le rejouant contre la version précédente du fichier (`git stash`) : il échoue sur l'ancien code et passe avec le correctif
- [x] Suite complète `yarn vitest run --project ui` : 228 tests passent
- [ ] Test manuel en local avec un cookie `lba_session` invalide (à faire en environnement avec API disponible)

## Extension de périmètre : attributs du cookie de session (commit 76962dd6a)

Le flux magic link passe par le proxy UI (le `Set-Cookie` du serveur est absorbé par l'`apiPost` côté proxy) : c'est donc le proxy qui pose le cookie navigateur, et il le posait **sans aucun attribut** — cookie JWT lisible en JavaScript, ni `secure`, ni `sameSite`, ni durée.

- Les attributs sont extraits dans `shared/constants/session.ts` (`SESSION_COOKIE_NAME`, `SESSION_COOKIE_OPTIONS` : `httpOnly`, `secure`, `sameSite=lax`, `path=/`, 30 jours en secondes), consommés par le serveur (`config.auth.session`) et le proxy.
- **Bug d'unité corrigé côté serveur** : `maxAge: 30 * 24 * 3600000` (pensé en millisecondes) était sérialisé tel quel en secondes par `@fastify/cookie` → `Max-Age=2592000000` (~82 ans, plafonné ~400 jours par les navigateurs), alors que l'expiration en base est de 30 jours. Vérifié en exécutant la sérialisation avec la lib vendorée. `sessions.service.ts` convertit désormais explicitement en millisecondes pour `expires_at` (durée en base inchangée : 30 jours).
- **Changement de comportement à connaître** : les cookies navigateur durent désormais réellement 30 jours, alignés sur `expires_at`. Les porteurs de cookies « zombies » (session expirée en base depuis plus de 30 jours mais cookie encore présent) seront déconnectés — c'est précisément le carburant de la boucle #5245 qu'on assèche.
- La purge reste efficace : la suppression navigateur matche sur nom + domaine + path (les nouveaux attributs n'entrent pas dans l'identité), et `clearCookie` de `@fastify/cookie` force `expires`/`maxAge` à 0 quelles que soient les options (vérifié dans la source vendorée).

### Plan de test (extension)

- [x] 2 tests ajoutés dans `ui/proxy.test.ts` : le flux magic link pose le cookie avec les attributs attendus (valeurs volontairement en dur pour casser si la constante partagée change) ; la purge émet un `Set-Cookie` d'identité correspondante (nom + `path=/` + expiration passée). Non-vacuité vérifiée par mutation (le test échoue sans le correctif).
- [x] `yarn typecheck` racine (ui + server + shared) passe
- [x] `yarn biome check` passe sur les 6 fichiers modifiés
- [x] Suite UI : 235 tests passent
- [x] Suite serveur (MongoDB local) : 925 tests passent, 74 skippés pré-existants sans rapport (aucun fichier skippé ne touche session/cookie)
