### PR TITLE
feat: ajout des balises canonical sur les pages détail offre et formation

### DIFF
--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
@@ -4,6 +4,7 @@ import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
 import type { ILbaItemLbaCompanyJson, /*ILbaItemLbaJobJson, */ ILbaItemPartnerJobJson } from "shared"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import { buildJobUrlPath } from "shared/metier/lbaitemutils"
 import { WidgetAwareHeader } from "@/app/_components/WidgetAwareHeader"
 import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import InfoBanner from "@/components/InfoBanner/InfoBanner"
@@ -26,8 +27,24 @@ export async function generateMetadata({ params }): Promise<Metadata> {
       title = `Offre d'emploi ${job?.title}`
       break
   }
+  // `id` arrive percent-encodé dans params et buildJobUrlPath ré-encode : on décode d'abord
+  // pour éviter un double encodage. Repli sur l'id brut si le segment n'est pas décodable
+  // (ex : `%` isolé) plutôt que de faire échouer generateMetadata sur une URIError.
+  let decodedId: string
+  try {
+    decodedId = decodeURIComponent(id)
+  } catch {
+    decodedId = id
+  }
+
   return {
     title: `${title} - La bonne alternance`,
+    alternates: {
+      // URL canonique sans query params : une même offre accessible avec des paramètres de recherche
+      // ou de tracking différents ne doit compter que comme une seule page pour les moteurs.
+      // Relative, résolue en absolu par le metadataBase du layout racine (convention du codebase).
+      canonical: buildJobUrlPath(type, decodedId, job.title || undefined),
+    },
   }
 }
 

--- a/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
+++ b/ui/app/(candidat)/formation/[id]/[intitule-formation]/page.tsx
@@ -2,6 +2,7 @@ import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import type { Metadata } from "next"
 import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
+import { buildTrainingUrl } from "shared/metier/lbaitemutils"
 import { WidgetAwareHeader } from "@/app/_components/WidgetAwareHeader"
 import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import { ApiError, apiGet } from "@/utils/api.utils"
@@ -33,8 +34,22 @@ export async function generateMetadata({ params }): Promise<Metadata> {
 
   if (!formation) return { title: "Offre de formation introuvable" }
 
+  // `training`/`title` sont nullish dans le schéma partagé et toKebabCase(null) throw :
+  // sans titre, on omet la canonical plutôt que de faire échouer generateMetadata.
+  const trainingTitle = formation?.training?.title
+
   return {
-    title: `Formation de ${formation?.training?.title} - La bonne alternance`,
+    title: trainingTitle ? `Formation de ${trainingTitle} - La bonne alternance` : "Formation en alternance - La bonne alternance",
+    ...(trainingTitle
+      ? {
+          alternates: {
+            // URL canonique sans query params : une même formation accessible avec des paramètres de recherche
+            // ou de tracking différents ne doit compter que comme une seule page pour les moteurs.
+            // Relative, résolue en absolu par le metadataBase du layout racine (convention du codebase).
+            canonical: buildTrainingUrl(idParam, trainingTitle),
+          },
+        }
+      : {}),
   }
 }
 


### PR DESCRIPTION
Closes #5264

## Changements

- Ajout de `alternates.canonical` dans le `generateMetadata` de la page détail offre (`/emploi/[type]/[id]/[intitule-offre]`), URL relative construite avec `buildJobUrlPath` (shared), résolue en absolu par le `metadataBase` du layout racine (convention du codebase), avec décodage préalable de l'id pour éviter un double encodage
- Idem sur la page détail formation (`/formation/[id]/[intitule-formation]`) avec `buildTrainingUrl`, en omettant la canonical quand le titre de formation est absent (évite un crash de `generateMetadata`)
- Les query params (paramètres de recherche, tracking) ne figurent jamais dans l'URL canonique

## Plan de test

- [ ] `curl` sur une fiche offre → balise canonical présente dans le HTML SSR, sans query params
- [ ] `curl` sur une fiche formation → idem
- [ ] Le slug de la canonical correspond à celui des liens internes (kebab-case)
- [ ] Cas candidature spontanée (`recruteurs_lba`) : la canonical reprend le siret comme identifiant, comme les liens internes

_Remplace la PR 5269, fermée automatiquement lors d'une réinitialisation de branche._