### PR TITLE
fix: relaie les erreurs de contrôle next au lieu de les capturer sur /rdva (#5307)

### DIFF
--- a/ui/app/(rdva)/rdva/RdvaPage.tsx
+++ b/ui/app/(rdva)/rdva/RdvaPage.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { fr } from "@codegouvfr/react-dsfr"
-import { Box, Container, Typography } from "@mui/material"
+import { Box, Typography } from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
+import type { PropsWithChildren } from "react"
 import { useEffect, useState } from "react"
 
 import { useFormationPrdvTracker } from "@/app/hooks/use-formation-prdv-tracker"
@@ -15,8 +16,17 @@ import { PAGES } from "@/utils/routes.utils"
 
 type PrdvData = NonNullable<Awaited<ReturnType<typeof getPrdvContext>>>
 
+// Le layout (rdva) déclare un lien d'évitement « Contenu » vers #main-content mais ne rend aucun
+// landmark : c'est à la page de le porter, comme le font les layouts espace-pro. Un seul wrapper
+// pour tous les états rendus — l'écran de confirmation n'en avait aucun jusqu'ici.
+const RdvaMain = ({ children }: PropsWithChildren) => (
+  <Box component="main" role="main" id="main-content" tabIndex={-1} sx={{ my: fr.spacing("6v"), mx: fr.spacing("2v") }}>
+    {children}
+  </Box>
+)
+
 const PrdvIndisponible = () => (
-  <Box id="main-content" tabIndex={-1} sx={{ my: fr.spacing("6v"), mx: fr.spacing("2v") }}>
+  <>
     <Typography variant="h1">Ce formulaire n'est plus disponible</Typography>
     <Typography sx={{ mt: fr.spacing("4v") }}>
       Le lien que vous avez suivi ne correspond plus à une formation acceptant les demandes de contact. Il a peut-être expiré, ou le centre de formation ne reçoit plus de demandes
@@ -25,7 +35,7 @@ const PrdvIndisponible = () => (
     <Typography sx={{ mt: fr.spacing("4v") }}>
       Vous pouvez <DsfrLink href={PAGES.dynamic.rechercheFormation(null).getPath()}>rechercher une autre formation</DsfrLink> et contacter le centre depuis sa fiche.
     </Typography>
-  </Box>
+  </>
 )
 
 type Props = {
@@ -82,7 +92,11 @@ const PageContent = ({ data: initialData, cleMinistereEducatif, referrer }: Prop
   // capturait un event Sentry par visite — 343 sur 7 jours, 936 depuis le 07/07
   // (LBA-UI-5CVZZZZZZG40G).
   if (!data) {
-    return <PrdvIndisponible />
+    return (
+      <RdvaMain>
+        <PrdvIndisponible />
+      </RdvaMain>
+    )
   }
 
   const context = { cle_ministere_educatif: data.cle_ministere_educatif, etablissement_formateur_entreprise_raison_sociale: data.etablissement_formateur_entreprise_raison_sociale }
@@ -92,18 +106,22 @@ const PageContent = ({ data: initialData, cleMinistereEducatif, referrer }: Prop
     setConfirmation(props)
   }
 
-  return confirmation ? (
-    <DemandeDeContactConfirmation {...confirmation} />
-  ) : (
-    <Box id="main-content" tabIndex={-1} sx={{ my: fr.spacing("6v"), mx: fr.spacing("2v") }}>
-      <ContactCfaSummary
-        entrepriseRaisonSociale={data.etablissement_formateur_entreprise_raison_sociale}
-        intitule={data.intitule_long}
-        adresse={data.lieu_formation_adresse}
-        codePostal={data.code_postal}
-        ville={data.localite}
-      />
-      <DemandeDeContactForm context={context} referrer={referrer ?? "lba"} onRdvSuccess={localOnSuccess} />
-    </Box>
+  return (
+    <RdvaMain>
+      {confirmation ? (
+        <DemandeDeContactConfirmation {...confirmation} />
+      ) : (
+        <>
+          <ContactCfaSummary
+            entrepriseRaisonSociale={data.etablissement_formateur_entreprise_raison_sociale}
+            intitule={data.intitule_long}
+            adresse={data.lieu_formation_adresse}
+            codePostal={data.code_postal}
+            ville={data.localite}
+          />
+          <DemandeDeContactForm context={context} referrer={referrer ?? "lba"} onRdvSuccess={localOnSuccess} />
+        </>
+      )}
+    </RdvaMain>
   )
 }

--- a/ui/app/(rdva)/rdva/RdvaPage.tsx
+++ b/ui/app/(rdva)/rdva/RdvaPage.tsx
@@ -1,17 +1,32 @@
 "use client"
 
 import { fr } from "@codegouvfr/react-dsfr"
-import { Box, Container } from "@mui/material"
+import { Box, Container, Typography } from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 
 import { useFormationPrdvTracker } from "@/app/hooks/use-formation-prdv-tracker"
+import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { ContactCfaSummary } from "@/components/espace_pro/Candidat/layout/ContactCfaSummary"
 import { DemandeDeContactConfirmation } from "@/components/RDV/DemandeDeContactConfirmation"
 import { DemandeDeContactForm } from "@/components/RDV/DemandeDeContactForm"
 import { getPrdvContext } from "@/utils/api"
+import { PAGES } from "@/utils/routes.utils"
 
 type PrdvData = NonNullable<Awaited<ReturnType<typeof getPrdvContext>>>
+
+const PrdvIndisponible = () => (
+  <Box id="main-content" tabIndex={-1} sx={{ my: fr.spacing("6v"), mx: fr.spacing("2v") }}>
+    <Typography variant="h1">Ce formulaire n'est plus disponible</Typography>
+    <Typography sx={{ mt: fr.spacing("4v") }}>
+      Le lien que vous avez suivi ne correspond plus à une formation acceptant les demandes de contact. Il a peut-être expiré, ou le centre de formation ne reçoit plus de demandes
+      par ce biais.
+    </Typography>
+    <Typography sx={{ mt: fr.spacing("4v") }}>
+      Vous pouvez <DsfrLink href={PAGES.dynamic.rechercheFormation(null).getPath()}>rechercher une autre formation</DsfrLink> et contacter le centre depuis sa fiche.
+    </Typography>
+  </Box>
+)
 
 type Props = {
   data: PrdvData | null
@@ -61,8 +76,13 @@ const PageContent = ({ data: initialData, cleMinistereEducatif, referrer }: Prop
     return null
   }
 
+  // Contexte introuvable : la clé ministère éducatif est inconnue, expirée, ou le CFA ne prend plus
+  // de rendez-vous. C'est un état fonctionnel attendu, pas une panne. Le `throw` précédent le
+  // faisait remonter à l'ErrorBoundary, qui affichait « Un problème technique est survenu » et
+  // capturait un event Sentry par visite — 343 sur 7 jours, 936 depuis le 07/07
+  // (LBA-UI-5CVZZZZZZG40G).
   if (!data) {
-    throw new Error(`Un problème est survenu lors de l’accès au formulaire de demande au CFA - cleMinistereEducatif: ${cleMinistereEducatif}, referrer: ${referrer}`)
+    return <PrdvIndisponible />
   }
 
   const context = { cle_ministere_educatif: data.cle_ministere_educatif, etablissement_formateur_entreprise_raison_sociale: data.etablissement_formateur_entreprise_raison_sociale }

--- a/ui/utils/api.prdv.test.ts
+++ b/ui/utils/api.prdv.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const captureException = vi.fn()
+const apiGet = vi.fn()
+
+vi.mock("@sentry/nextjs", () => ({ captureException }))
+
+vi.mock("./api.utils", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("./api.utils")>()
+  return { ...mod, apiGet }
+})
+
+const { getPrdvContext } = await import("./api")
+const { ApiError } = await import("./api.utils")
+
+const buildApiError = (statusCode: number) =>
+  new ApiError({
+    path: "/_private/appointment",
+    params: {},
+    querystring: {},
+    requestHeaders: {},
+    statusCode,
+    message: "boom",
+    name: "Api Error",
+    responseHeaders: {},
+    errorData: null,
+  })
+
+// Avec `cacheComponents`, un fetch non mis en cache pendant le prerender renvoie une promesse
+// suspendue qui rejette quand le prerender s'interrompt. Next marque cette erreur du digest
+// HANGING_PROMISE_REJECTION et attend qu'on la relaie ; capturée comme une erreur applicative,
+// elle produisait un event Sentry par requête sur /rdva (LBA-UI-5CVZZZZZZG501).
+const hangingPromiseRejection = () => Object.assign(new Error("During prerendering, fetch() rejects when the prerender is complete."), { digest: "HANGING_PROMISE_REJECTION" })
+
+describe("getPrdvContext", () => {
+  beforeEach(() => {
+    captureException.mockClear()
+    apiGet.mockReset()
+  })
+
+  it("relaie le rejet de prerender sans le remonter à Sentry", async () => {
+    apiGet.mockRejectedValue(hangingPromiseRejection())
+
+    const error = await getPrdvContext("cle", "lba").then(
+      () => null,
+      (e) => e
+    )
+
+    expect(error).toMatchObject({ digest: "HANGING_PROMISE_REJECTION" })
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  it("relaie aussi les erreurs de contrôle de Next (redirect, notFound)", async () => {
+    apiGet.mockRejectedValue(Object.assign(new Error("NEXT_HTTP_ERROR_FALLBACK;404"), { digest: "NEXT_HTTP_ERROR_FALLBACK;404" }))
+
+    await expect(getPrdvContext("cle", "lba")).rejects.toThrow()
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  it("remonte toujours une vraie erreur serveur à Sentry", async () => {
+    apiGet.mockRejectedValue(buildApiError(500))
+
+    await expect(getPrdvContext("cle", "lba")).rejects.toThrow()
+    expect(captureException).toHaveBeenCalledTimes(1)
+  })
+
+  it("traite un 4xx comme une absence de contexte, sans event Sentry", async () => {
+    apiGet.mockRejectedValue(buildApiError(404))
+
+    await expect(getPrdvContext("cle", "lba")).resolves.toBeNull()
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  it("renvoie les données quand l'appel réussit", async () => {
+    apiGet.mockResolvedValue({ cle_ministere_educatif: "cle" })
+
+    await expect(getPrdvContext("cle", "lba")).resolves.toMatchObject({ cle_ministere_educatif: "cle" })
+    expect(captureException).not.toHaveBeenCalled()
+  })
+})

--- a/ui/utils/api.ts
+++ b/ui/utils/api.ts
@@ -1,4 +1,5 @@
 import { captureException } from "@sentry/nextjs"
+import { unstable_rethrow } from "next/navigation"
 import type {
   IBody,
   IJobCreate,
@@ -164,6 +165,7 @@ export const getCfaInformation = async (siret: string) => {
     const data = await apiGet("/etablissement/cfa/:siret", { params: { siret } })
     return { statusCode: 200, data, error: false }
   } catch (error) {
+    unstable_rethrow(error)
     if (error instanceof ApiError && error.context?.statusCode >= 400) {
       const { errorData, statusCode, message } = error.context
       if (error.context.statusCode >= 500) {
@@ -191,6 +193,7 @@ export const getEntrepriseInformation = async (
     )
     return { statusCode: 200, data, error: false }
   } catch (error: unknown) {
+    unstable_rethrow(error)
     if (error instanceof ApiError && error.context?.statusCode >= 400) {
       const { errorData, statusCode, message } = error.context
       if (error.context.statusCode >= 500) {
@@ -208,6 +211,7 @@ export const getEntrepriseOpco = async (siret: string) => {
     const data = await apiGet("/etablissement/entreprise/:siret/opco", { params: { siret } }, { timeout: 7000 })
     return data
   } catch (error) {
+    unstable_rethrow(error)
     captureException(error)
     return null
   }
@@ -218,6 +222,12 @@ export const getPrdvContext = async (cleMinistereEducatif: string, referrer: str
     const data = await apiGet("/_private/appointment", { querystring: { cleMinistereEducatif, referrer: referrer || "lba" } }, { timeout: 7000 })
     return data
   } catch (error) {
+    // Rend la main à Next avant tout traitement applicatif. Avec `cacheComponents`, un fetch non
+    // mis en cache pendant le prerender renvoie une promesse suspendue qui rejette quand le
+    // prerender s'interrompt (digest HANGING_PROMISE_REJECTION) : capturée ici, elle produisait un
+    // event Sentry par requête sur /rdva — 20 467 sur 5 jours, 80 % du volume d'erreurs de l'UI
+    // (LBA-UI-5CVZZZZZZG501). unstable_rethrow relaie aussi notFound() et redirect().
+    unstable_rethrow(error)
     const isExpectedError = error instanceof ApiError && error.context.statusCode >= 400 && error.context.statusCode < 500
     if (isExpectedError) {
       return null


### PR DESCRIPTION
Closes #5307 (3/3). Issues Sentry : `LBA-UI-5CVZZZZZZG501` (20 467 events), `LBA-UI-5CVZZZZZZG40G` (343 events).

## Changements

**Les rejets de prerender étaient capturés comme des erreurs applicatives**

Avec `cacheComponents: true`, un `fetch()` non mis en cache pendant le prerender renvoie une promesse suspendue que Next rejette quand le prerender s'interrompt, avec le digest `HANGING_PROMISE_REJECTION`. Le framework attend qu'on la lui relaie pour basculer le segment sur le rendu dynamique.

`getPrdvContext` la traitait comme une erreur applicative : tout ce qui n'était pas une `ApiError` 4xx partait en `captureException`. Résultat sur `/rdva` : un event Sentry par requête, 20 467 en 5 jours, 80 % du volume d'erreurs de l'UI, en escalating. La stack Sentry le confirme (`handled: yes`, `mechanism: generic`, frames `a.trace` / `fetch` du SDK).

Ajout de `unstable_rethrow(error)` en tête des quatre blocs `catch` de `ui/utils/api.ts` — c'est l'échappatoire documentée par Next pour ne pas avaler les erreurs de contrôle du framework (`notFound()`, `redirect()`, rejets de prerender).

Les trois autres fonctions concernées (`getCfaInformation`, `getEntrepriseInformation`, `getEntrepriseOpco`) avaient le même défaut, en pire : elles avalent l'erreur et renvoient un objet d'erreur, ce qui aurait fait aboutir le prerender sur un résultat faux au lieu de le déférer. Elles n'ont pas produit d'event sur la fenêtre analysée, mais le correctif est le même.

Les deux `catch {}` de tracking non critique (`notifyJobDetailViewV3`, `notifyJobPostulerV3`) ne sont pas touchés : ils ne sont appelés que depuis des composants client, sur interaction, jamais pendant un prerender.

**Clé ME inconnue : état fonctionnel, pas panne**

`RdvaPage.tsx` faisait un `throw new Error(...)` quand le contexte PRDV est introuvable. L'usager tombait sur « Un problème technique est survenu » de l'ErrorBoundary, qui capture en plus un event Sentry — 343 sur 7 jours, 936 depuis le 07/07.

Remplacé par un écran dédié : le lien a expiré ou le CFA ne reçoit plus de demandes, avec un renvoi vers la recherche de formation.

## Ce que ça ne corrige pas

Le trafic crawler sur `/rdva` reste entier : 68 % des events venaient de GPTBot, SERankingBacklinksBot, Applebot, AionBot, bingbot et ClaudeBot. Passer la route en `noindex` + `Disallow` est un choix SEO à part, pas un correctif de bug — à arbitrer séparément.

## Plan de test

- [x] Nouveau `ui/utils/api.prdv.test.ts`, 5 tests : rejet de prerender relayé sans event Sentry, erreur de contrôle Next (`NEXT_HTTP_ERROR_FALLBACK`) relayée, **erreur serveur 500 toujours capturée**, 4xx toujours traité comme absence de contexte, cas nominal
- [x] Test non vacuous : `unstable_rethrow` retiré de `getPrdvContext` → 2 tests échouent ; restauré → 5/5 passent
- [x] `yarn typecheck --force` exit 0
- [x] `yarn vitest run --project ui` — 14 fichiers, 235 tests
- [x] `yarn build` de l'UI passe, `/rdva` sort en `◐ Partial Prerender` (shell statique + contenu dynamique streamé), ce qui est le comportement attendu
- [ ] **Non reproduit en local** : le cas des 20 467 events demande une instance de production avec l'API derrière. Confirmation à faire après déploiement — `LBA-UI-5CVZZZZZZG501` doit cesser de recevoir des events, et `LBA-UI-5CVZZZZZZG40G` aussi
- [ ] Vérifier à la main un lien `/rdva?cleMinistereEducatif=<clé inexistante>` : écran « Ce formulaire n'est plus disponible » et non la page d'erreur générique