### PR TITLE
fix: restaure le contexte de recherche des fiches détail (#5340)

### DIFF
--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.test.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { buildRecherchePageParams, IRechercheMode, parseRecherchePageParams } from "./recherche.route.utils"
+import { buildRecherchePageParams, IRechercheMode, parseRecherchePageParams, resolveRecherchePageParams, toURLSearchParams } from "./recherche.route.utils"
 
 /**
  * Ce module a perdu ses schémas zod (le type `IRecherchePageParams` est désormais explicite) :
@@ -56,5 +56,113 @@ describe("parseRecherchePageParams", () => {
       radius: 60,
       job_name: "Data analyst",
     })
+  })
+})
+
+/**
+ * Résolution du contexte de recherche d'une fiche détail. Les cas où `?from=` ne doit PAS être
+ * pris en compte passent en premier : un `from` accepté à tort remplacerait le métier et le lieu
+ * réels par ceux d'une URL forgée ou étrangère, et ces valeurs partent en base avec la
+ * candidature (`job_searched_by_user`) puis dans les mails recruteur.
+ *
+ * `from` est percent-encodé dans les vraies URL de fiche (buildHitDetailUrl) et décodé par
+ * URLSearchParams : les tests l'encodent de même, sinon ses `&` internes seraient lus comme des
+ * paramètres de l'URL de la fiche et le cas testé ne serait pas celui qu'on croit.
+ */
+describe("resolveRecherchePageParams", () => {
+  const legacy = "job_name=Boulanger&lat=45.75&lon=4.85&address=Lyon&radius=60"
+  const withFrom = (from: string, prefix = "") => new URLSearchParams(`${prefix}${prefix ? "&" : ""}from=${encodeURIComponent(from)}`)
+
+  describe("`from` ignoré → repli sur les paramètres legacy", () => {
+    it("sans `from` du tout", () => {
+      expect(resolveRecherchePageParams(new URLSearchParams(legacy), IRechercheMode.DEFAULT)).toMatchObject({
+        job_name: "Boulanger",
+        geo: { address: "Lyon", latitude: 45.75, longitude: 4.85 },
+        radius: 60,
+      })
+    })
+
+    it("`from` absolu externe, même si son chemin contient /recherche", () => {
+      const params = resolveRecherchePageParams(withFrom("https://evil.example/recherche?q=Piraté", legacy), IRechercheMode.DEFAULT)
+      expect(params.job_name).toBe("Boulanger")
+      expect(params.geo).toMatchObject({ address: "Lyon", latitude: 45.75, longitude: 4.85 })
+    })
+
+    it("`from` pointant sur un autre chemin interne", () => {
+      expect(resolveRecherchePageParams(withFrom("/emploi/partner/abc/titre?q=Piraté", legacy), IRechercheMode.DEFAULT).job_name).toBe("Boulanger")
+    })
+
+    // Le garde vient de `isInternalSearchUrl` (shared). Ces deux cas vérifient que le résolveur
+    // en hérite bien, et non qu'il refait la validation dans son coin.
+    it("`from` sur un chemin voisin de /recherche (near-miss de préfixe)", () => {
+      expect(resolveRecherchePageParams(withFrom("/recherchez-moi?q=Piraté", legacy), IRechercheMode.DEFAULT).job_name).toBe("Boulanger")
+    })
+
+    it("`from` remontant l'arborescence depuis /recherche", () => {
+      expect(resolveRecherchePageParams(withFrom("/recherche/../espace-pro/administration?q=Piraté", legacy), IRechercheMode.DEFAULT).job_name).toBe("Boulanger")
+    })
+
+    it("`from` répété : aucune des deux valeurs ne fait autorité", () => {
+      const search = toURLSearchParams({ job_name: "Boulanger", from: ["/recherche?q=Premier", "/recherche?q=Second"] })
+      expect(resolveRecherchePageParams(search, IRechercheMode.DEFAULT).job_name).toBe("Boulanger")
+    })
+  })
+
+  describe("`from` valide", () => {
+    it("prend le métier, le lieu et le rayon de la recherche d'origine", () => {
+      expect(
+        resolveRecherchePageParams(withFrom("/recherche?q=Développeur web&lieu_label=Nantes 44000&latitude=47.21&longitude=-1.55&radius=45"), IRechercheMode.DEFAULT)
+      ).toMatchObject({
+        job_name: "Développeur web",
+        geo: { address: "Nantes 44000", latitude: 47.21, longitude: -1.55 },
+        radius: 45,
+      })
+    })
+
+    it("fait autorité en bloc : un `from` sans métier n'hérite pas du job_name legacy", () => {
+      const params = resolveRecherchePageParams(withFrom("/recherche?latitude=47.21&longitude=-1.55", legacy), IRechercheMode.DEFAULT)
+      expect(params.job_name).toBeNull()
+      expect(params.geo).toMatchObject({ latitude: 47.21, longitude: -1.55 })
+    })
+
+    it("fait autorité en bloc : un `from` sans géo n'hérite pas de la géo legacy", () => {
+      expect(resolveRecherchePageParams(withFrom("/recherche?q=Plombier", legacy), IRechercheMode.DEFAULT)).toMatchObject({ job_name: "Plombier", geo: null })
+    })
+
+    it("ignore une coordonnée orpheline (latitude sans longitude)", () => {
+      expect(resolveRecherchePageParams(withFrom("/recherche?q=Plombier&latitude=47.21"), IRechercheMode.DEFAULT).geo).toBeNull()
+    })
+
+    it("applique le rayon par défaut du nouveau moteur (20), pas celui du legacy (30)", () => {
+      expect(resolveRecherchePageParams(withFrom("/recherche?q=Plombier"), IRechercheMode.DEFAULT).radius).toBe(20)
+    })
+
+    it("laisse intacts les champs qui ne décrivent pas la recherche (romes, diploma, toggles)", () => {
+      const params = resolveRecherchePageParams(withFrom("/recherche?q=Plombier", "romes=M1805&diploma=4 (BAC...)&displayFormations=false"), IRechercheMode.DEFAULT)
+      expect(params).toMatchObject({ romes: ["M1805"], diploma: "4 (BAC...)", displayFormations: false })
+    })
+  })
+})
+
+/**
+ * `new URLSearchParams(record)` aplatit un paramètre répété en une chaîne jointe par des
+ * virgules : la valeur produite n'est portée par aucun des liens d'origine, et les gardes en
+ * aval la valident comme une valeur unique. Les cas répétés passent donc en premier.
+ */
+describe("toURLSearchParams", () => {
+  it("conserve les valeurs répétées séparées, là où le constructeur natif les joint", () => {
+    const record = { from: ["/recherche?q=a", "/recherche?q=b"] }
+    expect(toURLSearchParams(record).getAll("from")).toEqual(["/recherche?q=a", "/recherche?q=b"])
+    // Le comportement natif qu'on remplace, pour que le test échoue si quelqu'un y revient.
+    expect(new URLSearchParams(record as unknown as Record<string, string>).getAll("from")).toEqual(["/recherche?q=a,/recherche?q=b"])
+  })
+
+  it("ignore les clés absentes et garde les valeurs simples", () => {
+    expect(toURLSearchParams({ job_name: "Boulanger", diploma: undefined }).getAll("diploma")).toEqual([])
+    expect(toURLSearchParams({ job_name: "Boulanger" }).get("job_name")).toBe("Boulanger")
+  })
+
+  it("préserve un tableau vide sans inventer de clé", () => {
+    expect([...toURLSearchParams({ from: [] }).keys()]).toEqual([])
   })
 })

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils.ts
@@ -9,6 +9,10 @@ import { NIVEAUX_POUR_LBA } from "shared/constants/recruteur"
 import { MAX_SEARCH_ROMES_PRIVATE } from "shared/constants/search"
 import { typedKeys } from "shared/utils/object-utils"
 
+import { parseSearchUrlFromParam } from "shared/utils/search-url-compat"
+
+import { parseSearchPageParams } from "./search.params.utils"
+
 /**
  * Paramètres d'URL du moteur de recherche legacy (`?job_name=…&romes=…`).
  *
@@ -164,5 +168,67 @@ export function parseRecherchePageParams(search: ReadonlyURLSearchParams | URLSe
     displayEntreprises,
     displayFormations,
     displayFilters,
+  }
+}
+
+/**
+ * Convertit les `searchParams` d'un Server Component en URLSearchParams sans perdre les
+ * paramètres répétés. `new URLSearchParams(record)` les aplatit en une chaîne jointe par des
+ * virgules (`?from=a&from=b` → `"a,b"`), ce qui fabrique une valeur qu'aucun des deux liens
+ * ne portait — et que les gardes en aval valident alors comme une valeur unique.
+ */
+export function toURLSearchParams(searchParams: Record<string, string | string[] | undefined>): URLSearchParams {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (value === undefined) continue
+    for (const item of Array.isArray(value) ? value : [value]) search.append(key, item)
+  }
+  return search
+}
+
+/**
+ * Contexte de recherche d'une fiche détail : le métier, le lieu et le rayon réellement
+ * cherchés par l'usager. C'est ce que les fiches poussent dans `DisplayContext.formValues`,
+ * et dont dépendent le `job_searched_by_user` enregistré avec chaque candidature (donc le bloc
+ * « Sa recherche d'alternance » des mails recruteur et la variable `metier` des relances J+7),
+ * l'affichage de la distance au lieu de recherche, et les dimensions métier/lieu des events
+ * Plausible « Affichage - Fiche emploi » et Matomo.
+ *
+ * Deux formats d'entrée, par priorité :
+ * 1. `?from=/recherche?q=…&latitude=…` — nouveau moteur. Les cartes de résultats ne posent plus
+ *    `job_name`/`lat`/`lon` sur l'URL de la fiche : la recherche d'origine n'est portée que par
+ *    l'URL de retour (cf. `buildHitDetailUrl`). C'est le seul format émis aujourd'hui.
+ * 2. `?job_name=…&lat=…&lon=…&address=…` — format legacy, encore porté par les liens en
+ *    circulation (pages éditoriales, liens partagés, résultats indexés).
+ *
+ * Un `?from=` valide fait autorité en bloc sur les trois champs : les deux formats décrivent la
+ * même chose, les mélanger produirait un métier et un lieu venant de deux recherches
+ * différentes. `?from=` externe ou malformé → repli legacy.
+ *
+ * Le garde du `from` n'est pas réimplémenté ici : `parseSearchUrlFromParam` (shared) le porte en
+ * un seul exemplaire, partagé avec le hook de navigation et le serveur. Il rejette aussi bien les
+ * préfixes voisins (`/recherche-formation`) que la remontée d'arborescence (`/recherche/../…`).
+ */
+export function resolveRecherchePageParams(search: URLSearchParams, mode: IRechercheMode): IRecherchePageParams {
+  // Non nul par construction : `search` n'est jamais null ici, contrairement à la signature
+  // large de parseRecherchePageParams (qui accepte le retour de useSearchParams).
+  const legacyParams = parseRecherchePageParams(search, mode)
+  if (legacyParams === null) throw new Error("resolveRecherchePageParams: searchParams manquants")
+
+  // `from` répété (`?from=a&from=b`) : aucune des deux valeurs ne fait autorité, on ne devine
+  // pas. Sans ce rejet, la première passerait le garde et la seconde finirait concaténée dans
+  // le métier stocké avec la candidature.
+  const fromValues = search.getAll("from")
+  const fromSearch = fromValues.length === 1 ? parseSearchUrlFromParam(fromValues[0]) : null
+  if (fromSearch === null) return legacyParams
+
+  const { q, lieu_label, latitude, longitude, radius } = parseSearchPageParams(fromSearch)
+
+  return {
+    ...legacyParams,
+    job_name: q ?? null,
+    // parseSearchPageParams ne renvoie une coordonnée que si la paire est complète.
+    geo: latitude !== undefined && longitude !== undefined ? { address: lieu_label ?? null, latitude, longitude } : null,
+    radius,
   }
 }

--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/JobDetailRendererClient.tsx
@@ -35,6 +35,12 @@ import { PAGES } from "@/utils/routes.utils"
 export default function JobDetailRendererClient({ job, rechercheParams }: { job: ILbaItemJobsGlobal; rechercheParams: IRecherchePageParams }) {
   const { setFormValues } = React.useContext(DisplayContext)
 
+  // `rechercheParams` est résolu par resolveRecherchePageParams : sur une fiche ouverte depuis
+  // le moteur, job_name/geo/radius viennent du `?from=` (les cartes ne posent plus job_name,
+  // lat ni lon sur l'URL de la fiche), sinon des paramètres legacy. Sans cette résolution,
+  // formValues restait { job: null, location: null } — d'où un `job_searched_by_user` vide sur
+  // les candidatures, la distance au lieu de recherche masquée et les dimensions métier/lieu
+  // perdues côté Plausible et Matomo.
   React.useEffect(() => {
     setFormValues({
       job: rechercheParams.job_name ? { label: rechercheParams.job_name } : null,
@@ -336,13 +342,21 @@ function JobDetail({ selectedItem, rechercheParams }: { rechercheParams: IRecher
 
           <Box id="detail-content-container" />
           <Box>
-            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && isMandataire && <LbaJobCfaDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}
-            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && (isCfaEntreprise || isGeiq) && <GeiqJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}
-            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && !isMandataire && !isCfaEntreprise && <LbaJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}
-            {kind === LBA_ITEM_TYPE.RECRUTEURS_LBA && <RecruteurLbaDetail recruteurLba={selectedItem as ILbaItemLbaCompanyJson} />}
-            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES && (isCfaEntreprise || isGeiq) && <GeiqJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />}
+            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && isMandataire && (
+              <LbaJobCfaDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} jobSearchedByUser={rechercheParams.job_name} />
+            )}
+            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && (isCfaEntreprise || isGeiq) && (
+              <GeiqJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} jobSearchedByUser={rechercheParams.job_name} />
+            )}
+            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA && !isMandataire && !isCfaEntreprise && (
+              <LbaJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} jobSearchedByUser={rechercheParams.job_name} />
+            )}
+            {kind === LBA_ITEM_TYPE.RECRUTEURS_LBA && <RecruteurLbaDetail recruteurLba={selectedItem as ILbaItemLbaCompanyJson} jobSearchedByUser={rechercheParams.job_name} />}
+            {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES && (isCfaEntreprise || isGeiq) && (
+              <GeiqJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} jobSearchedByUser={rechercheParams.job_name} />
+            )}
             {kind === LBA_ITEM_TYPE.OFFRES_EMPLOI_PARTENAIRES && !isCfaEntreprise && !isGeiq && (
-              <PartnerJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} />
+              <PartnerJobDetail title={actualTitle} job={selectedItem as ILbaItemPartnerJobJson} jobSearchedByUser={rechercheParams.job_name} />
             )}
 
             <AideApprentissage />

--- a/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
+++ b/ui/app/(candidat)/emploi/[type]/[id]/[intitule-offre]/page.tsx
@@ -6,7 +6,7 @@ import type { ILbaItemLbaCompanyJson, /*ILbaItemLbaJobJson, */ ILbaItemPartnerJo
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import { buildJobUrlPath } from "shared/metier/lbaitemutils"
 import { WidgetAwareHeader } from "@/app/_components/WidgetAwareHeader"
-import { IRechercheMode, parseRecherchePageParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
+import { IRechercheMode, resolveRecherchePageParams, toURLSearchParams } from "@/app/(candidat)/(recherche)/recherche/_utils/recherche.route.utils"
 import InfoBanner from "@/components/InfoBanner/InfoBanner"
 import { ApiError, apiGet } from "@/utils/api.utils"
 import JobDetailRendererClient from "./JobDetailRendererClient"
@@ -48,7 +48,14 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   }
 }
 
-export default async function JobOfferPage({ params, searchParams }: { params: Promise<{ type: LBA_ITEM_TYPE; id: string }>; searchParams: Promise<Record<string, string>> }) {
+export default async function JobOfferPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ type: LBA_ITEM_TYPE; id: string }>
+  // Next donne `string | string[]` dès qu'un paramètre est répété dans l'URL.
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
   const { type, id } = await params
   const job = await getOffreOption(type, id)
   if (!job) notFound()
@@ -66,7 +73,7 @@ export default async function JobOfferPage({ params, searchParams }: { params: P
       <WidgetAwareHeader />
       <JobDetailRendererClient
         job={job as ILbaItemLbaCompanyJson | ILbaItemPartnerJobJson}
-        rechercheParams={parseRecherchePageParams(new URLSearchParams(await searchParams), IRechercheMode.DEFAULT)}
+        rechercheParams={resolveRecherchePageParams(toURLSearchParams(await searchParams), IRechercheMode.DEFAULT)}
       />
     </>
   )

--- a/ui/components/ItemDetail/LbaJobComponents/LbaJobCfaDetail.tsx
+++ b/ui/components/ItemDetail/LbaJobComponents/LbaJobCfaDetail.tsx
@@ -2,7 +2,7 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Stack, Typography } from "@mui/material"
 import Image from "next/image"
-import React, { useEffect } from "react"
+import { useEffect } from "react"
 import type { ILbaItemPartnerJobJson } from "shared"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { ContratBlock } from "@/components/ItemDetail/ItemDetailServices/ContratBlock"
@@ -11,7 +11,6 @@ import ItemGoogleSearchLink from "@/components/ItemDetail/ItemDetailServices/Ite
 import ItemLocalisation from "@/components/ItemDetail/ItemDetailServices/ItemLocalisation"
 import { BAD_DESCRIPTION_LENGTH, JobDescription } from "@/components/ItemDetail/ItemDetailServices/JobDescription"
 import { JobPostingSchema } from "@/components/ItemDetail/JobPostingSchema"
-import { DisplayContext } from "@/context/DisplayContextProvider"
 import { notifyJobDetailViewV3 } from "@/utils/api"
 import { SendPlausibleEvent } from "@/utils/plausible"
 import LbaJobAcces from "./LbaJobAcces"
@@ -19,11 +18,9 @@ import LbaJobCompetences from "./LbaJobCompetences"
 import LbaJobQualites from "./LbaJobQualites"
 import LbaJobTechniques from "./LbaJobTechniques"
 
-export const LbaJobCfaDetail = ({ job, title }: { job: ILbaItemPartnerJobJson; title: string }) => {
-  const { formValues } = React.useContext(DisplayContext)
-
+export const LbaJobCfaDetail = ({ job, title, jobSearchedByUser }: { job: ILbaItemPartnerJobJson; title: string; jobSearchedByUser: string | null }) => {
   useEffect(() => {
-    SendPlausibleEvent("Affichage - Fiche emploi", { partner_label: job.ideaType, info_fiche: `${job?.job?.id}${formValues?.job?.label ? ` - ${formValues.job.label}` : ""}` })
+    SendPlausibleEvent("Affichage - Fiche emploi", { partner_label: job.ideaType, info_fiche: `${job?.job?.id}${jobSearchedByUser ? ` - ${jobSearchedByUser}` : ""}` })
     notifyJobDetailViewV3(job)
   }, [job?.job?.id])
 

--- a/ui/components/ItemDetail/LbaJobComponents/LbaJobDetail.tsx
+++ b/ui/components/ItemDetail/LbaJobComponents/LbaJobDetail.tsx
@@ -2,13 +2,12 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Stack, Typography } from "@mui/material"
 import Image from "next/image"
-import React, { useEffect } from "react"
+import { useEffect } from "react"
 import type { ILbaItemPartnerJobJson } from "shared"
 import { ContratBlock } from "@/components/ItemDetail/ItemDetailServices/ContratBlock"
 import { EmployeurPresentationBlock } from "@/components/ItemDetail/ItemDetailServices/EmployeurPresentationBlock"
 import { BAD_DESCRIPTION_LENGTH, JobDescription } from "@/components/ItemDetail/ItemDetailServices/JobDescription"
 import { JobPostingSchema } from "@/components/ItemDetail/JobPostingSchema"
-import { DisplayContext } from "@/context/DisplayContextProvider"
 import { notifyJobDetailViewV3 } from "@/utils/api"
 import { SendPlausibleEvent } from "@/utils/plausible"
 import LbaJobAcces from "./LbaJobAcces"
@@ -16,11 +15,9 @@ import LbaJobCompetences from "./LbaJobCompetences"
 import LbaJobQualites from "./LbaJobQualites"
 import LbaJobTechniques from "./LbaJobTechniques"
 
-export const LbaJobDetail = ({ job, title }: { job: ILbaItemPartnerJobJson; title: string }) => {
-  const { formValues } = React.useContext(DisplayContext)
-
+export const LbaJobDetail = ({ job, title, jobSearchedByUser }: { job: ILbaItemPartnerJobJson; title: string; jobSearchedByUser: string | null }) => {
   useEffect(() => {
-    SendPlausibleEvent("Affichage - Fiche emploi", { partner_label: job.ideaType, info_fiche: `${job?.job?.id}${formValues?.job?.label ? ` - ${formValues.job.label}` : ""}` })
+    SendPlausibleEvent("Affichage - Fiche emploi", { partner_label: job.ideaType, info_fiche: `${job?.job?.id}${jobSearchedByUser ? ` - ${jobSearchedByUser}` : ""}` })
     notifyJobDetailViewV3(job)
   }, [job?.job?.id])
 

--- a/ui/components/ItemDetail/PartnerJobComponents/GeiqJobDetail.tsx
+++ b/ui/components/ItemDetail/PartnerJobComponents/GeiqJobDetail.tsx
@@ -2,7 +2,7 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Stack, Typography } from "@mui/material"
 import Image from "next/image"
-import React, { useEffect } from "react"
+import { useEffect } from "react"
 import type { ILbaItemPartnerJobJson } from "shared"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import { ContratBlock } from "@/components/ItemDetail/ItemDetailServices/ContratBlock"
@@ -10,17 +10,14 @@ import { EmployeurPresentationBlock } from "@/components/ItemDetail/ItemDetailSe
 import { JobAccordion } from "@/components/ItemDetail/ItemDetailServices/JobAccordion"
 import { JobDescription } from "@/components/ItemDetail/ItemDetailServices/JobDescription"
 import { JobPostingSchema } from "@/components/ItemDetail/JobPostingSchema"
-import { DisplayContext } from "@/context/DisplayContextProvider"
 import { notifyJobDetailViewV3, notifyLbaJobDetailView } from "@/utils/api"
 import { SendPlausibleEvent } from "@/utils/plausible"
 
-export const GeiqJobDetail = ({ job, title }: { job: ILbaItemPartnerJobJson; title: string }) => {
-  const { formValues } = React.useContext(DisplayContext)
-
+export const GeiqJobDetail = ({ job, title, jobSearchedByUser }: { job: ILbaItemPartnerJobJson; title: string; jobSearchedByUser: string | null }) => {
   useEffect(() => {
     SendPlausibleEvent("Affichage - Fiche emploi", {
       partner_label: job.job.partner_label || job.ideaType,
-      info_fiche: `${job?.id}${formValues?.job?.label ? ` - ${formValues.job.label}` : ""}`,
+      info_fiche: `${job?.id}${jobSearchedByUser ? ` - ${jobSearchedByUser}` : ""}`,
     })
     if (job.ideaType === LBA_ITEM_TYPE.OFFRES_EMPLOI_LBA) {
       notifyLbaJobDetailView(job?.job?.id)

--- a/ui/components/ItemDetail/PartnerJobComponents/PartnerJobDetail.tsx
+++ b/ui/components/ItemDetail/PartnerJobComponents/PartnerJobDetail.tsx
@@ -2,22 +2,19 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import { Box, Link, Stack, Typography } from "@mui/material"
 import Image from "next/image"
-import React, { useEffect } from "react"
+import { useEffect } from "react"
 import type { ILbaItemPartnerJobJson } from "shared"
 import { ContratBlock } from "@/components/ItemDetail/ItemDetailServices/ContratBlock"
 import { EmployeurPresentationBlock } from "@/components/ItemDetail/ItemDetailServices/EmployeurPresentationBlock"
 import { JobAccordion } from "@/components/ItemDetail/ItemDetailServices/JobAccordion"
 import { JobDescription } from "@/components/ItemDetail/ItemDetailServices/JobDescription"
 import { JobPostingSchema } from "@/components/ItemDetail/JobPostingSchema"
-import { DisplayContext } from "@/context/DisplayContextProvider"
 import { notifyJobDetailViewV3 } from "@/utils/api"
 import { SendPlausibleEvent } from "@/utils/plausible"
 
-export const PartnerJobDetail = ({ job, title }: { job: ILbaItemPartnerJobJson; title: string }) => {
-  const { formValues } = React.useContext(DisplayContext)
-
+export const PartnerJobDetail = ({ job, title, jobSearchedByUser }: { job: ILbaItemPartnerJobJson; title: string; jobSearchedByUser: string | null }) => {
   useEffect(() => {
-    SendPlausibleEvent("Affichage - Fiche emploi", { partner_label: job.job.partner_label, info_fiche: `${job?.id}${formValues?.job?.label ? ` - ${formValues.job.label}` : ""}` })
+    SendPlausibleEvent("Affichage - Fiche emploi", { partner_label: job.job.partner_label, info_fiche: `${job?.id}${jobSearchedByUser ? ` - ${jobSearchedByUser}` : ""}` })
     notifyJobDetailViewV3(job)
   }, [job?.id])
 

--- a/ui/components/ItemDetail/RecruteurLbaComponents/RecruteurLbaDetail.tsx
+++ b/ui/components/ItemDetail/RecruteurLbaComponents/RecruteurLbaDetail.tsx
@@ -2,25 +2,22 @@ import { fr } from "@codegouvfr/react-dsfr"
 import Accordion from "@codegouvfr/react-dsfr/Accordion"
 import { Box, List, ListItem, Stack, Typography } from "@mui/material"
 import Image from "next/image"
-import { useContext, useEffect } from "react"
+import { useEffect } from "react"
 import type { ILbaItemLbaCompanyJson } from "shared"
 import { DsfrLink } from "@/components/dsfr/DsfrLink"
 import { EmployeurPresentationBlock } from "@/components/ItemDetail/ItemDetailServices/EmployeurPresentationBlock"
 import { getCompanyGoogleSearchLink } from "@/components/ItemDetail/ItemDetailServices/get-company-google-search-link"
-import { DisplayContext } from "@/context/DisplayContextProvider"
 import { notifyJobDetailViewV3 } from "@/utils/api"
 import { SendPlausibleEvent } from "@/utils/plausible"
 
-const RecruteurLbaDetail = ({ recruteurLba }: { recruteurLba: ILbaItemLbaCompanyJson }) => {
+const RecruteurLbaDetail = ({ recruteurLba, jobSearchedByUser }: { recruteurLba: ILbaItemLbaCompanyJson; jobSearchedByUser: string | null }) => {
   useEffect(() => {
     SendPlausibleEvent("Affichage - Fiche emploi", {
       partner_label: recruteurLba.ideaType,
-      info_fiche: `${recruteurLba?.company?.siret}${formValues?.job?.label ? ` - ${formValues.job.label}` : ""}`,
+      info_fiche: `${recruteurLba?.company?.siret}${jobSearchedByUser ? ` - ${jobSearchedByUser}` : ""}`,
     })
     notifyJobDetailViewV3(recruteurLba)
   }, [recruteurLba?.company?.siret])
-
-  const { formValues } = useContext(DisplayContext)
 
   return (
     <Box sx={{ mx: { xs: 0, md: "auto" } }}>


### PR DESCRIPTION
Closes #5340

Rebasée sur #5339, qui a introduit `search-url-compat` entre-temps : cette PR consomme ses helpers au lieu de dupliquer le garde du `from`.

## Changements

- `resolveRecherchePageParams` lit le `?from=` de la fiche pour en tirer le métier, le lieu et le rayon réellement cherchés, avec repli sur les paramètres legacy encore portés par les liens en circulation. Un `?from=` valide fait autorité en bloc sur les trois champs : les mélanger produirait un métier et un lieu venant de deux recherches différentes. Le garde vient de `parseSearchUrlFromParam` / `isInternalSearchUrl` (shared), pas d'une seconde implémentation.
- Le métier recherché passe en prop requise aux cinq composants de détail au lieu d'être lu dans `DisplayContext`. C'est une seconde cause, indépendante de la première : les effets remontant enfant vers parent, ces composants lisaient toujours un contexte encore vide, y compris sur les liens legacy. La dimension `info_fiche` de Plausible n'a donc jamais porté le métier.
- Nouveau `toURLSearchParams` : `new URLSearchParams(record)` aplatit un paramètre répété en chaîne jointe par des virgules, ce qui fabrique une valeur qu'aucun des liens ne portait et que les gardes en aval valident comme unique. Un `?from=` répété est désormais rejeté plutôt que deviné.

## Vérifications

Régression reproduite puis corrigée en navigateur. Payload `job_searched_by_user` capturé sur le POST `/v2/_private/application`, requête interceptée puis avortée :

| Cas | Avant | Après |
|---|---|---|
| `?from=` nouveau moteur | absent | `"boulanger"` |
| paramètres legacy | `"boulanger"` | `"boulanger"` |
| sans contexte de recherche | absent | absent |
| `?from=` absolu externe | absent | absent |
| `?from=/recherche-formation?q=pirate` | — | `"boulanger"` |
| `?from=/recherche/../espace-pro/administration` | — | `"boulanger"` |
| `?from=` répété | `"premier,/recherche?q=second"` | `"boulanger"` |

Les deux lignes sans « avant » sont couvertes par le garde de #5339 ; elles sont rejouées ici pour vérifier que le résolveur en hérite au lieu de revalider dans son coin. Le « avant » du `?from=` répété vient d'une sonde unitaire sur le résolveur, pas d'un run navigateur sur code muté.

Mêmes vérifications sur la distance au lieu de recherche et sur les dimensions Matomo `search_job_name` / `search_address`.

15 tests ajoutés, cas rejetés en premier, mutation-testés : réintroduire chacune des corrections fait passer les tests correspondants au rouge. 417 tests `ui` + `shared` verts, `tsc -b ui` et biome OK.

## Hors périmètre

- Le rattrapage de l'historique des candidatures dont `job_searched_by_user` est vide reste à trancher.
- La page formation reste sur `parseRecherchePageParams` : elle n'appelle jamais `setFormValues`, donc rien n'y change aujourd'hui.
- `job_searched_by_user` n'a aucune borne de longueur dans le schéma, contrairement à ses voisins en `.max(200)`. Pré-existant, à traiter à part.

## Plan de test

- [ ] Depuis `/recherche?q=…` avec un lieu, ouvrir une offre : la distance au lieu de recherche s'affiche sur la fiche.
- [ ] Envoyer une candidature depuis cette fiche, vérifier que le mail recruteur porte le métier dans « Sa recherche d'alternance ».
- [ ] Ouvrir une fiche par un lien legacy `?job_name=…&lat=…&lon=…` : même résultat.
- [ ] Ouvrir une fiche sans contexte de recherche : ni distance, ni métier, et aucune erreur.
- [ ] Vérifier dans Plausible que `info_fiche` porte à nouveau le suffixe ` - {métier}`.
