### PR TITLE
fix: cron jobs_partners par API toutes les 5 min avec concurrence exclusive (#5312)

### DIFF
--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -99,9 +99,10 @@ export async function setupJobProcessor() {
             tag: "main",
           },
           "Traitement complet des jobs_partners par API": {
-            cron_string: "*/10 * * * *",
+            cron_string: "*/5 * * * *",
             handler: processJobPartnersForApi,
             tag: "slave",
+            concurrency: { mode: "exclusive" },
           },
           "Expiration des offres jobs_partners": {
             cron_string: "*/30 * * * *",


### PR DESCRIPTION
Closes #5312

## Changements

- Cron `Traitement complet des jobs_partners par API` : `cron_string` passé de `*/10 * * * *` à `*/5 * * * *`.
- Ajout de `concurrency: { mode: "exclusive" }` sur ce même cron.

## Pourquoi

Ce cron fixe la latence entre le dépôt d'une offre via l'API partenaire et son apparition en recherche.

Mesures en production (Loki, service `jobs_processor`, env production) :

| Mesure | Valeur |
| --- | --- |
| Runs sur 24 h | 144 `début` / 144 `fin` — aucun run manqué ni échoué |
| Durée par run (18 runs consécutifs mesurés) | 29 à 34 s |
| Taux d'occupation de la fenêtre de 10 min | environ 5 % |

La marge est large : à 5 minutes le taux d'occupation monte à environ 10 %.

Le second point est le vrai correctif. Aucune garde de concurrence n'était déclarée, et `job-processor` v3 applique `mode: "concurrent"` par défaut : un nouveau run démarre même si le précédent est encore en cours. Or `processJobPartnersForApi` n'est pas réentrant — son claim initial filtre sur `partner_label` et `updated_at`, pas sur `currently_processed_id: null`. Un run B démarré pendant un run A ré-estampille les documents de A, l'appel `importFromComputedToJobsPartners` de A ne matche alors plus rien, et les offres concernées attendent un run suivant.

Avec `exclusive`, `job-processor` s'appuie sur l'index partiel unique `cron_task_exclusive_unique` : le run en conflit est marqué `skipped` avec `reason: "noConcurrent_conflict"` au lieu de s'exécuter en parallèle.

## Impact

Le surcoût est essentiellement de l'overhead fixe MongoDB — chaque étape de `fillComputedJobsPartners` déclenche une agrégation sur `computed_jobs_partners`. Le volume d'appels aux API externes dépend du nombre de documents à enrichir, pas du nombre de runs, et ne change donc pas.

Le gain de latence porte sur les offres déposées via l'API partenaire et sur celles arrivées entre deux runs. Pour les flux importés une fois par jour, la fréquence des importers reste le facteur limitant.

## Plan de test

- [ ] `yarn typecheck` passe (vérifié : `tsc` rejette bien une valeur invalide sur `concurrency.mode`, le champ est réellement couvert par le typage `CronDef`).
- [ ] Après déploiement, vérifier dans l'admin processeur que le cron est planifié toutes les 5 minutes.
- [ ] Sur 1 h de logs production, confirmer 12 `début de processJobPartnersForApi` et 12 `fin de processJobPartnersForApi`.
- [ ] Vérifier qu'aucun `cron_task` de ce job n'apparaît en statut `skipped` avec `reason: "noConcurrent_conflict"` en régime nominal — sa présence signalerait un run dépassant 5 minutes, à investiguer.
