### PR TITLE
fix: assainit les erreurs brevo remontées à sentry et rattrape le rejet des webhooks (#5307)

### DIFF
--- a/server/src/services/brevo.service.test.ts
+++ b/server/src/services/brevo.service.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const importContacts = vi.fn()
+
+vi.mock("@getbrevo/brevo", () => {
+  class ContactsApi {
+    setApiKey() {
+      // le SDK est entièrement mocké : la clé n'est jamais utilisée
+    }
+    importContacts = importContacts
+  }
+  class WebhooksApi {
+    setApiKey() {
+      // le SDK est entièrement mocké : la clé n'est jamais utilisée
+    }
+    createWebhook = createWebhook
+  }
+  class RequestContactImport {
+    fileBody?: string
+    listIds?: number[]
+    updateExistingContacts?: boolean
+    emptyContactsAttributes?: boolean
+  }
+  return {
+    default: { ContactsApi, WebhooksApi, RequestContactImport, ContactsApiApiKeys: { apiKey: "apiKey" }, WebhooksApiApiKeys: { apiKey: "apiKey" } },
+    CreateWebhook: { TypeEnum: { Transactional: "transactional", Marketing: "marketing" }, EventsEnum: {} },
+  }
+})
+
+const createWebhook = vi.fn()
+const loggerError = vi.fn()
+
+vi.mock("@/common/logger", async (importOriginal) => {
+  const mod = await importOriginal<{ logger: Record<string, unknown> }>()
+  return { ...mod, logger: { ...mod.logger, error: loggerError, warn: vi.fn(), info: vi.fn() } }
+})
+
+vi.mock("@/config", async (importOriginal) => {
+  const mod = await importOriginal<{ default: Record<string, unknown> }>()
+  // initBrevoWebhooks sort immédiatement hors production : il faut ce mock pour couvrir le handler.
+  return { default: { ...mod.default, env: "production" } }
+})
+
+const { initBrevoWebhooks, uploadContactListToBrevo } = await import("./brevo.service")
+
+// L'erreur du SDK Brevo porte `config.data`, c'est-à-dire le corps CSV complet de l'import : des
+// adresses email nominatives de recruteurs et de candidats. Relevée telle quelle, elle était
+// sérialisée dans Sentry par extraErrorDataIntegration (Sentry LBA-SERVER-5J7KF4ZZZTAAB).
+describe("uploadContactListToBrevo", () => {
+  const contacts = [
+    { EMAIL: "recruteur@exemple-entreprise.fr", PRENOM: "Camille", NOM: "Martin" },
+    { EMAIL: "candidat@exemple-perso.fr", PRENOM: "Dominique", NOM: "Bernard" },
+  ]
+  const contactMapper = [{ key: "EMAIL" }, { key: "PRENOM" }, { key: "NOM" }]
+
+  // Reproduit la forme réelle : l'AxiosError rejeté embarque la requête envoyée, corps inclus.
+  const erreurBrevo = (status: number, message: string) =>
+    Object.assign(new Error(`Request failed with status code ${status}`), {
+      isAxiosError: true,
+      config: { url: "https://api.brevo.com/v3/contacts/import", data: JSON.stringify({ fileBody: contacts.map((c) => Object.values(c).join(";")).join("\n") }) },
+      response: { status, data: { code: "unauthorized", message } },
+    })
+
+  const televerser = () => uploadContactListToBrevo("TRANSACTIONAL", contacts, contactMapper, "628")
+
+  beforeEach(() => {
+    importContacts.mockReset()
+  })
+
+  it("ne relève aucune adresse email de l'import dans l'erreur", async () => {
+    importContacts.mockRejectedValue(erreurBrevo(401, "Key not found"))
+
+    const error = await televerser().then(
+      () => null,
+      (e) => e
+    )
+
+    expect(error).not.toBeNull()
+    // Sérialisation large : message, data Boom, et toute propriété propre de l'erreur.
+    const serialise = JSON.stringify({ message: error.message, data: error.data, ...error })
+    expect(serialise).not.toContain("recruteur@exemple-entreprise.fr")
+    expect(serialise).not.toContain("candidat@exemple-perso.fr")
+    expect(serialise).not.toContain("fileBody")
+  })
+
+  it("conserve de quoi diagnostiquer", async () => {
+    importContacts.mockRejectedValue(erreurBrevo(401, "Key not found"))
+
+    const error = await televerser().then(
+      () => null,
+      (e) => e
+    )
+
+    expect(error.message).toContain("Key not found")
+    expect(error.data).toMatchObject({ account: "TRANSACTIONAL", listId: "628", status: 401, contactCount: 2 })
+  })
+
+  it("assainit aussi l'erreur après épuisement des retries sur 429", async () => {
+    importContacts.mockRejectedValue(erreurBrevo(429, "Rate limit"))
+
+    const error = await televerser().then(
+      () => null,
+      (e) => e
+    )
+
+    expect(JSON.stringify({ message: error.message, data: error.data, ...error })).not.toContain("recruteur@exemple-entreprise.fr")
+    expect(error.data).toMatchObject({ status: 429 })
+    expect(importContacts).toHaveBeenCalledTimes(5)
+  }, 20_000)
+
+  it("n'échoue pas quand l'import réussit", async () => {
+    importContacts.mockResolvedValue({})
+    await expect(televerser()).resolves.toBeUndefined()
+  })
+})
+
+// `error.response.res.text` était lu sans garde dans le handler de rejet : sur un échec réseau
+// (pas de `response`), le handler levait lui-même un TypeError que plus rien ne rattrapait — rejet
+// non rattrapé à chaque démarrage du serveur en production (Sentry LBA-SERVER-5J7KF4ZZZTA8E).
+describe("initBrevoWebhooks", () => {
+  const attendreLesRejets = () => new Promise((resolve) => setImmediate(resolve))
+
+  beforeEach(() => {
+    createWebhook.mockReset()
+  })
+
+  it("ne lève pas de rejet non rattrapé quand l'erreur n'a pas de response", async () => {
+    const rejetsNonRattrapes: unknown[] = []
+    const capture = (raison: unknown) => rejetsNonRattrapes.push(raison)
+    process.on("unhandledRejection", capture)
+    createWebhook.mockRejectedValue(Object.assign(new Error("getaddrinfo ENOTFOUND api.brevo.com"), { code: "ENOTFOUND" }))
+
+    try {
+      initBrevoWebhooks()
+      await attendreLesRejets()
+      await attendreLesRejets()
+    } finally {
+      process.off("unhandledRejection", capture)
+    }
+
+    expect(createWebhook).toHaveBeenCalledTimes(3)
+    expect(rejetsNonRattrapes).toEqual([])
+  })
+
+  it("journalise le message de l'API quand la response est présente", async () => {
+    loggerError.mockClear()
+    createWebhook.mockRejectedValue({ response: { status: 401, data: { message: "Key not found" } }, message: "Request failed with status code 401" })
+
+    initBrevoWebhooks()
+    await attendreLesRejets()
+    await attendreLesRejets()
+
+    const logged = loggerError.mock.calls.map(([message]) => String(message))
+    expect(logged).toHaveLength(3)
+    expect(logged[0]).toContain("status=401")
+    expect(logged[0]).toContain("Key not found")
+  })
+})

--- a/server/src/services/brevo.service.ts
+++ b/server/src/services/brevo.service.ts
@@ -1,10 +1,30 @@
 import brevo, { CreateWebhook } from "@getbrevo/brevo"
+import { internal } from "@hapi/boom"
 import type { ColumnOption } from "csv-stringify"
 import { stringify } from "csv-stringify/sync"
 import dayjs from "shared/helpers/dayjs"
 
 import { logger } from "@/common/logger"
 import config from "@/config"
+
+/**
+ * Décrit une erreur de l'API Brevo sans reprendre l'objet d'erreur brut.
+ *
+ * L'erreur levée par le SDK porte `config.data`, c'est-à-dire le corps CSV complet de la requête —
+ * adresses email nominatives de recruteurs et de candidats. `extraErrorDataIntegration` la
+ * sérialiserait telle quelle dans Sentry (`sendDefaultPii` actif) et aucune clé de ce corps ne
+ * correspond au scrub par nom de `sentry.ts`. Constaté en production sur le job « Export contact
+ * recruteurs vers Brevo » (Sentry LBA-SERVER-5J7KF4ZZZTAAB).
+ *
+ * Même logique que les clients france-travail, diagoriente, inserjeunes et api-entreprise.
+ */
+const describeBrevoError = (error: any): { status: number | undefined; brevoMessage: string | undefined; message: string } => ({
+  // Le SDK Brevo expose selon les appels `response.statusCode` (superagent) ou `response.status`
+  // (axios) — la boucle de retry ci-dessous lit déjà les deux.
+  status: error?.response?.statusCode ?? error?.response?.status,
+  brevoMessage: error?.response?.body?.message ?? error?.response?.data?.message,
+  message: error?.message ?? "erreur inconnue",
+})
 
 const clientBrevo = new brevo.WebhooksApi()
 clientBrevo.setApiKey(brevo.WebhooksApiApiKeys.apiKey, config.smtp.brevoApiKey)
@@ -33,6 +53,20 @@ const hardBounceWebhook = {
 }
 
 /**
+ * Journalise l'échec de création d'un webhook.
+ *
+ * L'ancienne version lisait `error.response.res.text` sans garde : quand `error.response` est
+ * absent (échec réseau, DNS, timeout), le handler de rejet levait lui-même un TypeError que plus
+ * rien ne rattrapait — rejet non rattrapé à chaque démarrage du serveur en production, et une
+ * nouvelle issue Sentry à chaque release puisque le culprit contient le hash du chunk
+ * (LBA-SERVER-5J7KF4ZZZTA8E et 5 issues jumelles).
+ */
+const logBrevoWebhookError = (webhook: string, error: any): void => {
+  const { status, brevoMessage, message } = describeBrevoError(error)
+  logger.error(`Brevo webhook API Error for ${webhook}. status=${status ?? "n/a"} message=${brevoMessage ?? message}`)
+}
+
+/**
  * Initialise les webhooks Brevo au démarrage du docker server. Echoue sans conséquences s'ils existent déjà
  */
 export const initBrevoWebhooks = () => {
@@ -50,7 +84,7 @@ export const initBrevoWebhooks = () => {
         logger.info("Brevo webhook API called successfully for email (appointment, application) status changes. Returned data: " + JSON.stringify(data))
       },
       function (error) {
-        logger.error("Brevo webhook API Error for email (appointment, application) status changes. Returned data: " + error.response.res.text)
+        logBrevoWebhookError("email (appointment, application) status changes", error)
       }
     )
 
@@ -59,7 +93,7 @@ export const initBrevoWebhooks = () => {
       logger.info("Brevo webhook API called successfully for transactional hardbounces. Returned data: " + JSON.stringify(data))
     },
     function (error) {
-      logger.error("Brevo webhook API Error for transactional hardbounces. Returned data: " + error.response.res.text)
+      logBrevoWebhookError("transactional hardbounces", error)
     }
   )
 
@@ -74,7 +108,7 @@ export const initBrevoWebhooks = () => {
         logger.info("Brevo webhook API called successfully for campaign hardbounce detection. Returned data: " + JSON.stringify(data))
       },
       function (error) {
-        logger.error("Brevo webhook API Error for campaign hardbounce detection. Returned data: " + error.response.res.text)
+        logBrevoWebhookError("campaign hardbounce detection", error)
       }
     )
 }
@@ -104,7 +138,15 @@ export const uploadContactListToBrevo = async (account: "TRANSACTIONAL" | "MARKE
 
   const maxRetries = 5
   let attempt = 0
-  let lastError: Error | null = null
+  let lastError: unknown = null
+
+  // Ne jamais relever l'erreur du SDK telle quelle : elle porte le corps CSV de l'import
+  // (cf. describeBrevoError). On la remplace par un Boom qui ne retient que le statut, le message
+  // renvoyé par Brevo, la liste ciblée et le nombre de contacts.
+  const toImportError = (error: unknown) => {
+    const { status, brevoMessage, message } = describeBrevoError(error)
+    return internal(`brevo: échec de l'import de contacts (${brevoMessage ?? message})`, { account, listId, status, contactCount: contacts.length })
+  }
 
   while (attempt < maxRetries) {
     try {
@@ -132,13 +174,13 @@ export const uploadContactListToBrevo = async (account: "TRANSACTIONAL" | "MARKE
           await new Promise((resolve) => setTimeout(resolve, delayMs))
         } else {
           logger.error(`Brevo API rate limit reached. Max retries (${maxRetries}) exceeded`)
-          throw error
+          throw toImportError(error)
         }
       } else {
-        throw error
+        throw toImportError(error)
       }
     }
   }
 
-  throw lastError
+  throw toImportError(lastError)
 }


### PR DESCRIPTION
Rattaché à #5307 (2/3). Issues Sentry : `LBA-SERVER-5J7KF4ZZZTAAB` (fuite), `LBA-SERVER-5J7KF4ZZZTA8E` + 5 jumelles (rejet non rattrapé).

## Changements

**Fuite d'adresses email vers Sentry**

`uploadContactListToBrevo` relevait l'erreur du SDK telle quelle. Celle-ci porte `config.data`, c'est-à-dire le corps CSV complet de l'import — adresses email nominatives de recruteurs et de candidats. `extraErrorDataIntegration` la sérialisait dans Sentry (`sendDefaultPii` actif) et aucune clé de ce corps ne correspond au scrub par nom ajouté en `8c7e2bcc4`.

Constaté en production sur le job « Export contact recruteurs vers Brevo » : l'event contient les emails en clair. Les trois sites de `throw` (échec direct, retries 429 épuisés, `lastError`) passent par un Boom qui ne retient que le compte, la liste ciblée, le statut HTTP, le message renvoyé par Brevo et le nombre de contacts.

C'est le même pattern « erreur dédiée plutôt que l'AxiosError brut » que les clients france-travail, diagoriente, inserjeunes, api-entreprise et france-competences.

**Rejet non rattrapé à chaque démarrage serveur**

`initBrevoWebhooks` lisait `error.response.res.text` sans garde dans ses trois handlers de rejet. Quand `error.response` est absent (échec réseau, DNS, timeout), le handler levait lui-même un `TypeError` que plus rien ne rattrapait : rejet non rattrapé (`mechanism: auto.node.onunhandledrejection`, `handled: no`) à chaque boot en production, et une nouvelle issue Sentry à chaque release puisque le culprit contient le hash du chunk — 6 issues pour ~46 events sur les 7 derniers jours.

## À noter

Ces events remontent aussi que la clé API Brevo utilisée sur `/v3/contacts/import` répond `401 Key not found` — 19 events dont 6 en production. Ce correctif rend l'erreur lisible dans Sentry, il ne répare pas la clé. À traiter séparément côté vault.

## Plan de test

- [x] Nouveau fichier `brevo.service.test.ts`, 6 tests, SDK et config mockés
- [x] Le cas nominal (import réussi) est couvert, pas seulement les cas d'erreur
- [x] Assertion négative sur la fuite : sérialisation large de l'erreur levée (message + `data` Boom + propriétés propres), aucune des deux adresses email de l'import ni la clé `fileBody` n'y apparaît
- [x] Le chemin « retries 429 épuisés » est vérifié séparément (5 appels, erreur assainie elle aussi)
- [x] Rejet non rattrapé : `unhandledRejection` écouté pendant l'appel, tableau attendu vide
- [x] Tests non vacuous — bugs réintroduits un par un : `throw error` fait échouer 3 tests, `error.response.res.text` en fait échouer 2 ; restaurés, 6/6 passent
- [x] `yarn typecheck --force` exit 0
- [x] `yarn vitest run --no-file-parallelism server/src/jobs` — 61/61 fichiers, 317 tests (les 5 jobs appelant `uploadContactListToBrevo` sont couverts)
- [ ] Après déploiement : vérifier qu'un nouvel event du job d'export ne contient plus `fileBody`, et qu'aucune issue « Cannot read properties of undefined (reading 'text') » n'apparaît sur la release suivante