### PR TITLE
fix: contourne la validation de schéma dans la migration NAF de jobs_partners (#5344)

### DIFF
--- a/server/src/migrations/20260901163000-normalize-naf-jobs-partners.ts
+++ b/server/src/migrations/20260901163000-normalize-naf-jobs-partners.ts
@@ -25,6 +25,13 @@ import { getDbCollection } from "@/common/utils/mongodb-utils"
  * `updated_at` n'est PAS touché : le cron « Sync delta search_items » resynchronise les
  * jobs_partners modifiés sur une fenêtre de 10 minutes, et bumper l'horodatage de tout le corpus
  * d'un coup lui ferait avaler la collection entière.
+ *
+ * `bypassDocumentValidation` est indispensable : hors production la collection est en
+ * `validationLevel: strict` + `validationAction: error` (cf. `configureDbSchemaValidation`), et un
+ * document historique qui ne respecte plus le schéma courant fait échouer TOUTE mise à jour, même
+ * un `$set` sans rapport. Sans ce flag, le premier déploiement en recette a planté (code 121
+ * « Document failed validation » sur ~93 % d'un lot de 1000) ; en production le même écart n'aurait
+ * produit qu'un warn, ce qui aurait masqué le problème.
  */
 
 const BATCH_SIZE = 1000
@@ -49,7 +56,7 @@ export const up = async () => {
 
   const flushBatch = async () => {
     if (!batch.length) return
-    const result = await collection.bulkWrite(batch, { ordered: false })
+    const result = await collection.bulkWrite(batch, { ordered: false, bypassDocumentValidation: true })
     updated += result.modifiedCount
     batch = []
   }

--- a/server/tests/integration/migrations/normalize-naf-jobs-partners.test.ts
+++ b/server/tests/integration/migrations/normalize-naf-jobs-partners.test.ts
@@ -1,5 +1,6 @@
 import { useMongo } from "@tests/utils/mongo.test.utils"
 import { generateJobsPartnersOfferPrivate } from "shared/fixtures/job-partners.fixture"
+import type { IJobsPartnersOfferPrivate } from "shared/models/jobs-partners.model"
 import { describe, expect, it } from "vitest"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { up } from "@/migrations/20260901163000-normalize-naf-jobs-partners"
@@ -34,6 +35,28 @@ describe("migration normalize-naf-jobs-partners", () => {
     expect.soft(byId.get("c")?.workplace_naf_label).toBe("Conseil en systèmes et logiciels informatiques")
     expect.soft(byId.get("d")?.workplace_naf_code).toBe(null)
     expect.soft(byId.get("d")?.workplace_naf_label).toBe(null)
+  })
+
+  it("réécrit aussi les documents legacy qui ne passent plus la validation de schéma", async () => {
+    // Hors production, jobs_partners est en validationLevel strict + validationAction error : un document
+    // historique qui ne respecte plus le schéma courant (ici un champ retiré du modèle depuis) fait échouer
+    // TOUTE mise à jour, y compris un $set sans rapport avec le champ fautif. C'est ce qui a fait planter le
+    // déploiement en recette (code 121 « Document failed validation » sur ~93 % d'un lot de 1000).
+    const legacyDoc = {
+      ...generateJobsPartnersOfferPrivate({ partner_job_id: "legacy", workplace_naf_code: "4673A", workplace_naf_label: "HÔTELS ET HÉBERGEMENT SIMILAIRE" }),
+      establishment_id: "champ-retire-du-modele",
+    } as IJobsPartnersOfferPrivate
+    const collection = getDbCollection("jobs_partners")
+
+    // Garde-fou anti-vacuité : le document doit réellement être refusé par le validateur, sinon ce test ne prouve rien.
+    await expect(collection.insertOne(legacyDoc)).rejects.toMatchObject({ code: 121 })
+    await collection.insertOne(legacyDoc, { bypassDocumentValidation: true })
+
+    await up()
+
+    const job = await collection.findOne({ partner_job_id: "legacy" })
+    expect.soft(job?.workplace_naf_code).toBe("46.73A")
+    expect.soft(job?.workplace_naf_label).toBe("Hôtels et hébergement similaire")
   })
 
   it("ne touche pas updated_at, pour ne pas noyer le cron delta search_items", async () => {


### PR DESCRIPTION
## Contexte

Le déploiement recette de ce soir a échoué sur `migrations:up`, après le merge de #5361 (issue #5344). La migration `20260901163000-normalize-naf-jobs-partners` remonte une `MongoBulkWriteError` code 121 « Document failed validation » sur la quasi-totalité d'un lot de 1000 `updateOne` (66 documents modifiés, le reste refusé).

## Cause

- Le `bulkWrite` de la migration ne passait pas `bypassDocumentValidation: true`, contrairement aux `updateMany` des autres migrations du repo.
- `configureDbSchemaValidation` pose sur chaque collection un validateur `validationLevel: strict` + `additionalProperties: false`, avec `validationAction: error` hors production et `warn` en production.
- Des offres LBA historiques de `jobs_partners` (ids 2023-2024) ne respectent plus le schéma courant pour une raison sans rapport avec le NAF. En mode `error`, n'importe quel `$set` sur ces documents est refusé. En production la même migration serait passée en silence : c'est la recette qui a révélé le trou.

## Changements

- `server/src/migrations/20260901163000-normalize-naf-jobs-partners.ts` : `bypassDocumentValidation: true` sur le `bulkWrite`, raison documentée dans l'en-tête de la migration.
- `server/tests/integration/migrations/normalize-naf-jobs-partners.test.ts` : nouveau cas « document legacy hors schéma », inséré en bypass avec un champ retiré du modèle. Un garde-fou vérifie d'abord que le validateur refuse bien ce document (code 121), pour que le test ne devienne pas vacuous si le schéma s'assouplit.

## Vérifications

- Le nouveau test reproduit l'erreur exacte de recette avant correctif (MongoBulkWriteError code 121 depuis `flushBatch`), puis passe après : 4 tests verts sur le fichier.
- `biome check` sans remarque, `tsc -b` du server OK (son `include` couvre `tests/`).

## Après merge

Le runner n'écrit le changelog qu'après succès, donc la migration se rejouera au prochain déploiement recette. Les 66 documents déjà réécrits sont idempotents et `updated_at` n'est toujours pas touché.

À noter hors de cette PR : une part importante des `jobs_partners` historiques ne respecte pas le schéma courant et le mode `warn` de la prod le masque. Le job `db:validate` lancé après chaque migration devrait le remonter, à vérifier dans ses logs.
