### PR TITLE
fix: cible l'indexation search_items sur les offres importées plutôt que sur une fenêtre de temps

### DIFF
--- a/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.test.ts
+++ b/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.test.ts
@@ -1,5 +1,6 @@
 import { createComputedJobPartner, createJobPartner } from "@tests/utils/jobsPartners.test.utils"
 import { useMongo } from "@tests/utils/mongo.test.utils"
+import type { ObjectId } from "mongodb"
 import { JOB_STATUS_ENGLISH } from "shared/models/index"
 import { JOB_PARTNER_BUSINESS_ERROR } from "shared/models/jobs-partners-computed.model"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -51,6 +52,40 @@ describe("Importing computed_jobs_partners into jobs_partners", () => {
     // les éléments validated et déjà dans jobs partners doivent toujours y être avec les data modifiées à jour
     const existing_3 = await getDbCollection("jobs_partners").findOne({ partner_job_id: "existing_3" })
     expect.soft(existing_3?.offer_description === newDesc)
+  })
+
+  describe("onImported", () => {
+    it("remonte les _id jobs_partners des offres importées, y compris quand ils diffèrent du computed", async () => {
+      // "existing_3" est déjà dans jobs_partners avec son propre _id, et son document computed en a
+      // un autre : c'est l'_id de jobs_partners qu'il faut remonter, sinon l'appelant travaille sur
+      // un _id qui n'existe pas dans la collection (l'indexation search_items le traiterait comme
+      // une offre disparue et tenterait de la retirer de l'index).
+      const existingJobPartner = await getDbCollection("jobs_partners").findOne({ partner_job_id: "existing_3" })
+      const computedOfExisting = await getDbCollection("computed_jobs_partners").findOne({ partner_job_id: "existing_3" })
+      const computedNew = await getDbCollection("computed_jobs_partners").findOne({ partner_job_id: "computed_1" })
+      expect.soft(existingJobPartner!._id.equals(computedOfExisting!._id)).toBe(false)
+
+      let importedIds: ObjectId[] = []
+      await importFromComputedToJobsPartners(undefined, (ids) => {
+        importedIds = ids
+      })
+
+      const asStrings = importedIds.map((id) => id.toString())
+      // Les deux offres validées : la nouvelle (_id du computed) et l'existante (_id de jobs_partners).
+      expect.soft(asStrings).toHaveLength(2)
+      expect.soft(asStrings).toContain(computedNew!._id.toString())
+      expect.soft(asStrings).toContain(existingJobPartner!._id.toString())
+      expect.soft(asStrings).not.toContain(computedOfExisting!._id.toString())
+    })
+
+    it("n'est pas appelé quand aucune offre n'est importée", async () => {
+      await getDbCollection("computed_jobs_partners").updateMany({}, { $set: { validated: false } })
+      const onImported = vi.fn()
+
+      await importFromComputedToJobsPartners(undefined, onImported)
+
+      expect(onImported).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.ts
@@ -1,5 +1,5 @@
 import { internal } from "@hapi/boom"
-import type { Filter } from "mongodb"
+import type { Filter, ObjectId } from "mongodb"
 import { TRAINING_CONTRACT_TYPE } from "shared/constants/index"
 import { JOB_STATUS_ENGLISH } from "shared/models/index"
 import type { IJobsPartnersOfferPrivate } from "shared/models/jobs-partners.model"
@@ -12,7 +12,17 @@ import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
 import { limitStream } from "@/common/utils/stream-utils"
 
-export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter<IComputedJobsPartners>) => {
+/**
+ * `onImported` reçoit, en fin d'import, les _id **jobs_partners** effectivement écrits — utile aux
+ * appelants qui doivent enchaîner sur ces offres précisément (indexation search_items du cron
+ * offres API). Les _id ne sont matérialisés que si un consommateur est branché : le flux nightly
+ * importe des centaines de milliers de documents et n'a pas à payer la liste.
+ *
+ * Attention, l'_id jobs_partners n'est PAS toujours celui du document computed : l'upsert cible
+ * `{partner_job_id, partner_label}`, donc une offre déjà présente conserve son propre _id et
+ * `$setOnInsert._id` ne s'applique qu'à la création.
+ */
+export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter<IComputedJobsPartners>, onImported?: (jobPartnerIds: ObjectId[]) => void | Promise<void>) => {
   logger.info(`import dans jobs_partners commencé`)
   const filters: Filter<IComputedJobsPartners>[] = [{ validated: true, business_error: null }]
   if (addedMatchFilter) {
@@ -22,6 +32,7 @@ export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter
   const stream = await getDbCollection("computed_jobs_partners").find({ $and: filters }).stream()
 
   const counters = { total: 0, success: 0, error: 0 }
+  const importedIds: ObjectId[] | null = onImported ? [] : null
   const importDate = new Date()
 
   const transform = limitStream<Omit<IJobsPartnersOfferPrivate, "created_at">>({
@@ -106,6 +117,11 @@ export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter
           { upsert: true }
         )
 
+        // Collecté après l'écriture réussie. L'_id de l'offre est celui du document existant s'il y
+        // en a un, sinon celui posé par $setOnInsert — la projection du findOne ci-dessus renvoie
+        // _id, inclus par défaut.
+        importedIds?.push(existingJob?._id ?? computedJobPartner._id)
+
         const historyEntriesToPush = [
           ...(computedJobPartner?.offer_status_history ?? []),
           ...(existingJob?.offer_status === JOB_STATUS_ENGLISH.ANNULEE && partnerJobToUpsert.offer_status === JOB_STATUS_ENGLISH.ACTIVE
@@ -152,6 +168,10 @@ export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter
   await pipeline(stream, transform)
 
   logger.info({ counters }, "import dans jobs_partners terminé")
+
+  if (importedIds?.length) {
+    await onImported?.(importedIds)
+  }
 
   return counters
 }

--- a/server/src/jobs/offre-partenaire/process-job-partners-for-api.test.ts
+++ b/server/src/jobs/offre-partenaire/process-job-partners-for-api.test.ts
@@ -1,6 +1,7 @@
-import { createComputedJobPartner } from "@tests/utils/jobsPartners.test.utils"
+import { createComputedJobPartner, createJobPartner } from "@tests/utils/jobsPartners.test.utils"
 import { useMongo } from "@tests/utils/mongo.test.utils"
 import { JOB_STATUS_ENGLISH } from "shared/models/index"
+import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { resetSearchItemBuildContextCache } from "@/services/search/search-items.service"
@@ -46,6 +47,33 @@ describe("process-job-partners-for-api", () => {
     const searchItem = await getDbCollection("search_items").findOne({ _id: computed._id })
     expect.soft(searchItem?.type).toBe("offre")
     expect.soft(searchItem?.title).toBe("TEST SANDBOX - ne pas traiter")
+  })
+
+  it("n'indexe pas ce qu'un autre job écrit pendant le run", async () => {
+    // Garde-fou du ciblage par _id : une borne `updated_at` absorberait tout ce que l'expiration,
+    // le dédoublonnage ou un import de flux écrit en parallèle, et ce cron hériterait de leur
+    // volume (jusqu'à 4 min mesurées sur le cron delta pendant les imports nocturnes).
+    const autreJob = await createJobPartner({
+      partner_job_id: "ecrit_par_un_autre_job",
+      partner_label: JOBPARTNERS_LABEL.HELLOWORK,
+      offer_status: JOB_STATUS_ENGLISH.ACTIVE,
+      updated_at: new Date(),
+    })
+
+    await createComputedJobPartner({
+      partner_label: "Mission Apprentissage",
+      partner_job_id: "api_offer_3",
+      validated: true,
+      business_error: null,
+      updated_at: new Date(),
+    })
+
+    await processJobPartnersForApi()
+
+    expect.soft(await getDbCollection("search_items").countDocuments({ _id: autreJob._id })).toBe(0)
+    // L'offre du run, elle, est bien indexée.
+    const importee = await getDbCollection("jobs_partners").findOne({ partner_job_id: "api_offer_3" })
+    expect.soft(await getDbCollection("search_items").countDocuments({ _id: importee!._id })).toBe(1)
   })
 
   it("n'indexe pas les offres que l'import a écartées", async () => {

--- a/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
+++ b/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
@@ -36,6 +36,10 @@ const syncImportedJobsToSearchItems = async (jobPartnerIds: ObjectId[]) => {
     const { upserted, removed } = await syncJobPartnersToSearchItemsInChunks(jobPartnerIds)
     logger.info(`processJobPartnersForApi: indexation search_items de ${jobPartnerIds.length} offres importées — ${upserted} upserts, ${removed} retraits`)
   } catch (err) {
+    // Loggué en plus de Sentry : le run sort en succès, donc sans cette ligne la dégradation est
+    // indiscernable d'un bon run dans les logs — or c'est là qu'on diagnostique la latence
+    // d'indexation. Les offres restent rattrapées par le cron delta puis par le nightly.
+    logger.error({ err, count: jobPartnerIds.length }, "processJobPartnersForApi: indexation search_items en échec, rattrapage laissé au cron delta")
     sentryCaptureException(err)
   }
 }

--- a/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
+++ b/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
@@ -5,7 +5,7 @@ import type { IComputedJobsPartners } from "shared/models/jobs-partners-computed
 import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
-import { syncSearchItemsDelta } from "@/services/search/search-items.service"
+import { syncJobPartnersToSearchItemsInChunks } from "@/services/search/search-items.service"
 import { fillComputedJobsPartners } from "./fill-computed-jobs-partners"
 import { fillLbaUrl } from "./fill-lba-url"
 import { importFromComputedToJobsPartners } from "./import-from-computed-to-jobs-partners"
@@ -13,21 +13,28 @@ import { importFromComputedToJobsPartners } from "./import-from-computed-to-jobs
 const excludedJobPartnersFromApi = Object.values(JOBPARTNERS_LABEL)
 
 /**
- * Indexe dans search_items ce que le run vient d'écrire dans jobs_partners, sans attendre le cron
- * delta : les deux crons n'ont aucun rendez-vous, et lancés sur la même minute le delta lit
+ * Indexe dans search_items les offres que le run vient d'écrire dans jobs_partners, sans attendre
+ * le cron delta : les deux crons n'ont aucun rendez-vous, et lancés sur la même minute le delta lit
  * jobs_partners AVANT le commit de l'import (observé en recette le 28/08/2026 : import terminé à
  * 10:00:49, delta démarré à 10:00:23 → « 0 modifiés », offre visible seulement à 10:15).
  *
- * Réutilise syncSearchItemsDelta plutôt que de collecter les _id dans la boucle d'import : la
- * borne `updated_at` désigne exactement les documents écrits par ce run, et on hérite du
- * découpage en chunks et du contexte de build partagé. Le cron delta reste le rattrapage.
+ * Indexation ciblée sur les _id importés, et non sur une fenêtre `updated_at` : une fenêtre
+ * absorberait tout ce qu'un AUTRE job écrit pendant ce run, donc jusqu'à 4 min de travail mesurées
+ * pendant les imports de masse nocturnes — de quoi allonger ce cron au-delà de son intervalle de
+ * 5 min et faire skipper des runs (concurrency exclusive), soit exactement la latence de
+ * publication qu'on cherche à réduire. Le cron delta reste le rattrapage.
  *
  * L'indexation ne doit pas faire échouer le run : l'import est déjà commité en base, et une erreur
  * ici serait rejouée par le cron delta puis par la réconciliation nightly.
  */
-const syncImportedJobsToSearchItems = async (since: Date) => {
+const syncImportedJobsToSearchItems = async (jobPartnerIds: ObjectId[]) => {
+  // La plupart des runs n'importent rien : pas de ligne de log toutes les 5 min pour 0 offre.
+  if (!jobPartnerIds.length) {
+    return
+  }
   try {
-    await syncSearchItemsDelta({ since })
+    const { upserted, removed } = await syncJobPartnersToSearchItemsInChunks(jobPartnerIds)
+    logger.info(`processJobPartnersForApi: indexation search_items de ${jobPartnerIds.length} offres importées — ${upserted} upserts, ${removed} retraits`)
   } catch (err) {
     sentryCaptureException(err)
   }
@@ -35,7 +42,6 @@ const syncImportedJobsToSearchItems = async (since: Date) => {
 
 export const processJobPartnersForApi = async () => {
   logger.info("début de processJobPartnersForApi")
-  const runStartedAt = new Date()
   const processId: string = new ObjectId().toString()
   const last2Days = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
   await getDbCollection("computed_jobs_partners").updateMany(
@@ -44,22 +50,27 @@ export const processJobPartnersForApi = async () => {
   )
 
   const filter = { currently_processed_id: processId }
+  let importedIds: ObjectId[] = []
   await fillComputedJobsPartners({ addedMatchFilter: filter })
-  await importFromComputedToJobsPartners(filter)
+  await importFromComputedToJobsPartners(filter, (ids) => {
+    importedIds = ids
+  })
   await fillLbaUrl()
   await getDbCollection("computed_jobs_partners").deleteMany({ $and: [filter, { validated: true }] })
   await getDbCollection("computed_jobs_partners").updateMany(filter, { $set: { currently_processed_id: null } })
-  await syncImportedJobsToSearchItems(runStartedAt)
+  await syncImportedJobsToSearchItems(importedIds)
   logger.info("fin de processJobPartnersForApi")
 }
 
 export const processJobPartnersWithFilter = async (filter: Filter<IComputedJobsPartners>) => {
   logger.info({ filter }, "début de processJobPartnersWithFilter")
-  const runStartedAt = new Date()
+  let importedIds: ObjectId[] = []
   await fillComputedJobsPartners({ addedMatchFilter: filter })
-  await importFromComputedToJobsPartners(filter)
+  await importFromComputedToJobsPartners(filter, (ids) => {
+    importedIds = ids
+  })
   await fillLbaUrl()
   await getDbCollection("computed_jobs_partners").deleteMany({ $and: [filter, { validated: true }] })
-  await syncImportedJobsToSearchItems(runStartedAt)
+  await syncImportedJobsToSearchItems(importedIds)
   logger.info({ filter }, "fin de processJobPartnersWithFilter")
 }

--- a/server/src/services/search/search-items.service.ts
+++ b/server/src/services/search/search-items.service.ts
@@ -517,15 +517,6 @@ export const removeJobPartnersFromSearchItems = async (ids: ObjectId[]): Promise
   return result.deletedCount
 }
 
-/**
- * Variante fire-and-forget pour les actions métier unitaires (création, activation,
- * annulation, pourvue…) : la synchronisation de l'index ne doit JAMAIS faire échouer
- * l'action — erreur capturée Sentry, rattrapage par le cron delta puis le nightly.
- */
-export const syncJobPartnersToSearchItemsInBackground = (ids: ObjectId[]): void => {
-  upsertJobPartnersToSearchItems(ids).catch((err) => sentryCaptureException(err))
-}
-
 // Fenêtre du delta : 2× l'intervalle du cron (5 min) — un run raté est rattrapé par le
 // suivant, les upserts sont idempotents, et le nightly réconcilie l'ensemble. À garder aligné
 // sur l'intervalle : une fenêtre plus large ne protège pas davantage (un run raté reste couvert)
@@ -535,13 +526,24 @@ const DELTA_DEFAULT_WINDOW_MS = 10 * 60 * 1000
 const DELTA_CHUNK_SIZE = 500
 
 /**
- * Synchronise une liste d'_id jobs_partners vers search_items : contexte de build chargé UNE fois
- * pour tout l'appel (pas par chunk : 2 agrégations full-scan sinon) et découpage en chunks, pour
- * ne pas charger des dizaines de milliers de documents d'un coup. Point d'entrée commun au cron
- * delta et aux appelants qui connaissent déjà les _id qu'ils ont écrits (import des offres API).
+ * Point d'entrée UNIQUE de la synchronisation incrémentale vers search_items, quelle que soit la
+ * taille de la liste : cron delta, import des offres API, et actions métier unitaires via la
+ * variante fire-and-forget ci-dessous.
+ *
+ * Deux garanties que les appelants n'ont pas à reproduire : découpage en chunks, pour ne pas
+ * charger des dizaines de milliers de documents d'un coup (`unsubscribeRecruteurLba` passe toutes
+ * les offres des entreprises désinscrites), et contexte de build chargé UNE fois pour tout l'appel
+ * — pas par chunk, sinon 2 agrégations full-scan sur search_items à chaque tranche.
+ *
+ * Contexte mémoïsé (`getSearchItemBuildContext`) et non rechargé : ces agrégations dominent le coût
+ * d'un run utile (mesuré en prod sur le cron delta : 2 à 3 s avec une poignée de documents contre
+ * 30 à 50 ms à vide, contexte non chargé), et ce point d'entrée est désormais appelé toutes les
+ * 5 min par l'import des offres API. La fraîcheur des maps de canonicalisation n'a pas besoin
+ * d'être parfaite : canonicalizeCase les enrichit en mémoire entre deux rechargements. Le batch
+ * nightly, lui, garde le chargement frais — c'est une reconstruction complète.
  */
 export const syncJobPartnersToSearchItemsInChunks = async (ids: ObjectId[]): Promise<{ upserted: number; removed: number }> => {
-  const ctx = ids.length ? await loadSearchItemBuildContext() : undefined
+  const ctx = ids.length ? await getSearchItemBuildContext() : undefined
 
   let upserted = 0
   let removed = 0
@@ -552,6 +554,15 @@ export const syncJobPartnersToSearchItemsInChunks = async (ids: ObjectId[]): Pro
   }
 
   return { upserted, removed }
+}
+
+/**
+ * Variante fire-and-forget pour les actions métier unitaires (création, activation, annulation,
+ * pourvue…) : la synchronisation de l'index ne doit JAMAIS faire échouer l'action — erreur
+ * capturée Sentry, rattrapage par le cron delta puis le nightly.
+ */
+export const syncJobPartnersToSearchItemsInBackground = (ids: ObjectId[]): void => {
+  syncJobPartnersToSearchItemsInChunks(ids).catch((err) => sentryCaptureException(err))
 }
 
 /**

--- a/server/src/services/search/search-items.service.ts
+++ b/server/src/services/search/search-items.service.ts
@@ -535,6 +535,26 @@ const DELTA_DEFAULT_WINDOW_MS = 10 * 60 * 1000
 const DELTA_CHUNK_SIZE = 500
 
 /**
+ * Synchronise une liste d'_id jobs_partners vers search_items : contexte de build chargé UNE fois
+ * pour tout l'appel (pas par chunk : 2 agrégations full-scan sinon) et découpage en chunks, pour
+ * ne pas charger des dizaines de milliers de documents d'un coup. Point d'entrée commun au cron
+ * delta et aux appelants qui connaissent déjà les _id qu'ils ont écrits (import des offres API).
+ */
+export const syncJobPartnersToSearchItemsInChunks = async (ids: ObjectId[]): Promise<{ upserted: number; removed: number }> => {
+  const ctx = ids.length ? await loadSearchItemBuildContext() : undefined
+
+  let upserted = 0
+  let removed = 0
+  for (let i = 0; i < ids.length; i += DELTA_CHUNK_SIZE) {
+    const result = await upsertJobPartnersToSearchItems(ids.slice(i, i + DELTA_CHUNK_SIZE), ctx)
+    upserted += result.upserted
+    removed += result.removed
+  }
+
+  return { upserted, removed }
+}
+
+/**
  * Cron delta : synchronise les jobs_partners modifiés depuis `since` (défaut : 10 min).
  * Couvre les écritures de masse (expiration, imports, dédoublonnage…) qui bumpent
  * `updated_at` — les suppressions physiques, invisibles ici, sont traitées par les appels
@@ -550,16 +570,7 @@ export const syncSearchItemsDelta = async (payload?: { since?: Date | string }) 
     .map((doc) => doc._id)
     .toArray()
 
-  // Contexte chargé UNE fois pour tout le run (pas par chunk : 2 agrégations full-scan sinon).
-  const ctx = ids.length ? await loadSearchItemBuildContext() : undefined
-
-  let upserted = 0
-  let removed = 0
-  for (let i = 0; i < ids.length; i += DELTA_CHUNK_SIZE) {
-    const result = await upsertJobPartnersToSearchItems(ids.slice(i, i + DELTA_CHUNK_SIZE), ctx)
-    upserted += result.upserted
-    removed += result.removed
-  }
+  const { upserted, removed } = await syncJobPartnersToSearchItemsInChunks(ids)
 
   logger.info(`syncSearchItemsDelta: ${ids.length} jobs_partners modifiés depuis ${since.toISOString()} — ${upserted} upserts, ${removed} retraits`)
   return { scanned: ids.length, upserted, removed }


### PR DESCRIPTION
Suite de la PR 5316, déjà mergée : elle indexait les offres fraîchement importées en réutilisant `syncSearchItemsDelta({ since: runStartedAt })`, donc en sélectionnant les documents **par fenêtre `updated_at`**. Ce point avait été relevé en revue et n'était pas corrigé au moment du merge.

## Le problème

Une borne temporelle ne désigne pas les offres du run : elle absorbe tout ce qu'un **autre** job écrit pendant ce run (expiration, annulation, dédoublonnage, import de flux). Le cron d'offres API héritait donc de leur volume — jusqu'à 4 min de travail mesurées sur le cron delta pendant les imports de masse nocturnes en production. Avec un intervalle de 5 min et `concurrency: exclusive`, un run allongé fait skipper le suivant, soit exactement la latence de publication que la PR 5316 cherchait à réduire.

## Changements

- `syncJobPartnersToSearchItemsInChunks(ids)` extrait dans `search-items.service.ts` : contexte de build chargé une fois, découpage par 500. `syncSearchItemsDelta` l'appelle aussi désormais, donc les deux chemins partagent le même code et la ligne de log du cron delta est inchangée.
- `importFromComputedToJobsPartners` accepte un callback optionnel `onImported`, qui reçoit les `_id` **jobs_partners** effectivement écrits.
  - Rien n'est matérialisé sans consommateur : le flux nightly importe des centaines de milliers de documents et ne paie pas la liste. La valeur de retour de la fonction est inchangée.
  - L'`_id` remonté est celui de `jobs_partners`, pas celui du document computed : l'upsert cible `{partner_job_id, partner_label}`, donc une offre déjà présente conserve son propre `_id`. Remonter l'`_id` du computed aurait été un piège silencieux, `upsertJobPartnersToSearchItems` traitant un `_id` inconnu de `jobs_partners` comme une offre disparue et la **retirant** de l'index. L'information vient du `findOne` déjà présent avant l'upsert, sans requête supplémentaire, et la collecte a lieu après l'écriture réussie.
- `processJobPartnersForApi` et `processJobPartnersWithFilter` passent ces `_id`, avec un early return quand il n'y a rien à indexer pour ne pas logger toutes les 5 minutes.

## Tests

Chacun vérifié en remettant le code précédent pour confirmer qu'il échoue sur l'entrée exacte :

- `n'indexe pas ce qu'un autre job écrit pendant le run` : garde-fou du ciblage par `_id`, échoue en `expected 1 to be +0` avec l'approche par fenêtre.
- `onImported remonte les _id jobs_partners, y compris quand ils diffèrent du computed` : asserte explicitement que les deux `_id` diffèrent avant de vérifier lequel est remonté.
- `onImported n'est pas appelé quand aucune offre n'est importée`.

## Plan de test

- [ ] `yarn vitest run --no-file-parallelism server/src/jobs/offre-partenaire server/src/services/search` : 50 suites vertes (63 skips préexistants, suites de pertinence qui exigent un index mongot)
- [ ] Suite serveur complète : 120 suites, 948 tests
- [ ] Déposer une offre en recette via une clé API sandbox et vérifier qu'elle remonte dans la recherche au tick suivant du cron d'offres API
- [ ] Après déploiement, vérifier dans les logs la ligne `processJobPartnersForApi: indexation search_items de N offres importées`, et que N correspond au nombre d'offres réellement importées par le run (et non au volume écrit par les autres jobs)
- [ ] Vérifier qu'une offre expirée ou annulée disparaît toujours de la recherche dans les 5 min, via le cron delta