### PR TITLE
fix: export France Travail vide depuis le 12/08 — décalage lookup/unwind (#5330)

### DIFF
--- a/server/src/jobs/partenaire-export/export-to-france-travail.test.ts
+++ b/server/src/jobs/partenaire-export/export-to-france-travail.test.ts
@@ -10,7 +10,7 @@ import type { ICFA } from "shared/models/cfa.model"
 import { type IJobsPartnersOfferPrivate, JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
 import { describe, expect, it } from "vitest"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
-import { getJobsToExport, offerToFTOffer } from "@/jobs/partenaire-export/export-to-france-travail"
+import { exportJobsToFranceTravail, getJobsToExport, offerToFTOffer } from "@/jobs/partenaire-export/export-to-france-travail"
 
 describe("offerToFTOffer", () => {
   it("should convert a job to an exported offer for FT", async () => {
@@ -185,5 +185,9 @@ describe("getJobsToExport", () => {
 
     expect(jobs.map((j) => j._id.toString())).toEqual([job._id.toString()])
     expect(jobsConfiee.map((j) => j._id.toString())).toEqual([jobConfiee._id.toString()])
+  })
+
+  it("fait échouer le job (rejet) quand le flux principal est vide, pour que le run soit marqué errored", async () => {
+    await expect(exportJobsToFranceTravail()).rejects.toThrow("Aucune offre à exporter")
   })
 })

--- a/server/src/jobs/partenaire-export/export-to-france-travail.test.ts
+++ b/server/src/jobs/partenaire-export/export-to-france-travail.test.ts
@@ -1,13 +1,16 @@
+import { useMongo } from "@tests/utils/mongo.test.utils"
 import { ObjectId } from "mongodb"
-import type { IEntreprise, IReferentielRome } from "shared"
+import { type IEntreprise, type IReferentielRome, JOB_STATUS_ENGLISH } from "shared"
 import { generateCfaFixture } from "shared/fixtures/cfa.fixture"
 import { generateEntrepriseFixture } from "shared/fixtures/entreprise.fixture"
 import { generateJobsPartnersOfferPrivate } from "shared/fixtures/job-partners.fixture"
 import { generateReferentielRome } from "shared/fixtures/rome.fixture"
+import dayjs from "shared/helpers/dayjs"
 import type { ICFA } from "shared/models/cfa.model"
-import type { IJobsPartnersOfferPrivate } from "shared/models/jobs-partners.model"
+import { type IJobsPartnersOfferPrivate, JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
 import { describe, expect, it } from "vitest"
-import { offerToFTOffer } from "@/jobs/partenaire-export/export-to-france-travail"
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { getJobsToExport, offerToFTOffer } from "@/jobs/partenaire-export/export-to-france-travail"
 
 describe("offerToFTOffer", () => {
   it("should convert a job to an exported offer for FT", async () => {
@@ -113,5 +116,74 @@ describe("offerToFTOffer", () => {
 
     expect(truncated).toHaveLength(450)
     expect(truncated).toBe(`Offre collectée par La bonne alternance : ${longDescription}`.slice(0, 450))
+  })
+})
+
+describe("getJobsToExport", () => {
+  useMongo()
+
+  const insertExportableJob = async (overrides: Partial<IJobsPartnersOfferPrivate> = {}) => {
+    const entreprise = generateEntrepriseFixture({})
+    const referentielRome = generateReferentielRome({})
+    // Les fixtures entreprise et rome portent des identifiants fixes (siret, code_rome) :
+    // upsert pour permettre plusieurs offres partageant la même entreprise et le même ROME sans dupliquer les jointures.
+    await getDbCollection("entreprises").updateOne({ siret: entreprise.siret }, { $setOnInsert: entreprise }, { upsert: true })
+    await getDbCollection("referentielromes").updateOne({ "rome.code_rome": referentielRome.rome.code_rome }, { $setOnInsert: referentielRome }, { upsert: true })
+    const job = generateJobsPartnersOfferPrivate({
+      partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA,
+      offer_status: JOB_STATUS_ENGLISH.ACTIVE,
+      updated_at: new Date(),
+      offer_target_diploma: { european: "3", label: "CAP" },
+      offer_rome_codes: [referentielRome.rome.code_rome],
+      workplace_siret: entreprise.siret,
+      ...overrides,
+    })
+    await getDbCollection("jobs_partners").insertOne(job)
+    return { job, referentielRome }
+  }
+
+  it("retourne les offres exportables avec le champ referentielRome peuplé par la jointure", async () => {
+    const { job, referentielRome } = await insertExportableJob()
+
+    const jobs = await getJobsToExport()
+
+    // Garde-fou de régression : un décalage entre le `as` du $lookup et le champ du $unwind
+    // (ex. "referentiel-rome" vs "$referentielRome") fait renvoyer 0 document à l'agrégation.
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0]._id.toString()).toBe(job._id.toString())
+    expect(jobs[0].referentielRome.rome.code_rome).toBe(referentielRome.rome.code_rome)
+  })
+
+  it("exclut une offre dont le code ROME n'a pas d'entrée dans le référentiel", async () => {
+    const { job } = await insertExportableJob()
+    await getDbCollection("jobs_partners").insertOne(
+      generateJobsPartnersOfferPrivate({
+        partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA,
+        offer_status: JOB_STATUS_ENGLISH.ACTIVE,
+        updated_at: new Date(),
+        offer_target_diploma: { european: "3", label: "CAP" },
+        offer_rome_codes: ["Z9999"],
+        workplace_siret: job.workplace_siret,
+      })
+    )
+
+    const jobs = await getJobsToExport()
+
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0]._id.toString()).toBe(job._id.toString())
+  })
+
+  it("sépare le flux principal du flux confiée via ft_support", async () => {
+    const { job } = await insertExportableJob()
+    const { job: jobConfiee } = await insertExportableJob({
+      ft_support: true,
+      offer_expiration: dayjs().add(30, "days").toDate(),
+    })
+
+    const jobs = await getJobsToExport()
+    const jobsConfiee = await getJobsToExport({ ftSupport: true })
+
+    expect(jobs.map((j) => j._id.toString())).toEqual([job._id.toString()])
+    expect(jobsConfiee.map((j) => j._id.toString())).toEqual([jobConfiee._id.toString()])
   })
 })

--- a/server/src/jobs/partenaire-export/export-to-france-travail.ts
+++ b/server/src/jobs/partenaire-export/export-to-france-travail.ts
@@ -251,7 +251,7 @@ const jobToFTOfferAddress = (job: DBJob): Partial<FTOffre> | null => {
   }
 }
 
-const getJobsToExport = async ({ ftSupport = false }: { ftSupport?: boolean } = {}) => {
+export const getJobsToExport = async ({ ftSupport = false }: { ftSupport?: boolean } = {}) => {
   const minDate = dayjs().subtract(60, "days").toDate()
 
   const jobPartnerFilter: Filter<IJobsPartnersOfferPrivate> = {
@@ -286,7 +286,7 @@ const getJobsToExport = async ({ ftSupport = false }: { ftSupport?: boolean } = 
         from: "referentielromes",
         localField: "offer_rome_codes",
         foreignField: "rome.code_rome",
-        as: "referentiel-rome",
+        as: "referentielRome",
       },
     },
     {
@@ -378,6 +378,10 @@ export const exportJobsToFranceTravailCsvOnly = async () => {
   const csvPath = new URL("./exportFT.csv", import.meta.url)
   try {
     const jobs = await getJobsToExport()
+    // 0 offre sur le flux principal est toujours anormal en production : on échoue plutôt que d'envoyer un fichier vide à FT.
+    if (jobs.length === 0) {
+      throw new Error("Aucune offre à exporter : l'agrégation a renvoyé 0 résultat, fichier non transmis")
+    }
     await generateCsvFile(csvPath, jobs)
     logger.info("Send CSV file to France Travail")
     if (config.env === "production") {
@@ -402,6 +406,11 @@ export const exportJobsToFranceTravail = async () => {
   try {
     const jobs = await getJobsToExport()
     const jobsConfiee = await getJobsToExport({ ftSupport: true })
+    // 0 offre sur le flux principal est toujours anormal en production : on échoue plutôt que d'envoyer un fichier vide à FT.
+    // Le flux confiée peut en revanche être légitimement vide, il n'est pas gardé.
+    if (jobs.length === 0) {
+      throw new Error("Aucune offre à exporter : l'agrégation a renvoyé 0 résultat, fichier non transmis")
+    }
     await generateCsvFile(csvPath, jobs)
     await generateCsvFileConfiee(csvPathConfiee, jobsConfiee)
     await zipAndSendToFranceTravail(csvPath, csvPathConfiee)

--- a/server/src/jobs/partenaire-export/export-to-france-travail.ts
+++ b/server/src/jobs/partenaire-export/export-to-france-travail.ts
@@ -397,6 +397,8 @@ export const exportJobsToFranceTravailCsvOnly = async () => {
       message: `Echec de l'export des offres France Travail. ${err}`,
       error: true,
     })
+    // Relance pour que le run job-processor soit marqué errored (capture Sentry) au lieu de finished.
+    throw err
   }
 }
 
@@ -424,5 +426,7 @@ export const exportJobsToFranceTravail = async () => {
       message: `Echec de l'export des offres France Travail. ${err}`,
       error: true,
     })
+    // Relance pour que le run job-processor soit marqué errored (capture Sentry) au lieu de finished.
+    throw err
   }
 }


### PR DESCRIPTION
Closes #5330

## Changements

- Restaure la cohérence du pipeline d'agrégation `getJobsToExport` : le `$lookup` écrit de nouveau dans `referentielRome` (le renommage kebab-case l'avait changé en `referentiel-rome` alors que le `$unwind` porte sur `$referentielRome`, ce qui supprimait tous les documents → 0 offre exportée depuis le 12/08)
- Rend le mode dégradé observable : si le flux principal renvoie 0 offre, le job échoue (notification Slack en erreur) et aucun fichier vide n'est transmis à France Travail ; le flux confiée, qui peut être légitimement vide, n'est pas gardé
- Ajoute des tests d'intégration Mongo sur `getJobsToExport` (exporté pour l'occasion) : jointure `referentielRome` peuplée, exclusion d'un code ROME hors référentiel, séparation flux principal / confiée via `ft_support` — vérifiés non vacuous (les 3 échouent si le décalage lookup/unwind est réintroduit)

## Plan de test

- [ ] `yarn vitest run server/src/jobs/partenaire-export/export-to-france-travail.test.ts` → 6/6 verts
- [ ] `yarn typecheck` et `biome check` passent
- [ ] Après déploiement, vérifier la notification Slack `#lba-jobs-production` du lendemain 5h30 : retour à un volume normal (~4 500 offres, dont ~40 en flux confiée)