### PR TITLE
fix: purge du cache du reverse proxy à chaque déploiement (#5366)

### DIFF
--- a/.infra/ansible/deploy.yml
+++ b/.infra/ansible/deploy.yml
@@ -108,13 +108,23 @@
     # mode maintenance, le renouvellement SSL et le setup Metabase — un prix sans rapport avec
     # l'enjeu, puisque la garantie de correction est la conf nginx, pas cette purge. On trace
     # donc le cas dans la sortie ansible plutôt que de le masquer.
+    # Non bloquant ne veut pas dire silencieux : le code retour et la sortie d'erreur sont
+    # affichés, et l'absence de conteneur est signalée. « cannot delete … No such file » est la
+    # course attendue avec nginx ; tout autre message signale un problème sur le conteneur.
     - name: "Purge du cache du Reverse Proxy"
       shell:
         chdir: /opt/app
         cmd: |
-          for containerId in $(sudo docker ps -q -f name=lba_reverse_proxy); do
-            sudo docker exec "$containerId" find /tmp/nginx_cache -mindepth 1 -delete \
-              || echo "Purge partielle sur $containerId : des entrées ont été supprimées par nginx pendant le parcours."
+          containers=$(sudo docker ps -q -f name=lba_reverse_proxy)
+          if [ -z "$containers" ]; then
+            echo "AVERTISSEMENT : aucun conteneur lba_reverse_proxy trouvé, le cache n'a pas été purgé."
+          fi
+          for containerId in $containers; do
+            sortie=$(sudo docker exec "$containerId" find /tmp/nginx_cache -mindepth 1 -delete 2>&1)
+            code=$?
+            if [ "$code" -ne 0 ]; then
+              echo "AVERTISSEMENT : purge incomplète sur $containerId (code $code) : $(echo "$sortie" | head -3)"
+            fi
           done
 
     - name: "Reload du Reverse Proxy"

--- a/.infra/ansible/deploy.yml
+++ b/.infra/ansible/deploy.yml
@@ -90,6 +90,33 @@
       async: 1800
       poll: 10
 
+    # Ceinture-bretelles. Le vrai correctif est dans l'image du reverse proxy
+    # (mission-apprentissage/infra, conf.d/cache.conf) : nginx ne stocke plus les réponses
+    # document de Next, qui portent un `Cache-Control: s-maxage=31536000` destiné à un CDN purgé
+    # à chaque déploiement. Sans ça, le HTML d'une page reste servi un an alors que les chunks JS
+    # qu'il référence sont renommés à chaque build → 404 sur les chunks, ChunkLoadError, page
+    # jamais hydratée (incident du 2026-09-01 sur /1jeune1solution-recruteurs).
+    # Cette purge ne remplace pas le correctif : elle ne couvre pas un `docker service update`
+    # manuel, seulement les déploiements passant par ce playbook. Elle borne la fenêtre
+    # d'exposition en cas de régression de la conf nginx.
+    # `rm -rf /tmp/nginx_cache/*` échoue en « Argument list too long » : le cache est stocké à
+    # plat (proxy_cache_path sans `levels=`), d'où le `find -delete`.
+    # La purge est volontairement non bloquante. `find -delete` retourne 1 dès qu'une entrée
+    # disparaît pendant le parcours, ce que nginx fait en continu sur un proxy qui sert du
+    # trafic (reproduit : 5 échecs sur 10 essais avec purges concurrentes). Un échec ferait
+    # échouer la tâche après `update-stack.sh`, donc sauterait `reload-proxy.sh`, la sortie du
+    # mode maintenance, le renouvellement SSL et le setup Metabase — un prix sans rapport avec
+    # l'enjeu, puisque la garantie de correction est la conf nginx, pas cette purge. On trace
+    # donc le cas dans la sortie ansible plutôt que de le masquer.
+    - name: "Purge du cache du Reverse Proxy"
+      shell:
+        chdir: /opt/app
+        cmd: |
+          for containerId in $(sudo docker ps -q -f name=lba_reverse_proxy); do
+            sudo docker exec "$containerId" find /tmp/nginx_cache -mindepth 1 -delete \
+              || echo "Purge partielle sur $containerId : des entrées ont été supprimées par nginx pendant le parcours."
+          done
+
     - name: "Reload du Reverse Proxy"
       shell:
         chdir: /opt/app

--- a/.infra/files/configs/reverse_proxy/extra-includes/proxy-iframe.conf.template
+++ b/.infra/files/configs/reverse_proxy/extra-includes/proxy-iframe.conf.template
@@ -1,6 +1,10 @@
 include includes/proxy.conf;
 
+# `add_header` n'est pas cumulatif : redéclarer le moindre en-tête ici fait perdre tous ceux
+# hérités de conf.d/headers.conf. Cette liste doit donc rester alignée sur celle de l'image du
+# reverse proxy, à l'exception de X-Frame-Options, vidé exprès pour autoriser l'iframe.
 add_header Strict-Transport-Security "max-age=31536000; includeSubdomains" always;
 add_header X-Frame-Options "";
 add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "no-referrer-when-downgrade";
+add_header X-Cache-Status $upstream_cache_status always;


### PR DESCRIPTION
Closes #5366

Part LBA du correctif de l'incident du 2026-09-01, où `/1jeune1solution-recruteurs` servait un HTML prérendu périmé référençant des chunks JS supprimés (404 → ChunkLoadError → page jamais hydratée, formulaire SIRET inutilisable).

Le correctif de fond est dans l'image du reverse proxy (`mission-apprentissage/infra`, version 1.7.9) : nginx ne stocke plus les réponses document de Next, qui portent un `Cache-Control: s-maxage=31536000` destiné à un CDN purgé à chaque déploiement. **Cette PR ne suffit pas seule** et doit être déployée après la PR infra.

## Changements

- Purge du cache proxy dans `deploy.yml`, entre l'attente du déploiement et le reload du proxy. En ceinture-bretelles : elle ne couvre pas un `docker service update` manuel, mais elle borne la fenêtre d'exposition si la conf nginx régresse.
- La purge est volontairement non bloquante. `find -delete` retourne 1 dès qu'une entrée disparaît pendant le parcours, ce que nginx fait en continu sur un proxy qui sert du trafic — reproduit, 5 échecs sur 10 essais avec purges concurrentes. Un échec ferait sauter le reload du proxy, la sortie du mode maintenance, le renouvellement SSL et le setup Metabase. Le cas est tracé dans la sortie ansible plutôt que masqué.
- `rm -rf /tmp/nginx_cache/*` n'est pas utilisable : le cache est stocké à plat (`proxy_cache_path` sans `levels=`), la commande échoue en « Argument list too long ».
- `X-Cache-Status` ajouté à `proxy-iframe.conf.template`. `add_header` n'est pas cumulatif : ces locations redéclarent leurs en-têtes et perdent donc tous ceux hérités de l'image.

## Vérifications déjà passées

- `bash -n` sur la commande de purge telle que rendue par le parseur YAML. Une première version en scalaire replié `>-` ne parsait pas — le `||` sur une ligne sur-indentée devenait une instruction séparée. Passée en bloc littéral.
- `ansible-playbook --syntax-check` sur `deploy.yml`.
- Course concurrente rejouée avec la commande corrigée sur un conteneur nginx réel : 0 code retour non nul sur 10 essais, message de purge partielle émis 4 fois.
- `yarn check:fix` : aucun fix appliqué. À noter que biome ne couvre ni le YAML ni les templates nginx, il ne dit donc rien sur les fichiers de cette PR.

## Plan de test

- [ ] Déployer d'abord la PR infra (image `mna_reverse_proxy` 1.7.9), puis celle-ci sur recette.
- [ ] Vérifier que la tâche « Purge du cache du Reverse Proxy » passe et se place bien avant le reload.
- [ ] `curl -sI <recette>/1jeune1solution-recruteurs | grep -i x-cache-status` doit renvoyer autre chose que `HIT`.
- [ ] Vérifier que les chunks de la page répondent tous en 200.
- [ ] `curl -sI <recette>/_next/static/chunks/<un-chunk>.js` doit renvoyer `X-Cache-Status: HIT` : les assets restent cachés.
- [ ] Redéployer une nouvelle version de l'UI et vérifier, sans purge manuelle, que la page sert immédiatement les nouveaux chunks.
- [ ] Vérifier qu'une page en iframe (`/recherche`) renvoie bien `X-Cache-Status`.