### PR TITLE
fix: évite la boucle de redirections 307 espace-pro depuis les pages candidat (#5383)

### DIFF
--- a/ui/app/(candidat)/detail-rendez-vous/[id]/layout.tsx
+++ b/ui/app/(candidat)/detail-rendez-vous/[id]/layout.tsx
@@ -2,9 +2,12 @@ import { fr } from "@codegouvfr/react-dsfr"
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
+import { Suspense } from "react"
 import { Footer } from "@/app/_components/Footer"
-import { PublicHeader } from "@/app/_components/PublicHeader"
-export default async function Layout({ children }: PropsWithChildren) {
+import { PublicHeader, PublicHeaderStatic } from "@/app/_components/PublicHeader"
+import { getSession } from "@/utils/get-session"
+
+export default function Layout({ children }: PropsWithChildren) {
   return (
     <>
       <SkipLinks
@@ -14,11 +17,20 @@ export default async function Layout({ children }: PropsWithChildren) {
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <PublicHeader hideConnectionButton={false} />
+      <Suspense fallback={<PublicHeaderStatic />}>
+        <DetailRendezVousHeaderWithUser />
+      </Suspense>
       <Box id="content-container" sx={{ pt: fr.spacing("4v") }} tabIndex={-1} role="main" component="main">
         {children}
       </Box>
       <Footer />
     </>
   )
+}
+
+// Même garde-fou que sur formulaire-intention : ne pas afficher « Connexion » à un utilisateur
+// connecté, sinon le préchargement du lien boucle sur le proxy (307 ↔ 307).
+async function DetailRendezVousHeaderWithUser() {
+  const { user } = await getSession()
+  return <PublicHeader user={user} hideConnectionButton={false} />
 }

--- a/ui/app/(candidat)/formulaire-intention/layout.tsx
+++ b/ui/app/(candidat)/formulaire-intention/layout.tsx
@@ -2,9 +2,12 @@ import { fr } from "@codegouvfr/react-dsfr"
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
 import type { PropsWithChildren } from "react"
+import { Suspense } from "react"
 import { Footer } from "@/app/_components/Footer"
-import { PublicHeader } from "@/app/_components/PublicHeader"
-export default async function Layout({ children }: PropsWithChildren) {
+import { PublicHeader, PublicHeaderStatic } from "@/app/_components/PublicHeader"
+import { getSession } from "@/utils/get-session"
+
+export default function Layout({ children }: PropsWithChildren) {
   return (
     <>
       <SkipLinks
@@ -14,11 +17,21 @@ export default async function Layout({ children }: PropsWithChildren) {
           { label: "Pied de page", anchor: "#footer-links" },
         ]}
       />
-      <PublicHeader hideConnectionButton={false} />
+      <Suspense fallback={<PublicHeaderStatic />}>
+        <IntentionHeaderWithUser />
+      </Suspense>
       <Box role="main" sx={{ py: fr.spacing("10v") }} component="main" tabIndex={-1} id="intention-content-container">
         {children}
       </Box>
       <Footer />
     </>
   )
+}
+
+// Le header doit connaître l'utilisateur connecté : sinon il affiche un lien « Connexion » vers
+// /espace-pro/authentification à un recruteur déjà authentifié, et le préchargement de ce lien
+// déclenche une boucle de redirections 307 entre le proxy et l'espace pro (incident du 2026-09-02).
+async function IntentionHeaderWithUser() {
+  const { user } = await getSession()
+  return <PublicHeader user={user} hideConnectionButton={false} />
 }

--- a/ui/proxy.test.ts
+++ b/ui/proxy.test.ts
@@ -170,7 +170,7 @@ describe("proxy - utilisateur connecté sur /espace-pro/authentification", () =>
     expect(new URL(response.headers.get("location")!).pathname).toBe("/espace-pro/entreprise")
   })
 
-  it("ne redirige pas un préchargement de lien (Next-Router-Prefetch) : sert la page, sans purge (pas de boucle)", async () => {
+  it("ne redirige pas un préchargement de lien (Next-Router-Prefetch) : sert la page avec la session, sans purge (pas de boucle)", async () => {
     const request = requestWithSessionCookie("/espace-pro/authentification?_rsc=abc")
     request.headers.set("rsc", "1")
     request.headers.set("next-router-prefetch", "1")
@@ -180,6 +180,19 @@ describe("proxy - utilisateur connecté sur /espace-pro/authentification", () =>
     expect(response.status).not.toBe(307)
     expect(response.headers.get("location")).toBeNull()
     expect(response.cookies.get("lba_session")).toBeUndefined()
+    // Le rendu préchargé reçoit la session : le header affiche l'utilisateur connecté, pas « Connexion ».
+    expect(response.headers.get("x-middleware-request-x-session")).toContain('"_id":"u1"')
+  })
+
+  it("un préchargement d'une route protégée par un utilisateur autorisé passe toujours, avec la session", async () => {
+    const request = requestWithSessionCookie("/espace-pro/entreprise?_rsc=abc")
+    request.headers.set("rsc", "1")
+    request.headers.set("next-router-prefetch", "1")
+
+    const response = await proxy(request)
+
+    expect(response.headers.get("location")).toBeNull()
+    expect(response.headers.get("x-middleware-request-x-session")).toContain('"_id":"u1"')
   })
 
   it("ne redirige pas non plus un préchargement par segment (Next-Router-Segment-Prefetch)", async () => {

--- a/ui/proxy.test.ts
+++ b/ui/proxy.test.ts
@@ -144,6 +144,66 @@ describe("proxy - panne API ambiguë (ni confirmée invalide, ni confirmée vali
   })
 })
 
+describe("proxy - utilisateur connecté sur /espace-pro/authentification", () => {
+  beforeEach(() => {
+    fetchMock.mockImplementation(
+      async (url: string) => new Response(url.endsWith("/auth/session") ? JSON.stringify({ _id: "u1", type: "ENTREPRISE" }) : JSON.stringify({}), { status: 200 })
+    )
+  })
+
+  it("redirige une navigation classique vers l'accueil de l'utilisateur", async () => {
+    const request = requestWithSessionCookie("/espace-pro/authentification")
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    expect(new URL(response.headers.get("location")!).pathname).toBe("/espace-pro/entreprise")
+  })
+
+  it("redirige aussi une navigation client (header RSC sans préchargement)", async () => {
+    const request = requestWithSessionCookie("/espace-pro/authentification?_rsc=abc")
+    request.headers.set("rsc", "1")
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(307)
+    expect(new URL(response.headers.get("location")!).pathname).toBe("/espace-pro/entreprise")
+  })
+
+  it("ne redirige pas un préchargement de lien (Next-Router-Prefetch) : sert la page, sans purge (pas de boucle)", async () => {
+    const request = requestWithSessionCookie("/espace-pro/authentification?_rsc=abc")
+    request.headers.set("rsc", "1")
+    request.headers.set("next-router-prefetch", "1")
+
+    const response = await proxy(request)
+
+    expect(response.status).not.toBe(307)
+    expect(response.headers.get("location")).toBeNull()
+    expect(response.cookies.get("lba_session")).toBeUndefined()
+  })
+
+  it("ne redirige pas non plus un préchargement par segment (Next-Router-Segment-Prefetch)", async () => {
+    const request = requestWithSessionCookie("/espace-pro/authentification?_rsc=abc")
+    request.headers.set("rsc", "1")
+    request.headers.set("next-router-segment-prefetch", "/_tree")
+
+    const response = await proxy(request)
+
+    expect(response.headers.get("location")).toBeNull()
+  })
+
+  it("un préchargement sans session ne change rien : la page d'authentification est servie", async () => {
+    fetchMock.mockReset()
+    const request = new NextRequest(new URL("/espace-pro/authentification?_rsc=abc", BASE_URL))
+    request.headers.set("next-router-prefetch", "1")
+
+    const response = await proxy(request)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(response.headers.get("location")).toBeNull()
+  })
+})
+
 describe("proxy - connexion par magic link (pose du cookie de session)", () => {
   it("pose le cookie avec les attributs alignés sur config.auth.session.cookie côté serveur", async () => {
     fetchMock.mockImplementation(async (url: string) => {

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -117,6 +117,22 @@ const redirectToAuthentication = (request: NextRequest, options: { purgeCookie: 
   return response
 }
 
+// Laisse passer la requête vers le rendu Next en lui transmettant la session résolue par le proxy.
+const passThroughWithSession = (request: NextRequest, result: SessionCheckResult) => {
+  const requestHeaders = new Headers(request.headers)
+  // seul le proxy a le droit de poser x-session : un client ne doit pas pouvoir le forger
+  requestHeaders.delete("x-session")
+  if (result.kind === "ok") {
+    requestHeaders.set("x-session", JSON.stringify({ user: result.user, access: result.access }))
+  }
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
+}
+
 const renderAuthenticationPage = (request: NextRequest, options: { purgeCookie: boolean }) => {
   // même sans session, ne pas laisser passer un x-session forgé par le client
   const anonymousHeaders = new Headers(request.headers)
@@ -142,7 +158,8 @@ export async function proxy(request: NextRequest) {
 
     if (result.kind === "ok") {
       if (isPrefetchRequest(request)) {
-        return renderAuthenticationPage(request, { purgeCookie: false })
+        // La session est transmise au rendu pour que le header préchargé affiche bien l'utilisateur.
+        return passThroughWithSession(request, result)
       }
       if (query.get(SESSION_RETRY_PARAM)) {
         // On vient de rebondir depuis une route protégée qui n'a pas pu confirmer la session
@@ -174,18 +191,7 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  const requestHeaders = new Headers(request.headers)
-  // seul le proxy a le droit de poser x-session : un client ne doit pas pouvoir le forger
-  requestHeaders.delete("x-session")
-  if (result.kind === "ok") {
-    requestHeaders.set("x-session", JSON.stringify({ user: result.user, access: result.access }))
-  }
-
-  return NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
-  })
+  return passThroughWithSession(request, result)
 }
 
 const excludedStartPaths = [

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -18,6 +18,13 @@ const removeAtEnd = (url: string, removed: string): string => (url.endsWith(remo
 // (cf. issue #5245).
 const SESSION_RETRY_PARAM = "sessionRetry"
 
+// Un préchargement Next (<Link prefetch>, segment cache) n'est pas une navigation : rediriger un
+// utilisateur connecté vers son accueil depuis /espace-pro/authentification n'a aucun sens dans ce
+// cas, et produit une boucle 307 ↔ 307 quand la page d'origine affiche un lien « Connexion » (le
+// navigateur suit la redirection, Next re-redirige pour rétablir le paramètre _rsc, et le routeur
+// relance le préchargement — incident du 2026-09-02). On sert alors la page telle quelle.
+const isPrefetchRequest = (request: NextRequest): boolean => request.headers.has("next-router-prefetch") || request.headers.has("next-router-segment-prefetch")
+
 type SessionCheckResult =
   | { kind: "no-cookie" }
   | { kind: "ok"; user: IUserRecruteurPublic; access: ComputedUserAccess }
@@ -134,6 +141,9 @@ export async function proxy(request: NextRequest) {
     const result = await checkSession(request)
 
     if (result.kind === "ok") {
+      if (isPrefetchRequest(request)) {
+        return renderAuthenticationPage(request, { purgeCookie: false })
+      }
       if (query.get(SESSION_RETRY_PARAM)) {
         // On vient de rebondir depuis une route protégée qui n'a pas pu confirmer la session
         // (panne API ambiguë) : même si elle semble valide ici, ne pas rebondir une nouvelle fois,


### PR DESCRIPTION
Closes #5383

## Changements

- Les layouts `formulaire-intention` et `detail-rendez-vous/[id]` passent désormais `user` au `PublicHeader` (composant asynchrone lisant `getSession()`, dans un `Suspense` avec `PublicHeaderStatic` en fallback), comme le layout d'authentification. Un recruteur connecté n'y voit plus de lien « Connexion ».
- `ui/proxy.ts` : sur `/espace-pro/authentification` avec une session valide, un préchargement Next (`next-router-prefetch` ou `next-router-segment-prefetch`) est laissé passer vers le rendu, session transmise via `x-session`, au lieu de recevoir un 307. Les navigations réelles, avec ou sans header `RSC`, gardent la redirection vers l'accueil de l'utilisateur. Le passage vers le rendu est factorisé dans `passThroughWithSession`.
- `ui/proxy.test.ts` : 6 cas ajoutés (navigation classique, navigation RSC, préchargement lien avec session transmise, préchargement segment, préchargement sans session, préchargement d'une route protégée par un utilisateur autorisé). Les cas préchargement échouent sur l'ancien proxy.

## Contexte

Alerte Grafana « volume de requêtes API anormal » du 2026-09-02 : ce n'était pas du scraping mais une boucle 307 entre `/espace-pro/entreprise` et `/espace-pro/authentification`, alimentée par le préchargement du lien « Connexion » affiché à des recruteurs connectés depuis les liens d'email « je-candidate-recruteur ». Analyse détaillée dans l'issue liée.

## Plan de test

- [ ] `yarn vitest --run ui/proxy.test.ts` : 15 tests verts
- [ ] En preview (build de production, le préchargement est désactivé en `next dev`) : se connecter en recruteur, ouvrir `/formulaire-intention?company_recruitment_intention=entretien&id=x&token=x`, vérifier dans l'onglet réseau l'absence de boucle `/espace-pro/authentification?_rsc` 307 → `/espace-pro/entreprise` 307
- [ ] Le header de cette page affiche le nom du recruteur connecté, pas le bouton « Connexion »
- [ ] Un recruteur connecté qui saisit `/espace-pro/authentification` dans la barre d'adresse est toujours renvoyé vers `/espace-pro/entreprise`
- [ ] Après déploiement : métrique `lba_backend:http_total:count_5m` de retour sous 5 400 et 307 sur `/espace-pro/entreprise` sous 200 par jour