### PR TITLE
fix: envoyer Referrer-Policy sur les réponses d'erreur des locations iframe

### DIFF
--- a/.infra/files/configs/reverse_proxy/extra-includes/proxy-iframe.conf.template
+++ b/.infra/files/configs/reverse_proxy/extra-includes/proxy-iframe.conf.template
@@ -6,5 +6,5 @@ include includes/proxy.conf;
 add_header Strict-Transport-Security "max-age=31536000; includeSubdomains" always;
 add_header X-Frame-Options "";
 add_header X-Content-Type-Options "nosniff" always;
-add_header Referrer-Policy "no-referrer-when-downgrade";
+add_header Referrer-Policy "no-referrer-when-downgrade" always;
 add_header X-Cache-Status $upstream_cache_status always;


### PR DESCRIPTION
Pendant côté LBA de mission-apprentissage/infra#233, relevé par Copilot lors de la revue du correctif de cache.

`add_header` n'est pas cumulatif : une location qui redéclare le moindre en-tête perd tous ceux hérités du niveau supérieur. `extra-includes/proxy-iframe.conf.template` redéclare donc la liste complète, et c'est cette copie qui s'applique aux locations en iframe (`/recherche`, `/recherche-emploi`, `/recherche-formation`, `/postuler`, `/espace-pro/widget`).

`Referrer-Policy` y était le seul en-tête déclaré sans `always`. nginx ne l'ajoute alors que sur les réponses 2xx et 3xx : la politique de referrer disparaissait sur les pages d'erreur de ces cinq routes.

## Mesure

Liste d'en-têtes du fichier rejouée telle quelle dans nginx 1.29, avant et après :

```
              200        404
avant         présent    absent
après         présent    présent
```

Les 200 sont inchangées. Les trois autres en-têtes, déjà en `always`, sortent dans les deux cas.

## Sur X-Cache-Status

Il n'apparaît pas dans le banc de mesure parce que `$upstream_cache_status` y est vide, faute d'amont proxifié, et que nginx omet un en-tête à valeur vide. Sans rapport avec ce changement.

## Ordre avec l'infra

Ce fichier vit dans ce dépôt et redéclare sa propre liste : le changement est autonome, il ne dépend pas de la version de l'image du reverse proxy. mission-apprentissage/infra#233 fait le même correctif dans `conf.d/headers.conf` pour toutes les autres locations et tous les autres produits. Les deux peuvent partir dans n'importe quel ordre, mais tant qu'une seule est déployée les deux listes divergent, ce que le commentaire en tête du fichier demande justement d'éviter.

## Plan de test

- [ ] Sur une route en iframe, provoquer une 404 et vérifier que `Referrer-Policy` est présent.
- [ ] Vérifier qu'une 200 sur la même route renvoie toujours les quatre en-têtes.
- [ ] Vérifier que l'affichage en iframe fonctionne toujours, `X-Frame-Options` restant vide.