### PR TITLE
fix: casse la boucle de redirections du layout connecté et trace la session absente

### DIFF
--- a/shared/src/constants/session.ts
+++ b/shared/src/constants/session.ts
@@ -1,5 +1,11 @@
 export const SESSION_COOKIE_NAME = "lba_session"
 
+// Paramètre de requête posé sur une redirection vers /espace-pro/authentification quand la session
+// n'a pas pu être exploitée (panne API côté proxy, ou session illisible dans le layout connecté).
+// Quand il est présent, le proxy UI affiche la page de connexion sans jamais renvoyer vers la
+// page protégée, ce qui casse toute boucle de redirections (issue #5245, incident du 2026-09-02).
+export const SESSION_RETRY_PARAM = "sessionRetry"
+
 // Attributs du cookie de session, partagés entre le serveur (@fastify/cookie) et le proxy UI
 // (NextResponse.cookies) : les deux sérialisent maxAge en secondes (Max-Age, RFC 6265).
 // L'expiration des sessions en base (expires_at) se dérive de cette même durée.

--- a/ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx
@@ -1,11 +1,11 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
-import { cookies, headers } from "next/headers"
+import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 import type { PropsWithChildren } from "react"
 import { Suspense } from "react"
-import { SESSION_COOKIE_NAME } from "shared/constants/session"
+import { SESSION_COOKIE_NAME, SESSION_RETRY_PARAM } from "shared/constants/session"
 import { AuthWatcher } from "@/app/_components/AuthWatcher"
 import { Footer } from "@/app/_components/Footer"
 import { UserContextProvider } from "@/app/(espace-pro)/espace-pro/contexts/userContext"
@@ -39,14 +39,16 @@ async function ConnectedShell({ children }: PropsWithChildren) {
     // Si on arrive ici, le proxy a laissé passer une route protégée mais la session n'est pas
     // lisible dans ce rendu. Deux précautions (incident du 2026-09-02, boucle 307 ↔ 307) :
     // 1. tracer l'incohérence, sans contenu de session, pour pouvoir l'analyser dans Loki ;
-    // 2. marquer le rebond avec sessionRetry pour que le proxy affiche la page de connexion au
-    //    lieu de renvoyer vers l'espace pro, ce qui rebouclerait sur ce même redirect.
-    const [headerStore, cookieStore] = await Promise.all([headers(), cookies()])
+    // 2. marquer le rebond avec SESSION_RETRY_PARAM pour que le proxy affiche la page de connexion
+    //    au lieu de renvoyer vers l'espace pro, ce qui rebouclerait sur ce même redirect.
+    // Le cookie est lu dans le header brut pour ne pas ajouter l'API dynamique cookies() ici.
+    const headerStore = await headers()
+    const rawCookies = headerStore.get("cookie") ?? ""
     console.error("[espace-pro] session absente dans le layout connecté", {
       hasSessionHeader: headerStore.has("x-session"),
-      hasSessionCookie: cookieStore.has(SESSION_COOKIE_NAME),
+      hasSessionCookie: rawCookies.split(";").some((cookie) => cookie.trim().startsWith(`${SESSION_COOKIE_NAME}=`)),
     })
-    redirect("/espace-pro/authentification?sessionRetry=true")
+    redirect(`/espace-pro/authentification?${SESSION_RETRY_PARAM}=true`)
   }
 
   return (

--- a/ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx
+++ b/ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx
@@ -1,9 +1,11 @@
 import { fr } from "@codegouvfr/react-dsfr"
 import SkipLinks from "@codegouvfr/react-dsfr/SkipLinks"
 import { Box } from "@mui/material"
+import { cookies, headers } from "next/headers"
 import { redirect } from "next/navigation"
 import type { PropsWithChildren } from "react"
 import { Suspense } from "react"
+import { SESSION_COOKIE_NAME } from "shared/constants/session"
 import { AuthWatcher } from "@/app/_components/AuthWatcher"
 import { Footer } from "@/app/_components/Footer"
 import { UserContextProvider } from "@/app/(espace-pro)/espace-pro/contexts/userContext"
@@ -34,7 +36,17 @@ async function ConnectedShell({ children }: PropsWithChildren) {
   // ui/proxy.ts est le garde-fou principal (redirige avant même d'atteindre ce rendu React).
   // Ce redirect est un filet de sécurité si jamais cette route est atteinte sans session valide.
   if (user == null) {
-    redirect("/espace-pro/authentification")
+    // Si on arrive ici, le proxy a laissé passer une route protégée mais la session n'est pas
+    // lisible dans ce rendu. Deux précautions (incident du 2026-09-02, boucle 307 ↔ 307) :
+    // 1. tracer l'incohérence, sans contenu de session, pour pouvoir l'analyser dans Loki ;
+    // 2. marquer le rebond avec sessionRetry pour que le proxy affiche la page de connexion au
+    //    lieu de renvoyer vers l'espace pro, ce qui rebouclerait sur ce même redirect.
+    const [headerStore, cookieStore] = await Promise.all([headers(), cookies()])
+    console.error("[espace-pro] session absente dans le layout connecté", {
+      hasSessionHeader: headerStore.has("x-session"),
+      hasSessionCookie: cookieStore.has(SESSION_COOKIE_NAME),
+    })
+    redirect("/espace-pro/authentification?sessionRetry=true")
   }
 
   return (

--- a/ui/proxy.test.ts
+++ b/ui/proxy.test.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server"
+import { SESSION_RETRY_PARAM } from "shared/constants/session"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { proxy } from "./proxy"
@@ -118,6 +119,22 @@ describe("proxy - panne API ambiguë (ni confirmée invalide, ni confirmée vali
     expect(response.cookies.get("lba_session")).toBeUndefined()
     const location = new URL(response.headers.get("location")!)
     expect(location.searchParams.get("sessionRetry")).toBe("true")
+  })
+
+  it("sert la page de connexion, sans rebond, sur l'URL exacte émise par le filet de sécurité du layout connecté", async () => {
+    // Contrat avec ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx : quand getSession() est vide
+    // alors que le proxy a laissé passer, le layout redirige vers cette URL. Le proxy doit l'afficher
+    // même si la session lui paraît valide, sinon la boucle 307 ↔ 307 du 2026-09-02 revient.
+    fetchMock.mockImplementation(
+      async (url: string) => new Response(url.endsWith("/auth/session") ? JSON.stringify({ _id: "u1", type: "ENTREPRISE" }) : JSON.stringify({}), { status: 200 })
+    )
+    const request = requestWithSessionCookie(`/espace-pro/authentification?${SESSION_RETRY_PARAM}=true`)
+
+    const response = await proxy(request)
+
+    expect(response.status).not.toBe(307)
+    expect(response.headers.get("location")).toBeNull()
+    expect(response.cookies.get("lba_session")).toBeUndefined()
   })
 
   it("ne rebondit pas une deuxième fois vers la page protégée même si la session semble valide au second essai (pas de boucle)", async () => {

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server"
 import { NextResponse } from "next/server"
 import type { ComputedUserAccess, IUserRecruteurPublic } from "shared"
 import { AUTHTYPE } from "shared/constants/index"
-import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from "shared/constants/session"
+import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS, SESSION_RETRY_PARAM } from "shared/constants/session"
 
 import { publicConfig } from "./config.public"
 import { apiPost } from "./utils/api.utils"
@@ -10,13 +10,13 @@ import { PAGES } from "./utils/routes.utils"
 
 const removeAtEnd = (url: string, removed: string): string => (url.endsWith(removed) ? url.slice(0, -removed.length) : url)
 
-// Marqueur de rebond posé sur la redirection espace-pro protégée → authentification quand la
-// session n'a pas pu être confirmée invalide (panne API, pas de 401). S'il est déjà présent quand
-// on atterrit sur /espace-pro/authentification, on ne fait plus jamais confiance à un résultat
-// "session valide" pour rebondir une nouvelle fois vers la page protégée : un signal instable
-// (JWT proche de l'expiration, API auth flaky) ne doit jamais produire plus d'un aller-retour
-// (cf. issue #5245).
-const SESSION_RETRY_PARAM = "sessionRetry"
+// SESSION_RETRY_PARAM (shared/constants/session) : marqueur de rebond posé sur la redirection
+// espace-pro protégée → authentification quand la session n'a pas pu être confirmée invalide (panne
+// API, pas de 401), et par le layout connecté quand la session est illisible dans le rendu. S'il est
+// déjà présent quand on atterrit sur /espace-pro/authentification, on ne fait plus jamais confiance
+// à un résultat "session valide" pour rebondir une nouvelle fois vers la page protégée : un signal
+// instable (JWT proche de l'expiration, API auth flaky) ne doit jamais produire plus d'un
+// aller-retour (cf. issue #5245).
 
 // Un préchargement Next (<Link prefetch>, segment cache) n'est pas une navigation : rediriger un
 // utilisateur connecté vers son accueil depuis /espace-pro/authentification n'a aucun sens dans ce


### PR DESCRIPTION
Suite de la PR https://github.com/mission-apprentissage/labonnealternance/pull/5384 et de l'issue https://github.com/mission-apprentissage/labonnealternance/issues/5383.

## Contexte

L'alerte « volume de requêtes API anormal » s'est redéclenchée le 2026-09-02 à 22 h 32 avec le premier correctif en production (v1.897.11). Même triplet de requêtes qu'en journée pour un recruteur connecté : `/espace-pro/authentification?_rsc` 307, `/espace-pro/entreprise` 307, `/espace-pro/entreprise?_rsc` 200, environ 3,7 tours par seconde depuis un onglet resté sur `/je-suis-recruteur`.

Les requêtes de la boucle ne portent pas de header de préchargement, donc le premier correctif ne s'applique pas. Fait décisif : les réponses 200 sur `/espace-pro/entreprise?_rsc` font toutes 1 740 octets, pour toutes les IP en boucle depuis ce matin, contre 17 à 172 Ko pour une vraie page. C'est un payload de redirection RSC. Le seul `redirect()` vers `/espace-pro/authentification` dans l'arbre espace-pro est le filet de sécurité de `(connected)/layout.tsx`, déclenché quand `getSession()` ne renvoie pas d'utilisateur alors que le proxy vient de valider la session et de poser `x-session`.

La cause exacte du `getSession()` vide n'est pas établie (suspect : le `"use cache: private"` qui l'entoure). Cette PR casse la boucle quelle que soit la cause et pose la trace qui permettra de trancher.

## Changements

- `ui/app/(espace-pro)/espace-pro/(connected)/layout.tsx` : le filet de sécurité redirige vers `/espace-pro/authentification?sessionRetry=true`. Le proxy connaît ce marqueur depuis la PR 5253 : avec une session valide il sert la page de connexion au lieu de renvoyer vers l'espace pro. La boucle devient un seul aller, l'utilisateur voit le formulaire de connexion.
- Avant de rediriger, le layout écrit dans stderr (collecté dans Loki, service `ui`, et remonté à Sentry par `captureConsoleIntegration`) une ligne `[espace-pro] session absente dans le layout connecté` avec deux booléens : présence du header `x-session` et présence du cookie `lba_session`, lu dans le header `cookie` brut. Aucun contenu de session n'est tracé. Au prochain épisode, cette ligne départage « header absent dans le rendu » et « cache privé périmé ».
- `shared/src/constants/session.ts` : le nom du paramètre devient la constante `SESSION_RETRY_PARAM`, utilisée par le proxy et le layout, pour qu'un renommage ne puisse pas rouvrir la boucle en silence.
- `ui/proxy.test.ts` : un test épingle l'URL exacte émise par le layout et vérifie que le proxy la sert sans redirection même quand la session lui paraît valide (échoue si le proxy ignore le marqueur, vérifié).

## Plan de test

- [ ] `yarn vitest --run ui/proxy.test.ts` : 16 tests verts
- [ ] `yarn tsc -b ui/tsconfig.json` et biome verts (vérifié en local)
- [ ] Le build de production passe (job « Measure bundle size »)
- [ ] En preview, connecté en recruteur : ouvrir `/espace-pro/entreprise`, la page s'affiche normalement (le filet de sécurité ne se déclenche pas)
- [ ] En preview, forcer le cas dégradé (par exemple en supprimant temporairement le header `x-session` côté proxy) : une seule redirection vers la page de connexion, pas de boucle, et la ligne de log apparaît dans stderr
- [ ] Après déploiement : surveiller la métrique `lba_backend:http_total:count_5m` et rechercher dans Loki `session absente dans le layout connecté`