### PR TITLE
fix: supprime les notifications slack de chargement des caches métiers (#5327)

### DIFF
--- a/server/src/services/metiers.service.ts
+++ b/server/src/services/metiers.service.ts
@@ -5,8 +5,6 @@ import { removeAccents, removeRegexChars } from "shared/utils/index"
 import { logger } from "@/common/logger"
 import { asyncForEach } from "@/common/utils/async-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
-import { notifyToSlack } from "@/common/utils/slack-utils"
-import config from "@/config"
 import { expandRomesV3toV4 } from "./rome.service"
 
 let globalCacheMetiers: IDomainesMetiers[] = []
@@ -23,15 +21,7 @@ export const initializeCacheMetiers = async () => {
     logger.info("initializeCacheMetiers on first use")
     globalCacheMetiers = await getDbCollection("domainesmetiers").find({}).toArray()
     cacheMetierLoading = false
-    const roughObjSize = JSON.stringify(globalCacheMetiers).length
-    if (config.env === "production") {
-      // biome-ignore lint/nursery/noFloatingPromises: migration
-      notifyToSlack({
-        subject: `Cache domaines metiers chargé`,
-        message: `Cache domaines metiers chargé. Taille estimée ${roughObjSize} octets`,
-        error: false,
-      })
-    }
+    logger.info({ roughObjSize: JSON.stringify(globalCacheMetiers).length }, "cache domaines metiers chargé")
   }
 }
 
@@ -44,15 +34,7 @@ export const initializeCacheDiplomas = async () => {
       diploma.codes_romes = await expandRomesV3toV4(diploma.codes_romes)
     })
     cacheDiplomaLoading = false
-    const roughObjSize = JSON.stringify(globalCacheDiplomas).length
-    if (config.env === "production") {
-      // biome-ignore lint/nursery/noFloatingPromises: migration
-      notifyToSlack({
-        subject: `Cache diplômes metiers chargé`,
-        message: `Cache diplômes metiers chargé. Taille estimée ${roughObjSize} octets`,
-        error: false,
-      })
-    }
+    logger.info({ roughObjSize: JSON.stringify(globalCacheDiplomas).length }, "cache diplômes metiers chargé")
   }
 }
 


### PR DESCRIPTION
Closes #5327

## Changements

- Suppression des deux appels `notifyToSlack` dans `initializeCacheMetiers` et `initializeCacheDiplomas` (`server/src/services/metiers.service.ts`)
- La taille estimée du cache est conservée en log structuré : `logger.info({ roughObjSize }, "cache … chargé")`
- Retrait des imports `notifyToSlack` et `config`, devenus inutiles dans ce fichier

## Pourquoi

Les caches sont lazy : ils se chargent au premier appel de `GET /rome` dans chaque process serveur. Avec plusieurs répliques et les redéploiements, ça produit ~44 messages Slack sur 7 jours en production (mesuré dans Loki sur le log `initializeCache*`), pour une information qui n'appelle aucune action.

## Ce qui n'est volontairement pas touché

Les caches et la route `GET /rome` restent en place. L'UI ne les utilise plus depuis la suppression du moteur de recherche legacy, mais la route publique reçoit toujours ~4 700 requêtes/jour en 200 d'un consommateur externe non identifié. Une éventuelle dépréciation est un sujet à part.

## Plan de test

- [ ] `yarn typecheck` passe (vérifié en local sur `server/tsconfig.json`, exit 0)
- [ ] `yarn check:ci` passe
- [ ] Après déploiement : plus aucun message « Cache domaines metiers chargé » / « Cache diplômes metiers chargé » dans Slack
- [ ] Après déploiement : `GET /rome?title=comptable` répond toujours 200 avec des résultats