### PR TITLE
fix: crash de GET /admin/processor (ZodEncodeError sur les ObjectId)

### DIFF
--- a/server/src/http/controllers/_private/admin/processor.admin.routes.test.ts
+++ b/server/src/http/controllers/_private/admin/processor.admin.routes.test.ts
@@ -1,7 +1,6 @@
 import { createAndLogUser } from "@tests/utils/login.test.utils"
 import { useMongo } from "@tests/utils/mongo.test.utils"
 import { useServer } from "@tests/utils/server.test.utils"
-import { ObjectId } from "mongodb"
 import { describe, expect, it, vi } from "vitest"
 
 // fixtureStatus déclaré via vi.hoisted : vi.mock est hoisté en tête de fichier par Vitest, une const

--- a/server/src/http/controllers/_private/admin/processor.admin.routes.test.ts
+++ b/server/src/http/controllers/_private/admin/processor.admin.routes.test.ts
@@ -1,16 +1,73 @@
 import { createAndLogUser } from "@tests/utils/login.test.utils"
 import { useMongo } from "@tests/utils/mongo.test.utils"
 import { useServer } from "@tests/utils/server.test.utils"
+import { ObjectId } from "mongodb"
 import { describe, expect, it, vi } from "vitest"
+
+// fixtureStatus déclaré via vi.hoisted : vi.mock est hoisté en tête de fichier par Vitest, une const
+// module-scope normale ne serait pas encore initialisée au moment où la factory du mock l'utilise.
+const { fixtureStatus } = vi.hoisted(() => {
+  // require plutôt que l'import ESM du haut de fichier : celui-ci est réécrit par Vitest en accès
+  // paresseux (__vi_import_N__), pas encore initialisé au moment où cette factory hoistée s'exécute.
+  // biome-ignore lint/style/noCommonJs: cf. commentaire ci-dessus
+  const { ObjectId: HoistedObjectId } = require("mongodb")
+  return {
+    fixtureStatus: {
+      now: new Date(),
+      workers: [],
+      queue: [],
+      crons: [],
+      jobs: [
+        {
+          name: "test-job",
+          tasks: [
+            {
+              _id: new HoistedObjectId(),
+              name: "test-job",
+              type: "simple",
+              status: "finished",
+              sync: false,
+              payload: null,
+              output: null,
+              scheduled_for: new Date(),
+              started_at: null,
+              ended_at: null,
+              updated_at: new Date(),
+              created_at: new Date(),
+              worker_id: null,
+            },
+          ],
+        },
+      ],
+    },
+  }
+})
 
 vi.mock("job-processor", async (importOriginal) => {
   const mod = await importOriginal<typeof import("job-processor")>()
-  return { ...mod, addJob: vi.fn().mockResolvedValue(undefined) }
+  return { ...mod, addJob: vi.fn().mockResolvedValue(undefined), getProcessorStatus: vi.fn().mockResolvedValue(fixtureStatus) }
 })
 
 describe("processorAdminRoutes", () => {
   useMongo()
   const httpClient = useServer()
+
+  it("Vérifie que GET /_private/admin/processor ne plante pas quand un job réel (donc un ObjectId) est présent", async () => {
+    // Régression : zProcessorStatus (job-processor) encode ses ObjectId via un .transform() zod-mini à
+    // sens unique. Le serializerCompiler par défaut de fastify-type-provider-zod tente d'encoder la
+    // réponse et lève ZodEncodeError dès qu'un job réel (donc un ObjectId) est présent — une réponse
+    // vide ne le déclenche pas, d'où le fixture ci-dessus plutôt qu'un simple appel à vide.
+    const { bearerToken } = await createAndLogUser(httpClient, "processorAdminStatus", { type: "ADMIN" })
+
+    const response = await httpClient().inject({
+      method: "GET",
+      path: "/api/_private/admin/processor",
+      headers: bearerToken,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().jobs).toEqual(expect.arrayContaining([expect.objectContaining({ name: "test-job" })]))
+  })
 
   it("Vérifie qu'un utilisateur non connecté ne peut pas déclencher un job", async () => {
     const response = await httpClient().inject({

--- a/server/src/http/controllers/_private/admin/processor.admin.routes.ts
+++ b/server/src/http/controllers/_private/admin/processor.admin.routes.ts
@@ -1,3 +1,4 @@
+import type { FastifySerializerCompiler } from "fastify"
 import { getProcessorStatus } from "job-processor"
 import { zRoutes } from "shared"
 import type { z } from "shared/helpers/zod-with-open-api"
@@ -21,12 +22,23 @@ const jobHandlers: Record<TriggerableJob, () => Promise<unknown>> = {
   updateHandiEngagementForce: () => updateHandiEngagement({ force: true }),
 }
 
+// zProcessorStatus (exporté par job-processor) est construit avec zod/v4-mini et utilise zObjectIdMini
+// (zod-mongodb-schema), un .transform() à sens unique (string|ObjectId -> ObjectId) sans direction
+// d'encodage — même défaut que celui documenté et corrigé sur zObjectId dans shared/models/common.ts,
+// mais côté job-processor (dépendance externe, déjà à sa dernière version publiée). Le serializerCompiler
+// par défaut de fastify-type-provider-zod encode la réponse via ce schéma : dès qu'un job/worker/
+// historique réel (donc un ObjectId) est présent, il lève ZodEncodeError. Sérialiseur JSON natif pour
+// cette seule route : getProcessorStatus() est déjà typée et correcte, seule l'étape d'encode zod
+// (inutile ici) est court-circuitée — les autres routes gardent le comportement par défaut.
+const rawJsonSerializerCompiler: FastifySerializerCompiler<unknown> = () => (data) => JSON.stringify(data)
+
 export function processorAdminRoutes(server: Server) {
   server.get(
     "/_private/admin/processor",
     {
       schema: zRoutes.get["/_private/admin/processor"],
       onRequest: [server.auth(zRoutes.get["/_private/admin/processor"])],
+      serializerCompiler: rawJsonSerializerCompiler,
     },
     async (_request, response) => {
       return response.status(200).send(await getProcessorStatus())


### PR DESCRIPTION
Closes #5346 

## Contexte

Crash reproductible sur `/espace-pro/administration/processeur` dès qu'un job/worker réel (donc un ObjectId) existe en base :

```
ZodEncodeError: Encountered unidirectional transform during encode: ZodMiniTransform
```

## Cause

`zProcessorStatus` (exporté par `job-processor`) est construit avec `zod/v4-mini` et utilise `zObjectIdMini` de `zod-mongodb-schema`, un `.transform()` à sens unique (string|ObjectId → ObjectId) sans direction d'encodage. Le `serializerCompiler` par défaut de `fastify-type-provider-zod` encode chaque réponse via son schéma zod, ce qui échoue dès qu'un ObjectId réel est présent.

Même défaut déjà rencontré et documenté sur `zObjectId` dans `shared/models/common.ts`, mais côté `job-processor` (dépendance externe, déjà à sa dernière version publiée : `job-processor@3.0.0`, `zod-mongodb-schema@3.0.2` — pas de fix amont disponible).

## Correctif

`serializerCompiler` JSON natif dédié à cette seule route (`GET /_private/admin/processor`), sans toucher au comportement du reste de l'application. `getProcessorStatus()` reste typée normalement côté contrôleur ; seule l'étape d'encode zod (inutile ici, la donnée est déjà correcte) est court-circuitée.

## Tests

Nouveau test de régression qui seed un fixture avec un ObjectId réel et vérifie `GET /_private/admin/processor` → `200` (échouait en `500` avant le correctif, vérifié en local par désactivation temporaire du fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)