### PR TITLE
fix: filtre le bruit Sentry UI non lié au code LBA (#5385)

### DIFF
--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -37,6 +37,11 @@ init({
     // "executors" dans le code ni le build Next — frames type app:///executors/200.js,
     // ex. TypeError "reading 'M_ID'", Sentry LBA-UI-5CVZZZZZZG4T4, ~2 300 events/7j).
     /\/executors\/\d+\.js/,
+    // Scripts de contenu des extensions Safari (macOS/iOS) : WebKit masque leur URL réelle
+    // derrière ce pseudo-schéma. Ex. "Zotero Connector: Failed to send message…"
+    // (LBA-UI-5CVZZZZZZG2T4, ~1 470 events) et "Error: No response" (LBA-UI-5CVZZZZZZG2ZN,
+    // ~1 050 events), aucune frame LBA.
+    /^webkit-masked-url:\/\/hidden\//,
   ],
   ignoreErrors: [
     "AbortError",
@@ -47,6 +52,16 @@ init({
     /SCDynimacBridge/,
     "No Listener: tabs:outgoing.message.ready",
     "Invalid call to runtime.sendMessage",
+    // Firefox iOS (WKWebView, UA "Mobile Safari") injecte ses propres scripts dans chaque page ;
+    // quand ils plantent, l'erreur est attribuée au document LBA ("global code", ligne 1) sans
+    // aucune frame applicative. Le code LBA ne lit jamais `innerText`. Sentry LBA-UI-1FM
+    // (~1 180 events) et LBA-UI-2G1 (~1 690 events), mêmes sessions.
+    "Can't find variable: __firefox__",
+    "null is not an object (evaluating 'r.innerText')",
+    // Script injecté par le scanner de liens Microsoft (Outlook SafeLinks / Defender) quand il
+    // pré-visite les URLs de nos emails (formulaire-intention, desinscription…). Jamais de
+    // stacktrace, 0 utilisateur, ~13 700 events depuis février 2026 (Sentry LBA-UI-2FT).
+    /Object Not Found Matching Id:\d+, MethodName:update, ParamCount:\d+/,
   ],
   beforeSend(event) {
     // Hydratation error comes from DSFR

--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -5,6 +5,7 @@
 import { extraErrorDataIntegration, httpClientIntegration, init, reportingObserverIntegration } from "@sentry/nextjs"
 
 import { shouldReloadOnce } from "@/utils/reload-guard.utils"
+import { isHeadlessBrowserUserAgent } from "@/utils/sentry-filters.utils"
 
 import { publicConfig } from "./config.public"
 
@@ -64,6 +65,14 @@ init({
     /Object Not Found Matching Id:\d+, MethodName:update, ParamCount:\d+/,
   ],
   beforeSend(event) {
+    // Navigateurs sans interface (Puppeteer, Playwright, scrapers) : leurs erreurs ne concernent
+    // aucun utilisateur et le filtre « web crawlers » de Sentry ne les connaît pas. Ex. « Wrong
+    // assertion encountered » dans react-dsfr (LBA-UI-1G1) : 97 events HeadlessChrome sur 240
+    // en 30 jours, vérifié 2026-09-02.
+    if (typeof navigator !== "undefined" && isHeadlessBrowserUserAgent(navigator.userAgent)) {
+      return null
+    }
+
     // Hydratation error comes from DSFR
     if (event.extra?.arguments && Array.isArray(event.extra?.arguments) && event.extra?.arguments?.includes("https://react.dev/link/hydration-mismatch")) {
       return null

--- a/ui/sentry.edge.config.ts
+++ b/ui/sentry.edge.config.ts
@@ -17,5 +17,11 @@ init({
   normalizeDepth: 8,
   sendDefaultPii: true,
   integrations: [captureConsoleIntegration({ levels: ["error"] }), extraErrorDataIntegration({ depth: 8 })],
-  ignoreErrors: ["AbortError"],
+  ignoreErrors: [
+    "AbortError",
+    // Avertissements de dépréciation Node émis par les internes de Next (url.parse, DEP0169…),
+    // remontés par captureConsoleIntegration comme des erreurs alors qu'ils ne sont pas
+    // actionnables côté LBA (Sentry LBA-UI-1B6ZZZZZZW2HZ, ~2 300 events sur 3 environnements).
+    /^\(node:\d+\) \[DEP\d+\] DeprecationWarning/,
+  ],
 })

--- a/ui/sentry.server.config.ts
+++ b/ui/sentry.server.config.ts
@@ -16,5 +16,11 @@ init({
   normalizeDepth: 8,
   sendDefaultPii: true,
   integrations: [captureConsoleIntegration({ levels: ["error"] }), extraErrorDataIntegration({ depth: 8 })],
-  ignoreErrors: ["AbortError"],
+  ignoreErrors: [
+    "AbortError",
+    // Avertissements de dépréciation Node émis par les internes de Next (url.parse, DEP0169…),
+    // remontés par captureConsoleIntegration comme des erreurs alors qu'ils ne sont pas
+    // actionnables côté LBA (Sentry LBA-UI-1B6ZZZZZZW2HZ, ~2 300 events sur 3 environnements).
+    /^\(node:\d+\) \[DEP\d+\] DeprecationWarning/,
+  ],
 })

--- a/ui/utils/sentry-filters.utils.test.ts
+++ b/ui/utils/sentry-filters.utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import { isHeadlessBrowserUserAgent } from "./sentry-filters.utils"
+
+describe("isHeadlessBrowserUserAgent", () => {
+  it("détecte HeadlessChrome (Puppeteer / Playwright), y compris avec un marqueur en fin de chaîne", () => {
+    expect(isHeadlessBrowserUserAgent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/148.0.7778.0 Safari/537.36")).toBe(true)
+    expect(isHeadlessBrowserUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36 HeadlessChrome")).toBe(
+      true
+    )
+  })
+
+  it("laisse passer les vrais navigateurs, même anciens ou figés (near-miss du scraper Chrome 126)", () => {
+    expect(isHeadlessBrowserUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36")).toBe(false)
+    expect(isHeadlessBrowserUserAgent("Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Mobile Safari/537.36")).toBe(false)
+    expect(
+      isHeadlessBrowserUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1")
+    ).toBe(false)
+  })
+
+  it("ne matche pas une mention voisine qui n'est pas le marqueur (headless en minuscules, Headless seul)", () => {
+    expect(isHeadlessBrowserUserAgent("Mozilla/5.0 (X11; Linux x86_64) headless-shell/120.0 Chrome/120.0.0.0")).toBe(false)
+    expect(isHeadlessBrowserUserAgent("Mozilla/5.0 Headless Firefox/154.0")).toBe(false)
+  })
+
+  it("renvoie faux sans user-agent", () => {
+    expect(isHeadlessBrowserUserAgent(undefined)).toBe(false)
+    expect(isHeadlessBrowserUserAgent(null)).toBe(false)
+    expect(isHeadlessBrowserUserAgent("")).toBe(false)
+  })
+})

--- a/ui/utils/sentry-filters.utils.ts
+++ b/ui/utils/sentry-filters.utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Détecte un navigateur Chromium sans interface (Puppeteer, Playwright, scrapers…) via son
+ * user-agent. Sentry ne le filtre pas : la regex « web crawlers » de Relay ne connaît pas
+ * HeadlessChrome (vérifié le 2026-09-02 dans relay-filter/src/web_crawlers.rs).
+ *
+ * Volontairement limité au marqueur explicite « HeadlessChrome » : un Chrome figé sur une vieille
+ * version (ex. « Chrome/126.0.0.0 ») est aussi typique d'un scraper, mais rien ne le distingue
+ * d'un vrai utilisateur qui n'a pas mis à jour, donc on ne le filtre pas.
+ */
+export function isHeadlessBrowserUserAgent(userAgent: string | undefined | null): boolean {
+  if (!userAgent) return false
+  return userAgent.includes("HeadlessChrome")
+}


### PR DESCRIPTION
Closes #5385

## Changements

- `ui/instrumentation-client.ts`
  - `ignoreErrors` : `Object Not Found Matching Id:N, MethodName:update, ParamCount:N` — script injecté par le scanner de liens Microsoft (Outlook SafeLinks / Defender) qui pré-visite les URLs de nos emails (`/formulaire-intention`, `/desinscription`). Sentry LBA-UI-2FT, ~13 700 events depuis février 2026, aucune stacktrace, 0 utilisateur.
  - `ignoreErrors` : `Can't find variable: __firefox__` et `null is not an object (evaluating 'r.innerText')` — scripts injectés par Firefox iOS (WKWebView), attribués au document LBA en "global code" ligne 1, sans frame applicative. Le code LBA ne lit jamais `innerText`. Sentry LBA-UI-1FM (~1 180 events) et LBA-UI-2G1 (~1 690 events), mêmes navigateurs et mêmes horodatages.
  - `denyUrls` : `webkit-masked-url://hidden/` — scripts de contenu des extensions Safari. Sentry LBA-UI-5CVZZZZZZG2T4 (Zotero, ~1 470 events) et LBA-UI-5CVZZZZZZG2ZN (`No response`, ~1 050 events).
- `ui/sentry.server.config.ts` et `ui/sentry.edge.config.ts`
  - `ignoreErrors` : `(node:N) [DEPxxxx] DeprecationWarning` — avertissements Node émis par les internes de Next (`url.parse`), remontés par `captureConsoleIntegration` comme des erreurs. Sentry LBA-UI-1B6ZZZZZZW2HZ, ~2 300 events sur 3 environnements.

- `ui/utils/sentry-filters.utils.ts` (nouveau) et `beforeSend` de `ui/instrumentation-client.ts`
  - Abandon des événements dont le `navigator.userAgent` contient `HeadlessChrome` (Puppeteer, Playwright, scrapers). Le filtre « web crawlers » de Sentry ne les connaît pas : la regex de Relay (`relay-filter/src/web_crawlers.rs`, vérifiée le 2026-09-02) ne contient pas HeadlessChrome. Ex. « Wrong assertion encountered » dans react-dsfr, Sentry LBA-UI-1G1 : 97 events HeadlessChrome sur 240 en 30 jours. Le marqueur est volontairement limité à `HeadlessChrome` : un Chrome figé sur une vieille version (116 events « Chrome 126.0.0 » sur la même issue) est typique d'un scraper mais indistinguable d'un vrai utilisateur non à jour. Tests unitaires avec les near-miss (`headless-shell`, `Headless Firefox`, Chrome 126).

Chaque règle est commentée dans le code avec l'issue Sentry correspondante. Les motifs restent étroits : le near-miss `evaluating 'e.innerText'` n'est volontairement pas couvert, et aucun filtre générique (`TypeError`, `Failed to fetch`…) n'est ajouté.

## Vérifications

- `yarn vitest --run ui/utils/sentry-filters.utils.test.ts` : 4 tests verts.
- Regex testées en Node contre les messages exacts des events Sentry (positifs et near-miss négatifs).
- `yarn check:fix` (biome) sans modification, `yarn typecheck` dans `ui/` vert, les 3 fichiers sont bien dans le périmètre de `tsc -p ui/tsconfig.json --listFilesOnly`.

## Plan de test

- [ ] Après MEP, vérifier dans Sentry que les 6 issues listées ne reçoivent plus d'événements sur la nouvelle release, puis les résoudre à la main.
- [ ] Vérifier qu'une vraie erreur applicative continue de remonter (par ex. déclencher une erreur en recette).

## Hors périmètre, à traiter à part

- `SecurityError: Failed to read the 'localStorage' property` (LBA-UI-2S6) et sa conséquence `react-dsfr not initialized` (LBA-UI-5CVZZZZZZG4C7 / G4D3) : accès `localStorage` non protégé dans `@codegouvfr/react-dsfr`, impact réel pour les navigateurs qui bloquent le stockage. Correctif en amont.
- `Wrong assertion encountered` (LBA-UI-1G1) : la part HeadlessChrome est couverte par cette PR, la part YandexBot par le filtre « web crawlers » des Inbound Filters côté Sentry (réglage manuel), la part « Chrome 126 figé » reste volontairement non filtrée.
