### PR TITLE
fix: afficher le nom du CFA sur les offres déléguées en recherche (#5343)

### DIFF
--- a/server/src/migrations/20260901120000-reindex-delegated-offers-cfa-name.ts
+++ b/server/src/migrations/20260901120000-reindex-delegated-offers-cfa-name.ts
@@ -1,0 +1,62 @@
+import type { ObjectId } from "mongodb"
+import { JOB_STATUS_ENGLISH } from "shared"
+import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
+
+import { logger } from "@/common/logger"
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+import { syncJobPartnersToSearchItemsInChunks } from "@/services/search/search-items.service"
+
+/**
+ * Les offres déléguées (déposées par un CFA pour le compte d'une entreprise d'accueil) étaient
+ * indexées dans `search_items` sous la raison sociale et l'adresse de l'entreprise : la carte de
+ * résultat affichait donc un employeur qui ne doit pas apparaître (issue #5343).
+ * `buildJobOfferSearchItem` retient désormais `cfa_legal_name` et `cfa_address_label`.
+ *
+ * Les offres modifiées après le déploiement sont rattrapées par le cron delta, mais une offre
+ * active dont le document source ne bouge plus resterait indexée sous l'ancien nom (la
+ * réconciliation nightly ne réécrit ni `organization_name` ni `address` sur un document déjà
+ * indexé) → on force ici une resynchronisation de toutes les offres déléguées actives, via le
+ * chemin de sync de production (keywords Mistral préservés, index Atlas Search resynchronisé
+ * automatiquement).
+ *
+ * Seules les offres `offres_emploi_lba` peuvent être déléguées : `is_delegated: true` n'est écrit
+ * que par `formulaire.service`, sur ce seul `partner_label`. Le filtre `offer_status` +
+ * `partner_label` sert l'index `{ offer_status, partner_label, … }` et évite un scan complet.
+ */
+
+// Curseur streamé et flush par tranches (même pattern que les autres migrations search_items) :
+// la liste des offres déléguées n'est jamais matérialisée en entier. Aligné sur DELTA_CHUNK_SIZE,
+// pour que chaque flush corresponde à un chunk de la sync.
+const BATCH_SIZE = 500
+
+export const up = async () => {
+  const cursor = getDbCollection("jobs_partners").find(
+    { offer_status: JOB_STATUS_ENGLISH.ACTIVE, partner_label: JOBPARTNERS_LABEL.OFFRES_EMPLOI_LBA, is_delegated: true },
+    { projection: { _id: 1 } }
+  )
+
+  let scanned = 0
+  let upserted = 0
+  let removed = 0
+  let batch: ObjectId[] = []
+
+  const flushBatch = async () => {
+    if (!batch.length) return
+    const result = await syncJobPartnersToSearchItemsInChunks(batch)
+    upserted += result.upserted
+    removed += result.removed
+    batch = []
+  }
+
+  for await (const doc of cursor) {
+    scanned++
+    batch.push(doc._id)
+    if (batch.length >= BATCH_SIZE) await flushBatch()
+  }
+  await flushBatch()
+
+  logger.info(`reindex-delegated-offers-cfa-name: ${scanned} offres déléguées actives, ${upserted} réindexées, ${removed} retirées de l'index`)
+}
+
+// set to false ONLY IF migration does not imply a breaking change (ex: update field value or add index)
+export const requireShutdown: boolean = false

--- a/server/src/services/search/search-items.service.test.ts
+++ b/server/src/services/search/search-items.service.test.ts
@@ -116,6 +116,62 @@ describe("searchItems.service — synchronisation jobs_partners → search_items
       expect(doc?.application_count).toBe(1)
     })
 
+    it("indexe une offre déléguée sous le nom du CFA, pas celui de l'entreprise d'accueil", async () => {
+      const job = generateJobsPartnersOfferPrivate({
+        is_delegated: true,
+        cfa_legal_name: "CFA des Métiers du Numérique",
+        cfa_siret: "42476141900045",
+        cfa_address_label: "12 rue de la Formation 75011 Paris",
+        workplace_name: "Boulangerie du Marché",
+        workplace_brand: "Aux Bons Pains",
+        workplace_legal_name: "SARL BOULANGERIE DU MARCHE",
+        workplace_address_label: "3 place du Four 75012 Paris",
+      })
+      await getDbCollection("jobs_partners").insertOne(job)
+
+      await upsertJobPartnersToSearchItems([job._id])
+
+      const doc = await getDbCollection("search_items").findOne({ _id: job._id })
+      expect(doc?.organization_name).toBe("CFA des Métiers du Numérique")
+      expect(doc?.type_filter_label).toBe("Offres d'emploi postées par des écoles")
+      // L'adresse de l'entreprise d'accueil la réidentifierait : c'est celle du CFA qui est indexée.
+      expect(doc?.address).toBe("12 rue de la Formation 75011 Paris")
+      // Le geopoint reste celui de l'entreprise — pertinence géographique et distance affichée.
+      expect(doc?.location?.coordinates).toEqual(job.workplace_geopoint.coordinates)
+    })
+
+    it("n'affiche aucun nom plutôt que celui de l'entreprise quand le CFA d'une offre déléguée est inconnu", async () => {
+      const job = generateJobsPartnersOfferPrivate({
+        is_delegated: true,
+        cfa_legal_name: null,
+        workplace_name: "Boulangerie du Marché",
+        workplace_legal_name: "SARL BOULANGERIE DU MARCHE",
+      })
+      await getDbCollection("jobs_partners").insertOne(job)
+
+      await upsertJobPartnersToSearchItems([job._id])
+
+      const doc = await getDbCollection("search_items").findOne({ _id: job._id })
+      expect(doc?.organization_name).toBe("")
+    })
+
+    it("near-miss : cfa_legal_name renseigné sur une offre NON déléguée → nom de l'entreprise conservé", async () => {
+      const job = generateJobsPartnersOfferPrivate({
+        is_delegated: false,
+        cfa_legal_name: "CFA des Métiers du Numérique",
+        cfa_address_label: "12 rue de la Formation 75011 Paris",
+        workplace_name: "Boulangerie du Marché",
+        workplace_address_label: "3 place du Four 75012 Paris",
+      })
+      await getDbCollection("jobs_partners").insertOne(job)
+
+      await upsertJobPartnersToSearchItems([job._id])
+
+      const doc = await getDbCollection("search_items").findOne({ _id: job._id })
+      expect(doc?.organization_name).toBe("Boulangerie du Marché")
+      expect(doc?.address).toBe("3 place du Four 75012 Paris")
+    })
+
     it("préserve les keywords Mistral lors d'un ré-upsert", async () => {
       const job = generateJobsPartnersOfferPrivate({ offer_title: "Titre initial" })
       await getDbCollection("jobs_partners").insertOne(job)

--- a/server/src/services/search/search-items.service.ts
+++ b/server/src/services/search/search-items.service.ts
@@ -58,6 +58,8 @@ export const jobsProjection: Partial<Record<keyof IJobsPartnersOfferPrivate, 1>>
   partner_label: 1,
   apply_email: 1,
   is_delegated: 1,
+  cfa_legal_name: 1,
+  cfa_address_label: 1,
   contract_type: 1,
   contract_start: 1,
   contract_start_type: 1,
@@ -81,6 +83,8 @@ type ProjectedJobFields =
   | "partner_label"
   | "apply_email"
   | "is_delegated"
+  | "cfa_legal_name"
+  | "cfa_address_label"
   | "contract_type"
   | "contract_start"
   | "contract_start_type"
@@ -329,6 +333,28 @@ export const buildFormationSearchItem = (formation: IFormationForSearchItem, ctx
   rome_labels: resolveRomeLabels(formation.rome_codes, ctx.romeLabelByCode),
 })
 
+/**
+ * Nom d'organisme affiché sur la carte de résultat, et valeur indexée du champ de facette
+ * `organization_name` (calculé par `search.service` et filtrable par paramètre d'URL ; aucune
+ * liste d'options ne l'expose aujourd'hui dans les filtres de l'interface).
+ *
+ * Offre déléguée = offre déposée par un CFA pour le compte d'une entreprise d'accueil : c'est le
+ * nom du CFA qui doit apparaître, jamais la raison sociale de l'entreprise (cf. issue #5343).
+ * Même règle que la fiche détail (`partner-job.service`) et l'API v3 (`jobs.routes.v3.model`).
+ *
+ * Aucun repli sur les champs `workplace_*` quand `cfa_legal_name` est absent : ce repli
+ * réafficherait exactement le nom que l'on masque. La carte affiche alors « Offre anonyme ».
+ * `||` et non `??` sur la chaîne de repli entreprise : les champs sont sanitizés en amont et
+ * peuvent valoir "" (cf. `formatTextFieldsJobsPartners`), ce qui court-circuiterait un `??`.
+ */
+export const getJobOrganizationName = (
+  job: Pick<IJobPartnerForSearchItem, "is_delegated" | "cfa_legal_name" | "workplace_name" | "workplace_brand" | "workplace_legal_name">,
+  ctx: SearchItemBuildContext
+): string => {
+  const name = job.is_delegated ? job.cfa_legal_name : job.workplace_name || job.workplace_brand || job.workplace_legal_name
+  return canonicalizeCase(ctx.organizationCaseMap, name || "")
+}
+
 export const buildJobOfferSearchItem = (job: IJobPartnerForSearchItem, ctx: SearchItemBuildContext): ISearchItem => ({
   _id: job._id,
   url_id: job._id.toString(),
@@ -347,12 +373,17 @@ export const buildJobOfferSearchItem = (job: IJobPartnerForSearchItem, ctx: Sear
   application_count: job.application_count,
   title: dedupeRepeatedTitle(job.offer_title || ""),
   description: stripHtmlToText(job.offer_description),
-  address: job.workplace_address_label || "",
+  // Offre déléguée : adresse du CFA, comme la fiche détail (`partner-job.service`) — afficher
+  // celle de l'entreprise d'accueil la réidentifierait alors qu'on masque son nom (issue #5343).
+  // `location` reste en revanche le geopoint de l'entreprise : c'est lui qui porte la pertinence
+  // géographique et la distance affichée. Même compromis que la fiche détail, où l'adresse du CFA
+  // cohabite déjà avec les coordonnées de l'entreprise.
+  address: (job.is_delegated ? job.cfa_address_label : job.workplace_address_label) || "",
   location: {
     type: "Point",
     coordinates: [job.workplace_geopoint.coordinates[0], job.workplace_geopoint.coordinates[1]],
   },
-  organization_name: canonicalizeCase(ctx.organizationCaseMap, job.workplace_name || job.workplace_brand || job.workplace_legal_name || ""),
+  organization_name: getJobOrganizationName(job, ctx),
   level: job.offer_target_diploma?.label || "",
   activity_sector: job.workplace_naf_label ? canonicalizeCase(ctx.sectorCaseMap, job.workplace_naf_label) : job.workplace_naf_label,
   keywords: null,


### PR DESCRIPTION
Closes #5343

## Changements

Les offres déléguées (déposées par un CFA pour le compte d'une entreprise d'accueil, `is_delegated: true`) s'affichaient en recherche sous la raison sociale et l'adresse de l'entreprise. Correction dans le mapping de l'index `search_items`, sans nouveau champ.

- `buildJobOfferSearchItem` retient `cfa_legal_name` et `cfa_address_label` quand l'offre est déléguée, au lieu des champs `workplace_*`. Même règle que la fiche détail (`partner-job.service`) et l'API v3 (`jobs.routes.v3.model`), que la recherche était seule à ne pas appliquer.
- Pas de repli sur les champs `workplace_*` quand `cfa_legal_name` est vide : ce repli réafficherait exactement le nom que l'on masque. La carte tombe alors sur « Offre anonyme ».
- `location` reste le geopoint de l'entreprise : c'est lui qui porte la pertinence géographique et la distance affichée. Le compromis « adresse du CFA, coordonnées de l'entreprise » est celui qui existe déjà sur la fiche détail.
- Migration de rattrapage : la réconciliation nightly ne réécrit ni `organization_name` ni `address` sur un document déjà indexé, donc une offre déléguée active dont le `jobs_partners` ne bouge plus resterait indexée sous l'ancien nom. La migration repasse par le chemin de sync de production (`syncJobPartnersToSearchItemsInChunks`, keywords Mistral préservés), curseur streamé par tranches de 500.

Aucun changement côté interface : la carte et le contenu SEO lisent `organization_name` et `address`.

Deux effets de bord assumés : la facette API `organization_name` et l'événement Matomo `job_offer_company` portent désormais le nom du CFA sur ces offres, et une recherche par nom d'entreprise ne remonte plus ses offres déléguées.

## Points ouverts pour la review

- `cfas.raison_sociale` est `nullish` : une offre déléguée sans `cfa_legal_name` affichera « Offre anonyme ». Aucun repli n'est possible sans stocker l'enseigne du CFA dans `jobs_partners`. Volume à mesurer en production avant de trancher.
- Le filtre de la migration est `partner_label: offres_emploi_lba` + `is_delegated: true`, pour servir l'index `{ offer_status, partner_label, … }` plutôt que scanner tous les statuts ACTIVE. Vérifié par revue des écritures de `is_delegated: true` (uniquement `formulaire.service`, sur ce seul `partner_label`), non confirmé sur les données de production.

## Plan de test

- [ ] `yarn test --run server/src/services/search server/src/jobs/search` : 3 nouveaux tests sur la délégation (nom du CFA, adresse du CFA + geopoint entreprise, near-miss `cfa_legal_name` renseigné sur une offre non déléguée, CFA inconnu). Non-vacuité vérifiée en réintroduisant le bug.
- [ ] `yarn typecheck` sur `server` et `yarn check`.
- [ ] Après déploiement, vérifier le log de la migration `reindex-delegated-offers-cfa-name` (nombre d'offres réindexées, `removed` attendu à 0).
- [ ] Recherche emploi + formation sur https://labonnealternance.apprentissage.beta.gouv.fr/recherche?q=ressource+humaine&search_source=free_text&mode=emplois_formation : les offres marquées « Offres d'emploi postées par des écoles » affichent le nom et l'adresse du CFA.
- [ ] Ouvrir une de ces offres : le nom affiché sur la carte correspond à celui de la fiche détail.