### PR TITLE
fix: missed check-in en masse sur les cron monitors Sentry (#5324)

### DIFF
--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -269,13 +269,18 @@ export async function setupJobProcessor() {
           // (expiration */30, annulation, dédoublonnage, imports de flux) et sert de rattrapage.
           // Maintenu à 5 min pour le retrait : une offre expirée ou annulée reste sinon proposée en
           // recherche jusqu'au run suivant. Runs à vide à 30-50 ms, 2 à 3 s en régime nominal.
-          // concurrency exclusive : jusqu'à 4 min pendant les imports de masse nocturnes (mesuré le
-          // 28/08/2026 à 03:35 UTC) — au-delà de l'intervalle, deux runs se chevaucheraient.
+          // Pas de `concurrency: { mode: "exclusive" }`, pour la même raison que le cron jobs_partners
+          // ci-dessus : mesuré en prod le 29/08/2026, ce cron perdait 127 slots par 24 h en
+          // `noConcurrent_conflict`, soit un sur deux. La cadence effective retombait à 10 min, très
+          // exactement la largeur de DELTA_DEFAULT_WINDOW_MS — plus aucune marge de recouvrement, donc
+          // le moindre retard de démarrage ouvrait un trou rattrapé seulement par la réconciliation
+          // nocturne. Le chevauchement que `exclusive` évitait est sans danger ici : le handler lit
+          // jobs_partners et upsert search_items par _id sans muter la source, deux runs concurrents
+          // sont idempotents.
           "Sync delta search_items (jobs_partners modifiés)": {
             cron_string: "*/5 * * * *",
             handler: async () => syncSearchItemsDelta(),
             tag: "slave",
-            concurrency: { mode: "exclusive" },
           },
           // Après processComputedAndImportToJobPartners (départ 00:01, maxRuntime 300 min → fin
           // au plus tard ~05:00) : rattrape ce que la sync incrémentale a manqué et purge les

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -98,11 +98,14 @@ export async function setupJobProcessor() {
             handler: async () => processApplications(),
             tag: "main",
           },
+          // Pas de `concurrency: { mode: "exclusive" }` ici : le scheduler de job-processor crée le
+          // cron_task du slot suivant en `pending`, et l'index unique partiel cron_task_exclusive_unique
+          // couvre `pending` — un slot encore en attente bloque donc la création du suivant, qui part en
+          // `skipped` sans check-in Sentry. À 5 min de cadence, un slot sur deux était perdu.
           "Traitement complet des jobs_partners par API": {
             cron_string: "*/5 * * * *",
             handler: processJobPartnersForApi,
             tag: "slave",
-            concurrency: { mode: "exclusive" },
           },
           "Expiration des offres jobs_partners": {
             cron_string: "*/30 * * * *",
@@ -215,10 +218,15 @@ export async function setupJobProcessor() {
             handler: updateParcoursupAndAffelnetInfoOnFormationCatalogue,
             tag: "main",
           },
+          // Durées prod mesurées sur 7 nuits : 68 à 96 min, donc au-delà du maxRuntime par défaut
+          // (60 min) — le monitor Sentry partait en timeout chaque nuit. La marge de check-in tient
+          // compte de l'import catalogue (02:15, maxRuntime 90) qui peut déborder sur le même worker.
           "Synchronise les formations eligibles à la prise de rendez-vous": {
             cron_string: "45 2 * * *",
             handler: syncEtablissementsAndFormations,
             tag: "main",
+            checkinMargin: 30,
+            maxRuntimeInMinutes: 120,
           },
           "Export des offres sur S3 v2": {
             cron_string: "0 3 * * *",

--- a/server/src/jobs/offre-partenaire/process-job-partners-for-api.test.ts
+++ b/server/src/jobs/offre-partenaire/process-job-partners-for-api.test.ts
@@ -1,5 +1,6 @@
 import { createComputedJobPartner, createJobPartner } from "@tests/utils/jobsPartners.test.utils"
 import { useMongo } from "@tests/utils/mongo.test.utils"
+import { ObjectId } from "mongodb"
 import { JOB_STATUS_ENGLISH } from "shared/models/index"
 import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -47,6 +48,61 @@ describe("process-job-partners-for-api", () => {
     const searchItem = await getDbCollection("search_items").findOne({ _id: computed._id })
     expect.soft(searchItem?.type).toBe("offre")
     expect.soft(searchItem?.title).toBe("TEST SANDBOX - ne pas traiter")
+  })
+
+  it("ne revendique pas les documents déjà pris par un run en cours", async () => {
+    // Sans ce filtre, ce run réattribuerait le document et l'import du run concurrent, qui cible son
+    // propre processId, ne matcherait plus rien : son travail serait perdu sans erreur.
+    const autreRun = new ObjectId().toString()
+    const computed = await createComputedJobPartner({
+      partner_label: "Mission Apprentissage",
+      partner_job_id: "api_offer_pris",
+      validated: true,
+      business_error: null,
+      updated_at: new Date(),
+      currently_processed_id: autreRun,
+    })
+
+    await processJobPartnersForApi()
+
+    const apres = await getDbCollection("computed_jobs_partners").findOne({ _id: computed._id })
+    expect.soft(apres?.currently_processed_id).toBe(autreRun)
+    expect(await getDbCollection("jobs_partners").findOne({ partner_job_id: "api_offer_pris" })).toBeNull()
+  })
+
+  it("réattribue les documents laissés par un processId périmé", async () => {
+    // Un run tué net (redéploiement) ne passe pas par la libération : sans échappatoire ses
+    // documents resteraient revendiqués pour toujours, donc jamais publiés.
+    const runMort = ObjectId.createFromTime(Math.floor((Date.now() - 2 * 60 * 60 * 1000) / 1000)).toString()
+    const computed = await createComputedJobPartner({
+      partner_label: "Mission Apprentissage",
+      partner_job_id: "api_offer_orphelin",
+      validated: true,
+      business_error: null,
+      updated_at: new Date(),
+      currently_processed_id: runMort,
+    })
+
+    await processJobPartnersForApi()
+
+    expect.soft((await getDbCollection("jobs_partners").findOne({ partner_job_id: "api_offer_orphelin" }))?._id.toString()).toBe(computed._id.toString())
+  })
+
+  it("libère les documents revendiqués même quand le run échoue", async () => {
+    const computed = await createComputedJobPartner({
+      partner_label: "Mission Apprentissage",
+      partner_job_id: "api_offer_echec",
+      validated: true,
+      business_error: null,
+      updated_at: new Date(),
+    })
+    const importer = await import("./import-from-computed-to-jobs-partners")
+    vi.spyOn(importer, "importFromComputedToJobsPartners").mockRejectedValueOnce(new Error("panne simulée"))
+
+    await expect(processJobPartnersForApi()).rejects.toThrow("panne simulée")
+
+    const apres = await getDbCollection("computed_jobs_partners").findOne({ _id: computed._id })
+    expect(apres?.currently_processed_id).toBeNull()
   })
 
   it("n'indexe pas ce qu'un autre job écrit pendant le run", async () => {

--- a/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
+++ b/server/src/jobs/offre-partenaire/process-job-partners-for-api.ts
@@ -21,8 +21,8 @@ const excludedJobPartnersFromApi = Object.values(JOBPARTNERS_LABEL)
  * Indexation ciblée sur les _id importés, et non sur une fenêtre `updated_at` : une fenêtre
  * absorberait tout ce qu'un AUTRE job écrit pendant ce run, donc jusqu'à 4 min de travail mesurées
  * pendant les imports de masse nocturnes — de quoi allonger ce cron au-delà de son intervalle de
- * 5 min et faire skipper des runs (concurrency exclusive), soit exactement la latence de
- * publication qu'on cherche à réduire. Le cron delta reste le rattrapage.
+ * 5 min et faire chevaucher deux runs, soit exactement la latence de publication qu'on cherche à
+ * réduire. Le cron delta reste le rattrapage.
  *
  * L'indexation ne doit pas faire échouer le run : l'import est déjà commité en base, et une erreur
  * ici serait rejouée par le cron delta puis par la réconciliation nightly.
@@ -44,24 +44,50 @@ const syncImportedJobsToSearchItems = async (jobPartnerIds: ObjectId[]) => {
   }
 }
 
+/**
+ * Au-delà de ce délai, un `currently_processed_id` est considéré orphelin et ses documents sont
+ * réattribués. Sans cette échappatoire, un run tué net (redéploiement swarm en cours de traitement)
+ * laisserait ses documents revendiqués pour toujours, donc jamais publiés — le `finally` ci-dessous
+ * ne couvre que les arrêts propres. Le seuil est très au-dessus des durées observées (30 s en
+ * régime normal, ~4 min pendant les imports nocturnes) pour ne jamais voler les documents d'un run
+ * légitimement lent.
+ */
+const STALE_PROCESS_ID_AFTER_MS = 60 * 60 * 1000
+
 export const processJobPartnersForApi = async () => {
   logger.info("début de processJobPartnersForApi")
   const processId: string = new ObjectId().toString()
   const last2Days = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
+
+  // Ne revendiquer que les documents libres, comme processMissingRomeAndImportToJobPartners : ce
+  // job n'est pas réentrant, et sans ce filtre un run concurrent réattribue les documents du run en
+  // cours, dont l'import ne matche alors plus rien et se perd sans erreur.
+  // Les 4 premiers octets d'un ObjectId encodent sa date de création et l'hexadécimal se compare
+  // dans le même ordre : un `$lt` sur la chaîne suffit à détecter un processId périmé.
+  const staleProcessIdBefore = ObjectId.createFromTime(Math.floor((Date.now() - STALE_PROCESS_ID_AFTER_MS) / 1000)).toString()
   await getDbCollection("computed_jobs_partners").updateMany(
-    { partner_label: { $nin: excludedJobPartnersFromApi }, updated_at: { $gte: last2Days } },
+    {
+      partner_label: { $nin: excludedJobPartnersFromApi },
+      updated_at: { $gte: last2Days },
+      $or: [{ currently_processed_id: null }, { currently_processed_id: { $lt: staleProcessIdBefore } }],
+    },
     { $set: { currently_processed_id: processId, errors: [] } }
   )
 
   const filter = { currently_processed_id: processId }
   let importedIds: ObjectId[] = []
-  await fillComputedJobsPartners({ addedMatchFilter: filter })
-  await importFromComputedToJobsPartners(filter, (ids) => {
-    importedIds = ids
-  })
-  await fillLbaUrl()
-  await getDbCollection("computed_jobs_partners").deleteMany({ $and: [filter, { validated: true }] })
-  await getDbCollection("computed_jobs_partners").updateMany(filter, { $set: { currently_processed_id: null } })
+  try {
+    await fillComputedJobsPartners({ addedMatchFilter: filter })
+    await importFromComputedToJobsPartners(filter, (ids) => {
+      importedIds = ids
+    })
+    await fillLbaUrl()
+    await getDbCollection("computed_jobs_partners").deleteMany({ $and: [filter, { validated: true }] })
+  } finally {
+    // Libération dans un finally, comme le job voisin : sur échec, laisser les documents
+    // revendiqués les rendrait invisibles au run suivant pendant une heure.
+    await getDbCollection("computed_jobs_partners").updateMany(filter, { $set: { currently_processed_id: null } })
+  }
   await syncImportedJobsToSearchItems(importedIds)
   logger.info("fin de processJobPartnersForApi")
 }

--- a/server/src/jobs/rdv/sync-etablissements-and-formations.test.ts
+++ b/server/src/jobs/rdv/sync-etablissements-and-formations.test.ts
@@ -1,0 +1,180 @@
+import { useMongo } from "@tests/utils/mongo.test.utils"
+import { ObjectId } from "mongodb"
+import type { IFormationCatalogue } from "shared"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { syncEtablissementsAndFormations } from "./sync-etablissements-and-formations"
+
+const GESTIONNAIRE_SIRET = "11000001500013"
+const FORMATEUR_SIRET = "13002526500013"
+
+const givenFormation = (overrides: Partial<IFormationCatalogue> = {}): IFormationCatalogue =>
+  ({
+    _id: new ObjectId(),
+    cle_ministere_educatif: "cle-1",
+    cfd: "40025214",
+    num_tel: null,
+    intitule_long: "BTS Management commercial opérationnel",
+    published: true,
+    email: null,
+    parcoursup_id: null,
+    parcoursup_visible: false,
+    affelnet_visible: false,
+    id_rco_formation: "rco-1",
+    lieu_formation_adresse: "2 rue du Lieu",
+    localite: "Lyon",
+    code_postal: "69001",
+    etablissement_gestionnaire_siret: GESTIONNAIRE_SIRET,
+    etablissement_gestionnaire_courriel: null,
+    etablissement_formateur_siret: FORMATEUR_SIRET,
+    etablissement_formateur_adresse: "1 rue du Formateur",
+    etablissement_formateur_code_postal: "75001",
+    etablissement_formateur_localite: "Paris",
+    etablissement_formateur_nom_departement: "Paris",
+    etablissement_formateur_entreprise_raison_sociale: "CFA TEST",
+    ...overrides,
+  }) as IFormationCatalogue
+
+describe("sync-etablissements-and-formations", () => {
+  useMongo()
+
+  beforeEach(() => {
+    return async () => {
+      await getDbCollection("formationcatalogues").deleteMany({})
+      await getDbCollection("eligible_trainings_for_appointments").deleteMany({})
+      await getDbCollection("etablissements").deleteMany({})
+    }
+  })
+
+  it("crée la fiche eligible_trainings_for_appointments avec tous les champs projetés", async () => {
+    await getDbCollection("formationcatalogues").insertOne(givenFormation())
+
+    const stats = await syncEtablissementsAndFormations()
+
+    expect(stats).toMatchObject({ processed: 1, inserted: 1, updated: 0, errors: 0 })
+
+    const etfa = await getDbCollection("eligible_trainings_for_appointments").findOne({ cle_ministere_educatif: "cle-1" })
+    // Champs couvrant les deux extrémités de la projection du curseur : un champ oublié dans
+    // FORMATION_PROJECTION arriverait ici en null.
+    expect(etfa).toMatchObject({
+      training_intitule_long: "BTS Management commercial opérationnel",
+      training_code_formation_diplome: "40025214",
+      is_catalogue_published: true,
+      lieu_formation_street: "2 rue du Lieu",
+      lieu_formation_city: "Lyon",
+      lieu_formation_zip_code: "69001",
+      etablissement_formateur_raison_sociale: "CFA TEST",
+      etablissement_formateur_street: "1 rue du Formateur",
+      etablissement_formateur_zip_code: "75001",
+      etablissement_formateur_city: "Paris",
+      departement_etablissement_formateur: "Paris",
+      etablissement_formateur_siret: FORMATEUR_SIRET,
+      etablissement_gestionnaire_siret: GESTIONNAIRE_SIRET,
+      rco_formation_id: "rco-1",
+      referrers: [],
+    })
+  })
+
+  it("met à jour la fiche existante sans en créer une seconde", async () => {
+    const existingId = new ObjectId()
+    await getDbCollection("eligible_trainings_for_appointments").insertOne({
+      _id: existingId,
+      cle_ministere_educatif: "cle-1",
+      training_id_catalogue: "ancien",
+      training_intitule_long: "Ancien intitulé",
+      training_code_formation_diplome: "00000000",
+      lieu_formation_email: null,
+      parcoursup_id: null,
+      rco_formation_id: "rco-origine",
+      is_catalogue_published: false,
+      referrers: [],
+      lieu_formation_street: "ancienne rue",
+      lieu_formation_city: "ancienne ville",
+      lieu_formation_zip_code: "00000",
+      etablissement_formateur_raison_sociale: "ANCIEN",
+      etablissement_formateur_street: null,
+      departement_etablissement_formateur: null,
+      created_at: new Date("2020-01-01"),
+      last_catalogue_sync_date: new Date("2020-01-01"),
+    })
+    await getDbCollection("formationcatalogues").insertOne(givenFormation())
+
+    const stats = await syncEtablissementsAndFormations()
+
+    expect(stats).toMatchObject({ processed: 1, inserted: 0, updated: 1, errors: 0 })
+
+    const fiches = await getDbCollection("eligible_trainings_for_appointments").find({ cle_ministere_educatif: "cle-1" }).toArray()
+    expect(fiches).toHaveLength(1)
+    expect(fiches[0]._id).toEqual(existingId)
+    expect(fiches[0].training_intitule_long).toBe("BTS Management commercial opérationnel")
+    // rco_formation_id n'appartient pas au `$set` de mise à jour, comme avant le passage en bulk.
+    expect(fiches[0].rco_formation_id).toBe("rco-origine")
+  })
+
+  it("ne crée qu'une fiche quand deux formations partagent une cle_ministere_educatif", async () => {
+    await getDbCollection("formationcatalogues").insertMany([
+      givenFormation({ intitule_long: "Première" }),
+      givenFormation({ intitule_long: "Seconde", id_rco_formation: "rco-2" }),
+    ])
+
+    const stats = await syncEtablissementsAndFormations()
+
+    expect(stats.errors).toBe(0)
+    const fiches = await getDbCollection("eligible_trainings_for_appointments").find({ cle_ministere_educatif: "cle-1" }).toArray()
+    expect(fiches).toHaveLength(1)
+    // Dernière formation lue gagne sur les champs partagés, mais pas sur les champs propres à la
+    // création : même arbitrage que l'ancien insert-puis-update.
+    expect(fiches[0].training_intitule_long).toBe("Seconde")
+    expect(fiches[0].rco_formation_id).toBe("rco-1")
+  })
+
+  it("n'active aucun referrer tant que l'établissement n'a ni opt-out ni premium", async () => {
+    await getDbCollection("etablissements").insertOne({
+      _id: new ObjectId(),
+      gestionnaire_siret: GESTIONNAIRE_SIRET,
+      formateur_siret: FORMATEUR_SIRET,
+      raison_sociale: "CFA TEST",
+      gestionnaire_email: null,
+    })
+    await getDbCollection("formationcatalogues").insertOne(givenFormation())
+
+    await syncEtablissementsAndFormations()
+
+    const etfa = await getDbCollection("eligible_trainings_for_appointments").findOne({ cle_ministere_educatif: "cle-1" })
+    expect(etfa?.referrers).toEqual([])
+  })
+
+  it("active LBA et 1jeune1solution quand l'opt-out est activé sans refus", async () => {
+    await getDbCollection("etablissements").insertOne({
+      _id: new ObjectId(),
+      gestionnaire_siret: GESTIONNAIRE_SIRET,
+      formateur_siret: FORMATEUR_SIRET,
+      raison_sociale: "CFA TEST",
+      gestionnaire_email: null,
+      optout_activation_date: new Date("2026-01-01"),
+    })
+    await getDbCollection("formationcatalogues").insertOne(givenFormation())
+
+    await syncEtablissementsAndFormations()
+
+    const etfa = await getDbCollection("eligible_trainings_for_appointments").findOne({ cle_ministere_educatif: "cle-1" })
+    expect(etfa?.referrers).toEqual(["LBA", "JEUNE_1_SOLUTION"])
+  })
+
+  it("écrit les formations valides d'un lot même si l'une d'elles est rejetée, et échoue à la fin", async () => {
+    await getDbCollection("formationcatalogues").insertMany([
+      givenFormation({ cle_ministere_educatif: "cle-ok-1" }),
+      // intitule_long absent -> training_intitule_long null -> rejeté par le validateur de schéma.
+      givenFormation({ cle_ministere_educatif: "cle-ko", intitule_long: undefined }),
+      givenFormation({ cle_ministere_educatif: "cle-ok-2" }),
+    ])
+
+    await expect(syncEtablissementsAndFormations()).rejects.toThrow(/formation\(s\) en erreur/)
+
+    // Le cœur de la régression évitée : en lot ordonné, le document rejeté aurait emporté tout ce
+    // qui le suit dans le même bulkWrite.
+    const cles = (await getDbCollection("eligible_trainings_for_appointments").find({}).toArray()).map((f) => f.cle_ministere_educatif).sort()
+    expect(cles).toEqual(["cle-ok-1", "cle-ok-2"])
+  })
+})

--- a/server/src/jobs/rdv/sync-etablissements-and-formations.test.ts
+++ b/server/src/jobs/rdv/sync-etablissements-and-formations.test.ts
@@ -170,7 +170,9 @@ describe("sync-etablissements-and-formations", () => {
       givenFormation({ cle_ministere_educatif: "cle-ok-2" }),
     ])
 
-    await expect(syncEtablissementsAndFormations()).rejects.toThrow(/formation\(s\) en erreur/)
+    // Message asserté au caractère près : le dénominateur doit être le nombre de formations
+    // parcourues (3), pas `processed + errors` qui compte deux fois celle qui a été rejetée.
+    await expect(syncEtablissementsAndFormations()).rejects.toThrow("syncEtablissementsAndFormations: 1 erreur(s) sur 3 formation(s) parcourue(s)")
 
     // Le cœur de la régression évitée : en lot ordonné, le document rejeté aurait emporté tout ce
     // qui le suit dans le même bulkWrite.

--- a/server/src/jobs/rdv/sync-etablissements-and-formations.ts
+++ b/server/src/jobs/rdv/sync-etablissements-and-formations.ts
@@ -1,7 +1,9 @@
 import { Writable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 
-import { ObjectId } from "mongodb"
+import type { AnyBulkWriteOperation } from "mongodb"
+import { MongoBulkWriteError, ObjectId } from "mongodb"
+import type { IEligibleTrainingsForAppointment, IFormationCatalogue } from "shared"
 import { referrers } from "shared/constants/referers"
 
 import { logger } from "@/common/logger"
@@ -9,14 +11,149 @@ import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { getEmailForRdv } from "@/services/eligible-trainings-for-appointment.service"
 import { findFirstNonBlacklistedEmail } from "@/services/formation.service"
 
-const hasDateProperty = (etablissements, propertyName) => {
-  return etablissements.some((etab) => etab[propertyName] !== null && etab[propertyName] !== undefined)
-}
+/**
+ * Champs de formationcatalogues réellement consommés ici. Sans projection le curseur tire aussi le
+ * lieu_formation_geopoint, les rome_codes et les bcn_mefs_10 sur toute la collection : trafic réseau
+ * et décodage BSON inutiles.
+ */
+const FORMATION_PROJECTION = {
+  cle_ministere_educatif: 1,
+  etablissement_gestionnaire_siret: 1,
+  etablissement_gestionnaire_courriel: 1,
+  etablissement_formateur_siret: 1,
+  etablissement_formateur_adresse: 1,
+  etablissement_formateur_code_postal: 1,
+  etablissement_formateur_localite: 1,
+  etablissement_formateur_nom_departement: 1,
+  etablissement_formateur_entreprise_raison_sociale: 1,
+  lieu_formation_adresse: 1,
+  localite: 1,
+  code_postal: 1,
+  email: 1,
+  cfd: 1,
+  intitule_long: 1,
+  published: 1,
+  parcoursup_id: 1,
+  parcoursup_visible: 1,
+  affelnet_visible: 1,
+  id_rco_formation: 1,
+} as const
+
+const ETABLISSEMENT_PROJECTION = {
+  premium_affelnet_activation_date: 1,
+  optout_refusal_date: 1,
+  optout_activation_date: 1,
+  premium_refusal_date: 1,
+  premium_activation_date: 1,
+  premium_affelnet_refusal_date: 1,
+  gestionnaire_email: 1,
+} as const
+
+/** Le job faisait une écriture unitaire par formation sur eligible_trainings_for_appointments. */
+const BULK_SIZE = 500
+
+/**
+ * Le job parcourt tout le catalogue : une erreur isolée sur une formation ne doit pas perdre le
+ * travail déjà fait (l'ancien `callback(err)` avortait tout le pipeline). Au-delà de ce nombre
+ * d'erreurs consécutives on considère la panne systémique et on arrête.
+ */
+const MAX_CONSECUTIVE_ERRORS = 50
+
+type IFormationEmailFields = Pick<IFormationCatalogue, "email" | "etablissement_gestionnaire_courriel" | "etablissement_gestionnaire_siret">
+
+const isSet = (value: unknown) => value !== null && value !== undefined
+
+const cacheKey = (...parts: unknown[]) => JSON.stringify(parts)
 
 export const syncEtablissementsAndFormations = async () => {
   logger.info("Cron #syncEtablissementsAndFormations started.")
 
-  const readable = getDbCollection("formationcatalogues").find({}).stream()
+  // Horodatage unique pour tout le run : last_catalogue_sync_date devient un vrai marqueur de
+  // passage, homogène sur l'ensemble des documents touchés.
+  const syncedAt = new Date()
+
+  const stats = { processed: 0, inserted: 0, updated: 0, errors: 0 }
+  let consecutiveErrors = 0
+
+  /**
+   * getEmailForRdv ne lit que formationcatalogues et emailblacklists, deux collections que ce job
+   * n'écrit pas : le résultat ne dépend que de la clé, mémoïser est sans effet de bord. C'est ce qui
+   * évite de rejouer getMostFrequentEmailByGestionnaireSiret pour chaque formation d'un même
+   * gestionnaire. Les caches vivent le temps du run : le coût mémoire est borné par le nombre de
+   * triplets (email, courriel gestionnaire, siret gestionnaire) distincts du catalogue.
+   */
+  const emailRdvCache = new Map<string, string | null>()
+  const gestionnaireCourrielCache = new Map<string, string | null>()
+
+  const resolveEmailRdv = async (formation: IFormationEmailFields): Promise<string | null> => {
+    const key = cacheKey(formation.email, formation.etablissement_gestionnaire_courriel, formation.etablissement_gestionnaire_siret)
+    const cached = emailRdvCache.get(key)
+    if (cached !== undefined) return cached
+
+    const email = await getEmailForRdv({
+      email: formation.email,
+      etablissement_gestionnaire_courriel: formation.etablissement_gestionnaire_courriel,
+      etablissement_gestionnaire_siret: formation.etablissement_gestionnaire_siret,
+    })
+    emailRdvCache.set(key, email)
+    return email
+  }
+
+  const resolveGestionnaireCourriel = async (formation: IFormationEmailFields): Promise<string | null> => {
+    const key = cacheKey(formation.etablissement_gestionnaire_courriel, formation.etablissement_gestionnaire_siret)
+    const cached = gestionnaireCourrielCache.get(key)
+    if (cached !== undefined) return cached
+
+    const email = await getEmailForRdv(
+      {
+        etablissement_gestionnaire_courriel: formation.etablissement_gestionnaire_courriel,
+        etablissement_gestionnaire_siret: formation.etablissement_gestionnaire_siret,
+      },
+      "etablissement_gestionnaire_courriel"
+    )
+    gestionnaireCourrielCache.set(key, email)
+    return email
+  }
+
+  const etfaOps: AnyBulkWriteOperation<IEligibleTrainingsForAppointment>[] = []
+
+  /**
+   * Deux documents du catalogue peuvent partager une cle_ministere_educatif (l'index n'est pas
+   * unique) et, les écritures étant différées, le findOne du second ne verrait pas encore
+   * l'opération mise en file par le premier. On garde une référence sur l'objet déjà en file —
+   * document d'insert ou payload de `$set` — pour y réappliquer les champs au lieu d'empiler une
+   * seconde opération sur le même _id. C'est ce qui rend le lot non ordonné sûr : aucune paire
+   * d'opérations concurrentes sur un même document.
+   */
+  const queuedFieldsByCle = new Map<string, Record<string, unknown>>()
+
+  const flushEtfaOps = async () => {
+    if (etfaOps.length === 0) return
+    const ops = etfaOps.splice(0, etfaOps.length)
+    try {
+      const result = await getDbCollection("eligible_trainings_for_appointments").bulkWrite(ops, { ordered: false })
+      stats.inserted += result.insertedCount
+      stats.updated += result.matchedCount
+    } catch (err) {
+      // En lot non ordonné, les opérations valides sont appliquées et seules les fautives remontent.
+      // Un document invalide ne doit pas emporter les 499 autres, mais il doit rester compté.
+      if (err instanceof MongoBulkWriteError) {
+        const writeErrors = Array.isArray(err.writeErrors) ? err.writeErrors : [err.writeErrors]
+        stats.inserted += err.insertedCount
+        stats.updated += err.matchedCount
+        stats.errors += writeErrors.length
+        logger.error({ err, count: writeErrors.length }, "syncEtablissementsAndFormations: écritures rejetées dans un lot")
+        return
+      }
+      throw err
+    } finally {
+      // Les opérations sont sorties de la file : les références conservées ne sont plus mutables
+      // utilement, et la map reste bornée à BULK_SIZE au lieu de croître sur tout le catalogue.
+      queuedFieldsByCle.clear()
+    }
+  }
+
+  const readable = getDbCollection("formationcatalogues").find({}, { projection: FORMATION_PROJECTION }).stream()
 
   const writable = new Writable({
     objectMode: true,
@@ -27,130 +164,105 @@ export const syncEtablissementsAndFormations = async () => {
             { cle_ministere_educatif: formation.cle_ministere_educatif },
             { projection: { lieu_formation_email: 1, is_lieu_formation_email_customized: 1 } }
           ),
-          getDbCollection("etablissements")
-            .find(
-              { gestionnaire_siret: formation.etablissement_gestionnaire_siret },
-              {
-                projection: {
-                  premium_affelnet_activation_date: 1,
-                  optout_refusal_date: 1,
-                  optout_activation_date: 1,
-                  premium_refusal_date: 1,
-                  premium_activation_date: 1,
-                  premium_affelnet_refusal_date: 1,
-                  gestionnaire_email: 1,
-                },
-              }
-            )
-            .toArray(),
-          getDbCollection("referentieloniseps").findOne({ cle_ministere_educatif: formation.cle_ministere_educatif }),
+          getDbCollection("etablissements").find({ gestionnaire_siret: formation.etablissement_gestionnaire_siret }, { projection: ETABLISSEMENT_PROJECTION }).toArray(),
+          // Seule l'existence est utilisée en aval.
+          getDbCollection("referentieloniseps").findOne({ cle_ministere_educatif: formation.cle_ministere_educatif }, { projection: { _id: 1 } }),
         ])
 
-        const hasPremiumAffelnetActivation = hasDateProperty(etablissements, "premium_affelnet_activation_date")
-        const hasOptOutRefusal = hasDateProperty(etablissements, "optout_refusal_date")
-        const hasOptOutActivation = hasDateProperty(etablissements, "optout_activation_date")
-        const hasPremiumRefusal = hasDateProperty(etablissements, "premium_refusal_date")
-        const hasPremiumActivation = hasDateProperty(etablissements, "premium_activation_date")
-        const hasPremiumAffelnetRefusal = hasDateProperty(etablissements, "premium_affelnet_refusal_date")
+        const dateFlags = {
+          hasPremiumAffelnetActivation: false,
+          hasOptOutRefusal: false,
+          hasOptOutActivation: false,
+          hasPremiumRefusal: false,
+          hasPremiumActivation: false,
+          hasPremiumAffelnetRefusal: false,
+        }
+        for (const etablissement of etablissements) {
+          if (isSet(etablissement.premium_affelnet_activation_date)) dateFlags.hasPremiumAffelnetActivation = true
+          if (isSet(etablissement.optout_refusal_date)) dateFlags.hasOptOutRefusal = true
+          if (isSet(etablissement.optout_activation_date)) dateFlags.hasOptOutActivation = true
+          if (isSet(etablissement.premium_refusal_date)) dateFlags.hasPremiumRefusal = true
+          if (isSet(etablissement.premium_activation_date)) dateFlags.hasPremiumActivation = true
+          if (isSet(etablissement.premium_affelnet_refusal_date)) dateFlags.hasPremiumAffelnetRefusal = true
+        }
 
         const emailArray = etablissements.map((etab) => ({ email: etab.gestionnaire_email }))
         let gestionnaireEmail = await findFirstNonBlacklistedEmail(emailArray)
 
         const referrersToActivate: string[] = []
-        if (hasOptOutActivation && !hasOptOutRefusal) {
+        if (dateFlags.hasOptOutActivation && !dateFlags.hasOptOutRefusal) {
           referrersToActivate.push(referrers.LBA.name, referrers.JEUNE_1_SOLUTION.name)
           if (existInReferentielOnisep) referrersToActivate.push(referrers.ONISEP.name)
         }
 
-        if (hasPremiumActivation && !hasPremiumRefusal && formation.parcoursup_visible) {
+        if (dateFlags.hasPremiumActivation && !dateFlags.hasPremiumRefusal && formation.parcoursup_visible) {
           referrersToActivate.push(referrers.PARCOURSUP.name)
         }
-        if (hasPremiumAffelnetActivation && !hasPremiumAffelnetRefusal && formation.affelnet_visible) {
+        if (dateFlags.hasPremiumAffelnetActivation && !dateFlags.hasPremiumAffelnetRefusal && formation.affelnet_visible) {
           referrersToActivate.push(referrers.AFFELNET.name)
         }
 
-        if (eligibleTrainingsForAppointment) {
-          let emailRdv = eligibleTrainingsForAppointment.lieu_formation_email
-          if (!eligibleTrainingsForAppointment?.is_lieu_formation_email_customized) {
-            emailRdv = await getEmailForRdv({
-              email: formation.email,
-              etablissement_gestionnaire_courriel: formation.etablissement_gestionnaire_courriel,
-              etablissement_gestionnaire_siret: formation.etablissement_gestionnaire_siret,
-            })
-          }
+        // Un email personnalisé sur la fiche existante n'est jamais réécrit ; sinon on le recalcule.
+        const emailRdv = eligibleTrainingsForAppointment?.is_lieu_formation_email_customized
+          ? eligibleTrainingsForAppointment.lieu_formation_email
+          : await resolveEmailRdv(formation)
 
-          await getDbCollection("eligible_trainings_for_appointments").updateOne(
-            { _id: eligibleTrainingsForAppointment._id },
-            {
-              $set: {
-                training_id_catalogue: formation._id.toString(),
-                lieu_formation_email: emailRdv,
-                parcoursup_id: formation.parcoursup_id,
-                parcoursup_visible: formation.parcoursup_visible,
-                affelnet_visible: formation.affelnet_visible,
-                training_code_formation_diplome: formation.cfd,
-                etablissement_formateur_zip_code: formation.etablissement_formateur_code_postal,
-                training_intitule_long: formation.intitule_long,
-                referrers: referrersToActivate,
-                is_catalogue_published: formation.published,
-                last_catalogue_sync_date: new Date(),
-                lieu_formation_street: formation.lieu_formation_adresse,
-                lieu_formation_city: formation.localite,
-                lieu_formation_zip_code: formation.code_postal,
-                etablissement_formateur_raison_sociale: formation.etablissement_formateur_entreprise_raison_sociale,
-                etablissement_formateur_street: formation.etablissement_formateur_adresse,
-                departement_etablissement_formateur: formation.etablissement_formateur_nom_departement,
-                etablissement_formateur_city: formation.etablissement_formateur_localite,
-              },
-            }
-          )
+        // Champs communs à la création et à la mise à jour. Les cinq champs propres à la création
+        // (created_at, rco_formation_id, cle_ministere_educatif et les deux sirets) n'en font pas
+        // partie : l'ancien `$set` ne les touchait pas non plus.
+        const sharedFields = {
+          training_id_catalogue: formation._id.toString(),
+          lieu_formation_email: emailRdv ?? null,
+          parcoursup_id: formation.parcoursup_id,
+          parcoursup_visible: formation.parcoursup_visible,
+          affelnet_visible: formation.affelnet_visible,
+          training_code_formation_diplome: formation.cfd,
+          etablissement_formateur_zip_code: formation.etablissement_formateur_code_postal,
+          training_intitule_long: formation.intitule_long,
+          referrers: referrersToActivate,
+          is_catalogue_published: formation.published,
+          last_catalogue_sync_date: syncedAt,
+          lieu_formation_street: formation.lieu_formation_adresse,
+          lieu_formation_city: formation.localite,
+          lieu_formation_zip_code: formation.code_postal,
+          etablissement_formateur_raison_sociale: formation.etablissement_formateur_entreprise_raison_sociale,
+          etablissement_formateur_street: formation.etablissement_formateur_adresse,
+          departement_etablissement_formateur: formation.etablissement_formateur_nom_departement,
+          etablissement_formateur_city: formation.etablissement_formateur_localite,
+        }
+
+        const queuedFields = queuedFieldsByCle.get(formation.cle_ministere_educatif)
+        if (queuedFields) {
+          Object.assign(queuedFields, sharedFields)
+        } else if (eligibleTrainingsForAppointment) {
+          const update = { ...sharedFields }
+          etfaOps.push({ updateOne: { filter: { _id: eligibleTrainingsForAppointment._id }, update: { $set: update } } })
+          queuedFieldsByCle.set(formation.cle_ministere_educatif, update)
         } else {
-          const emailRdv = await getEmailForRdv({
-            email: formation.email,
-            etablissement_gestionnaire_courriel: formation.etablissement_gestionnaire_courriel,
-            etablissement_gestionnaire_siret: formation.etablissement_gestionnaire_siret,
-          })
-
-          const now = new Date()
-
-          await getDbCollection("eligible_trainings_for_appointments").insertOne({
+          const document = {
             _id: new ObjectId(),
-            created_at: now,
-            last_catalogue_sync_date: now,
+            created_at: syncedAt,
             rco_formation_id: formation.id_rco_formation,
-            training_id_catalogue: formation._id.toString(),
-            lieu_formation_email: emailRdv ?? null,
-            parcoursup_id: formation.parcoursup_id,
-            parcoursup_visible: formation.parcoursup_visible,
-            affelnet_visible: formation.affelnet_visible,
             cle_ministere_educatif: formation.cle_ministere_educatif,
-            training_code_formation_diplome: formation.cfd,
-            training_intitule_long: formation.intitule_long,
-            referrers: referrersToActivate,
-            is_catalogue_published: formation.published,
-            lieu_formation_street: formation.lieu_formation_adresse,
-            lieu_formation_city: formation.localite,
-            lieu_formation_zip_code: formation.code_postal,
-            etablissement_formateur_raison_sociale: formation.etablissement_formateur_entreprise_raison_sociale,
-            etablissement_formateur_street: formation.etablissement_formateur_adresse,
-            etablissement_formateur_zip_code: formation.etablissement_formateur_code_postal,
-            departement_etablissement_formateur: formation.etablissement_formateur_nom_departement,
-            etablissement_formateur_city: formation.etablissement_formateur_localite,
             etablissement_formateur_siret: formation.etablissement_formateur_siret,
             etablissement_gestionnaire_siret: formation.etablissement_gestionnaire_siret,
-          })
+            ...sharedFields,
+          }
+          etfaOps.push({ insertOne: { document } })
+          queuedFieldsByCle.set(formation.cle_ministere_educatif, document)
+        }
+
+        if (etfaOps.length >= BULK_SIZE) {
+          await flushEtfaOps()
         }
 
         if (!gestionnaireEmail) {
-          gestionnaireEmail = await getEmailForRdv(
-            {
-              etablissement_gestionnaire_courriel: formation.etablissement_gestionnaire_courriel,
-              etablissement_gestionnaire_siret: formation.etablissement_gestionnaire_siret,
-            },
-            "etablissement_gestionnaire_courriel"
-          )
+          gestionnaireEmail = await resolveGestionnaireCourriel(formation)
         }
 
+        // Écriture volontairement immédiate, contrairement à eligible_trainings_for_appointments :
+        // la lecture d'etablissements en tête de boucle voit les gestionnaire_email posés par les
+        // formations précédentes du même gestionnaire, et différer casserait cette dépendance.
         await getDbCollection("etablissements").updateMany(
           {
             $and: [
@@ -169,21 +281,57 @@ export const syncEtablissementsAndFormations = async () => {
               formateur_address: formation.etablissement_formateur_adresse,
               formateur_zip_code: formation.etablissement_formateur_code_postal,
               formateur_city: formation.etablissement_formateur_localite,
-              last_catalogue_sync_date: new Date(),
+              last_catalogue_sync_date: syncedAt,
             },
           },
           { upsert: true }
         )
 
+        stats.processed++
+        consecutiveErrors = 0
         callback()
       } catch (err: any) {
-        logger.error(err, "Erreur dans syncEtablissementsAndFormations")
-        callback(err)
+        stats.errors++
+        consecutiveErrors++
+        logger.error({ err, cle_ministere_educatif: formation?.cle_ministere_educatif }, "Erreur dans syncEtablissementsAndFormations")
+
+        if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+          callback(new Error(`syncEtablissementsAndFormations: ${consecutiveErrors} erreurs consécutives, arrêt`, { cause: err }))
+          return
+        }
+        callback()
       }
     },
   })
 
-  await pipeline(readable, writable)
+  let runError: unknown = null
+  try {
+    await pipeline(readable, writable)
+  } catch (err) {
+    runError = err
+  }
 
-  logger.info("Cron #syncEtablissementsAndFormations done.")
+  try {
+    // Le dernier lot doit partir même si le pipeline s'est arrêté sur une panne systémique.
+    await flushEtfaOps()
+  } catch (err) {
+    if (runError) {
+      // Ne pas écraser la cause racine par l'erreur du flush final.
+      logger.error({ err }, "syncEtablissementsAndFormations: flush final en échec")
+    } else {
+      runError = err
+    }
+  }
+
+  logger.info(stats, "Cron #syncEtablissementsAndFormations done.")
+
+  if (runError) throw runError
+
+  // Les erreurs isolées n'avortent plus le run, mais elles doivent rester visibles : le job échoue
+  // après avoir traité l'intégralité du catalogue, et le check-in Sentry passe en `error`.
+  if (stats.errors > 0) {
+    throw new Error(`syncEtablissementsAndFormations: ${stats.errors} formation(s) en erreur sur ${stats.processed + stats.errors}`)
+  }
+
+  return stats
 }

--- a/server/src/jobs/rdv/sync-etablissements-and-formations.ts
+++ b/server/src/jobs/rdv/sync-etablissements-and-formations.ts
@@ -72,7 +72,10 @@ export const syncEtablissementsAndFormations = async () => {
   // passage, homogène sur l'ensemble des documents touchés.
   const syncedAt = new Date()
 
-  const stats = { processed: 0, inserted: 0, updated: 0, errors: 0 }
+  // `read` compte les formations sorties du curseur. C'est le seul dénominateur juste : une
+  // formation peut être comptée dans `processed` (son opération a été mise en file) puis dans
+  // `errors` si le lot rejette cette opération, donc `processed + errors` sur-compte.
+  const stats = { read: 0, processed: 0, inserted: 0, updated: 0, errors: 0 }
   let consecutiveErrors = 0
 
   /**
@@ -158,6 +161,7 @@ export const syncEtablissementsAndFormations = async () => {
   const writable = new Writable({
     objectMode: true,
     async write(formation, _encoding, callback) {
+      stats.read++
       try {
         const [eligibleTrainingsForAppointment, etablissements, existInReferentielOnisep] = await Promise.all([
           getDbCollection("eligible_trainings_for_appointments").findOne(
@@ -330,7 +334,7 @@ export const syncEtablissementsAndFormations = async () => {
   // Les erreurs isolées n'avortent plus le run, mais elles doivent rester visibles : le job échoue
   // après avoir traité l'intégralité du catalogue, et le check-in Sentry passe en `error`.
   if (stats.errors > 0) {
-    throw new Error(`syncEtablissementsAndFormations: ${stats.errors} formation(s) en erreur sur ${stats.processed + stats.errors}`)
+    throw new Error(`syncEtablissementsAndFormations: ${stats.errors} erreur(s) sur ${stats.read} formation(s) parcourue(s)`)
   }
 
   return stats

--- a/server/src/migrations/20260828160000-add-rdv-sync-indexes.ts
+++ b/server/src/migrations/20260828160000-add-rdv-sync-indexes.ts
@@ -1,0 +1,8 @@
+import { recreateIndexes } from "@/jobs/database/recreate-indexes"
+
+export const up = async () => {
+  await recreateIndexes()
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/server/src/services/formation.service.ts
+++ b/server/src/services/formation.service.ts
@@ -187,7 +187,8 @@ export const getMostFrequentEmailByGestionnaireSiret = async (
           email: { $ne: null },
           etablissement_gestionnaire_siret,
         },
-        { projection: { email: 1 } }
+        // `_id: 0` : sans lui la projection force un FETCH et l'index {etablissement_gestionnaire_siret, email} n'est pas couvrant.
+        { projection: { email: 1, _id: 0 } }
       )
       .toArray()
   } else {
@@ -197,7 +198,7 @@ export const getMostFrequentEmailByGestionnaireSiret = async (
           etablissement_gestionnaire_courriel: { $ne: null },
           etablissement_gestionnaire_siret,
         },
-        { projection: { etablissement_gestionnaire_courriel: 1 } }
+        { projection: { etablissement_gestionnaire_courriel: 1, _id: 0 } }
       )
       .toArray()
   }

--- a/shared/src/models/etablissement.model.ts
+++ b/shared/src/models/etablissement.model.ts
@@ -40,8 +40,11 @@ export type IEtablissementJson = Jsonify<z.input<typeof ZEtablissement>>
 export default {
   zod: ZEtablissement,
   indexes: [
-    [{ formateur_siret: 1 }, {}],
     [{ gestionnaire_siret: 1 }, {}],
+    // Filtre de l'updateMany upsert de syncEtablissementsAndFormations. Remplace l'index simple
+    // {formateur_siret} dont il est le préfixe : le garder coûtait une écriture d'index par update
+    // sans servir de requête que celui-ci ne couvre pas.
+    [{ formateur_siret: 1, gestionnaire_siret: 1 }, {}],
     [{ premium_activation_date: 1 }, {}],
     [{ premium_affelnet_activation_date: 1 }, {}],
     [{ to_CFA_invite_optout_last_message_id: 1 }, {}],

--- a/shared/src/models/formation.model.ts
+++ b/shared/src/models/formation.model.ts
@@ -205,6 +205,11 @@ export default {
     [{ catalogue_published: 1, intitule_long: 1 }, {}],
     [{ cfd: 1 }, {}],
     [{ "bcn_mefs_10.mef10": 1 }, {}],
+    // Index couvrants pour getMostFrequentEmailByGestionnaireSiret, appelé par formation dans
+    // syncEtablissementsAndFormations : la requête filtre sur le siret gestionnaire et ne projette
+    // que l'un des deux champs email.
+    [{ etablissement_gestionnaire_siret: 1, email: 1 }, {}],
+    [{ etablissement_gestionnaire_siret: 1, etablissement_gestionnaire_courriel: 1 }, {}],
   ],
   collectionName,
 } as const satisfies IModelDescriptor

--- a/shared/src/models/referentiel-onisep.model.ts
+++ b/shared/src/models/referentiel-onisep.model.ts
@@ -16,6 +16,10 @@ export type IReferentielOnisep = z.output<typeof ZReferentielOnisep>
 
 export default {
   zod: ZReferentielOnisep,
-  indexes: [[{ id_action_ideo2: 1 }, {}]],
+  indexes: [
+    [{ id_action_ideo2: 1 }, {}],
+    // syncEtablissementsAndFormations interroge cette collection par formation du catalogue.
+    [{ cle_ministere_educatif: 1 }, {}],
+  ],
   collectionName,
 } as const satisfies IModelDescriptor


### PR DESCRIPTION
Closes #5324

## Changements

### Crons

- retrait de `concurrency: { mode: "exclusive" }` sur « Traitement complet des jobs_partners par API ». Le mode est incompatible avec la planification de job-processor, qui pré-crée le slot suivant en `pending` : un slot sur deux partait en `skipped`, sans check-in, donc compté `missed` par Sentry.
- garde de réentrance dans `processJobPartnersForApi`, qui remplace `exclusive` et couvre en plus le déclenchement manuel via la route admin : claim filtré sur `currently_processed_id: null`, libération dans un `finally`, et réattribution des `processId` périmés depuis plus d'une heure pour qu'un run tué net ne bloque pas ses documents. Même forme que `processMissingRomeAndImportToJobPartners`, à l'échappatoire près.
- retrait du même `concurrency: { mode: "exclusive" }` sur « Sync delta search_items (jobs_partners modifiés) », qui portait le défaut identique. Mesuré en prod le 29/08 : 127 slots perdus en `noConcurrent_conflict` sur 24 h, un sur deux. La cadence effective retombait à 10 min, très exactement la largeur de `DELTA_DEFAULT_WINDOW_MS` — plus aucune marge de recouvrement. Aucune garde applicative nécessaire ici : le handler lit `jobs_partners` et upsert `search_items` par `_id` sans muter la source, deux runs concurrents sont idempotents.
- `checkinMargin: 30` et `maxRuntimeInMinutes: 120` sur la sync RDVA, dont les durées réelles dépassent le `maxRuntime` par défaut.

### Performance de syncEtablissementsAndFormations

- quatre index : `referentieloniseps.cle_ministere_educatif`, deux index couvrants sur `formationcatalogues.etablissement_gestionnaire_siret`, et un composé `{formateur_siret, gestionnaire_siret}` sur `etablissements` qui remplace l'index simple dont il est le préfixe. Les deux premiers suppriment un balayage de collection par formation.
- `_id: 0` sur les projections de `getMostFrequentEmailByGestionnaireSiret` : sans lui la projection force un `FETCH` et l'index n'est pas couvrant. Vérifié par `explain` sur la requête réelle, `PROJECTION_COVERED` et `docsExamined` à 0.
- projection explicite sur le curseur `formationcatalogues`, 20 champs au lieu du document complet, et sur les lectures d'`etablissements`.
- mémoïsation de `getEmailForRdv` par clé composite. Sans effet de bord : la fonction ne lit que des collections que ce job n'écrit pas.
- écritures sur `eligible_trainings_for_appointments` groupées en `bulkWrite` non ordonné de 500, avec déduplication des opérations par `cle_ministere_educatif`. En lot ordonné, un document rejeté aurait emporté les suivants.
- les écritures sur `etablissements` restent immédiates : la lecture en tête de boucle dépend des `gestionnaire_email` posés par les formations précédentes du même gestionnaire, différer casserait ce chaînage.

### Robustesse et observabilité

- une formation en erreur ne fait plus avorter le parcours du catalogue. Le job continue, compte les erreurs et échoue à la fin, avec arrêt anticipé au bout de 50 erreurs consécutives.
- compteurs `processed` / `inserted` / `updated` / `errors` retournés et logués, les deux derniers dérivés du `BulkWriteResult`.
- neuf tests d'intégration ajoutés, six sur la sync RDVA et trois sur la garde de réentrance. Non vacuous : cinq mutations vérifiées, chacune fait échouer exactement le test visé.

## Ce qui n'est pas dans cette PR

Les trois amplificateurs décrits dans l'issue sont des actions manuelles côté Sentry : le seuil `failure_issue_threshold`, la configuration de monitor partagée entre environnements, et la suppression du monitor mort `rappel-aux-etablissements-que-le-premium-est-activ`.

La parallélisation du curseur de la sync reste à faire. Elle demande de partitionner par `gestionnaire_siret` à cause de l'`updateMany` upsert sur `etablissements`.

## Plan de test

- [ ] `yarn cli migrations:up`, puis vérifier la présence des quatre index et l'absence de `formateur_siret_1` sur `etablissements`
- [ ] sur le monitor `traitement-complet-des-jobs_partners-par-api`, vérifier 12 check-in `ok` par heure et par environnement, et zéro `missed`
- [ ] vérifier qu'aucun `cron_task` de ce job n'apparaît en `skipped`
- [ ] même contrôle sur « Sync delta search_items » : `sum by (job) (count_over_time({env="production", service="jobs_processor"} |= "skipped due to conflict" | json job="log_jobName" [24h]))` doit tomber à 0 pour les deux crons
- [ ] après une nuit, vérifier que `synchronise-les-formations-eligibles-a-la-prise-de` sort en `ok` et non en `timeout`, et relever sa nouvelle durée
- [ ] confirmer la disparition du trou de check-in nocturne sur `scan-et-envoi-des-candidatures` et `emission-des-intentions-des-recruteurs`
- [ ] `explain("executionStats")` sur `referentieloniseps.findOne({cle_ministere_educatif})` pour confirmer la bascule en `IXSCAN`

