### PR TITLE
fix: 500 sur /api/etablissement/cfas-proches et regroupement sentry des erreurs 500 (#5307)

### DIFF
--- a/server/src/services/formulaire.service.ts
+++ b/server/src/services/formulaire.service.ts
@@ -557,13 +557,13 @@ const getRecruiterFromJobsPartnerFilter = async ({
     getDbCollection("userswithaccounts").findOne({ _id: userId }),
   ])
   if (!mainRole) {
-    throw internal(`inattendu: mainRole vide pour userId=${userId}, siret=${siret}`)
+    throw internal("inattendu: mainRole vide", { userId: userId.toString(), siret })
   }
   if (!entreprise) {
-    throw internal(`inattendu: entreprise vide pour userId=${userId}, siret=${siret}`)
+    throw internal("inattendu: entreprise vide", { userId: userId.toString(), siret })
   }
   if (!user) {
-    throw internal(`inattendu: user vide pour userId=${userId}, siret=${siret}`)
+    throw internal("inattendu: user vide", { userId: userId.toString(), siret })
   }
   let cfa: ICFA | null = null
   if (mainRole.authorized_type === AccessEntityType.CFA) {

--- a/server/src/services/role-management.service.ts
+++ b/server/src/services/role-management.service.ts
@@ -123,15 +123,15 @@ export const getPublicUserRecruteurProps = async (
 ): Promise<Pick<IUserRecruteurPublic, "type" | "establishment_id" | "establishment_siret" | "scope" | "status_current"> | { error: string }> => {
   const mainRole = await getMainRoleManagement(userId, includeUserAwaitingValidation)
   if (!mainRole) {
-    return { error: `inattendu : aucun role trouvé pour user id=${userId}` }
+    return { error: "inattendu : aucun role trouvé pour l'utilisateur" }
   }
   const type = roleToUserType(mainRole)
   if (!type) {
-    return { error: `inattendu : aucun type trouvé pour user id=${userId}` }
+    return { error: "inattendu : aucun type trouvé pour l'utilisateur" }
   }
   const status_current = roleToStatus(mainRole)
   if (!status_current) {
-    return { error: `inattendu : aucun status trouvé pour user id=${userId}` }
+    return { error: "inattendu : aucun status trouvé pour l'utilisateur" }
   }
   const commonFields = {
     type,
@@ -166,7 +166,9 @@ export const getPublicUserRecruteurPropsOrError = async (
 ): Promise<Pick<IUserRecruteurPublic, "type" | "establishment_id" | "establishment_siret" | "scope" | "status_current">> => {
   const result = await getPublicUserRecruteurProps(userId, includeUserAwaitingValidation)
   if ("error" in result) {
-    throw internal(result.error)
+    // userId hors du message : interpolé, il crée une issue Sentry par utilisateur et casse le
+    // regroupement (6 issues pour 2 bugs, cf. LBA-SERVER-5J7KF4ZZZTAFH / -TAHJ / -TAN3).
+    throw internal(result.error, { userId: userId.toString() })
   }
   return result
 }

--- a/shared/src/interface/etablissement.types.test.ts
+++ b/shared/src/interface/etablissement.types.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import { ZEtablissementCatalogueProcheWithDistance } from "./etablissement.types.js"
+
+// Schéma de réponse de GET /api/etablissement/cfas-proches. Un z.string() strict sur
+// entreprise_raison_sociale faisait échouer la sérialisation Fastify en production dès qu'un CFA
+// remontait une raison sociale nulle (Sentry LBA-SERVER-5J7KF4ZZZTAKP, 500 sur le parcours de
+// création d'offre).
+describe("ZEtablissementCatalogueProcheWithDistance", () => {
+  const etablissement = {
+    _id: "5e8df8e720ff3b2161269f7a",
+    siret: "13002526500013",
+    numero_voie: "12",
+    type_voie: "RUE",
+    nom_voie: "DE LA PAIX",
+    code_postal: "75002",
+    nom_departement: "Paris",
+    localite: "PARIS",
+    entreprise_raison_sociale: "CFA DE LA PAIX",
+    geo_coordonnees: "48.868,2.331",
+    distance_en_km: 3.2,
+  }
+
+  it("accepte une raison sociale renseignée", () => {
+    expect(ZEtablissementCatalogueProcheWithDistance.parse(etablissement).entreprise_raison_sociale).toBe("CFA DE LA PAIX")
+  })
+
+  it("accepte une raison sociale nulle", () => {
+    expect(ZEtablissementCatalogueProcheWithDistance.parse({ ...etablissement, entreprise_raison_sociale: null }).entreprise_raison_sociale).toBeNull()
+  })
+
+  it("refuse une raison sociale absente", () => {
+    const { entreprise_raison_sociale: _absent, ...sansRaisonSociale } = etablissement
+    expect(ZEtablissementCatalogueProcheWithDistance.safeParse(sansRaisonSociale).success).toBe(false)
+  })
+
+  it("refuse une raison sociale d'un autre type", () => {
+    expect(ZEtablissementCatalogueProcheWithDistance.safeParse({ ...etablissement, entreprise_raison_sociale: 42 }).success).toBe(false)
+  })
+})

--- a/shared/src/interface/etablissement.types.ts
+++ b/shared/src/interface/etablissement.types.ts
@@ -44,7 +44,10 @@ export const ZEtablissementCatalogue = z.strictObject({
   entreprise_procedure_collective: z.boolean(),
   entreprise_enseigne: z.null(),
   entreprise_numero_tva_intracommunautaire: z.null(),
-  entreprise_raison_sociale: z.string(),
+  // Nullable côté catalogue : la donnée remonte à null pour certains OF (constaté en production sur
+  // /api/etablissement/cfas-proches, Sentry LBA-SERVER-5J7KF4ZZZTAKP). Le schéma sert aussi de
+  // schéma de réponse de cette route, un z.string() strict la faisait échouer en sérialisation.
+  entreprise_raison_sociale: z.string().nullable(),
   entreprise_nom_commercial: z.null(),
   entreprise_date_creation: z.date(),
   entreprise_date_radiation: z.date(),


### PR DESCRIPTION
Rattaché à #5307 (1/3). Issue Sentry principale : `LBA-SERVER-5J7KF4ZZZTAKP`.

## Changements

**`GET /api/etablissement/cfas-proches` renvoyait 500**

`ZEtablissementCatalogue.entreprise_raison_sociale` était déclaré `z.string()` alors que la donnée du catalogue remonte à `null` pour certains OF. Comme ce schéma sert aussi de schéma de réponse à la route, la sérialisation Fastify échouait (`FST_ERR_RESPONSE_SERIALIZATION`) dès qu'un CFA proche avait une raison sociale vide — 18 events le 27/08, apparus avec `1.894.0`, tous avec `/espace-pro/entreprise/creation-offre` en referer.

Passage en `z.string().nullable()`. Le seul consommateur UI (`MiseEnRelation.tsx`) rend la valeur comme enfant React, `null` y est déjà valide.

**Regroupement Sentry des erreurs 500 serveur**

`inattendu : aucun role trouvé pour user id=<oid>` et `inattendu: entreprise vide pour userId=<oid>, siret=<siret>` interpolaient l'identifiant dans le message : Sentry créait une issue par usager (6 issues distinctes pour 2 bugs — `LBA-SERVER-5J7KF4ZZZTAFH`, `-TAHJ`, `-TAN3`, `-TAFJ`, `-TAHX`).

Message rendu stable, identifiants déplacés dans le `data` du Boom — `extraErrorDataIntegration` les remonte dans le contexte de l'event.

Périmètre volontairement limité aux deux familles observées dans Sentry sur la fenêtre analysée. Le fichier `formulaire.service.ts` contient d'autres messages interpolés (lignes 125, 389, 455, 458, 466, 506, 510) qui n'ont produit aucun event sur les 7 derniers jours : pas touchés.

## Ce que ça ne corrige pas

Le 500 lui-même sur `POST /api/etablissement/validation` reste : un usager qui valide son email sans `roleManagement` associé tombe toujours en erreur, après que la session ait déjà démarré. Décider quoi renvoyer dans ce cas est un arbitrage produit, hors périmètre de ce correctif.

## Plan de test

- [x] `yarn typecheck --force` — exit 0, aucun consommateur TS cassé par le passage en nullable
- [x] Nouveau test `shared/src/interface/etablissement.types.test.ts` — 4 cas dont le near-miss (raison sociale absente, raison sociale d'un autre type)
- [x] Test non vacuous : bug réintroduit → `accepte une raison sociale nulle` échoue, restauré → 4/4 passent
- [x] `formulaire.service.test.ts` 23/23, `login.controller.test.ts` + `etablissement-recruteur.controller.test.ts` 23/23, suite `shared` 126/126
- [ ] Après déploiement : vérifier que `LBA-SERVER-5J7KF4ZZZTAKP` ne reçoit plus d'event et que le parcours création d'offre passe sur un ROME dont un CFA proche a une raison sociale nulle