### PR TITLE
feat: ajout du badge Google « sources préférées » dans le footer

### DIFF
--- a/ui/app/_components/Footer.tsx
+++ b/ui/app/_components/Footer.tsx
@@ -256,7 +256,7 @@ export function Footer({ isWidget = false }: { isWidget?: boolean }) {
                 href={GOOGLE_PREFERRED_SOURCE_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                title="Ajouter La bonne alternance à vos sources préférées sur Google - nouvelle fenêtre"
+                aria-label="Ajouter La bonne alternance à vos sources préférées sur Google - nouvelle fenêtre"
               >
                 Ajouter à vos sources préférées sur Google
               </a>

--- a/ui/app/_components/Footer.tsx
+++ b/ui/app/_components/Footer.tsx
@@ -6,6 +6,11 @@ import { publicConfig } from "@/config.public"
 import { PAGES } from "@/utils/routes.utils"
 import { DsfrHeaderProps } from "./Header"
 
+// Deeplink officiel Google "sources préférées" (sans script tiers) :
+// https://developers.google.com/search/docs/appearance/preferred-sources
+// Le domaine de production est utilisé quel que soit l'environnement, car c'est lui qui est référencé par Google.
+const GOOGLE_PREFERRED_SOURCE_URL = "https://www.google.com/preferences/source?q=labonnealternance.apprentissage.beta.gouv.fr"
+
 type LinkItem = {
   linkProps: {
     href: string
@@ -245,6 +250,17 @@ export function Footer({ isWidget = false }: { isWidget?: boolean }) {
                 </a>
               </li>
             </ul>
+            {!isWidget && (
+              <a
+                className="fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-google-fill fr-mt-2w"
+                href={GOOGLE_PREFERRED_SOURCE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Ajouter La bonne alternance à vos sources préférées sur Google - nouvelle fenêtre"
+              >
+                Ajouter à vos sources préférées sur Google
+              </a>
+            )}
           </div>
         </div>
         <div className="fr-footer__bottom">


### PR DESCRIPTION
Closes #5262

## Changements

- Ajout d'un bouton DSFR « Ajouter à vos sources préférées sur Google » dans le footer commun du site (`ui/app/_components/Footer.tsx`)
- Implémentation via le deeplink officiel Google (sans script tiers : pas d'impact CSP ni RGPD), avec le domaine de production en dur car c'est le seul référencé par Google
- Bouton masqué dans la version widget du footer (intégrations partenaires)

## Plan de test

- [ ] Le bouton s'affiche dans le footer sur les pages du site (home, page éditoriale, fiche offre)
- [ ] Le clic ouvre dans un nouvel onglet la page Google « Ajouter cette source » pré-remplie avec labonnealternance.apprentissage.beta.gouv.fr
- [ ] Le bouton n'apparaît pas dans le footer du widget (`/test-widget`)
- [ ] Aucune requête vers un domaine Google au chargement de la page (onglet réseau)