### PR TITLE
feat: données structurées schema.org organisation et fiches formation

### DIFF
--- a/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
+++ b/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
@@ -4,6 +4,7 @@ import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
 import { WidgetAwareHeader } from "@/app/_components/WidgetAwareHeader"
 import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
+import { TrainingSchema } from "@/components/ItemDetail/TrainingSchema"
 import { ApiError, apiGet } from "@/utils/api.utils"
 import TrainingDetailRendererClient from "./TrainingDetailRendererClient"
 
@@ -46,6 +47,8 @@ export default async function FormationPage({ params, searchParams }: { params: 
 
   return (
     <>
+      {/* Rendu dans le server component pour que le JSON-LD soit présent dans le HTML initial, visible des crawlers sans JavaScript. */}
+      <TrainingSchema formation={formation} id={idParam} />
       <SkipLinks
         links={[
           { label: "En-tête", anchor: "#detail-header" },

--- a/ui/app/(home)/page.tsx
+++ b/ui/app/(home)/page.tsx
@@ -29,6 +29,16 @@ export default function HomePage() {
         url={PAGES.static.home.getPath()}
         breadcrumbs={[{ name: PAGES.static.home.title, url: PAGES.static.home.getPath() }]}
       />
+      {/* Nœuds site + organisation (émis uniquement sur la home) : c'est par eux que les
+          moteurs et les IA identifient l'entité « La bonne alternance ». */}
+      <SchemaOrg
+        type="WebSite"
+        title={METADATA.static.home().title}
+        description={METADATA.static.home().description}
+        url={PAGES.static.home.getPath()}
+        breadcrumbs={[]}
+        omitBreadcrumb
+      />
       <Container
         component="main"
         sx={{

--- a/ui/components/ItemDetail/TrainingSchema.tsx
+++ b/ui/components/ItemDetail/TrainingSchema.tsx
@@ -101,8 +101,13 @@ const buildProvider = (formation: ILbaItemFormation2Json) => {
 
 // Pour les formations, la rue est portée par `place.address` (cf. transformFormationV2,
 // server/src/services/formation.service.ts) — `numberAndStreet` n'y est jamais renseigné.
+// `place.address` y est construit par interpolation de template (`${...}`) : quand la donnée
+// source est absente, on récupère la chaîne littérale "undefined", jamais `null`/`undefined`
+// lui-même — il faut donc l'exclure explicitement en plus du test de falsy.
+const isUsableStreet = (value?: string | null): value is string => Boolean(value) && value !== "undefined"
+
 const buildAddress = (place: { address?: string | null; numberAndStreet?: string | null; city?: string | null; zipCode?: string | null }) => {
-  const street = place.address || place.numberAndStreet
+  const street = [place.address, place.numberAndStreet].find(isUsableStreet)
   return {
     "@type": "PostalAddress",
     ...(street ? { streetAddress: street } : {}),

--- a/ui/components/ItemDetail/TrainingSchema.tsx
+++ b/ui/components/ItemDetail/TrainingSchema.tsx
@@ -1,0 +1,113 @@
+// documentation :
+// Course (seul type avec résultat enrichi Google) : https://schema.org/Course et https://developers.google.com/search/docs/appearance/structured-data/course-info
+// EducationalOccupationalProgram (compréhension par les moteurs et les IA) : https://schema.org/EducationalOccupationalProgram
+
+import type { ILbaItemFormation2Json, ILbaItemRome } from "shared"
+import { buildTrainingUrl } from "shared/metier/lbaitemutils"
+import { JsonLdScript } from "@/components/JsonLdScript"
+import { publicConfig } from "@/config.public"
+
+type TrainingSchemaProps = {
+  formation: ILbaItemFormation2Json
+  /** Identifiant de la formation, déjà décodé (clé ministère éducatif). */
+  id: string
+}
+
+export const TrainingSchema = ({ formation, id }: TrainingSchemaProps) => {
+  const schemas = buildTrainingSchemas(formation, id)
+  if (schemas.length === 0) {
+    return null
+  }
+  return <JsonLdScript id="training-schema" schema={schemas} />
+}
+
+// Règle : tout champ sans donnée fiable est omis, jamais rempli avec une valeur inventée ou figée.
+const buildTrainingSchemas = (formation: ILbaItemFormation2Json, id: string): object[] => {
+  const title = formation.training?.title
+  if (!title) {
+    return []
+  }
+
+  const url = `${publicConfig.baseUrl}${buildTrainingUrl(id, title)}`
+  const courseId = `${url}#course`
+  const description = formation.training?.description || formation.training?.objectif || null
+  const credential = formation.training?.rncpLabel || formation.training?.diploma || null
+  const provider = buildProvider(formation)
+  // `Jsonify` dégrade le type des éléments de `romes` en JsonValue : on restaure le type source,
+  // structurellement identique après sérialisation (uniquement des strings nullables).
+  const romes = (formation.training?.romes ?? []) as ILbaItemRome[]
+  const occupationalCategories = romes.filter((rome) => rome.code).map((rome) => (rome.label ? `${rome.code} - ${rome.label}` : (rome.code as string)))
+
+  const course = {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    "@id": courseId,
+    name: title,
+    url,
+    ...(description ? { description } : {}),
+    ...(provider ? { provider } : {}),
+    ...(credential ? { educationalCredentialAwarded: credential } : {}),
+    // Champ requis du résultat enrichi Google : la formation en alternance est gratuite
+    // pour l'alternant (financement OPCO / employeur).
+    offers: {
+      "@type": "Offer",
+      category: "Free",
+    },
+    hasCourseInstance: {
+      "@type": "CourseInstance",
+      // L'alternance combine formation en centre et travail en entreprise.
+      courseMode: "Blended",
+      ...(formation.place?.city
+        ? {
+            location: {
+              "@type": "Place",
+              address: buildAddress(formation.place),
+            },
+          }
+        : {}),
+    },
+    inLanguage: "fr",
+  }
+
+  const program = {
+    "@context": "https://schema.org",
+    "@type": "EducationalOccupationalProgram",
+    name: title,
+    url,
+    programType: "apprenticeship",
+    ...(description ? { description } : {}),
+    ...(provider ? { provider } : {}),
+    ...(credential ? { educationalCredentialAwarded: credential } : {}),
+    ...(occupationalCategories.length > 0 ? { occupationalCategory: occupationalCategories } : {}),
+    hasCourse: { "@id": courseId },
+    inLanguage: "fr",
+  }
+
+  return [course, program]
+}
+
+const buildProvider = (formation: ILbaItemFormation2Json) => {
+  const name = formation.company?.name
+  if (!name) {
+    return null
+  }
+  const place = formation.company?.place
+  return {
+    "@type": "EducationalOrganization",
+    name,
+    ...(place?.city ? { address: buildAddress(place) } : {}),
+  }
+}
+
+// Pour les formations, la rue est portée par `place.address` (cf. transformFormationV2,
+// server/src/services/formation.service.ts) — `numberAndStreet` n'y est jamais renseigné.
+const buildAddress = (place: { address?: string | null; numberAndStreet?: string | null; city?: string | null; zipCode?: string | null }) => {
+  const street = place.address || place.numberAndStreet
+  return {
+    "@type": "PostalAddress",
+    ...(street ? { streetAddress: street } : {}),
+    ...(place.city ? { addressLocality: place.city } : {}),
+    ...(place.zipCode ? { postalCode: place.zipCode } : {}),
+    addressCountry: "France",
+  }
+}

--- a/ui/components/JsonLdScript.tsx
+++ b/ui/components/JsonLdScript.tsx
@@ -1,0 +1,17 @@
+type JsonLdScriptProps = {
+  schema: object | object[]
+  id?: string
+}
+
+/**
+ * Émetteur unique de JSON-LD : centralise l'échappement pour que tous les schémas du site
+ * partagent la même protection.
+ */
+export const JsonLdScript = ({ schema, id }: JsonLdScriptProps) => (
+  <script
+    type="application/ld+json"
+    {...(id ? { id } : {})}
+    // On échappe le caractère inférieur en séquence unicode pour qu'un libellé contenant une balise fermante de script ne puisse pas casser le script (XSS script-breakout).
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(schema).replace(/</g, "\\u003c") }}
+  />
+)

--- a/ui/components/SchemaOrg.tsx
+++ b/ui/components/SchemaOrg.tsx
@@ -1,4 +1,8 @@
+import { JsonLdScript } from "@/components/JsonLdScript"
+import { publicConfig } from "@/config.public"
+
 const BASE_URL = "https://labonnealternance.apprentissage.beta.gouv.fr"
+const ORGANIZATION_ID = `${BASE_URL}/#organization`
 
 type BreadcrumbItem = {
   name: string
@@ -60,6 +64,33 @@ export const SchemaOrg = ({
   }
 
   if (type === "WebSite") {
+    // Nœud organisation autonome décrivant l'entité « La bonne alternance » elle-même :
+    // c'est lui que les knowledge graphs des moteurs et les IA utilisent pour identifier le service.
+    // `sameAs` ne référence que des pages officielles vérifiées de l'entité.
+    schemas.push({
+      "@context": "https://schema.org",
+      "@type": "GovernmentOrganization",
+      "@id": ORGANIZATION_ID,
+      name: "La bonne alternance",
+      url: BASE_URL,
+      description,
+      logo: {
+        "@type": "ImageObject",
+        url: `${BASE_URL}/images/logo_LBA.svg`,
+      },
+      contactPoint: {
+        "@type": "ContactPoint",
+        email: publicConfig.publicEmail,
+        contactType: "customer support",
+        availableLanguage: "fr",
+      },
+      parentOrganization: {
+        "@type": "GovernmentOrganization",
+        name: "Délégation générale à l'emploi et à la formation professionnelle (DGEFP)",
+        url: "https://travail-emploi.gouv.fr",
+      },
+      sameAs: ["https://beta.gouv.fr/startups/la-bonne-alternance.html", "https://github.com/mission-apprentissage/labonnealternance"],
+    })
     schemas.push({
       "@context": "https://schema.org",
       "@type": "WebSite",
@@ -67,9 +98,7 @@ export const SchemaOrg = ({
       url: BASE_URL,
       description,
       publisher: {
-        "@type": "GovernmentOrganization",
-        name: "Délégation générale à l'emploi et à la formation professionnelle (DGEFP)",
-        url: "https://travail-emploi.gouv.fr",
+        "@id": ORGANIZATION_ID,
       },
       potentialAction: {
         "@type": "SearchAction",
@@ -213,8 +242,7 @@ export const SchemaOrg = ({
   return (
     <>
       {schemas.map((schema, index) => (
-        // On échappe le caractère inférieur en séquence unicode pour qu'un libellé contenant une balise fermante de script ne puisse pas casser le script (XSS script-breakout).
-        <script key={index} type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema).replace(/</g, "\\u003c") }} />
+        <JsonLdScript key={index} schema={schema} />
       ))}
     </>
   )


### PR DESCRIPTION
Closes #5265

## Changements

- `ui/components/SchemaOrg.tsx` : nœud `GovernmentOrganization` autonome décrivant l'entité « La bonne alternance » (`@id`, logo, contact public, rattachement DGEFP, `sameAs` vers la fiche beta.gouv et le dépôt GitHub — uniquement des pages officielles vérifiées), référencé comme `publisher` du schéma `WebSite`, rendu sur la home
- Nouveau composant `ui/components/ItemDetail/TrainingSchema.tsx` (même pattern que `JobPostingSchema`, échappement anti script-breakout inclus) : JSON-LD `Course` + `EducationalOccupationalProgram` sur les fiches formation, avec CFA en `provider`, codes ROME en `occupationalCategory`, diplôme/RNCP en `educationalCredentialAwarded`
- Rendu dans le server component `page.tsx` de la fiche formation → présent dans le HTML initial, visible des crawlers sans JavaScript
- Tout champ sans donnée fiable est omis, jamais rempli avec une valeur inventée

## Plan de test

- [ ] `curl` sur la home → nœuds JSON-LD `GovernmentOrganization` + `WebSite` (publisher pointant l'`@id` de l'organisation)
- [ ] `curl` sur une fiche formation → JSON-LD `Course` + `EducationalOccupationalProgram` dans le HTML SSR
- [ ] Validation sans erreur sur https://validator.schema.org
- [ ] Fiche formation sans description/diplôme → les champs correspondants sont absents du JSON-LD (pas de valeur vide)