### PR TITLE
fix: nom d'entreprise vide sur la fiche détail et indexation immédiate des offres api (#5315)

### DIFF
--- a/server/src/http/controllers/jobs.controller.test.ts
+++ b/server/src/http/controllers/jobs.controller.test.ts
@@ -1,7 +1,7 @@
 import { useMongo } from "@tests/utils/mongo.test.utils"
 import { useServer } from "@tests/utils/server.test.utils"
 import { ObjectId } from "mongodb"
-import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import { LBA_ITEM_TYPE, UNKNOWN_COMPANY } from "shared/constants/lbaitem"
 import { generateJobsPartnersOfferPrivate } from "shared/fixtures/job-partners.fixture"
 import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
 import { describe, expect, it } from "vitest"
@@ -43,6 +43,64 @@ describe("jobs.controller", () => {
 
         expect(response.statusCode).toBe(200)
         expect(response.json().id).toBe(job._id.toString())
+      })
+    })
+
+    describe(`source: ${LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES}`, () => {
+      it("retourne la raison sociale quand workplace_name est une chaîne vide", async () => {
+        // Faux positif du `??` : "" n'est pas nullish, la fiche détail affichait un employeur vide
+        // alors que la carte de résultat (buildJobOfferSearchItem, en `||`) affichait bien le nom.
+        const job = generateJobsPartnersOfferPrivate({
+          partner_label: "Mission Apprentissage",
+          workplace_name: "",
+          workplace_brand: null,
+          workplace_legal_name: "DIRECTION INTERMINISTERIELLE DU NUMERIQUE",
+        })
+        await getDbCollection("jobs_partners").insertOne(job)
+
+        const response = await httpClient().inject({
+          method: "GET",
+          path: `/api/_private/jobs/${LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES}/${job._id.toString()}`,
+        })
+
+        expect.soft(response.statusCode).toBe(200)
+        expect.soft(response.json().company.name).toBe("DIRECTION INTERMINISTERIELLE DU NUMERIQUE")
+      })
+
+      it("retourne le nom par défaut quand tous les noms sont vides ou absents", async () => {
+        const job = generateJobsPartnersOfferPrivate({
+          partner_label: "Mission Apprentissage",
+          workplace_name: "",
+          workplace_brand: "",
+          workplace_legal_name: null,
+        })
+        await getDbCollection("jobs_partners").insertOne(job)
+
+        const response = await httpClient().inject({
+          method: "GET",
+          path: `/api/_private/jobs/${LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES}/${job._id.toString()}`,
+        })
+
+        expect.soft(response.statusCode).toBe(200)
+        expect.soft(response.json().company.name).toBe(UNKNOWN_COMPANY)
+      })
+
+      it("privilégie workplace_name quand il est renseigné", async () => {
+        const job = generateJobsPartnersOfferPrivate({
+          partner_label: "Mission Apprentissage",
+          workplace_name: "Nom customisé",
+          workplace_brand: "Enseigne",
+          workplace_legal_name: "Raison sociale",
+        })
+        await getDbCollection("jobs_partners").insertOne(job)
+
+        const response = await httpClient().inject({
+          method: "GET",
+          path: `/api/_private/jobs/${LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES}/${job._id.toString()}`,
+        })
+
+        expect.soft(response.statusCode).toBe(200)
+        expect.soft(response.json().company.name).toBe("Nom customisé")
       })
     })
 

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -256,10 +256,18 @@ export async function setupJobProcessor() {
             handler: config.env === "production" ? async () => exportJobsToFranceTravail() : async () => Promise.resolve(0),
             tag: "main",
           },
+          // Les offres déposées par API sont indexées directement en fin de processJobPartnersForApi :
+          // ce cron ne porte plus leur latence, il couvre les écritures de masse des AUTRES chemins
+          // (expiration */30, annulation, dédoublonnage, imports de flux) et sert de rattrapage.
+          // Maintenu à 5 min pour le retrait : une offre expirée ou annulée reste sinon proposée en
+          // recherche jusqu'au run suivant. Runs à vide à 30-50 ms, 2 à 3 s en régime nominal.
+          // concurrency exclusive : jusqu'à 4 min pendant les imports de masse nocturnes (mesuré le
+          // 28/08/2026 à 03:35 UTC) — au-delà de l'intervalle, deux runs se chevaucheraient.
           "Sync delta search_items (jobs_partners modifiés)": {
-            cron_string: "*/15 * * * *",
+            cron_string: "*/5 * * * *",
             handler: async () => syncSearchItemsDelta(),
             tag: "slave",
+            concurrency: { mode: "exclusive" },
           },
           // Après processComputedAndImportToJobPartners (départ 00:01, maxRuntime 300 min → fin
           // au plus tard ~05:00) : rattrape ce que la sync incrémentale a manqué et purge les

--- a/server/src/jobs/offre-partenaire/close-jobs-partners-on-application-threshold.ts
+++ b/server/src/jobs/offre-partenaire/close-jobs-partners-on-application-threshold.ts
@@ -24,7 +24,9 @@ const getReminderCompanyName = ({
   workplace_brand,
   workplace_legal_name,
 }: Pick<IJobsPartnersOfferPrivate, "workplace_name" | "workplace_brand" | "workplace_legal_name">) => {
-  return workplace_name ?? workplace_brand ?? workplace_legal_name ?? ""
+  // Chaîne de repli en `||` : workplace_name est sanitizé côté pipeline et peut valoir "" (cf.
+  // formatTextFieldsJobsPartners), ce qui court-circuiterait le repli sur brand / raison sociale.
+  return workplace_name || workplace_brand || workplace_legal_name || ""
 }
 
 const sendThresholdEmails = async (closedJobs: IJobsPartnersOfferPrivate[]) => {

--- a/server/src/jobs/offre-partenaire/expire-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/expire-jobs-partners.ts
@@ -20,7 +20,9 @@ const getReminderCompanyName = ({
   workplace_brand,
   workplace_legal_name,
 }: Pick<IJobsPartnersOfferPrivate, "workplace_name" | "workplace_brand" | "workplace_legal_name">) => {
-  return workplace_name ?? workplace_brand ?? workplace_legal_name ?? ""
+  // Chaîne de repli en `||` : workplace_name est sanitizé côté pipeline et peut valoir "" (cf.
+  // formatTextFieldsJobsPartners), ce qui court-circuiterait le repli sur brand / raison sociale.
+  return workplace_name || workplace_brand || workplace_legal_name || ""
 }
 
 const sendExpirationEmails = async (expiredJobs: IJobsPartnersOfferPrivate[]) => {

--- a/server/src/jobs/offre-partenaire/fill-siret-infos-for-partners.test.ts
+++ b/server/src/jobs/offre-partenaire/fill-siret-infos-for-partners.test.ts
@@ -101,6 +101,45 @@ describe("fill-siret-infos-for-partners", () => {
     expect.soft(job.business_error).toEqual(null)
     expect.soft(pick(job, filledFields)).toMatchSnapshot()
   })
+  it("should fill workplace_name from the siret when it is an empty string", async () => {
+    // Faux positif du `??` : "" n'est pas nullish, donc l'enseigne du SIRET n'était jamais reprise.
+    // Le corpus contient des "" écrits par formatTextFieldsJobsPartners avant son correctif.
+    const siret = "42476141900010"
+    await givenSomeComputedJobPartners([
+      {
+        workplace_siret: siret,
+        ...emptyFilledObject,
+        workplace_name: "",
+      },
+    ])
+    await getDbCollection("cache_siret").insertOne(generateCacheInfoSiretForSiret(siret))
+    // when
+    await fillSiretInfosForPartners()
+    // then
+    const jobs = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect.soft(jobs.length).toBe(1)
+    const [job] = jobs
+    expect.soft(job.errors).toEqual([])
+    expect.soft(job.workplace_name).toBe("Plop brand")
+  })
+
+  it("should keep the partner workplace_name when it is provided", async () => {
+    const siret = "42476141900010"
+    await givenSomeComputedJobPartners([
+      {
+        workplace_siret: siret,
+        ...emptyFilledObject,
+        workplace_name: "Nom fourni par le partenaire",
+      },
+    ])
+    await getDbCollection("cache_siret").insertOne(generateCacheInfoSiretForSiret(siret))
+    // when
+    await fillSiretInfosForPartners()
+    // then
+    const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect.soft(job.workplace_name).toBe("Nom fourni par le partenaire")
+  })
+
   it("should add an error in the document when data is not found", async () => {
     // given
     await givenSomeComputedJobPartners([

--- a/server/src/jobs/offre-partenaire/fill-siret-infos-for-partners.ts
+++ b/server/src/jobs/offre-partenaire/fill-siret-infos-for-partners.ts
@@ -57,7 +57,10 @@ export const fillSiretInfosForPartners = async ({ addedMatchFilter }: FillComput
         workplace_brand: document.workplace_brand ?? establishment_enseigne,
         workplace_naf_code: document.workplace_naf_code ?? naf_code,
         workplace_naf_label: document.workplace_naf_label ?? naf_label,
-        workplace_name: document.workplace_name ?? establishment_enseigne ?? establishment_raison_sociale,
+        // `||` et non `??` : workplace_name passe par formatTextFieldsJobsPartners, qui a longtemps
+        // écrit "" sur les champs texte absents — le corpus déjà importé en contient. Une chaîne vide
+        // doit valoir « absent », sinon l'enseigne / la raison sociale du SIRET n'est jamais reprise.
+        workplace_name: document.workplace_name || establishment_enseigne || establishment_raison_sociale,
         workplace_address_label: document.workplace_address_label ?? address ?? null,
         workplace_address_street_label: document.workplace_address_street_label ?? address_street_label ?? null,
         workplace_address_city: document.workplace_address_city ?? address_detail?.libelle_commune ?? null,

--- a/server/src/jobs/offre-partenaire/format-text-fields-jobs-partners.test.ts
+++ b/server/src/jobs/offre-partenaire/format-text-fields-jobs-partners.test.ts
@@ -3,6 +3,7 @@ import { useMongo } from "@tests/utils/mongo.test.utils"
 import { beforeEach, describe, expect, it } from "vitest"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { formatTextFieldsJobsPartners } from "./format-text-fields-jobs-partners"
+import { validateComputedJobPartners } from "./validate-computed-job-partners"
 
 describe("format-text-fields-jobs-partners", () => {
   useMongo()
@@ -35,8 +36,26 @@ describe("format-text-fields-jobs-partners", () => {
     expect.soft(job.offer_title).toBe("Développeur web en alternance")
   })
 
-  it("normalise à null un champ déjà à la chaîne vide", async () => {
-    // Le corpus importé avant ce correctif contient des "" : le job ne doit pas les perpétuer.
+  it("laisse la chaîne vide d'un champ renseigné qui se vide à la sanitization", async () => {
+    // Garde-fou : écrire null ici ferait échouer la validation zod de jobs_partners, qui refuse
+    // null sur offer_description (non-nullable) mais accepte "" — l'offre ne serait plus importée.
+    // Un "" est traité comme absent côté lecture, où les chaînes de repli utilisent `||`.
+    await givenSomeComputedJobPartners([
+      {
+        offer_title: "Développeur web en alternance",
+        offer_description: "<img src=x>",
+        workplace_name: "   ",
+      },
+    ])
+
+    await formatTextFieldsJobsPartners({})
+
+    const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect.soft(job.offer_description).toBe("")
+    expect.soft(job.workplace_name).toBe("")
+  })
+
+  it("laisse tel quel un champ déjà à la chaîne vide", async () => {
     await givenSomeComputedJobPartners([
       {
         offer_title: "Développeur web en alternance",
@@ -47,21 +66,26 @@ describe("format-text-fields-jobs-partners", () => {
     await formatTextFieldsJobsPartners({})
 
     const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
-    expect(job.workplace_name).toBe(null)
+    expect(job.workplace_name).toBe("")
   })
 
-  it("normalise à null un champ dont il ne reste rien après sanitization", async () => {
+  it("laisse une offre dont la description se vide franchir la validation", async () => {
+    // La conséquence réelle du garde-fou ci-dessus : avec null, la validation refuse l'offre
+    // (offer_description est non-nullable) et elle n'est plus importée dans jobs_partners.
     await givenSomeComputedJobPartners([
       {
         offer_title: "Développeur web en alternance",
-        workplace_name: "   ",
+        offer_description: "<script>alert(1)</script>",
+        offer_rome_codes: ["M1805"],
       },
     ])
 
     await formatTextFieldsJobsPartners({})
+    await validateComputedJobPartners({})
 
     const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
-    expect(job.workplace_name).toBe(null)
+    expect.soft(job.errors).toEqual([])
+    expect.soft(job.validated).toBe(true)
   })
 
   it("sanitize les champs renseignés sans les vider", async () => {

--- a/server/src/jobs/offre-partenaire/format-text-fields-jobs-partners.test.ts
+++ b/server/src/jobs/offre-partenaire/format-text-fields-jobs-partners.test.ts
@@ -1,0 +1,86 @@
+import { givenSomeComputedJobPartners } from "@tests/fixture/givenSomeComputedJobPartners"
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { beforeEach, describe, expect, it } from "vitest"
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { formatTextFieldsJobsPartners } from "./format-text-fields-jobs-partners"
+
+describe("format-text-fields-jobs-partners", () => {
+  useMongo()
+
+  beforeEach(() => {
+    return async () => {
+      await getDbCollection("computed_jobs_partners").deleteMany({})
+    }
+  })
+
+  it("laisse à null les champs texte absents du document", async () => {
+    // Cas du bug : le filtre du job sélectionne un document dès qu'UN des quatre champs est
+    // renseigné, mais les trois autres étaient réécrits à "" — ce qui neutralisait ensuite le
+    // repli `??` de fillSiretInfosForPartners sur l'enseigne / la raison sociale du SIRET.
+    await givenSomeComputedJobPartners([
+      {
+        offer_title: "Développeur web en alternance",
+        workplace_name: null,
+        workplace_description: null,
+        offer_description: null,
+      },
+    ])
+
+    await formatTextFieldsJobsPartners({})
+
+    const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect.soft(job.workplace_name).toBe(null)
+    expect.soft(job.workplace_description).toBe(null)
+    expect.soft(job.offer_description).toBe(null)
+    expect.soft(job.offer_title).toBe("Développeur web en alternance")
+  })
+
+  it("normalise à null un champ déjà à la chaîne vide", async () => {
+    // Le corpus importé avant ce correctif contient des "" : le job ne doit pas les perpétuer.
+    await givenSomeComputedJobPartners([
+      {
+        offer_title: "Développeur web en alternance",
+        workplace_name: "",
+      },
+    ])
+
+    await formatTextFieldsJobsPartners({})
+
+    const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect(job.workplace_name).toBe(null)
+  })
+
+  it("normalise à null un champ dont il ne reste rien après sanitization", async () => {
+    await givenSomeComputedJobPartners([
+      {
+        offer_title: "Développeur web en alternance",
+        workplace_name: "   ",
+      },
+    ])
+
+    await formatTextFieldsJobsPartners({})
+
+    const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect(job.workplace_name).toBe(null)
+  })
+
+  it("sanitize les champs renseignés sans les vider", async () => {
+    await givenSomeComputedJobPartners([
+      {
+        offer_title: "  Développeur web  ",
+        workplace_name: "  ACME  ",
+        workplace_description: "<p>Une <strong>vraie</strong> entreprise</p>",
+        offer_description: '<a href="http://spam.example">Postulez ici</a>',
+      },
+    ])
+
+    await formatTextFieldsJobsPartners({})
+
+    const [job] = await getDbCollection("computed_jobs_partners").find({}).toArray()
+    expect.soft(job.offer_title).toBe("Développeur web")
+    expect.soft(job.workplace_name).toBe("ACME")
+    // Les balises de mise en forme sont conservées (keepFormat), le lien est retiré.
+    expect.soft(job.workplace_description).toBe("<p>Une <strong>vraie</strong> entreprise</p>")
+    expect.soft(job.offer_description).toBe("Postulez ici")
+  })
+})

--- a/server/src/jobs/offre-partenaire/format-text-fields-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/format-text-fields-jobs-partners.ts
@@ -12,14 +12,18 @@ const fields = ["workplace_description", "workplace_name", "offer_description", 
  * les quatre, les autres sont réécrits quand même). Une chaîne vide neutralise tous les fallbacks
  * `??` en aval — en particulier fillSiretInfosForPartners, qui ne remplissait plus workplace_name
  * depuis l'enseigne / la raison sociale du SIRET, puisque `"" ?? x` vaut "".
- * Un champ absent — ou dont il ne reste rien après sanitization (espaces ou balises seules) — reste
- * donc null : « pas de texte exploitable » se représente par null, jamais par "".
+ *
+ * Un champ absent reste donc null. En revanche un champ renseigné dont il ne reste rien après
+ * sanitization (espaces ou balises seules) garde sa chaîne vide, volontairement : offer_title et
+ * offer_description sont NON-nullables dans jobs_partners, et y écrire null fait échouer la
+ * validation d'une offre qui passait avec "" — l'offre ne serait plus importée du tout. Le "" est
+ * traité comme une valeur absente côté lecture, où les chaînes de repli utilisent `||`.
  */
 const sanitizeNullableTextField = (text: string | null | undefined): string | null => {
   if (text == null) {
     return null
   }
-  return sanitizeTextField(text, true) || null
+  return sanitizeTextField(text, true)
 }
 
 export const formatTextFieldsJobsPartners = async ({ addedMatchFilter }: FillComputedJobsPartnersContext) => {

--- a/server/src/jobs/offre-partenaire/format-text-fields-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/format-text-fields-jobs-partners.ts
@@ -6,6 +6,22 @@ import { fillFieldsForComputedPartnersFactory } from "./fill-fields-for-partners
 
 const fields = ["workplace_description", "workplace_name", "offer_description", "offer_title"] as const satisfies (keyof IComputedJobsPartners)[]
 
+/**
+ * sanitizeTextField normalise null/undefined en "" : appliqué tel quel, il écrasait par une chaîne
+ * vide les champs absents du document (le filtre ci-dessous ne sélectionne qu'un champ non nul sur
+ * les quatre, les autres sont réécrits quand même). Une chaîne vide neutralise tous les fallbacks
+ * `??` en aval — en particulier fillSiretInfosForPartners, qui ne remplissait plus workplace_name
+ * depuis l'enseigne / la raison sociale du SIRET, puisque `"" ?? x` vaut "".
+ * Un champ absent — ou dont il ne reste rien après sanitization (espaces ou balises seules) — reste
+ * donc null : « pas de texte exploitable » se représente par null, jamais par "".
+ */
+const sanitizeNullableTextField = (text: string | null | undefined): string | null => {
+  if (text == null) {
+    return null
+  }
+  return sanitizeTextField(text, true) || null
+}
+
 export const formatTextFieldsJobsPartners = async ({ addedMatchFilter }: FillComputedJobsPartnersContext) => {
   const job = COMPUTED_ERROR_SOURCE.SANITIZE_TEXT_FIELDS
   return fillFieldsForComputedPartnersFactory({
@@ -21,10 +37,10 @@ export const formatTextFieldsJobsPartners = async ({ addedMatchFilter }: FillCom
         const { _id, workplace_description, offer_description, offer_title, workplace_name } = document
         const result: Pick<IComputedJobsPartners, (typeof fields)[number] | "_id"> = {
           _id,
-          workplace_description: sanitizeTextField(workplace_description, true),
-          workplace_name: sanitizeTextField(workplace_name, true),
-          offer_description: sanitizeTextField(offer_description, true),
-          offer_title: sanitizeTextField(offer_title, true),
+          workplace_description: sanitizeNullableTextField(workplace_description),
+          workplace_name: sanitizeNullableTextField(workplace_name),
+          offer_description: sanitizeNullableTextField(offer_description),
+          offer_title: sanitizeNullableTextField(offer_title),
         }
         return result
       })

--- a/server/src/jobs/offre-partenaire/process-job-partners-for-api.test.ts
+++ b/server/src/jobs/offre-partenaire/process-job-partners-for-api.test.ts
@@ -1,0 +1,66 @@
+import { createComputedJobPartner } from "@tests/utils/jobsPartners.test.utils"
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { JOB_STATUS_ENGLISH } from "shared/models/index"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { resetSearchItemBuildContextCache } from "@/services/search/search-items.service"
+import { processJobPartnersForApi } from "./process-job-partners-for-api"
+
+// fillComputedJobsPartners neutralisé : ses étapes appellent les API externes (SIRET, ROME,
+// classification) et ne sont pas le sujet ici — les documents du test sont déjà validés. Le reste
+// de la chaîne (import vers jobs_partners puis indexation search_items) tourne pour de vrai.
+vi.mock("./fill-computed-jobs-partners", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./fill-computed-jobs-partners")>()),
+  fillComputedJobsPartners: vi.fn(async () => ({})),
+}))
+
+describe("process-job-partners-for-api", () => {
+  useMongo()
+
+  beforeEach(() => {
+    resetSearchItemBuildContextCache()
+    return async () => {
+      await getDbCollection("computed_jobs_partners").deleteMany({})
+      await getDbCollection("jobs_partners").deleteMany({})
+      await getDbCollection("search_items").deleteMany({})
+    }
+  })
+
+  it("indexe dans search_items les offres importées, sans attendre le cron delta", async () => {
+    const computed = await createComputedJobPartner({
+      partner_label: "Mission Apprentissage",
+      partner_job_id: "api_offer_1",
+      offer_title: "TEST SANDBOX - ne pas traiter",
+      validated: true,
+      business_error: null,
+      updated_at: new Date(),
+    })
+
+    await processJobPartnersForApi()
+
+    const jobPartner = await getDbCollection("jobs_partners").findOne({ partner_job_id: "api_offer_1" })
+    expect.soft(jobPartner?._id.toString()).toBe(computed._id.toString())
+    expect.soft(jobPartner?.offer_status).toBe(JOB_STATUS_ENGLISH.ACTIVE)
+
+    // Le _id est conservé de bout en bout : computed_jobs_partners → jobs_partners → search_items.
+    const searchItem = await getDbCollection("search_items").findOne({ _id: computed._id })
+    expect.soft(searchItem?.type).toBe("offre")
+    expect.soft(searchItem?.title).toBe("TEST SANDBOX - ne pas traiter")
+  })
+
+  it("n'indexe pas les offres que l'import a écartées", async () => {
+    // Near-miss : un document non validé traverse le même run sans être importé ni indexé.
+    const computed = await createComputedJobPartner({
+      partner_label: "Mission Apprentissage",
+      partner_job_id: "api_offer_2",
+      validated: false,
+      business_error: null,
+      updated_at: new Date(),
+    })
+
+    await processJobPartnersForApi()
+
+    expect.soft(await getDbCollection("jobs_partners").countDocuments({ partner_job_id: "api_offer_2" })).toBe(0)
+    expect.soft(await getDbCollection("search_items").countDocuments({ _id: computed._id })).toBe(0)
+  })
+})

--- a/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
+++ b/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
@@ -4,14 +4,38 @@ import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
 import type { IComputedJobsPartners } from "shared/models/jobs-partners-computed.model"
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { sentryCaptureException } from "@/common/utils/sentry-utils"
+import { syncSearchItemsDelta } from "@/services/search/search-items.service"
 import { fillComputedJobsPartners } from "./fill-computed-jobs-partners"
 import { fillLbaUrl } from "./fill-lba-url"
 import { importFromComputedToJobsPartners } from "./import-from-computed-to-jobs-partners"
 
 const excludedJobPartnersFromApi = Object.values(JOBPARTNERS_LABEL)
 
+/**
+ * Indexe dans search_items ce que le run vient d'écrire dans jobs_partners, sans attendre le cron
+ * delta : les deux crons n'ont aucun rendez-vous, et lancés sur la même minute le delta lit
+ * jobs_partners AVANT le commit de l'import (observé en recette le 28/08/2026 : import terminé à
+ * 10:00:49, delta démarré à 10:00:23 → « 0 modifiés », offre visible seulement à 10:15).
+ *
+ * Réutilise syncSearchItemsDelta plutôt que de collecter les _id dans la boucle d'import : la
+ * borne `updated_at` désigne exactement les documents écrits par ce run, et on hérite du
+ * découpage en chunks et du contexte de build partagé. Le cron delta reste le rattrapage.
+ *
+ * L'indexation ne doit pas faire échouer le run : l'import est déjà commité en base, et une erreur
+ * ici serait rejouée par le cron delta puis par la réconciliation nightly.
+ */
+const syncImportedJobsToSearchItems = async (since: Date) => {
+  try {
+    await syncSearchItemsDelta({ since })
+  } catch (err) {
+    sentryCaptureException(err)
+  }
+}
+
 export const processJobPartnersForApi = async () => {
   logger.info("début de processJobPartnersForApi")
+  const runStartedAt = new Date()
   const processId: string = new ObjectId().toString()
   const last2Days = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
   await getDbCollection("computed_jobs_partners").updateMany(
@@ -25,14 +49,17 @@ export const processJobPartnersForApi = async () => {
   await fillLbaUrl()
   await getDbCollection("computed_jobs_partners").deleteMany({ $and: [filter, { validated: true }] })
   await getDbCollection("computed_jobs_partners").updateMany(filter, { $set: { currently_processed_id: null } })
+  await syncImportedJobsToSearchItems(runStartedAt)
   logger.info("fin de processJobPartnersForApi")
 }
 
 export const processJobPartnersWithFilter = async (filter: Filter<IComputedJobsPartners>) => {
   logger.info({ filter }, "début de processJobPartnersWithFilter")
+  const runStartedAt = new Date()
   await fillComputedJobsPartners({ addedMatchFilter: filter })
   await importFromComputedToJobsPartners(filter)
   await fillLbaUrl()
   await getDbCollection("computed_jobs_partners").deleteMany({ $and: [filter, { validated: true }] })
+  await syncImportedJobsToSearchItems(runStartedAt)
   logger.info({ filter }, "fin de processJobPartnersWithFilter")
 }

--- a/server/src/jobs/recruiters/recruiter-offer-expiration-reminder-job.test.ts
+++ b/server/src/jobs/recruiters/recruiter-offer-expiration-reminder-job.test.ts
@@ -36,7 +36,13 @@ describe("recruiter-offer-expiration-reminder-job", () => {
     }
   })
 
-  it("utilise un fallback sur workplace_brand si workplace_name est vide", async () => {
+  // Les deux formes d'« absence » de workplace_name doivent mener au même repli. La chaîne vide
+  // est le cas réel du corpus : formatTextFieldsJobsPartners écrivait "" sur les champs texte
+  // absents, et un `??` ne bascule pas sur "".
+  it.for([
+    { label: "null", workplace_name: null },
+    { label: "chaîne vide", workplace_name: "" },
+  ])("utilise un fallback sur workplace_brand si workplace_name vaut $label", async ({ workplace_name }) => {
     const user = await saveUserWithAccount({
       email: "recruteur@email.fr",
       first_name: "Jean",
@@ -48,7 +54,7 @@ describe("recruiter-offer-expiration-reminder-job", () => {
       partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA,
       offer_status: JOB_STATUS_ENGLISH.ACTIVE,
       offer_expiration: dayjs().add(7, "day").add(1, "hour").toDate(),
-      workplace_name: null,
+      workplace_name,
       workplace_brand: "ACME Brand",
       workplace_legal_name: "ACME Legal",
       relance_mail_expiration_J7: null,

--- a/server/src/jobs/recruiters/recruiter-offer-expiration-reminder-job.ts
+++ b/server/src/jobs/recruiters/recruiter-offer-expiration-reminder-job.ts
@@ -26,7 +26,9 @@ const getReminderCompanyName = ({
   workplace_brand,
   workplace_legal_name,
 }: Pick<IJobsPartnersOfferPrivate, "workplace_name" | "workplace_brand" | "workplace_legal_name">) => {
-  return workplace_name ?? workplace_brand ?? workplace_legal_name ?? ""
+  // Chaîne de repli en `||` : workplace_name est sanitizé côté pipeline et peut valoir "" (cf.
+  // formatTextFieldsJobsPartners), ce qui court-circuiterait le repli sur brand / raison sociale.
+  return workplace_name || workplace_brand || workplace_legal_name || ""
 }
 
 export const recruiterOfferExpirationReminderJob = async (numberOfDaysToExpirationDate: number /* number of days to expiration for the reminder email to be sent */) => {

--- a/server/src/jobs/simple-job-definitions.ts
+++ b/server/src/jobs/simple-job-definitions.ts
@@ -419,8 +419,8 @@ export const simpleJobDefinitions: SimpleJobDefinition[] = [
   },
   {
     fct: syncSearchItemsDelta,
-    description: "Synchronise vers search_items les jobs_partners modifiés récemment (updated_at, fenêtre 30 min par défaut)",
-    cliOptions: [{ flags: "--since <date>", description: "Borne basse ISO 8601 des updated_at à synchroniser (défaut : now − 30 min)" }],
+    description: "Synchronise vers search_items les jobs_partners modifiés récemment (updated_at, fenêtre 10 min par défaut)",
+    cliOptions: [{ flags: "--since <date>", description: "Borne basse ISO 8601 des updated_at à synchroniser (défaut : now − 10 min)" }],
   },
   {
     fct: controlSearchItemsDrift,

--- a/server/src/services/formulaire-notifications.service.ts
+++ b/server/src/services/formulaire-notifications.service.ts
@@ -69,7 +69,9 @@ export async function sendMailNouvelleOffre(user: IUserWithAccount, job: IJobsPa
   const { email, last_name, first_name } = user
   const { is_delegated, workplace_name, workplace_siret, cfa_siret, cfa_legal_name, workplace_legal_name, workplace_brand } = job
   const raisonSocialeEntreprise = workplace_name || workplace_legal_name || workplace_brand
-  const establishmentTitle = workplace_name ?? workplace_siret
+  // `||` comme la ligne au-dessus : workplace_name peut valoir "" (champ sanitizé côté pipeline),
+  // auquel cas le mail partait avec une raison sociale vide au lieu du SIRET.
+  const establishmentTitle = workplace_name || workplace_siret
   // Send mail with action links to manage offers
   await mailer.sendEmail({
     to: email,

--- a/server/src/services/partner-job.service.ts
+++ b/server/src/services/partner-job.service.ts
@@ -50,7 +50,11 @@ function transformPartnerJob(
     },
     company: {
       siret: partnerJob.is_delegated ? partnerJob.cfa_siret : partnerJob.workplace_siret,
-      name: partnerJob.is_delegated ? partnerJob.cfa_legal_name : (partnerJob.workplace_name ?? partnerJob.workplace_brand ?? partnerJob.workplace_legal_name ?? UNKNOWN_COMPANY),
+      // `||` et non `??` sur la chaîne de repli : workplace_name est sanitizé côté pipeline et peut
+      // valoir "" (cf. formatTextFieldsJobsPartners), ce qui court-circuitait tous les replis et
+      // affichait une fiche détail sans employeur, alors que la carte de résultat — qui utilise `||`
+      // dans buildJobOfferSearchItem — affichait bien la raison sociale.
+      name: partnerJob.is_delegated ? partnerJob.cfa_legal_name : partnerJob.workplace_name || partnerJob.workplace_brand || partnerJob.workplace_legal_name || UNKNOWN_COMPANY,
       size: partnerJob.workplace_size,
       opco: { label: partnerJob.workplace_opco, url: null },
       url: partnerJob.workplace_website,

--- a/server/src/services/search/search-items.service.ts
+++ b/server/src/services/search/search-items.service.ts
@@ -526,13 +526,16 @@ export const syncJobPartnersToSearchItemsInBackground = (ids: ObjectId[]): void 
   upsertJobPartnersToSearchItems(ids).catch((err) => sentryCaptureException(err))
 }
 
-// Fenêtre du delta : 2× l'intervalle du cron (15 min) — un run raté est rattrapé par le
-// suivant, les upserts sont idempotents, et le nightly réconcilie l'ensemble.
-const DELTA_DEFAULT_WINDOW_MS = 30 * 60 * 1000
+// Fenêtre du delta : 2× l'intervalle du cron (5 min) — un run raté est rattrapé par le
+// suivant, les upserts sont idempotents, et le nightly réconcilie l'ensemble. À garder aligné
+// sur l'intervalle : une fenêtre plus large ne protège pas davantage (un run raté reste couvert)
+// mais réécrit chaque document autant de fois qu'il y a de runs dans la fenêtre — ce qui pesait
+// pendant les imports de masse nocturnes.
+const DELTA_DEFAULT_WINDOW_MS = 10 * 60 * 1000
 const DELTA_CHUNK_SIZE = 500
 
 /**
- * Cron delta : synchronise les jobs_partners modifiés depuis `since` (défaut : 30 min).
+ * Cron delta : synchronise les jobs_partners modifiés depuis `since` (défaut : 10 min).
  * Couvre les écritures de masse (expiration, imports, dédoublonnage…) qui bumpent
  * `updated_at` — les suppressions physiques, invisibles ici, sont traitées par les appels
  * explicites et la purge des orphelins du nightly.


### PR DESCRIPTION
Closes #5315

## Changements

**Chaîne vide au lieu de null sur les champs texte sanitizés**

- `formatTextFieldsJobsPartners` préserve `null` au lieu de l'écraser par `""` (un champ absent, ou dont il ne reste rien après sanitization, reste `null`). C'est la cause racine : le filtre du job ne sélectionne qu'un champ non nul sur les quatre, les trois autres étaient réécrits quand même.
- `||` au lieu de `??` sur les 5 chaînes de repli réellement impactées : `fillSiretInfosForPartners` (qui tourne après la sanitization et ne remplissait donc plus `workplace_name` depuis l'enseigne / la raison sociale du SIRET), la fiche détail `transformPartnerJob`, les 3 helpers de nom d'entreprise dupliqués des mails (expiration, clôture au seuil, relance J-7/J-1) et la notification de nouvelle offre.
- Convention confirmée : `application.service.ts`, le converter API v3 et le builder `search_items` utilisaient déjà `||` — l'API v3 n'était pas affectée.
- Les autres `?? ""` / `?? undefined` / `?? null` sur ces champs sont laissés tels quels : leur repli est déjà la valeur vide, aucun changement de comportement.

**Indexation des offres déposées par API**

- `processJobPartnersForApi` et `processJobPartnersWithFilter` indexent dans `search_items` ce que le run vient d'écrire, via `syncSearchItemsDelta({ since: runStartedAt })`, dans un try/catch : l'import est déjà commité, une erreur d'indexation ne doit pas faire échouer le run et serait rejouée par le cron delta puis par la réconciliation nightly.
- Cron delta `search_items` passé de 15 à 5 min avec `concurrency: exclusive`. Il ne porte plus la latence des offres API : il couvre les chemins de **retrait** (expiration, annulation, clôture au seuil) qui écrivent `offer_status: ANNULEE` + `updated_at` sans aucune sync directe. Exclusive parce que le run monte à 4 min pendant les imports de masse nocturnes (mesuré en prod).
- `DELTA_DEFAULT_WINDOW_MS` ramené de 30 à 10 min pour garder l'invariant « 2x l'intervalle » : une fenêtre plus large ne protège pas davantage mais réécrit chaque document autant de fois qu'il y a de runs dans la fenêtre.

**Tests** — chacun vérifié en remettant le code d'origine pour confirmer l'échec sur l'entrée exacte :

- `format-text-fields-jobs-partners.test.ts` (nouveau) : champ absent qui reste `null`, `""` existant normalisé, champ renseigné sanitizé sans être vidé.
- `process-job-partners-for-api.test.ts` (nouveau) : un document validé traverse `computed_jobs_partners` -> `jobs_partners` -> `search_items` dans le même appel, plus le near-miss du document non validé qui n'est ni importé ni indexé.
- `fill-siret-infos-for-partners.test.ts` : `workplace_name: ""` rempli depuis le SIRET, nom fourni par le partenaire préservé.
- `jobs.controller.test.ts` : fiche détail d'une offre partenaire, raison sociale servie quand `workplace_name` vaut `""`, nom par défaut quand tout est vide, `workplace_name` prioritaire sinon.

## Plan de test

- [ ] `yarn vitest run --no-file-parallelism server/src/jobs server/src/http/controllers/jobs.controller.test.ts server/src/services/search` : 70 suites vertes (63 skips préexistants, suites de pertinence qui exigent un index mongot). En exécution parallèle, un jeu variable de suites échoue sur un timeout du hook `useMongo` — contention locale du harness, pas de la PR.
- [ ] Déposer une offre en recette via une clé API sandbox avec seulement `workplace.siret`, `apply.email`, `offer.title` et `offer.description`.
- [ ] Vérifier que la fiche détail affiche la raison sociale de l'entreprise et non un employeur vide.
- [ ] Vérifier que l'offre remonte dans la recherche au tick suivant du cron d'offres API (5 min max), sans attendre le cron delta.
- [ ] Après déploiement, contrôler dans Loki qu'aucun run du cron delta n'apparaît en `skipped` (signe d'un run dépassant 5 min) et que la ligne `syncSearchItemsDelta` apparaît bien dans les logs de `processJobPartnersForApi`.
- [ ] Vérifier qu'une offre expirée ou annulée disparaît de la recherche dans les 5 min.