### PR TITLE
feat: recherche par département et région dans le champ lieu (#5248)

### DIFF
--- a/.infra/files/configs/mongodb/seed.gpg
+++ b/.infra/files/configs/mongodb/seed.gpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b7e13ebd0cbe855a0d2fde185f4b4ba1c06f294335ed9e696acd529a817ce2a
-size 305804796
+oid sha256:a038971eccf543780c000d18a8403870687e0ed3022eef530af205e76a28fc5b
+size 148565913

--- a/server/src/jobs/offre-partenaire/fill-fields-for-partners-factory.ts
+++ b/server/src/jobs/offre-partenaire/fill-fields-for-partners-factory.ts
@@ -221,7 +221,6 @@ export const fillFieldsForPartnersFactory = async <SourceFields extends keyof IJ
   logger.info(`${toUpdateCount} documents à traiter`)
 
   const counters = { total: 0, success: 0, error: 0 }
-  const now = new Date()
 
   const sourceStream = getDbCollection("jobs_partners")
     .find(queryFilter, {
@@ -246,7 +245,9 @@ export const fillFieldsForPartnersFactory = async <SourceFields extends keyof IJ
         const responses = await getData(documents)
         const dataToWrite = responses.flatMap((response) => {
           const { _id, ...newFields } = response
-          const updates: AnyBulkWriteOperation<IJobsPartnersOfferPrivate>[] = [{ updateOne: { filter: { _id }, update: { $set: { ...newFields, updated_at: now } } } }]
+          // Même règle que l'import computed → jobs_partners : horodatage à l'écriture, sinon un
+          // groupe traité tard dans un run long échappe à la fenêtre du cron delta search_items.
+          const updates: AnyBulkWriteOperation<IJobsPartnersOfferPrivate>[] = [{ updateOne: { filter: { _id }, update: { $set: { ...newFields, updated_at: new Date() } } } }]
           return updates
         })
 

--- a/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.test.ts
+++ b/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import * as mongodbUtils from "@/common/utils/mongodb-utils"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import * as sentryUtils from "@/common/utils/sentry-utils"
+import { syncSearchItemsDelta } from "@/services/search/search-items.service"
 import { importFromComputedToJobsPartners } from "./import-from-computed-to-jobs-partners"
 
 useMongo()
@@ -238,5 +239,98 @@ describe("offer_status_history lors de l'import", () => {
       reason: historyEntry.reason,
       granted_by: historyEntry.granted_by,
     })
+  })
+})
+
+describe("updated_at posé par l'import et fenêtre du cron delta search_items", () => {
+  useMongo()
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    await getDbCollection("computed_jobs_partners").deleteMany({})
+    await getDbCollection("jobs_partners").deleteMany({})
+    await getDbCollection("search_items").deleteMany({})
+  })
+
+  /**
+   * Reproduction du trou observé en prod le 2026-09-11 : 965 offres modifiées depuis moins de
+   * 30 jours dont la position indexée ne correspondait plus à la source. L'import nocturne dure
+   * ~26 min, le delta lit `updated_at >= now − 10 min` toutes les 5 min : un document écrit plus
+   * de 10 min après le DÉBUT de l'import, mais horodaté à ce début, est déjà hors fenêtre quand
+   * il arrive en base. Le delta ne le voit jamais.
+   *
+   * L'horloge est simulée sur Date seulement (pas les timers, le driver Mongo en dépend) et
+   * avancée de 6 min à chaque lecture de l'existant dans jobs_partners, c'est-à-dire juste avant
+   * chaque écriture, comme le ferait un import long : 1re offre écrite à t0+6, 2e à t0+12. Le
+   * delta qui suit la fin de l'import (t0+12, fenêtre [t0+2, t0+12]) doit voir les deux ; datées
+   * du début de l'import (t0), il n'en voyait aucune.
+   */
+  it("un document écrit tard dans un import long est repris par le delta : updated_at doit dater de l'écriture, pas du début de l'import", async () => {
+    const t0 = new Date("2026-09-11T00:01:00.000Z")
+    vi.useFakeTimers({ toFake: ["Date"] })
+    vi.setSystemTime(t0)
+
+    // Deux offres déjà indexées, dont la source va changer d'adresse pendant l'import.
+    const stale = await Promise.all(
+      ["late_1", "late_2"].map((id) =>
+        createJobPartner({
+          partner_job_id: id,
+          workplace_address_label: "L'Arsenal (65)",
+          workplace_geopoint: { type: "Point", coordinates: [0.07696, 43.24636] },
+          updated_at: new Date("2026-08-01T00:00:00.000Z"),
+        })
+      )
+    )
+    for (const id of ["late_1", "late_2"]) {
+      await createComputedJobPartner({
+        partner_job_id: id,
+        validated: true,
+        workplace_address_label: "l'arsenal 44190 Gétigné",
+        workplace_geopoint: { type: "Point", coordinates: [-1.264835, 47.08357] },
+      })
+    }
+
+    // L'import lit l'offre existante (findOne) puis l'écrit (updateOne) : avancer l'horloge à la
+    // RÉSOLUTION de la lecture place chaque écriture 6 min plus tard que la précédente. Ni à
+    // l'appel de findOne (les deux lectures partent ensemble, l'horloge avancerait deux fois avant
+    // la première écriture), ni sur updateOne (ses arguments, dont l'horodatage, sont évalués
+    // avant l'appel).
+    const getDbCollectionOriginal = mongodbUtils.getDbCollection
+    vi.spyOn(mongodbUtils, "getDbCollection").mockImplementation((name) => {
+      const collection = getDbCollectionOriginal(name)
+      if (name !== "jobs_partners") return collection
+      return new Proxy(collection, {
+        get(target, prop, receiver) {
+          const value = Reflect.get(target, prop, receiver)
+          if (prop === "findOne") {
+            return (...args: unknown[]) =>
+              ((value as (...a: unknown[]) => Promise<unknown>).apply(target, args) as Promise<unknown>).then((found) => {
+                vi.setSystemTime(new Date(Date.now() + 6 * 60_000))
+                return found
+              })
+          }
+          return typeof value === "function" ? value.bind(target) : value
+        },
+      }) as typeof collection
+    })
+
+    await importFromComputedToJobsPartners()
+
+    // Le delta tourne juste après la fin de l'import, avec sa fenêtre par défaut de 10 min.
+    const { scanned } = await syncSearchItemsDelta()
+
+    const written = await getDbCollection("jobs_partners")
+      .find({ partner_job_id: { $in: ["late_1", "late_2"] } })
+      .toArray()
+    // Chaque document est horodaté à sa propre écriture : deux valeurs distinctes, toutes ≥ t0+6.
+    expect(new Set(written.map((d) => d.updated_at.getTime())).size).toBe(2)
+    for (const d of written) expect(d.updated_at.getTime()).toBeGreaterThanOrEqual(t0.getTime() + 6 * 60_000)
+    // Et le delta les a vus tous les deux.
+    expect(scanned).toBe(2)
+    for (const s of stale) {
+      const indexed = await getDbCollection("search_items").findOne({ _id: s._id })
+      expect(indexed?.location?.coordinates).toEqual([-1.264835, 47.08357])
+    }
   })
 })

--- a/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.ts
+++ b/server/src/jobs/offre-partenaire/import-from-computed-to-jobs-partners.ts
@@ -49,7 +49,6 @@ export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter
         }
 
         const partnerJobToUpsert: Partial<IJobsPartnersOfferPrivate> = {
-          updated_at: importDate,
           partner_label: computedJobPartner.partner_label,
           partner_job_id: computedJobPartner.partner_job_id,
           contract_start: computedJobPartner.contract_start ?? null,
@@ -122,7 +121,12 @@ export const importFromComputedToJobsPartners = async (addedMatchFilter?: Filter
         await getDbCollection("jobs_partners").updateOne(
           { partner_job_id: partnerJobToUpsert.partner_job_id, partner_label: partnerJobToUpsert.partner_label },
           {
-            $set: { ...partnerJobToUpsert },
+            // updated_at horodaté à l'écriture, pas au début de l'import : le cron delta
+            // search_items lit `updated_at >= now − 10 min` toutes les 5 min, et l'import dure
+            // ~26 min. Un document écrit tard mais daté du début arrivait déjà hors fenêtre et
+            // n'était jamais resynchronisé (965 offres à position périmée en prod le 2026-09-11).
+            // `importDate` reste la date du lot pour created_at et l'historique de statut.
+            $set: { ...partnerJobToUpsert, updated_at: new Date() },
             $setOnInsert: {
               created_at: importDate,
               offer_status_history: [],

--- a/server/src/jobs/offre-partenaire/recruteur-lba/recruteurs-lba-mapper.test.ts
+++ b/server/src/jobs/offre-partenaire/recruteur-lba/recruteurs-lba-mapper.test.ts
@@ -1,0 +1,93 @@
+import { ObjectId } from "bson"
+import type { IRecruteursLbaRaw } from "shared/models/raw-recruteurs-lba.model"
+import { describe, expect, it } from "vitest"
+
+import { getWorkplaceGeolocation, recruteursLbaToJobPartners } from "./recruteurs-lba-mapper"
+
+/**
+ * SIRENE livre les coordonnées dans la projection légale du territoire : Lambert 93 en
+ * métropole, UTM 40 sud (RGR92) à La Réunion, etc. Le mapper choisit la projection d'après le
+ * préfixe du code postal. Sans code postal, il retombait sur Lambert 93 quel que soit le
+ * territoire : 7 établissements réunionnais sont ainsi apparus en mer du Nord au large de
+ * Dundee (prod, 2026-09-11). Le code INSEE de la commune, toujours livré, porte le même
+ * préfixe territorial : il sert de repli.
+ */
+
+// Saint-Denis de La Réunion en RGR92 / UTM 40S, obtenu par proj4 depuis [55.4504, -20.8823].
+const SAINT_DENIS_REUNION_UTM40S = { x: 338811, y: 7690101 }
+// Coordonnées Lambert 93 de la fixture process-recruteurs-lba.test.1.json (métropole).
+const METROPOLE_LAMBERT93 = { x: 563785.301401543, y: 6980103.034818875 }
+// Ce que donne la lecture correcte de ces coordonnées, en Lambert 93 : la référence métropole.
+const METROPOLE_WGS84 = getWorkplaceGeolocation(METROPOLE_LAMBERT93.x, METROPOLE_LAMBERT93.y, "54460")!.coordinates
+
+const raw = (overrides: Partial<IRecruteursLbaRaw>): IRecruteursLbaRaw => ({
+  _id: new ObjectId(),
+  createdAt: new Date("2026-09-01T00:00:00.000Z"),
+  siret: "80841382700011",
+  enseigne: "DRYSOFT",
+  naf_code: "5510Z",
+  naf_label: "Hôtels et hébergement similaire",
+  activitePrincipaleEtablissement: "5510Z",
+  labelActivitePrincipaleEtablissement: "Hôtels et hébergement similaire",
+  raison_sociale: "ETABLISSEMENTS FRERES",
+  street_number: null,
+  street_name: null,
+  insee_city_code: "54318",
+  zip_code: "54460",
+  email: null,
+  phone: null,
+  company_size: "1-2",
+  libelleCommuneEtablissement: "LIVERDUN",
+  coordonneeLambertAbscisseEtablissement: METROPOLE_LAMBERT93.x,
+  coordonneeLambertOrdonneeEtablissement: METROPOLE_LAMBERT93.y,
+  rome_codes: [{ rome_code: "G1703", normalized_score: 1 }],
+  ...overrides,
+})
+
+const coords = (job: ReturnType<typeof recruteursLbaToJobPartners>) => job.workplace_geopoint?.coordinates
+
+describe("getWorkplaceGeolocation", () => {
+  it("sans code postal ni INSEE, la métropole reste le défaut", () => {
+    const point = getWorkplaceGeolocation(METROPOLE_LAMBERT93.x, METROPOLE_LAMBERT93.y, null)
+    expect(point?.coordinates).toEqual(METROPOLE_WGS84)
+    // Garde-fou sur la référence elle-même : un point en France métropolitaine.
+    expect(METROPOLE_WGS84[0]).toBeGreaterThan(-5.5)
+    expect(METROPOLE_WGS84[0]).toBeLessThan(9.6)
+    expect(METROPOLE_WGS84[1]).toBeGreaterThan(41)
+    expect(METROPOLE_WGS84[1]).toBeLessThan(51.2)
+  })
+
+  it("coordonnées absentes ou nulles : pas de point plutôt qu'un point à l'origine", () => {
+    expect(getWorkplaceGeolocation(null, 7690101, "97400")).toBeNull()
+    expect(getWorkplaceGeolocation(0, 0, "97400")).toBeNull()
+  })
+})
+
+describe("recruteursLbaToJobPartners : projection choisie sans code postal", () => {
+  it("un établissement réunionnais sans code postal reste à La Réunion grâce au code INSEE", () => {
+    const job = recruteursLbaToJobPartners(
+      raw({
+        siret: "12345678900011",
+        zip_code: null,
+        insee_city_code: "97411",
+        libelleCommuneEtablissement: "SAINT-DENIS",
+        coordonneeLambertAbscisseEtablissement: SAINT_DENIS_REUNION_UTM40S.x,
+        coordonneeLambertOrdonneeEtablissement: SAINT_DENIS_REUNION_UTM40S.y,
+      })
+    )
+    const [lon, lat] = coords(job)!
+    // Lambert 93 appliqué à tort donnerait [-2.73, 56.14], en mer du Nord.
+    expect(lon).toBeCloseTo(55.45, 1)
+    expect(lat).toBeCloseTo(-20.88, 1)
+  })
+
+  it("le code postal garde la priorité sur l'INSEE quand les deux sont là", () => {
+    const job = recruteursLbaToJobPartners(raw({ zip_code: "54460", insee_city_code: "97411" }))
+    expect(coords(job)).toEqual(METROPOLE_WGS84)
+  })
+
+  it("métropole sans code postal : inchangé, Lambert 93", () => {
+    const job = recruteursLbaToJobPartners(raw({ zip_code: null, insee_city_code: "54318" }))
+    expect(coords(job)).toEqual(METROPOLE_WGS84)
+  })
+})

--- a/server/src/jobs/offre-partenaire/recruteur-lba/recruteurs-lba-mapper.ts
+++ b/server/src/jobs/offre-partenaire/recruteur-lba/recruteurs-lba-mapper.ts
@@ -17,6 +17,7 @@ export const recruteursLbaToJobPartners = (recruteursLba: IRecruteursLbaRaw): IC
     street_name,
     street_number,
     zip_code,
+    insee_city_code,
     email,
     phone,
     company_size,
@@ -42,7 +43,9 @@ export const recruteursLbaToJobPartners = (recruteursLba: IRecruteursLbaRaw): IC
     workplace_address_street_label: street_name,
     workplace_address_zipcode: zip_code,
     workplace_address_label: joinNonNullStrings([street_number, street_name, zip_code, libelleCommuneEtablissement]),
-    workplace_geopoint: getWorkplaceGeolocation(coordonneeLambertAbscisseEtablissement, coordonneeLambertOrdonneeEtablissement, zip_code),
+    // La projection SIRENE dépend du territoire ; sans code postal, le code INSEE porte le même
+    // préfixe (974xx…). Sans lui, un établissement réunionnais retombait en Lambert 93, en mer du Nord.
+    workplace_geopoint: getWorkplaceGeolocation(coordonneeLambertAbscisseEtablissement, coordonneeLambertOrdonneeEtablissement, zip_code ?? insee_city_code),
     workplace_size: company_size,
     apply_email: email,
     apply_phone: phone,

--- a/server/src/jobs/search/generate-search-items-collection.ts
+++ b/server/src/jobs/search/generate-search-items-collection.ts
@@ -25,6 +25,7 @@ import {
   stripHtmlToText,
   upsertSearchItem,
 } from "@/services/search/search-items.service"
+import { resolveAdminCodes } from "@/services/search/search-items-admin-codes"
 
 // Génération des mots-clés Mistral : déplacée dans search-items-keywords.service.ts
 // (cron continu + batch hebdo recruteurs + ramasse des jobs + import manuel).
@@ -164,10 +165,18 @@ export const fillSearchItemsCollection = async () => {
     // Déjà en base → on conserve le doc (keywords compris), on resynchronise seulement les
     // champs contrat (backfill des ajouts de schéma sans régénérer la collection).
     if (existingIds.has(formation._id.toString())) {
+      const built = buildFormationSearchItem(formation, ctx)
       await searchItemsCollection.updateOne(
         { _id: formation._id },
         {
           $set: {
+            // Lieu et organisme : 1 593 offres en prod (0,48 %) étaient affichées à une position
+            // que la source avait corrigée depuis ; la delta ne revoit pas les items dont
+            // updated_at ne bouge plus, seul le nightly peut les rattraper (mesure du 2026-09-11).
+            address: built.address,
+            location: built.location,
+            organization_name: built.organization_name,
+            level: built.level,
             is_disabled_elligible: null,
             start_date: null,
             start_type: null,
@@ -176,6 +185,8 @@ export const fillSearchItemsCollection = async () => {
             is_formation_included: null,
             title: dedupeRepeatedTitle(formation.intitule_rco || ""),
             description: stripHtmlToText(formation.contenu),
+            // Emprise administrative (ban-plateforme#781) : backfill des items antérieurs au champ.
+            ...resolveAdminCodes({ insee: formation.code_commune_insee, zipcode: formation.code_postal, geopoint: formation.lieu_formation_geopoint }, ctx.adminCodes),
           },
         }
       )
@@ -192,10 +203,16 @@ export const fillSearchItemsCollection = async () => {
     // Déjà en base → on conserve le doc (keywords compris), on resynchronise seulement les
     // champs contrat (backfill des ajouts de schéma sans régénérer la collection).
     if (existingIds.has(job._id.toString())) {
+      const built = buildJobOfferSearchItem(job, ctx)
       await searchItemsCollection.updateOne(
         { _id: job._id },
         {
           $set: {
+            address: built.address,
+            location: built.location,
+            organization_name: built.organization_name,
+            level: built.level,
+            activity_sector: built.activity_sector,
             is_disabled_elligible: job.contract_is_disabled_elligible ?? false,
             start_date: sanitizeContractStart(job.contract_start),
             start_type: job.contract_start_type ?? null,
@@ -209,6 +226,7 @@ export const fillSearchItemsCollection = async () => {
             // (déjà calculé par le $lookup du pipeline — gratuit).
             application_count: job.application_count,
             smart_apply: job.apply_email ? true : false,
+            ...resolveAdminCodes({ zipcode: job.workplace_address_zipcode, geopoint: job.workplace_geopoint }, ctx.adminCodes),
           },
         }
       )
@@ -222,10 +240,17 @@ export const fillSearchItemsCollection = async () => {
     // Déjà en base → on conserve le doc (keywords compris), on resynchronise seulement les
     // champs contrat (backfill des ajouts de schéma sans régénérer la collection).
     if (existingIds.has(job._id.toString())) {
+      const built = buildRecruteurSearchItem(job, ctx)
       await searchItemsCollection.updateOne(
         { _id: job._id },
         {
           $set: {
+            title: built.title,
+            address: built.address,
+            location: built.location,
+            organization_name: built.organization_name,
+            level: built.level,
+            activity_sector: built.activity_sector,
             is_disabled_elligible: job.contract_is_disabled_elligible ?? false,
             start_date: null,
             start_type: null,
@@ -234,6 +259,7 @@ export const fillSearchItemsCollection = async () => {
             is_formation_included: false,
             application_count: job.application_count,
             smart_apply: job.apply_email ? true : false,
+            ...resolveAdminCodes({ zipcode: job.workplace_address_zipcode, geopoint: job.workplace_geopoint }, ctx.adminCodes),
           },
         }
       )

--- a/server/src/jobs/search/generate-search-items-collection.ts
+++ b/server/src/jobs/search/generate-search-items-collection.ts
@@ -277,6 +277,9 @@ export const fillSearchItemsCollection = async () => {
     })
   }
 
+  // Observable en Loki, pas un warn avalé : une correction de données source doit se voir.
+  logger.info({ corrections: ctx.corrections }, "fillSearchItemsCollection: corrections appliquées aux données source")
+
   // Les mots-clés des documents `keywords: null` sont générés par les crons dédiés
   // (generateSearchItemsKeywordsContinuous / submitSearchItemsKeywordsBatch) — cf.
   // searchItemsKeywords.service.ts.

--- a/server/src/jobs/search/generate-search-items-collection.ts
+++ b/server/src/jobs/search/generate-search-items-collection.ts
@@ -16,16 +16,11 @@ import {
   buildFormationSearchItem,
   buildJobOfferSearchItem,
   buildRecruteurSearchItem,
-  dedupeRepeatedTitle,
   formationProjection,
-  isFormationIncluded,
   jobsProjection,
   loadSearchItemBuildContext,
-  sanitizeContractStart,
-  stripHtmlToText,
   upsertSearchItem,
 } from "@/services/search/search-items.service"
-import { resolveAdminCodes } from "@/services/search/search-items-admin-codes"
 
 // Génération des mots-clés Mistral : déplacée dans search-items-keywords.service.ts
 // (cron continu + batch hebdo recruteurs + ramasse des jobs + import manuel).
@@ -161,111 +156,26 @@ export const fillSearchItemsCollection = async () => {
   const processedIds = new Set<string>()
   const searchItemsCollection = getDbCollection("search_items")
 
+  // Un seul chemin par source, item nouveau ou déjà indexé : upsertSearchItem réécrit tous les
+  // champs sauf `keywords` (préservés). L'ancienne variante « déjà en base → $set d'une liste
+  // fermée de champs » a laissé dériver `address` et `location` : 1 593 offres affichées en prod
+  // à une position que la source avait corrigée (2026-09-11). Le coût d'une réécriture complète
+  // est le même qu'un $set partiel : un updateOne par item.
   await processCursorStream(formationsCursor, "formations", processedIds, async (formation) => {
-    // Déjà en base → on conserve le doc (keywords compris), on resynchronise seulement les
-    // champs contrat (backfill des ajouts de schéma sans régénérer la collection).
-    if (existingIds.has(formation._id.toString())) {
-      const built = buildFormationSearchItem(formation, ctx)
-      await searchItemsCollection.updateOne(
-        { _id: formation._id },
-        {
-          $set: {
-            // Lieu et organisme : 1 593 offres en prod (0,48 %) étaient affichées à une position
-            // que la source avait corrigée depuis ; la delta ne revoit pas les items dont
-            // updated_at ne bouge plus, seul le nightly peut les rattraper (mesure du 2026-09-11).
-            address: built.address,
-            location: built.location,
-            organization_name: built.organization_name,
-            level: built.level,
-            is_disabled_elligible: null,
-            start_date: null,
-            start_type: null,
-            is_start_flexible: null,
-            is_algo_company: false,
-            is_formation_included: null,
-            title: dedupeRepeatedTitle(formation.intitule_rco || ""),
-            description: stripHtmlToText(formation.contenu),
-            // Emprise administrative (ban-plateforme#781) : backfill des items antérieurs au champ.
-            ...resolveAdminCodes({ insee: formation.code_commune_insee, zipcode: formation.code_postal, geopoint: formation.lieu_formation_geopoint }, ctx.adminCodes),
-          },
-        }
-      )
+    // Sans géopoint, pas d'item de recherche possible : on le compte plutôt que de laisser une
+    // exception le dire à Sentry. L'item indexé, s'il existe, garde son état précédent.
+    if (!formation.lieu_formation_geopoint) {
+      ctx.corrections.formations_sans_geopoint++
       return
     }
-
-    // upsertSearchItem (pas replaceOne) : préserve les keywords d'un doc inséré par la sync
-    // incrémentale APRÈS le snapshot existingIds (le nightly dure jusqu'à 3 h en parallèle
-    // du cron delta et du cron keywords).
     await upsertSearchItem(buildFormationSearchItem(formation, ctx))
   })
 
   await processCursorStream(jobsCursor, "offres", processedIds, async (job) => {
-    // Déjà en base → on conserve le doc (keywords compris), on resynchronise seulement les
-    // champs contrat (backfill des ajouts de schéma sans régénérer la collection).
-    if (existingIds.has(job._id.toString())) {
-      const built = buildJobOfferSearchItem(job, ctx)
-      await searchItemsCollection.updateOne(
-        { _id: job._id },
-        {
-          $set: {
-            address: built.address,
-            location: built.location,
-            organization_name: built.organization_name,
-            level: built.level,
-            activity_sector: built.activity_sector,
-            is_disabled_elligible: job.contract_is_disabled_elligible ?? false,
-            start_date: sanitizeContractStart(job.contract_start),
-            start_type: job.contract_start_type ?? null,
-            is_start_flexible: job.contract_start_is_flexible ?? null,
-            is_algo_company: false,
-            is_formation_included: isFormationIncluded(job),
-            title: dedupeRepeatedTitle(job.offer_title || ""),
-            description: stripHtmlToText(job.offer_description),
-            // application_count sert au tri (search.service) et rien ne bumpe updated_at à
-            // chaque candidature : le nightly est la voie de rafraîchissement de ce compteur
-            // (déjà calculé par le $lookup du pipeline — gratuit).
-            application_count: job.application_count,
-            smart_apply: job.apply_email ? true : false,
-            ...resolveAdminCodes({ zipcode: job.workplace_address_zipcode, geopoint: job.workplace_geopoint }, ctx.adminCodes),
-          },
-        }
-      )
-      return
-    }
-
     await upsertSearchItem(buildJobOfferSearchItem(job, ctx))
   })
 
   await processCursorStream(recruteursCursor, "recruteurs", processedIds, async (job) => {
-    // Déjà en base → on conserve le doc (keywords compris), on resynchronise seulement les
-    // champs contrat (backfill des ajouts de schéma sans régénérer la collection).
-    if (existingIds.has(job._id.toString())) {
-      const built = buildRecruteurSearchItem(job, ctx)
-      await searchItemsCollection.updateOne(
-        { _id: job._id },
-        {
-          $set: {
-            title: built.title,
-            address: built.address,
-            location: built.location,
-            organization_name: built.organization_name,
-            level: built.level,
-            activity_sector: built.activity_sector,
-            is_disabled_elligible: job.contract_is_disabled_elligible ?? false,
-            start_date: null,
-            start_type: null,
-            is_start_flexible: null,
-            is_algo_company: true,
-            is_formation_included: false,
-            application_count: job.application_count,
-            smart_apply: job.apply_email ? true : false,
-            ...resolveAdminCodes({ zipcode: job.workplace_address_zipcode, geopoint: job.workplace_geopoint }, ctx.adminCodes),
-          },
-        }
-      )
-      return
-    }
-
     await upsertSearchItem(buildRecruteurSearchItem(job, ctx))
   })
 

--- a/server/src/migrations/20260911180000-backfill-search-items-admin-codes.ts
+++ b/server/src/migrations/20260911180000-backfill-search-items-admin-codes.ts
@@ -1,0 +1,29 @@
+import { addJob } from "job-processor"
+
+import { logger } from "@/common/logger"
+import { createSearchIndexes } from "@/common/utils/mongodb-utils"
+
+/**
+ * Filtre exact par département ou région dans la recherche (ban-plateforme#781) : `search_items`
+ * porte désormais `departement_code` et `region_code`, indexés en `token` dans Atlas Search.
+ *
+ * Deux choses doivent suivre le déploiement, sinon une recherche « Bretagne » renvoie zéro
+ * résultat en silence (un `equals` sur un champ absent ne matche rien) :
+ *  1. la définition de l'index Atlas Search avec les deux nouveaux champs : appliquée ici via
+ *     `updateSearchIndex` (idempotent), mongot reconstruit en arrière-plan ;
+ *  2. le peuplement des deux champs sur les items existants : `fillSearchItemsCollection`
+ *     réécrit chaque item depuis sa source (un `updateOne` par item, jusqu'à 3 h en prod).
+ *     Trop long pour une migration synchrone, donc mis en file pour le job processor.
+ *
+ * Contrôle après coup, dans Compass sur `search_items` :
+ *   [{ $listSearchIndexes: {} }]                      → status READY, queryable true
+ *   $group par type, $cond sur { $type: "$departement_code" } = "missing" → 0 attendu
+ * (pipelines détaillés dans tools/geo-781/compass.md).
+ */
+export const up = async () => {
+  logger.info("search_items : mise à jour de la définition de l'index Atlas Search (departement_code, region_code)")
+  await createSearchIndexes()
+
+  logger.info("search_items : mise en file de fillSearchItemsCollection pour peupler departement_code / region_code")
+  await addJob({ name: "fillSearchItemsCollection", queued: true, payload: {} })
+}

--- a/server/src/services/application.service.ts
+++ b/server/src/services/application.service.ts
@@ -721,7 +721,7 @@ export const sendMailToApplicant = async ({
       sentMessageId = await mailer.sendEmail({
         to: applicantEmail,
         cc: email || undefined,
-        subject: `Objet : Suite donnée à votre candidature - ${application.company_name}${partner ? ` via ${partner}` : ""}`,
+        subject: `Suite donnée à votre candidature - ${application.company_name}${partner ? ` via ${partner}` : ""}`,
         template: getEmailTemplate("mail-candidat-entretien"),
         data: {
           ...sanitizeApplicationForEmail(application),

--- a/server/src/services/geo-administrative/admin-area.test.ts
+++ b/server/src/services/geo-administrative/admin-area.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import { buildAdminAreaClause, parseAdminArea } from "./admin-area"
+
+describe("parseAdminArea", () => {
+  // Les cas qui doivent répondre "non" d'abord : c'est une saisie qui arrive de l'URL.
+  it.each([
+    ["chaîne vide", ""],
+    ["valeur absente", undefined],
+    ["maille inconnue", "epci:244400404"],
+    ["sans code", "region:"],
+    ["sans maille", ":53"],
+    ["code trop long", "departement:44000"],
+    ["code non administratif", "departement:nantes"],
+    ["segment en trop", "region:53:extra"],
+    ["corse en minuscules", "departement:2a"],
+    ["injection", "region:53; drop"],
+  ])("rejette %s", (_, value) => {
+    expect(parseAdminArea(value)).toBeNull()
+  })
+
+  it("accepte les deux mailles", () => {
+    expect(parseAdminArea("region:53")).toEqual({ kind: "region", code: "53" })
+    expect(parseAdminArea("departement:44")).toEqual({ kind: "departement", code: "44" })
+  })
+
+  it("accepte la Corse et les DROM", () => {
+    expect(parseAdminArea("departement:2A")).toEqual({ kind: "departement", code: "2A" })
+    expect(parseAdminArea("departement:2B")).toEqual({ kind: "departement", code: "2B" })
+    expect(parseAdminArea("departement:974")).toEqual({ kind: "departement", code: "974" })
+    expect(parseAdminArea("region:04")).toEqual({ kind: "region", code: "04" })
+  })
+})
+
+describe("buildAdminAreaClause", () => {
+  it("vise le champ de la maille demandée", () => {
+    expect(buildAdminAreaClause({ kind: "departement", code: "44" })).toEqual({ equals: { path: "departement_code", value: "44" } })
+    expect(buildAdminAreaClause({ kind: "region", code: "53" })).toEqual({ equals: { path: "region_code", value: "53" } })
+  })
+})

--- a/server/src/services/geo-administrative/admin-area.test.ts
+++ b/server/src/services/geo-administrative/admin-area.test.ts
@@ -1,36 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { buildAdminAreaClause, parseAdminArea } from "./admin-area"
-
-describe("parseAdminArea", () => {
-  // Les cas qui doivent répondre "non" d'abord : c'est une saisie qui arrive de l'URL.
-  it.each([
-    ["chaîne vide", ""],
-    ["valeur absente", undefined],
-    ["maille inconnue", "epci:244400404"],
-    ["sans code", "region:"],
-    ["sans maille", ":53"],
-    ["code trop long", "departement:44000"],
-    ["code non administratif", "departement:nantes"],
-    ["segment en trop", "region:53:extra"],
-    ["corse en minuscules", "departement:2a"],
-    ["injection", "region:53; drop"],
-  ])("rejette %s", (_, value) => {
-    expect(parseAdminArea(value)).toBeNull()
-  })
-
-  it("accepte les deux mailles", () => {
-    expect(parseAdminArea("region:53")).toEqual({ kind: "region", code: "53" })
-    expect(parseAdminArea("departement:44")).toEqual({ kind: "departement", code: "44" })
-  })
-
-  it("accepte la Corse et les DROM", () => {
-    expect(parseAdminArea("departement:2A")).toEqual({ kind: "departement", code: "2A" })
-    expect(parseAdminArea("departement:2B")).toEqual({ kind: "departement", code: "2B" })
-    expect(parseAdminArea("departement:974")).toEqual({ kind: "departement", code: "974" })
-    expect(parseAdminArea("region:04")).toEqual({ kind: "region", code: "04" })
-  })
-})
+import { buildAdminAreaClause } from "./admin-area"
 
 describe("buildAdminAreaClause", () => {
   it("vise le champ de la maille demandée", () => {

--- a/server/src/services/geo-administrative/admin-area.ts
+++ b/server/src/services/geo-administrative/admin-area.ts
@@ -1,0 +1,35 @@
+/**
+ * Filtrage de la recherche par entité administrative (région, département).
+ * Contexte et mesures : issue BaseAdresseNationale/ban-plateforme#781, tools/geo-781.
+ *
+ * Le géocodeur Géoplateforme résout "Bretagne" en région 53 (index `poi`, code dans `citycode`)
+ * mais ne renvoie pas d'emprise. Plutôt que d'approximer à la requête (rayon, bbox, contour),
+ * le code est dérivé à la construction des items (`search-items-admin-codes.ts`) et indexé en
+ * `token` : le filtre est un `equals`, exact et le moins coûteux possible.
+ */
+
+export type IAdminArea = {
+  kind: "region" | "departement"
+  code: string
+}
+
+const ADMIN_AREA_PATTERN = /^(region|departement):([0-9]{1,3}|2[AB])$/
+
+/** `"region:53"` / `"departement:44"`. Renvoie null sur toute autre forme, jamais d'exception. */
+export function parseAdminArea(value: string | undefined | null): IAdminArea | null {
+  if (!value) return null
+  const match = ADMIN_AREA_PATTERN.exec(value)
+  if (!match) return null
+  return { kind: match[1] as IAdminArea["kind"], code: match[2] }
+}
+
+/** Champ `search_items` porteur du code pour la maille demandée. */
+export const ADMIN_AREA_FIELD: Record<IAdminArea["kind"], "departement_code" | "region_code"> = {
+  region: "region_code",
+  departement: "departement_code",
+}
+
+/** Clause de filtre Atlas Search : un `equals` sur le champ token de la maille. */
+export function buildAdminAreaClause({ kind, code }: IAdminArea): object {
+  return { equals: { path: ADMIN_AREA_FIELD[kind], value: code } }
+}

--- a/server/src/services/geo-administrative/admin-area.ts
+++ b/server/src/services/geo-administrative/admin-area.ts
@@ -1,3 +1,5 @@
+import type { IAdminArea } from "shared/utils/admin-area"
+
 /**
  * Filtrage de la recherche par entité administrative (région, département).
  * Contexte et mesures : issue BaseAdresseNationale/ban-plateforme#781, tools/geo-781.
@@ -8,23 +10,8 @@
  * `token` : le filtre est un `equals`, exact et le moins coûteux possible.
  */
 
-export type IAdminArea = {
-  kind: "region" | "departement"
-  code: string
-}
-
-const ADMIN_AREA_PATTERN = /^(region|departement):([0-9]{1,3}|2[AB])$/
-
-/** `"region:53"` / `"departement:44"`. Renvoie null sur toute autre forme, jamais d'exception. */
-export function parseAdminArea(value: string | undefined | null): IAdminArea | null {
-  if (!value) return null
-  const match = ADMIN_AREA_PATTERN.exec(value)
-  if (!match) return null
-  return { kind: match[1] as IAdminArea["kind"], code: match[2] }
-}
-
 /** Champ `search_items` porteur du code pour la maille demandée. */
-export const ADMIN_AREA_FIELD: Record<IAdminArea["kind"], "departement_code" | "region_code"> = {
+const ADMIN_AREA_FIELD: Record<IAdminArea["kind"], "departement_code" | "region_code"> = {
   region: "region_code",
   departement: "departement_code",
 }

--- a/server/src/services/search/search-items-admin-codes.test.ts
+++ b/server/src/services/search/search-items-admin-codes.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest"
+
+import type { AdminCodeIndex } from "./search-items-admin-codes"
+import { addCommune, emptyAdminCodeIndex, normalizeInsee, normalizeZipcode, resolveAdminCodes } from "./search-items-admin-codes"
+
+const point = (lon: number, lat: number) => ({ type: "Point" as const, coordinates: [lon, lat] as [number, number] })
+
+/**
+ * Référentiel de test réduit aux cas qui comptent, tous relevés en production le 2026-09-11 :
+ * un CP monodépartemental, le CP 42620 à cheval Allier/Loire, Paris (commune 75056, dont le
+ * catalogue code les arrondissements 751xx), la Corse (20xxx ambigu 2A/2B), la Guadeloupe (971,
+ * même préfixe postal que Saint-Martin et Saint-Barthélemy qui n'en font pas partie).
+ * Les bbox se recouvrent volontairement entre Nantes et Rezé pour tester le départage.
+ */
+const buildIndex = (): AdminCodeIndex => {
+  const index = emptyAdminCodeIndex()
+  addCommune(index, {
+    insee: "44109",
+    departement_code: "44",
+    region_code: "52",
+    zipcodes: ["44000", "44100", "44200", "44300"],
+    centre: [-1.55, 47.22],
+    bbox: [-1.64, 47.18, -1.48, 47.3],
+  })
+  addCommune(index, { insee: "44143", departement_code: "44", region_code: "52", zipcodes: ["44400"], centre: [-1.57, 47.18], bbox: [-1.62, 47.15, -1.5, 47.21] })
+  addCommune(index, { insee: "42147", departement_code: "42", region_code: "84", zipcodes: ["42620"], centre: [3.75, 46.28], bbox: [3.7, 46.24, 3.8, 46.32] })
+  addCommune(index, { insee: "03119", departement_code: "03", region_code: "84", zipcodes: ["42620"], centre: [3.8, 46.31], bbox: [3.76, 46.28, 3.86, 46.36] })
+  addCommune(index, { insee: "75056", departement_code: "75", region_code: "11", zipcodes: ["75001", "75015"], centre: [2.35, 48.86], bbox: [2.22, 48.81, 2.47, 48.9] })
+  addCommune(index, { insee: "2A004", departement_code: "2A", region_code: "94", zipcodes: ["20000"], centre: [8.74, 41.93], bbox: [8.6, 41.85, 8.85, 42.0] })
+  addCommune(index, { insee: "2B033", departement_code: "2B", region_code: "94", zipcodes: ["20200"], centre: [9.45, 42.7], bbox: [9.4, 42.65, 9.5, 42.75] })
+  addCommune(index, { insee: "97105", departement_code: "971", region_code: "01", zipcodes: ["97110"], centre: [-61.53, 16.24], bbox: [-61.6, 16.2, -61.48, 16.3] })
+  return index
+}
+
+const NONE = { departement_code: null, region_code: null }
+const NANTES = { departement_code: "44", region_code: "52" }
+const PARIS = { departement_code: "75", region_code: "11" }
+
+describe("resolveAdminCodes", () => {
+  const index = buildIndex()
+
+  describe("dit non quand il faut", () => {
+    it("sans aucune source", () => {
+      expect(resolveAdminCodes({}, index)).toEqual(NONE)
+    })
+
+    it("CP à cheval sans géopoint : on ne choisit pas au hasard", () => {
+      expect(resolveAdminCodes({ zipcode: "42620" }, index)).toEqual(NONE)
+    })
+
+    it("Saint-Martin et Saint-Barthélemy ne sont pas la Guadeloupe malgré le préfixe 971", () => {
+      // Sans géopoint : la règle de numérotation doit être court-circuitée.
+      expect(resolveAdminCodes({ zipcode: "97150" }, index)).toEqual(NONE)
+      expect(resolveAdminCodes({ zipcode: "97133" }, index)).toEqual(NONE)
+      // Avec géopoint réel (Marigot, 250 km de la Guadeloupe) : hors de toute bbox.
+      expect(resolveAdminCodes({ zipcode: "97150", geopoint: point(-63.08, 18.07) }, index)).toEqual(NONE)
+    })
+
+    it("Corse : un CP 20xxx inconnu ne se tranche pas par la numérotation, 2A ou 2B", () => {
+      expect(resolveAdminCodes({ zipcode: "20090" }, index)).toEqual(NONE)
+    })
+
+    it("CP inconnu d'un département inconnu du référentiel", () => {
+      expect(resolveAdminCodes({ zipcode: "99123" }, index)).toEqual(NONE)
+    })
+
+    it("géopoint hors de toute bbox (en mer)", () => {
+      expect(resolveAdminCodes({ geopoint: point(-5.0, 46.0) }, index)).toEqual(NONE)
+    })
+
+    it("un INSEE inconnu n'est pas une preuve : on retombe sur le CP, qui reste à cheval", () => {
+      expect(resolveAdminCodes({ insee: "00000", zipcode: "42620" }, index)).toEqual(NONE)
+    })
+  })
+
+  describe("étape 1 : code INSEE", () => {
+    it("prime sur un CP contradictoire", () => {
+      expect(resolveAdminCodes({ insee: "44109", zipcode: "75001" }, index)).toEqual(NANTES)
+    })
+
+    it("ramène un arrondissement de Paris, Lyon ou Marseille à sa commune", () => {
+      expect(resolveAdminCodes({ insee: "75115" }, index)).toEqual(PARIS)
+      expect(normalizeInsee("69389")).toBe("69123")
+      expect(normalizeInsee("13212")).toBe("13055")
+    })
+
+    it("ne touche pas aux autres codes, Corse comprise", () => {
+      expect(normalizeInsee("2a004")).toBe("2A004")
+      expect(normalizeInsee("74011")).toBe("74011")
+      expect(normalizeInsee("7501")).toBeNull()
+    })
+  })
+
+  describe("étape 2 : code postal connu", () => {
+    it("un seul département derrière le CP", () => {
+      expect(resolveAdminCodes({ zipcode: "44400" }, index)).toEqual(NANTES)
+    })
+
+    it("CP à cheval tranché par la commune du CP la plus proche du géopoint", () => {
+      expect(resolveAdminCodes({ zipcode: "42620", geopoint: point(3.74, 46.27) }, index).departement_code).toBe("42")
+      expect(resolveAdminCodes({ zipcode: "42620", geopoint: point(3.81, 46.32) }, index).departement_code).toBe("03")
+    })
+
+    it("CP mal formé mais récupérable", () => {
+      expect(resolveAdminCodes({ zipcode: "44 400" }, index)).toEqual(NANTES)
+    })
+
+    it("Corse résolue par le référentiel quand le CP y est", () => {
+      expect(resolveAdminCodes({ zipcode: "20200" }, index)).toEqual({ departement_code: "2B", region_code: "94" })
+    })
+  })
+
+  describe("étape 3 : CP inconnu de forme départementale", () => {
+    it("CEDEX : le département est dans le code", () => {
+      expect(resolveAdminCodes({ zipcode: "75948" }, index)).toEqual(PARIS)
+      expect(resolveAdminCodes({ zipcode: "44406" }, index)).toEqual(NANTES)
+    })
+
+    it("75000 et 13000 sans arrondissement", () => {
+      expect(resolveAdminCodes({ zipcode: "75000" }, index)).toEqual(PARIS)
+    })
+
+    it("outre-mer sur trois chiffres", () => {
+      expect(resolveAdminCodes({ zipcode: "97464" }, index)).toEqual(NONE) // 974 absent de l'index de test : pas d'invention
+      expect(resolveAdminCodes({ zipcode: "97190" }, index)).toEqual({ departement_code: "971", region_code: "01" })
+    })
+  })
+
+  describe("étape 4 : géopoint seul", () => {
+    it("commune dont la bbox contient le point", () => {
+      expect(resolveAdminCodes({ geopoint: point(2.35, 48.86) }, index)).toEqual(PARIS)
+    })
+
+    it("bbox qui se recouvrent : la commune au centre le plus proche", () => {
+      // Dans les deux bbox Nantes/Rezé, plus près du centre de Rezé.
+      expect(resolveAdminCodes({ geopoint: point(-1.57, 47.19) }, index)).toEqual(NANTES)
+    })
+
+    it("Corse ambiguë tranchée par le géopoint", () => {
+      expect(resolveAdminCodes({ zipcode: "20090", geopoint: point(8.74, 41.93) }, index).departement_code).toBe("2A")
+      expect(resolveAdminCodes({ zipcode: "20090", geopoint: point(9.45, 42.7) }, index).departement_code).toBe("2B")
+    })
+  })
+})
+
+describe("normalizeZipcode", () => {
+  it.each([
+    [null, null],
+    ["", null],
+    ["abc", null],
+    ["123456", null],
+    ["44000", "44000"],
+    ["44 000", "44000"],
+    ["4400", "04400"],
+    ["1000", "01000"],
+  ])("%s → %s", (input, expected) => {
+    expect(normalizeZipcode(input)).toBe(expected)
+  })
+})

--- a/server/src/services/search/search-items-admin-codes.ts
+++ b/server/src/services/search/search-items-admin-codes.ts
@@ -1,0 +1,196 @@
+import type { IPointGeometry } from "shared/models/index"
+
+import { getDbCollection } from "@/common/utils/mongodb-utils"
+
+/**
+ * Dérivation des codes département et région d'un item de recherche, à partir du référentiel
+ * communes déjà en base (`referentiel.communes`, alimenté par l'API Découpage administratif).
+ *
+ * Pourquoi à la construction et pas à la requête : un filtre `equals` sur un champ `token` est
+ * l'opération la moins chère d'Atlas Search, et il est exact par construction. Les alternatives
+ * à la requête (rayon, bbox, contour) ramènent 42 à 82 % de hors-périmètre ou transportent
+ * jusqu'à 416 Ko de géométrie par appel (mesures : tools/geo-781, issue ban-plateforme#781).
+ *
+ * Ordre de résolution, du plus sûr au moins sûr, chaque étape ne s'appliquant que si la
+ * précédente n'a rien donné. Chiffres de production du 2026-09-11 (tools/geo-781/compass.md) :
+ *  1. code INSEE de la commune (formations) : 92,7 % des formations ;
+ *     les arrondissements de Paris, Lyon et Marseille (3 423 formations) sont ramenés à leur
+ *     commune, le référentiel ne connaissant pas les arrondissements ;
+ *  2. code postal connu du référentiel : 99,4 % des offres ; un CP à cheval sur deux
+ *     départements (16 CP, 402 offres) est tranché par la commune du CP la plus proche du géopoint ;
+ *  3. code postal inconnu du référentiel mais de forme départementale (CEDEX, 75000, 13000 :
+ *     ~160 offres) : le département est lu dans le code lui-même, c'est la règle de numérotation ;
+ *  4. géopoint seul (1 185 offres sans CP) : commune dont la bbox contient le point, la plus
+ *     proche en cas de recouvrement. Hors de toute bbox, on renonce.
+ * Saint-Martin et Saint-Barthélemy (105 offres) ne sont rattachées à rien : ce sont des
+ * collectivités, pas des départements, et leur CP commence pourtant par 971. Elles sont exclues
+ * de l'étape 3 explicitement et tombent hors de toute bbox à l'étape 4.
+ */
+
+export type IAdminCodes = { departement_code: string | null; region_code: string | null }
+
+const NO_CODES: IAdminCodes = { departement_code: null, region_code: null }
+
+type Bbox = [minLon: number, minLat: number, maxLon: number, maxLat: number]
+
+type CommuneRef = {
+  insee: string
+  departement_code: string
+  region_code: string
+  centre: [number, number] | null
+  bbox: Bbox | null
+}
+
+export type AdminCodeIndex = {
+  byInsee: Map<string, CommuneRef>
+  byZipcode: Map<string, CommuneRef[]>
+  regionByDepartement: Map<string, string>
+  /** Toutes les communes avec une bbox, pour la résolution par géopoint seul. */
+  withBbox: CommuneRef[]
+}
+
+export const emptyAdminCodeIndex = (): AdminCodeIndex => ({ byInsee: new Map(), byZipcode: new Map(), regionByDepartement: new Map(), withBbox: [] })
+
+/** Une lecture du référentiel (~35 000 communes) par chargement du contexte de build. */
+export const loadAdminCodeIndex = async (): Promise<AdminCodeIndex> => {
+  const communes = await getDbCollection("referentiel.communes")
+    .find({}, { projection: { _id: 0, code: 1, codesPostaux: 1, codeDepartement: 1, codeRegion: 1, centre: 1, bbox: 1 } })
+    .toArray()
+
+  const index = emptyAdminCodeIndex()
+  for (const commune of communes) {
+    addCommune(index, {
+      insee: commune.code,
+      departement_code: commune.codeDepartement,
+      region_code: commune.codeRegion,
+      zipcodes: commune.codesPostaux,
+      centre: commune.centre?.coordinates ?? null,
+      bbox: toBbox(commune.bbox),
+    })
+  }
+  return index
+}
+
+/** Ajout d'une commune à l'index. Exporté pour construire des index de test sans base. */
+export const addCommune = (
+  index: AdminCodeIndex,
+  commune: { insee: string; departement_code: string; region_code: string; zipcodes: string[]; centre: [number, number] | null; bbox: Bbox | null }
+): void => {
+  const { zipcodes, ...ref } = commune
+  index.byInsee.set(ref.insee, ref)
+  for (const zipcode of zipcodes) {
+    const list = index.byZipcode.get(zipcode)
+    if (list) list.push(ref)
+    else index.byZipcode.set(zipcode, [ref])
+  }
+  index.regionByDepartement.set(ref.departement_code, ref.region_code)
+  if (ref.bbox) index.withBbox.push(ref)
+}
+
+/** La bbox du référentiel est un Polygon GeoJSON à 5 sommets ; on n'en garde que les bornes. */
+const toBbox = (geometry: { type: string; coordinates: unknown } | null | undefined): Bbox | null => {
+  if (!geometry || geometry.type !== "Polygon") return null
+  const ring = (geometry.coordinates as [number, number][][])[0]
+  if (!ring?.length) return null
+  const lons = ring.map((c) => c[0])
+  const lats = ring.map((c) => c[1])
+  return [Math.min(...lons), Math.min(...lats), Math.max(...lons), Math.max(...lats)]
+}
+
+const toCodes = ({ departement_code, region_code }: CommuneRef): IAdminCodes => ({ departement_code, region_code })
+
+/** Distance au carré en degrés : suffit pour départager des communes voisines, pas besoin de haversine. */
+const squaredDistance = (a: [number, number], b: [number, number]) => (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2
+
+const nearest = (candidates: CommuneRef[], point: [number, number]): CommuneRef | null => {
+  let best: CommuneRef | null = null
+  let bestDistance = Number.POSITIVE_INFINITY
+  for (const candidate of candidates) {
+    if (!candidate.centre) continue
+    const d = squaredDistance(candidate.centre, point)
+    if (d < bestDistance) {
+      bestDistance = d
+      best = candidate
+    }
+  }
+  return best
+}
+
+const contains = ([minLon, minLat, maxLon, maxLat]: Bbox, [lon, lat]: [number, number]) => lon >= minLon && lon <= maxLon && lat >= minLat && lat <= maxLat
+
+/**
+ * Arrondissements municipaux → commune. Le catalogue des formations code Paris, Lyon et
+ * Marseille à l'arrondissement ; le référentiel (API Découpage, `/departements/{code}/communes`)
+ * ne connaît que la commune. Même département, même région dans les deux cas.
+ */
+export const ARRONDISSEMENT_PARENT: Record<string, string> = {
+  "751": "75056", // Paris 75101–75120
+  "693": "69123", // Lyon 69381–69389
+  "132": "13055", // Marseille 13201–13216
+}
+
+export const normalizeInsee = (insee: string | null | undefined): string | null => {
+  const value = insee?.trim().toUpperCase()
+  if (!value || value.length !== 5) return null
+  return ARRONDISSEMENT_PARENT[value.slice(0, 3)] ?? value
+}
+
+/**
+ * Collectivités d'outre-mer dont le CP commence par 971 comme la Guadeloupe, sans en faire
+ * partie. Sans cette exclusion, la règle de numérotation les rattacherait au 971.
+ */
+const COLLECTIVITE_ZIPCODES = new Set(["97133", "97150"])
+
+/**
+ * Département lu dans un CP de forme départementale (CEDEX, ou 75000 / 13000 sans arrondissement).
+ * C'est la règle de numérotation postale : deux premiers chiffres, trois pour l'outre-mer.
+ * La Corse (20xxx) est ambiguë entre 2A et 2B : on ne tranche pas ici, le géopoint le fera.
+ */
+const departementFromZipcode = (zipcode: string, index: AdminCodeIndex): IAdminCodes | null => {
+  if (COLLECTIVITE_ZIPCODES.has(zipcode)) return null
+  if (zipcode.startsWith("20")) return null
+  const departement_code = zipcode.startsWith("97") ? zipcode.slice(0, 3) : zipcode.slice(0, 2)
+  const region_code = index.regionByDepartement.get(departement_code)
+  return region_code ? { departement_code, region_code } : null
+}
+
+export const resolveAdminCodes = (source: { insee?: string | null; zipcode?: string | null; geopoint?: IPointGeometry | null }, index: AdminCodeIndex): IAdminCodes => {
+  const insee = normalizeInsee(source.insee)
+  if (insee) {
+    const ref = index.byInsee.get(insee)
+    if (ref) return toCodes(ref)
+  }
+
+  const point = source.geopoint?.coordinates
+
+  const zipcode = normalizeZipcode(source.zipcode)
+  if (zipcode) {
+    const candidates = index.byZipcode.get(zipcode)
+    if (candidates?.length) {
+      const departements = new Set(candidates.map((c) => c.departement_code))
+      if (departements.size === 1) return toCodes(candidates[0])
+      // CP à cheval : la commune du CP la plus proche du géopoint. Sans géopoint, on renonce
+      // plutôt que de choisir au hasard.
+      const best = point ? nearest(candidates, point) : null
+      return best ? toCodes(best) : NO_CODES
+    }
+    const fromZipcode = departementFromZipcode(zipcode, index)
+    if (fromZipcode) return fromZipcode
+  }
+
+  if (point) {
+    const enclosing = index.withBbox.filter((c) => contains(c.bbox!, point))
+    const best = nearest(enclosing, point)
+    if (best) return toCodes(best)
+  }
+
+  return NO_CODES
+}
+
+/** "44 000" → "44000", "4400" → "04400" (zéro initial perdu par un cast numérique en amont). */
+export const normalizeZipcode = (zipcode: string | null | undefined): string | null => {
+  if (!zipcode) return null
+  const digits = zipcode.replace(/\D/g, "")
+  if (!digits || digits.length > 5) return null
+  return digits.padStart(5, "0")
+}

--- a/server/src/services/search/search-items-admin-codes.ts
+++ b/server/src/services/search/search-items-admin-codes.ts
@@ -123,7 +123,7 @@ const contains = ([minLon, minLat, maxLon, maxLat]: Bbox, [lon, lat]: [number, n
  * Marseille à l'arrondissement ; le référentiel (API Découpage, `/departements/{code}/communes`)
  * ne connaît que la commune. Même département, même région dans les deux cas.
  */
-export const ARRONDISSEMENT_PARENT: Record<string, string> = {
+const ARRONDISSEMENT_PARENT: Record<string, string> = {
   "751": "75056", // Paris 75101–75120
   "693": "69123", // Lyon 69381–69389
   "132": "13055", // Marseille 13201–13216

--- a/server/src/services/search/search-items-admin-codes.ts
+++ b/server/src/services/search/search-items-admin-codes.ts
@@ -194,3 +194,38 @@ export const normalizeZipcode = (zipcode: string | null | undefined): string | n
   if (!digits || digits.length > 5) return null
   return digits.padStart(5, "0")
 }
+
+/**
+ * Tolérance autour de la bbox communale, en degrés (~2 km) : absorbe un géocodage posé juste de
+ * l'autre côté de la limite communale, qui n'est pas une erreur à corriger.
+ */
+const BBOX_TOLERANCE_DEG = 0.02
+
+/**
+ * Garde-fou sur le géopoint d'une formation. Le catalogue livre `lieu_formation_geo_coordonnees`
+ * tel quel, LBA ne géocode pas : 85 formations en prod (0,18 %, relevé du 2026-09-11) ont un point
+ * à plus de 30 km de la commune de leur adresse (La Roche-sur-Yon affichée à l'ouest de Nantes,
+ * Angers en plein Nantes…), donc présentées comme locales à des jeunes qui cherchent ailleurs.
+ *
+ * Le critère n'est pas une distance mais l'emprise réelle de la commune : un point à 100 km du
+ * centre de Maripasoula (18 000 km²) est légitime, un point à 30 km du centre de La Roche-sur-Yon
+ * ne l'est pas. Hors de la bbox communale (plus tolérance), on recentre sur le centre de la
+ * commune : position approximative mais dans la bonne ville, plutôt qu'exacte dans la mauvaise.
+ * Sans INSEE résolu, sans bbox, ou sans géopoint : on ne touche à rien.
+ */
+export const snapGeopointToCommune = (
+  source: { insee?: string | null; geopoint?: IPointGeometry | null },
+  index: AdminCodeIndex
+): { location: IPointGeometry | null; snapped: boolean } => {
+  const geopoint = source.geopoint ?? null
+  const insee = normalizeInsee(source.insee)
+  if (!geopoint || !insee) return { location: geopoint, snapped: false }
+  const commune = index.byInsee.get(insee)
+  if (!commune?.bbox || !commune.centre) return { location: geopoint, snapped: false }
+
+  const [minLon, minLat, maxLon, maxLat] = commune.bbox
+  const [lon, lat] = geopoint.coordinates
+  const inside = lon >= minLon - BBOX_TOLERANCE_DEG && lon <= maxLon + BBOX_TOLERANCE_DEG && lat >= minLat - BBOX_TOLERANCE_DEG && lat <= maxLat + BBOX_TOLERANCE_DEG
+  if (inside) return { location: geopoint, snapped: false }
+  return { location: { type: "Point", coordinates: [commune.centre[0], commune.centre[1]] }, snapped: true }
+}

--- a/server/src/services/search/search-items-formation-location.test.ts
+++ b/server/src/services/search/search-items-formation-location.test.ts
@@ -1,0 +1,114 @@
+import { ObjectId } from "bson"
+import { describe, expect, it } from "vitest"
+import type { IFormationForSearchItem, SearchItemBuildContext } from "./search-items.service"
+import { buildFormationSearchItem } from "./search-items.service"
+import type { AdminCodeIndex } from "./search-items-admin-codes"
+import { addCommune, emptyAdminCodeIndex, snapGeopointToCommune } from "./search-items-admin-codes"
+
+const point = (lon: number, lat: number) => ({ type: "Point" as const, coordinates: [lon, lat] as [number, number] })
+
+/**
+ * Bbox et centres relevés sur geo.api.gouv.fr le 2026-09-11.
+ * Maripasoula : 18 000 km², 1,55° × 1,88°. La Roche-sur-Yon et Paris : communes ordinaires.
+ */
+const buildIndex = (): AdminCodeIndex => {
+  const index = emptyAdminCodeIndex()
+  addCommune(index, {
+    insee: "97353",
+    departement_code: "973",
+    region_code: "03",
+    zipcodes: ["97370"],
+    centre: [-53.8276, 3.049],
+    bbox: [-54.602416, 2.111073, -53.052708, 3.986871],
+  })
+  addCommune(index, { insee: "85191", departement_code: "85", region_code: "52", zipcodes: ["85000"], centre: [-1.4266, 46.6705], bbox: [-1.5, 46.6, -1.35, 46.74] })
+  addCommune(index, { insee: "75056", departement_code: "75", region_code: "11", zipcodes: ["75001", "75015"], centre: [2.3522, 48.8566], bbox: [2.224, 48.815, 2.47, 48.902] })
+  addCommune(index, { insee: "44109", departement_code: "44", region_code: "52", zipcodes: ["44000"], centre: [-1.5603, 47.2382], bbox: null })
+  return index
+}
+
+const buildCtx = (adminCodes: AdminCodeIndex): SearchItemBuildContext => ({
+  romeLabelByCode: new Map(),
+  organizationCaseMap: new Map(),
+  sectorCaseMap: new Map(),
+  adminCodes,
+  corrections: { formations_recentrees: 0 },
+})
+
+const formation = (overrides: Partial<IFormationForSearchItem>): IFormationForSearchItem => ({
+  _id: new ObjectId(),
+  intitule_rco: "CAP Boulanger",
+  contenu: "",
+  niveau: "3 (CAP...)",
+  lieu_formation_geopoint: point(-1.4266, 46.6705),
+  lieu_formation_adresse: "5 Boulevard Branly",
+  code_postal: "85000",
+  code_commune_insee: "85191",
+  localite: "La Roche-sur-Yon",
+  etablissement_formateur_entreprise_raison_sociale: "CFA",
+  entierement_a_distance: false,
+  cle_ministere_educatif: "cle-1",
+  rome_codes: [],
+  ...overrides,
+})
+
+describe("snapGeopointToCommune", () => {
+  const index = buildIndex()
+
+  // Le faux positif d'abord : une distance seule aurait recentré ce point à tort.
+  it("laisse en place un point à 100 km du centre d'une très grande commune, tant qu'il est dans son emprise", () => {
+    const farButInside = point(-54.5, 2.2) // sud-ouest de Maripasoula, ~120 km du centre
+    expect(snapGeopointToCommune({ insee: "97353", geopoint: farButInside }, index)).toEqual({ location: farButInside, snapped: false })
+  })
+
+  it("tolère un point juste de l'autre côté de la limite communale (~2 km)", () => {
+    const justOutside = point(-1.515, 46.65) // 0,015° à l'ouest de la bbox de La Roche-sur-Yon
+    expect(snapGeopointToCommune({ insee: "85191", geopoint: justOutside }, index).snapped).toBe(false)
+  })
+
+  it("ne touche à rien sans INSEE résolu, sans bbox, ou sans géopoint", () => {
+    const p = point(-1.952, 47.3593)
+    expect(snapGeopointToCommune({ insee: "00000", geopoint: p }, index)).toEqual({ location: p, snapped: false })
+    expect(snapGeopointToCommune({ insee: null, geopoint: p }, index)).toEqual({ location: p, snapped: false })
+    expect(snapGeopointToCommune({ insee: "44109", geopoint: p }, index)).toEqual({ location: p, snapped: false }) // commune sans bbox
+    expect(snapGeopointToCommune({ insee: "85191", geopoint: null }, index)).toEqual({ location: null, snapped: false })
+  })
+
+  it("recentre sur la commune un point hors de son emprise (cas prod : La Roche-sur-Yon affichée près de Nantes)", () => {
+    const result = snapGeopointToCommune({ insee: "85191", geopoint: point(-1.952, 47.3593) }, index)
+    expect(result).toEqual({ location: point(-1.4266, 46.6705), snapped: true })
+  })
+
+  it("utilise l'emprise de la commune pour un arrondissement municipal", () => {
+    const inParis = point(2.29, 48.84) // 15e arrondissement
+    expect(snapGeopointToCommune({ insee: "75115", geopoint: inParis }, index).snapped).toBe(false)
+    expect(snapGeopointToCommune({ insee: "75115", geopoint: point(-1.5, 47.2) }, index).snapped).toBe(true)
+  })
+})
+
+describe("buildFormationSearchItem : géopoint et compteur de corrections", () => {
+  it("garde le géopoint source quand il est dans l'emprise de la commune, compteur à zéro", () => {
+    const ctx = buildCtx(buildIndex())
+    const item = buildFormationSearchItem(formation({}), ctx)
+    expect(item.location?.coordinates).toEqual([-1.4266, 46.6705])
+    expect(item.departement_code).toBe("85")
+    expect(ctx.corrections.formations_recentrees).toBe(0)
+  })
+
+  it("recentre et compte quand le géopoint est hors de la commune, sans changer les codes administratifs", () => {
+    const ctx = buildCtx(buildIndex())
+    const item = buildFormationSearchItem(formation({ lieu_formation_geopoint: point(-1.952, 47.3593) }), ctx)
+    expect(item.location?.coordinates).toEqual([-1.4266, 46.6705])
+    expect(item.departement_code).toBe("85")
+    expect(item.region_code).toBe("52")
+    expect(ctx.corrections.formations_recentrees).toBe(1)
+  })
+
+  it("le compteur s'accumule sur le contexte partagé d'un run", () => {
+    const ctx = buildCtx(buildIndex())
+    buildFormationSearchItem(formation({ lieu_formation_geopoint: point(-1.952, 47.3593) }), ctx)
+    buildFormationSearchItem(formation({ lieu_formation_geopoint: point(-1.509, 47.279) }), ctx)
+    buildFormationSearchItem(formation({}), ctx)
+    expect(ctx.corrections.formations_recentrees).toBe(2)
+  })
+})

--- a/server/src/services/search/search-items-formation-location.test.ts
+++ b/server/src/services/search/search-items-formation-location.test.ts
@@ -32,7 +32,7 @@ const buildCtx = (adminCodes: AdminCodeIndex): SearchItemBuildContext => ({
   organizationCaseMap: new Map(),
   sectorCaseMap: new Map(),
   adminCodes,
-  corrections: { formations_recentrees: 0 },
+  corrections: { formations_recentrees: 0, formations_sans_geopoint: 0 },
 })
 
 const formation = (overrides: Partial<IFormationForSearchItem>): IFormationForSearchItem => ({

--- a/server/src/services/search/search-items.service.ts
+++ b/server/src/services/search/search-items.service.ts
@@ -10,8 +10,9 @@ import { logger } from "@/common/logger"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
 import { notifyToSlack } from "@/common/utils/slack-utils"
-
 import { sanitizeTextField, sanitizeToPlainText } from "@/common/utils/string-utils"
+import type { AdminCodeIndex } from "./search-items-admin-codes"
+import { loadAdminCodeIndex, resolveAdminCodes } from "./search-items-admin-codes"
 
 /**
  * Construction et synchronisation des documents `search_items` (index MongoDB Search).
@@ -33,6 +34,7 @@ export const formationProjection: Partial<Record<keyof IFormationCatalogue, 1>> 
   lieu_formation_geopoint: 1,
   lieu_formation_adresse: 1,
   code_postal: 1,
+  code_commune_insee: 1,
   localite: 1,
   etablissement_formateur_entreprise_raison_sociale: 1,
   entierement_a_distance: 1,
@@ -49,6 +51,7 @@ export const jobsProjection: Partial<Record<keyof IJobsPartnersOfferPrivate, 1>>
 
   workplace_legal_name: 1,
   workplace_address_label: 1,
+  workplace_address_zipcode: 1,
   workplace_geopoint: 1,
   workplace_naf_label: 1,
   workplace_siret: 1,
@@ -75,6 +78,7 @@ type ProjectedJobFields =
   | "offer_creation"
   | "workplace_legal_name"
   | "workplace_address_label"
+  | "workplace_address_zipcode"
   | "workplace_geopoint"
   | "workplace_naf_label"
   | "workplace_siret"
@@ -106,6 +110,7 @@ type ProjectedFormationFields =
   | "lieu_formation_geopoint"
   | "lieu_formation_adresse"
   | "code_postal"
+  | "code_commune_insee"
   | "localite"
   | "etablissement_formateur_entreprise_raison_sociale"
   | "entierement_a_distance"
@@ -273,15 +278,17 @@ export type SearchItemBuildContext = {
   romeLabelByCode: Map<string, string>
   organizationCaseMap: Map<string, string>
   sectorCaseMap: Map<string, string>
+  adminCodes: AdminCodeIndex
 }
 
 export const loadSearchItemBuildContext = async (): Promise<SearchItemBuildContext> => {
-  const [romeLabelByCode, organizationCaseMap, sectorCaseMap] = await Promise.all([
+  const [romeLabelByCode, organizationCaseMap, sectorCaseMap, adminCodes] = await Promise.all([
     loadRomeLabelByCode(),
     buildCanonicalCaseMap("organization_name"),
     buildCanonicalCaseMap("activity_sector"),
+    loadAdminCodeIndex(),
   ])
-  return { romeLabelByCode, organizationCaseMap, sectorCaseMap }
+  return { romeLabelByCode, organizationCaseMap, sectorCaseMap, adminCodes }
 }
 
 // buildCanonicalCaseMap = 2 agrégations $group sur TOUTE la collection search_items : trop
@@ -326,6 +333,7 @@ export const buildFormationSearchItem = (formation: IFormationForSearchItem, ctx
     type: "Point",
     coordinates: [formation.lieu_formation_geopoint!.coordinates[0], formation.lieu_formation_geopoint!.coordinates[1]],
   },
+  ...resolveAdminCodes({ insee: formation.code_commune_insee, zipcode: formation.code_postal, geopoint: formation.lieu_formation_geopoint }, ctx.adminCodes),
   organization_name: canonicalizeCase(ctx.organizationCaseMap, formation.etablissement_formateur_entreprise_raison_sociale || ""),
   level: convertFormationNiveauDiplome(formation.niveau || ""),
   activity_sector: null,
@@ -383,6 +391,8 @@ export const buildJobOfferSearchItem = (job: IJobPartnerForSearchItem, ctx: Sear
     type: "Point",
     coordinates: [job.workplace_geopoint.coordinates[0], job.workplace_geopoint.coordinates[1]],
   },
+  // Toujours l'entreprise d'accueil, comme `location` : l'emprise suit le lieu de travail.
+  ...resolveAdminCodes({ zipcode: job.workplace_address_zipcode, geopoint: job.workplace_geopoint }, ctx.adminCodes),
   organization_name: getJobOrganizationName(job, ctx),
   level: job.offer_target_diploma?.label || "",
   activity_sector: job.workplace_naf_label ? canonicalizeCase(ctx.sectorCaseMap, job.workplace_naf_label) : job.workplace_naf_label,
@@ -421,6 +431,7 @@ export const buildRecruteurSearchItem = (job: IJobPartnerForSearchItem, ctx: Sea
       type: "Point",
       coordinates: [job.workplace_geopoint.coordinates[0], job.workplace_geopoint.coordinates[1]],
     },
+    ...resolveAdminCodes({ zipcode: job.workplace_address_zipcode, geopoint: job.workplace_geopoint }, ctx.adminCodes),
     organization_name: organizationName,
     level: job.offer_target_diploma?.label || "",
     activity_sector: job.workplace_naf_label ? canonicalizeCase(ctx.sectorCaseMap, job.workplace_naf_label) : job.workplace_naf_label,

--- a/server/src/services/search/search-items.service.ts
+++ b/server/src/services/search/search-items.service.ts
@@ -2,6 +2,7 @@ import type { ObjectId } from "bson"
 import type { IFormationCatalogue } from "shared"
 import { JOB_STATUS_ENGLISH } from "shared"
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import type { IPointGeometry } from "shared/models/address.model"
 import type { IJobsPartnersOfferPrivate } from "shared/models/jobs-partners.model"
 import { JOBPARTNERS_LABEL } from "shared/models/jobs-partners.model"
 import type { ISearchItem } from "shared/models/search-items.model"
@@ -12,7 +13,7 @@ import { sentryCaptureException } from "@/common/utils/sentry-utils"
 import { notifyToSlack } from "@/common/utils/slack-utils"
 import { sanitizeTextField, sanitizeToPlainText } from "@/common/utils/string-utils"
 import type { AdminCodeIndex } from "./search-items-admin-codes"
-import { loadAdminCodeIndex, resolveAdminCodes } from "./search-items-admin-codes"
+import { loadAdminCodeIndex, resolveAdminCodes, snapGeopointToCommune } from "./search-items-admin-codes"
 
 /**
  * Construction et synchronisation des documents `search_items` (index MongoDB Search).
@@ -279,6 +280,11 @@ export type SearchItemBuildContext = {
   organizationCaseMap: Map<string, string>
   sectorCaseMap: Map<string, string>
   adminCodes: AdminCodeIndex
+  /**
+   * Compteurs des corrections appliquées aux données source pendant le build, à logger par
+   * l'appelant en fin de run : une correction silencieuse serait indiscernable d'une donnée saine.
+   */
+  corrections: { formations_recentrees: number }
 }
 
 export const loadSearchItemBuildContext = async (): Promise<SearchItemBuildContext> => {
@@ -288,7 +294,7 @@ export const loadSearchItemBuildContext = async (): Promise<SearchItemBuildConte
     buildCanonicalCaseMap("activity_sector"),
     loadAdminCodeIndex(),
   ])
-  return { romeLabelByCode, organizationCaseMap, sectorCaseMap, adminCodes }
+  return { romeLabelByCode, organizationCaseMap, sectorCaseMap, adminCodes, corrections: { formations_recentrees: 0 } }
 }
 
 // buildCanonicalCaseMap = 2 agrégations $group sur TOUTE la collection search_items : trop
@@ -310,7 +316,15 @@ export const resetSearchItemBuildContextCache = (): void => {
   ctxCache = null
 }
 
-export const buildFormationSearchItem = (formation: IFormationForSearchItem, ctx: SearchItemBuildContext): ISearchItem => ({
+export const buildFormationSearchItem = (formation: IFormationForSearchItem, ctx: SearchItemBuildContext): ISearchItem => {
+  // Géopoint hors de l'emprise de la commune INSEE → recentré sur la commune (cf. snapGeopointToCommune).
+  const { location, snapped } = snapGeopointToCommune({ insee: formation.code_commune_insee, geopoint: formation.lieu_formation_geopoint }, ctx.adminCodes)
+  if (snapped) ctx.corrections.formations_recentrees++
+  const point = location ?? formation.lieu_formation_geopoint!
+  return buildFormationSearchItemFrom(formation, point, ctx)
+}
+
+const buildFormationSearchItemFrom = (formation: IFormationForSearchItem, point: IPointGeometry, ctx: SearchItemBuildContext): ISearchItem => ({
   _id: formation._id,
   url_id: formation.cle_ministere_educatif,
   type: "formation",
@@ -331,8 +345,10 @@ export const buildFormationSearchItem = (formation: IFormationForSearchItem, ctx
   address: [formation.lieu_formation_adresse, formation.code_postal, formation.localite].filter(Boolean).join(" "),
   location: {
     type: "Point",
-    coordinates: [formation.lieu_formation_geopoint!.coordinates[0], formation.lieu_formation_geopoint!.coordinates[1]],
+    coordinates: [point.coordinates[0], point.coordinates[1]],
   },
+  // Codes dérivés du géopoint SOURCE, pas du point recentré : l'INSEE prime de toute façon, et le
+  // géopoint ne sert qu'à trancher un CP à cheval.
   ...resolveAdminCodes({ insee: formation.code_commune_insee, zipcode: formation.code_postal, geopoint: formation.lieu_formation_geopoint }, ctx.adminCodes),
   organization_name: canonicalizeCase(ctx.organizationCaseMap, formation.etablissement_formateur_entreprise_raison_sociale || ""),
   level: convertFormationNiveauDiplome(formation.niveau || ""),

--- a/server/src/services/search/search-items.service.ts
+++ b/server/src/services/search/search-items.service.ts
@@ -281,10 +281,12 @@ export type SearchItemBuildContext = {
   sectorCaseMap: Map<string, string>
   adminCodes: AdminCodeIndex
   /**
-   * Compteurs des corrections appliquées aux données source pendant le build, à logger par
-   * l'appelant en fin de run : une correction silencieuse serait indiscernable d'une donnée saine.
+   * Compteurs des corrections et renoncements sur les données source pendant le build, à logger
+   * par l'appelant en fin de run : une correction silencieuse serait indiscernable d'une donnée
+   * saine. Ne concernent que les formations, donc seul le nightly (contexte frais) les fait
+   * bouger ; sur le contexte mémoïsé de la sync delta ils restent à zéro.
    */
-  corrections: { formations_recentrees: number }
+  corrections: { formations_recentrees: number; formations_sans_geopoint: number }
 }
 
 export const loadSearchItemBuildContext = async (): Promise<SearchItemBuildContext> => {
@@ -294,7 +296,7 @@ export const loadSearchItemBuildContext = async (): Promise<SearchItemBuildConte
     buildCanonicalCaseMap("activity_sector"),
     loadAdminCodeIndex(),
   ])
-  return { romeLabelByCode, organizationCaseMap, sectorCaseMap, adminCodes, corrections: { formations_recentrees: 0 } }
+  return { romeLabelByCode, organizationCaseMap, sectorCaseMap, adminCodes, corrections: { formations_recentrees: 0, formations_sans_geopoint: 0 } }
 }
 
 // buildCanonicalCaseMap = 2 agrégations $group sur TOUTE la collection search_items : trop

--- a/server/src/services/search/search-query-log.service.ts
+++ b/server/src/services/search/search-query-log.service.ts
@@ -47,6 +47,7 @@ type SearchQuerystring = {
   latitude?: number
   longitude?: number
   radius?: number
+  admin_area?: string
   search_source?: "suggestion" | "free_text" | "training_links" | "external_sites"
   // Alias déprécié (cf. search.routes.ts) : encore envoyé volontairement par l'UI courante
   // (transition anti-version-skew) et par les liens traininglinks émis avant le 2026-08-24.
@@ -89,6 +90,7 @@ export async function logSearchQuery(query: SearchQuerystring, outcome: SearchOu
       has_geo: hasGeo,
       geo: hasGeo ? { lat: roundCoord(query.latitude!), lng: roundCoord(query.longitude!) } : null,
       radius: hasGeo ? (query.radius ?? null) : null,
+      admin_area: query.admin_area ?? null,
       created_at: now,
     })
   } catch (error) {

--- a/server/src/services/search/search.service.ts
+++ b/server/src/services/search/search.service.ts
@@ -1,11 +1,11 @@
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
 import type { ISearchItem } from "shared/models/index"
 import { JOB_START_TYPE } from "shared/models/job.model"
-
+import { parseAdminArea } from "shared/utils/admin-area"
 import { getDistanceInKm } from "@/common/utils/geolib"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
-import { buildAdminAreaClause, parseAdminArea } from "@/services/geo-administrative/admin-area"
+import { buildAdminAreaClause } from "@/services/geo-administrative/admin-area"
 import { retryOnTransientSearchCancellation } from "@/services/search/search-transient-retry"
 
 const HIGHLIGHT_MAX_PASSAGES = 5
@@ -802,7 +802,10 @@ export async function searchItems(params: ISearchFilters): Promise<{
   const nbHits = rows[0]?._meta?.count?.total ?? 0
   const nbPages = Math.ceil(nbHits / hitsPerPage)
 
-  const hasGeo = latitude !== undefined && longitude !== undefined
+  // Pas de distance affichée pour une recherche par emprise : elle serait mesurée depuis le
+  // centroïde de la région ou du département (« 137 km du lieu de recherche » pour « Bretagne »),
+  // vraie et trompeuse. La paire lat/lon reste utilisée par le tri de proximité.
+  const hasGeo = latitude !== undefined && longitude !== undefined && !parseAdminArea(params.admin_area)
 
   const hits: SearchHit[] = rows.map(({ highlights, _meta: _m, ...doc }) => {
     const itemDoc = doc as ISearchItem

--- a/server/src/services/search/search.service.ts
+++ b/server/src/services/search/search.service.ts
@@ -5,6 +5,7 @@ import { JOB_START_TYPE } from "shared/models/job.model"
 import { getDistanceInKm } from "@/common/utils/geolib"
 import { getDbCollection } from "@/common/utils/mongodb-utils"
 import { sentryCaptureException } from "@/common/utils/sentry-utils"
+import { buildAdminAreaClause, parseAdminArea } from "@/services/geo-administrative/admin-area"
 import { retryOnTransientSearchCancellation } from "@/services/search/search-transient-retry"
 
 const HIGHLIGHT_MAX_PASSAGES = 5
@@ -123,6 +124,12 @@ interface ISearchFilters {
   radius: number
   page: number
   hitsPerPage: number
+  /**
+   * Emprise administrative ("region:53", "departement:44") quand la saisie désigne un département
+   * ou une région (cf. ban-plateforme#781). Prioritaire sur latitude/longitude/radius pour le
+   * filtrage ; la paire lat/lon reste utilisée pour le tri par proximité et la distance affichée.
+   */
+  admin_area?: string
 }
 
 interface ISearchFacets {
@@ -405,6 +412,26 @@ function buildTextBonusClauses(q?: string): object[] {
   ]
 }
 
+/**
+ * Restriction géographique de la recherche. L'emprise administrative prime sur le point + rayon :
+ * un département n'est pas un disque, et le rayon qui le couvre ramène 51 à 82 % de résultats
+ * hors périmètre selon l'entité (mesures dans tools/geo-781). Un `admin_area` mal formé est
+ * ignoré plutôt que rejeté : la route l'a déjà validé, et une valeur inconnue du référentiel
+ * donne simplement zéro résultat sur le token.
+ */
+function buildGeoClause(filters: ISearchFilters): object | null {
+  const adminArea = parseAdminArea(filters.admin_area)
+  if (adminArea) return buildAdminAreaClause(adminArea)
+  const { latitude, longitude, radius } = filters
+  if (latitude === undefined || longitude === undefined) return null
+  return {
+    geoWithin: {
+      circle: { center: { type: "Point", coordinates: [longitude, latitude] }, radius: radius * 1000 },
+      path: "location",
+    },
+  }
+}
+
 function buildCompoundOperator(filters: ISearchFilters, simplifyQuery: boolean) {
   const {
     q,
@@ -423,7 +450,6 @@ function buildCompoundOperator(filters: ISearchFilters, simplifyQuery: boolean) 
     sort,
     latitude,
     longitude,
-    radius,
   } = filters
   const hasGeo = latitude !== undefined && longitude !== undefined
   const proximity = sort === "proximity" && hasGeo
@@ -448,14 +474,8 @@ function buildCompoundOperator(filters: ISearchFilters, simplifyQuery: boolean) 
   // Type d'offres d'emploi : true = entreprises à contacter (candidatures spontanées de
   // l'algo), false = offres d'emploi. Absent = les deux (aucun filtre).
   if (is_algo_company !== undefined) filter.push({ equals: { path: "is_algo_company", value: is_algo_company } })
-  if (hasGeo) {
-    filter.push({
-      geoWithin: {
-        circle: { center: { type: "Point", coordinates: [longitude, latitude] }, radius: radius * 1000 },
-        path: "location",
-      },
-    })
-  }
+  const geoClause = buildGeoClause(filters)
+  if (geoClause) filter.push(geoClause)
 
   // Tri par date : on écarte les docs sans vraie date de publication (formations à
   // publication_date null — un range ne matche que les valeurs date indexées, contrairement à
@@ -568,11 +588,7 @@ function buildFacetCompound(filters: ISearchFilters, exclude: FacetDimension | n
     start_date,
     smart_apply,
     is_algo_company,
-    latitude,
-    longitude,
-    radius,
   } = filters
-  const hasGeo = latitude !== undefined && longitude !== undefined
   // Même porte de pertinence que la recherche → les counts de facettes reflètent le même result set.
   const gate = buildTextGate(q, simplifyQuery)
   const filter: object[] = []
@@ -590,7 +606,8 @@ function buildFacetCompound(filters: ISearchFilters, exclude: FacetDimension | n
   if (start_date) filter.push(buildStartDateFilter(start_date))
   if (smart_apply) filter.push({ equals: { path: "smart_apply", value: true } })
   if (is_algo_company !== undefined) filter.push({ equals: { path: "is_algo_company", value: is_algo_company } })
-  if (hasGeo) filter.push({ geoWithin: { circle: { center: { type: "Point", coordinates: [longitude, latitude] }, radius: radius * 1000 }, path: "location" } })
+  const geoClause = buildGeoClause(filters)
+  if (geoClause) filter.push(geoClause)
 
   // Mêmes restrictions qu'en recherche pour les tris → les counts de facettes reflètent le result set réel.
   if (filters.sort === "date") {

--- a/shared/src/fixtures/search-items.fixture.ts
+++ b/shared/src/fixtures/search-items.fixture.ts
@@ -23,6 +23,9 @@ export function generateSearchItemFixture(data: Partial<ISearchItem> = {}): ISea
     description: "Nous recherchons un développeur web en alternance pour rejoindre notre équipe.",
     address: "126 Rue de l'Université, 75007 Paris",
     location: { type: "Point", coordinates: [2.3522, 48.8566] },
+    // Cohérent avec l'adresse et le géopoint : Paris, Île-de-France.
+    departement_code: "75",
+    region_code: "11",
     organization_name: "Entreprise Test",
     level: "6",
     activity_sector: "Informatique",

--- a/shared/src/models/search-items.model.ts
+++ b/shared/src/models/search-items.model.ts
@@ -37,8 +37,13 @@ export const ZSearchItem = z.object({
   // Emprise administrative dérivée à la construction (référentiel communes) : permet un filtre
   // exact par département ou région, là où point + rayon ramène 51 à 82 % de hors-périmètre
   // (cf. ban-plateforme#781). null quand la commune de l'item n'est pas résolue.
-  departement_code: z.string().nullable().describe("Code INSEE du département du lieu (01…95, 2A, 2B, 971…976)"),
-  region_code: z.string().nullable().describe("Code INSEE de la région du lieu"),
+  // Optionnels, pas seulement nullables : le validateur de collection est `strict` et refuse
+  // l'écriture hors production. Requis, ils faisaient échouer toute mise à jour partielle d'un
+  // item indexé avant le backfill (cron keywords, anciennes migrations rejouées sur une base
+  // fraîche : déploiement preview de la PR 5461 tombé sur sanitize-offer-titles). Les builders
+  // les posent toujours ; un `equals` sur un champ absent ne matche simplement rien.
+  departement_code: z.string().nullable().optional().describe("Code INSEE du département du lieu (01…95, 2A, 2B, 971…976) ; absent sur un item indexé avant le backfill"),
+  region_code: z.string().nullable().optional().describe("Code INSEE de la région du lieu ; absent sur un item indexé avant le backfill"),
   organization_name: z.string().describe("Nom de l'entreprise"),
   level: z.string().nullable().describe("Niveau de diplôme visé"),
   activity_sector: z.string().nullable().describe("Secteur d'activité"),

--- a/shared/src/models/search-items.model.ts
+++ b/shared/src/models/search-items.model.ts
@@ -34,6 +34,11 @@ export const ZSearchItem = z.object({
   description: z.string().describe("Description de l'offre"),
   address: z.string().describe("Adresse complète"),
   location: ZSearchItemLocation.optional().describe("GeoJSON Point pour MongoDB Search"),
+  // Emprise administrative dérivée à la construction (référentiel communes) : permet un filtre
+  // exact par département ou région, là où point + rayon ramène 51 à 82 % de hors-périmètre
+  // (cf. ban-plateforme#781). null quand la commune de l'item n'est pas résolue.
+  departement_code: z.string().nullable().describe("Code INSEE du département du lieu (01…95, 2A, 2B, 971…976)"),
+  region_code: z.string().nullable().describe("Code INSEE de la région du lieu"),
   organization_name: z.string().describe("Nom de l'entreprise"),
   level: z.string().nullable().describe("Niveau de diplôme visé"),
   activity_sector: z.string().nullable().describe("Secteur d'activité"),
@@ -86,6 +91,8 @@ export default {
             is_algo_company: { type: "boolean" },
             is_formation_included: { type: "boolean" },
             location: { type: "geo" },
+            departement_code: { type: "token" },
+            region_code: { type: "token" },
           },
         },
         analyzers: [

--- a/shared/src/models/search-queries.model.ts
+++ b/shared/src/models/search-queries.model.ts
@@ -42,6 +42,7 @@ export const ZSearchQuery = z.object({
   has_geo: z.boolean(),
   geo: z.object({ lat: z.number(), lng: z.number() }).nullable().describe("Position arrondie à 1 décimale (~11 km)"),
   radius: z.number().nullable(),
+  admin_area: z.string().nullable().describe("Emprise administrative demandée (region:53, departement:44), null pour une recherche par point + rayon ou sans lieu"),
   created_at: z.date(),
 })
 

--- a/shared/src/routes/search.routes.ts
+++ b/shared/src/routes/search.routes.ts
@@ -62,6 +62,13 @@ export const zSearchRoutes = {
         latitude: ZLatitudeParam.pipe(z.number().min(-90).max(90).optional()),
         longitude: ZLongitudeParam.pipe(z.number().min(-180).max(180).optional()),
         radius: ZRadiusParam.pipe(z.number().min(0).max(200).optional()).default(30),
+        admin_area: z
+          .string()
+          .regex(/^(region|departement):([0-9]{1,3}|2[AB])$/)
+          .optional()
+          .describe(
+            "Emprise administrative exacte (region:53, departement:44). Prioritaire sur latitude/longitude/radius pour le filtrage ; le tri par proximité garde la paire lat/lon si fournie."
+          ),
         page: z.coerce.number<number>().min(0).default(0).describe("Index de page (0-based)"),
         hitsPerPage: z.coerce.number<number>().min(1).max(100).default(20).describe("Nombre de résultats par page (max 100)"),
         search_source: z

--- a/shared/src/routes/search.routes.ts
+++ b/shared/src/routes/search.routes.ts
@@ -1,6 +1,7 @@
 import { z } from "../helpers/zod-with-open-api.js"
 import { JOB_START_TYPE } from "../models/job.model.js"
 import { ZSearchItem } from "../models/search-items.model.js"
+import { ADMIN_AREA_PATTERN } from "../utils/admin-area.js"
 import type { IRoutesDef } from "./common.routes.js"
 import { ZLatitudeParam, ZLongitudeParam, ZRadiusParam } from "./params.js"
 
@@ -64,7 +65,7 @@ export const zSearchRoutes = {
         radius: ZRadiusParam.pipe(z.number().min(0).max(200).optional()).default(30),
         admin_area: z
           .string()
-          .regex(/^(region|departement):([0-9]{1,3}|2[AB])$/)
+          .regex(ADMIN_AREA_PATTERN)
           .optional()
           .describe(
             "Emprise administrative exacte (region:53, departement:44). Prioritaire sur latitude/longitude/radius pour le filtrage ; le tri par proximité garde la paire lat/lon si fournie."

--- a/shared/src/utils/admin-area.test.ts
+++ b/shared/src/utils/admin-area.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { parseAdminArea } from "./admin-area.js"
+
+describe("parseAdminArea", () => {
+  // Les cas qui doivent répondre "non" d'abord : c'est une saisie qui arrive de l'URL.
+  it.each([
+    ["chaîne vide", ""],
+    ["valeur absente", undefined],
+    ["maille inconnue", "epci:244400404"],
+    ["sans code", "region:"],
+    ["sans maille", ":53"],
+    ["code trop long", "departement:44000"],
+    ["code non administratif", "departement:nantes"],
+    ["segment en trop", "region:53:extra"],
+    ["corse en minuscules", "departement:2a"],
+    ["injection", "region:53; drop"],
+  ])("rejette %s", (_, value) => {
+    expect(parseAdminArea(value)).toBeNull()
+  })
+
+  it("accepte les deux mailles", () => {
+    expect(parseAdminArea("region:53")).toEqual({ kind: "region", code: "53" })
+    expect(parseAdminArea("departement:44")).toEqual({ kind: "departement", code: "44" })
+  })
+
+  it("accepte la Corse et les DROM", () => {
+    expect(parseAdminArea("departement:2A")).toEqual({ kind: "departement", code: "2A" })
+    expect(parseAdminArea("departement:2B")).toEqual({ kind: "departement", code: "2B" })
+    expect(parseAdminArea("departement:974")).toEqual({ kind: "departement", code: "974" })
+    expect(parseAdminArea("region:04")).toEqual({ kind: "region", code: "04" })
+  })
+})

--- a/shared/src/utils/admin-area.test.ts
+++ b/shared/src/utils/admin-area.test.ts
@@ -15,6 +15,13 @@ describe("parseAdminArea", () => {
     ["segment en trop", "region:53:extra"],
     ["corse en minuscules", "departement:2a"],
     ["injection", "region:53; drop"],
+    ["département à un chiffre", "departement:2"],
+    ["département 00", "departement:00"],
+    ["département 96", "departement:96"],
+    ["Saint-Barthélemy, collectivité", "departement:977"],
+    ["Saint-Pierre-et-Miquelon, collectivité", "departement:975"],
+    ["région inexistante", "region:12"],
+    ["région 999", "region:999"],
   ])("rejette %s", (_, value) => {
     expect(parseAdminArea(value)).toBeNull()
   })
@@ -29,5 +36,12 @@ describe("parseAdminArea", () => {
     expect(parseAdminArea("departement:2B")).toEqual({ kind: "departement", code: "2B" })
     expect(parseAdminArea("departement:974")).toEqual({ kind: "departement", code: "974" })
     expect(parseAdminArea("region:04")).toEqual({ kind: "region", code: "04" })
+  })
+
+  it("accepte les bornes des séries : 01, 19, 21, 95, 971, 976, et les 18 régions", () => {
+    for (const code of ["01", "19", "21", "95", "971", "976"]) expect(parseAdminArea(`departement:${code}`)?.code).toBe(code)
+    for (const code of ["01", "02", "03", "04", "06", "11", "24", "27", "28", "32", "44", "52", "53", "75", "76", "84", "93", "94"]) {
+      expect(parseAdminArea(`region:${code}`)?.code, code).toBe(code)
+    }
   })
 })

--- a/shared/src/utils/admin-area.ts
+++ b/shared/src/utils/admin-area.ts
@@ -9,13 +9,22 @@ export type IAdminArea = {
   code: string
 }
 
-/** Codes INSEE : départements 01…95, 2A, 2B, 971…976 ; régions 01…94. */
-export const ADMIN_AREA_PATTERN = /^(region|departement):([0-9]{1,3}|2[AB])$/
+/**
+ * Codes INSEE réels, pas une forme approchée : une faute de frappe dans l'URL (`departement:2`,
+ * `region:999`) doit être ignorée côté page et refusée côté API, plutôt que de produire une
+ * recherche à zéro résultat sans explication.
+ * Départements : 01…19, 2A, 2B, 21…95, 971, 972, 973, 974, 976 (975 est une collectivité). Régions (découpage 2016) : 01…06 outre-mer,
+ * 11, 24, 27, 28, 32, 44, 52, 53, 75, 76, 84, 93, 94.
+ */
+export const ADMIN_AREA_PATTERN = /^(?:(departement):(0[1-9]|1[0-9]|2[AB1-9]|[3-8][0-9]|9[0-5]|97[1-46])|(region):(0[1-6]|11|24|27|28|32|44|52|53|75|76|84|93|94))$/
 
 /** Renvoie null sur toute autre forme, jamais d'exception : la valeur arrive de l'URL. */
 export const parseAdminArea = (value: string | undefined | null): IAdminArea | null => {
   if (!value) return null
   const match = ADMIN_AREA_PATTERN.exec(value)
   if (!match) return null
-  return { kind: match[1] as IAdminArea["kind"], code: match[2] }
+  // Deux alternatives dans la regex : les groupes de l'une sont vides quand l'autre matche.
+  const kind = (match[1] ?? match[3]) as IAdminArea["kind"]
+  const code = match[2] ?? match[4]
+  return { kind, code }
 }

--- a/shared/src/utils/admin-area.ts
+++ b/shared/src/utils/admin-area.ts
@@ -1,0 +1,21 @@
+/**
+ * Emprise administrative d'une recherche : `"region:53"` ou `"departement:44"`.
+ * Une seule définition pour la route, le moteur et l'URL de la page de résultats
+ * (cf. ban-plateforme#781).
+ */
+
+export type IAdminArea = {
+  kind: "region" | "departement"
+  code: string
+}
+
+/** Codes INSEE : départements 01…95, 2A, 2B, 971…976 ; régions 01…94. */
+export const ADMIN_AREA_PATTERN = /^(region|departement):([0-9]{1,3}|2[AB])$/
+
+/** Renvoie null sur toute autre forme, jamais d'exception : la valeur arrive de l'URL. */
+export const parseAdminArea = (value: string | undefined | null): IAdminArea | null => {
+  if (!value) return null
+  const match = ADMIN_AREA_PATTERN.exec(value)
+  if (!match) return null
+  return { kind: match[1] as IAdminArea["kind"], code: match[2] }
+}

--- a/tools/geo-781/README.md
+++ b/tools/geo-781/README.md
@@ -133,15 +133,19 @@ serveur n'en dépend plus depuis que le code est indexé.
   transmis jusqu'à l'URL (`admin_area`) puis à l'API. L'élargissement automatique du rayon est
   désactivé quand une emprise est posée.
 
-## Déployer dans le bon ordre
+## Déployer
 
-1. Déployer : `updateSearchIndex` est appliqué au démarrage, mongot reconstruit l'index en
-   arrière-plan. Vérifier `status: READY` avec `[{ $listSearchIndexes: {} }]` (cf. compass.md).
-2. Peupler les codes : `yarn cli fillSearchItemsCollection` (ou attendre le nightly de 6 h).
-   Le job réécrit aussi les items déjà présents : les nouveaux champs sont dans son bloc de
-   backfill. Tant que ce n'est pas fait, `equals` renvoie zéro résultat en silence.
-3. Vérifier la part de `departement_code: null` par type (compass.md, section après déploiement).
-4. Mesurer : `node tools/geo-781/bench.mjs "Nord"`, la ligne 4-code doit être à 0 % hors périmètre.
+La migration `20260911180000-backfill-search-items-admin-codes` fait les deux gestes qui suivent le
+déploiement : mise à jour de la définition de l'index Atlas Search (`updateSearchIndex`, mongot
+reconstruit en arrière-plan) et mise en file de `fillSearchItemsCollection` pour peupler
+`departement_code` / `region_code` sur tous les items. Tant que ces deux étapes ne sont pas
+terminées, un `equals` renvoie zéro résultat en silence.
+
+À vérifier après la MEP, dans Compass sur `search_items` (pipelines dans compass.md) :
+
+1. `search_items_index_status` : `status: READY`, `queryable: true`, `a_les_nouveaux_champs: true`.
+2. `search_items_resolution_post_deploiement` : `champ_absent: 0` par type, une fois le job terminé.
+3. `node tools/geo-781/bench.mjs "Nord"` : la ligne 4-code à 0 % hors périmètre.
 
 ## Limites connues
 
@@ -150,8 +154,6 @@ serveur n'en dépend plus depuis que le code est indexé.
 - Quatre entités dépassent le plafond de 200 km de l'API v3 : Nouvelle-Aquitaine (261 km),
   Occitanie (228), Auvergne-Rhône-Alpes (213), Guyane (244). C'est la raison pour laquelle le
   rayon ne pouvait pas être la solution générale.
-- `search_queries` (log des requêtes) n'enregistre pas encore `admin_area` : la télémétrie ne
-  distingue pas une recherche par département d'une recherche sans lieu.
 - Les items dont la commune n'est pas résolue (CP inconnu du référentiel, CP à cheval sans
   géopoint) ont `departement_code: null` et sortent du filtre par emprise. Ils restent trouvables
   par point + rayon. La part exacte est à relever en production (compass.md).

--- a/tools/geo-781/README.md
+++ b/tools/geo-781/README.md
@@ -1,0 +1,157 @@
+# Emprise administrative : banc d'essai des 3 solutions
+
+Contexte : issue [BaseAdresseNationale/ban-plateforme#781](https://github.com/BaseAdresseNationale/ban-plateforme/issues/781).
+
+Une saisie « Bretagne » ou « dans le Nord » doit restreindre la recherche à une région ou un
+département. Le géocodeur Géoplateforme sait résoudre la saisie (index `poi`, `category=région`,
+code renvoyé dans `citycode`), mais ne renvoie pas d'emprise : un centroïde, ou le contour complet
+via `returntruegeometry` (46 Ko pour un département, 416 Ko pour la Bretagne).
+
+Ce dossier sert à mesurer ce que chaque stratégie ramène vraiment. Il est jetable : rien ici
+n'est importé par le serveur ni par l'UI.
+
+## Les stratégies comparées
+
+| | Stratégie | Emprise | Coût à la requête | Dans l'application |
+|---|---|---|---|---|
+| 1 | rayon (avant) | 51 à 82 % de bruit | faible | remplacé quand `admin_area` est posé |
+| 2 | bbox précalculée | 42 à 70 % de bruit | faible | non, banc seulement |
+| 3 | contour officiel | exacte | 46 à 416 Ko de géométrie par requête | non, banc seulement |
+| 4 | code indexé (retenu) | exacte | `equals` sur un `token`, le moins cher possible | oui |
+
+La 4 est la solution retenue : `departement_code` et `region_code` sont dérivés à la construction
+des items (`server/src/services/search/search-items-admin-codes.ts`) depuis le référentiel
+`referentiel.communes`, et indexés en `token`. À la requête, `admin_area=departement:44` devient
+`{ equals: { path: "departement_code", value: "44" } }`. Aucune géométrie, aucun appel réseau.
+
+Dérivation, du plus sûr au moins sûr (chiffres de production du 2026-09-11 dans compass.md) :
+
+1. code INSEE de la commune (formations, 92,7 %) ; les arrondissements de Paris, Lyon et
+   Marseille sont ramenés à leur commune, le référentiel ne les connaît pas ;
+2. code postal connu du référentiel (offres, 99,4 %) ; un CP à cheval sur deux départements
+   (16 CP, 402 offres) est tranché par la commune du CP la plus proche du géopoint ;
+3. CP inconnu du référentiel mais de forme départementale (CEDEX, 75000, 13000) : département
+   lu dans le code, Corse exclue (2A/2B), Saint-Martin et Saint-Barthélemy exclus (préfixe 971) ;
+4. géopoint seul (1 185 offres sans CP) : commune dont la bbox contient le point, la plus proche
+   en cas de recouvrement. Hors de toute bbox, `null`.
+
+Attendu après déploiement : moins de 0,05 % d'items à `null`, essentiellement Saint-Martin,
+Saint-Barthélemy et Saint-Pierre-et-Miquelon, qui ne sont pas des départements.
+
+## Tester en local
+
+Prérequis : services démarrés (`yarn services:start` lance mongodb + mongot), `server/.env`
+généré par `yarn setup` (il porte `LBA_MONGODB_URI`), une base locale avec des `jobs_partners`
+et des `formationcatalogues`.
+
+`yarn cli` exécute `server/dist` : rebuild `shared` et `server` d'abord, sinon la CLI tourne sur
+l'ancien code sans les nouveaux champs.
+
+```bash
+yarn workspace shared build && yarn workspace server build
+
+# 1. Référentiel communes (~35 000 communes, une trentaine de secondes ; inutile s'il est déjà là)
+yarn cli referentiel:commune:import
+
+# 2. Index Atlas Search : applique la nouvelle définition (updateSearchIndex, idempotent),
+#    mongot reconstruit en arrière-plan
+yarn cli indexes:recreate
+
+# 3. Peuple departement_code / region_code sur tous les items, existants compris
+yarn cli fillSearchItemsCollection
+
+# 4. Attendre status READY avant de chercher. La variable n'est pas exportée dans le shell :
+#    on la lit dans server/.env (la commande tourne dans le conteneur, localhost y est le bon hôte)
+docker compose exec -T mongodb mongosh "$(grep -m1 '^LBA_MONGODB_URI=' server/.env | cut -d= -f2- | tr -d '"')" --quiet --eval \
+  'db.search_items.aggregate([{ $listSearchIndexes: {} }]).forEach(i => print(i.name, i.status, i.queryable))'
+```
+
+Puis `yarn dev`, et dans la barre de recherche taper « Bretagne » ou « Nord » : la région ou le
+département remonte en tête des suggestions, l'URL porte `admin_area=region:53`, et l'API reçoit
+le filtre. Sans sélection d'une entité administrative, rien ne change.
+
+Vérifier directement l'API :
+
+```bash
+curl -s "http://localhost:5001/api/v1/search?admin_area=departement:44&hitsPerPage=3" | jq '.nbHits, [.hits[].address]'
+curl -s "http://localhost:5001/api/v1/search?admin_area=region:53&mode=formations&hitsPerPage=3" | jq '.nbHits, [.hits[].address]'
+```
+
+`nbHits: 0` alors que la base a des offres dans le 44 : soit l'index n'est pas `READY` (étape 4),
+soit les codes ne sont pas peuplés (étape 3), à distinguer avec `search_items_resolution_post_deploiement`
+dans compass.md.
+
+## Mesurer
+
+```bash
+node tools/geo-781/bench.mjs "Bretagne"
+```
+
+Sans base : compare les emprises entre elles (aires, rayon nécessaire, dépassement du plafond
+de 200 km de l'API v3).
+
+```bash
+export LBA_MONGODB_URI="$(grep -m1 '^LBA_MONGODB_URI=' server/.env | cut -d= -f2- | tr -d '"')"
+node tools/geo-781/bench.mjs "Nord" --limit 5000 --diff
+```
+
+`--diff` liste les items dans le contour sans le code attendu, et ceux qui ont le code mais un
+géopoint hors du contour : c'est là qu'on lit si un écart vient de la source (CP et géopoint qui
+se contredisent) ou du résolveur.
+
+Avec base : exécute les quatre requêtes `$search` sur `search_items` et compte ce que chacune
+ramène. La vérité terrain est l'appartenance au contour officiel vérifiée point par point,
+pas la stratégie elle-même. Sortie : ramenés, dans le périmètre, hors périmètre, rappel, temps.
+La ligne `4-code` doit être à 0 % hors périmètre et 100 % de rappel face à `3-contour`.
+
+Saisies intéressantes : `Nord` et `Somme` (homonymie commune/département), `Bretagne` (région
+très concave, la bbox y est mauvaise), `Nouvelle-Aquitaine` (261 km, au-dessus du plafond),
+`Corse-du-Sud`, `La Réunion`.
+
+## Régénérer les bbox du banc
+
+```bash
+node tools/geo-781/build-bbox.mjs > tools/geo-781/admin-areas-bbox.json
+```
+
+119 entités, ~40 secondes, 25 Ko. Le script sort en code 1 si une entité manque ou si le code
+renvoyé ne correspond pas à celui attendu. Ce fichier ne sert qu'au banc (stratégie 2) ; le
+serveur n'en dépend plus depuis que le code est indexé.
+
+## Ce qui est branché dans l'application
+
+- `shared/src/models/search-items.model.ts` : `departement_code`, `region_code`, indexés `token`.
+- `server/src/services/search/search-items-admin-codes.ts` : chargement du référentiel et
+  résolution INSEE → CP → géopoint. Testé sur les cas ambigus en premier.
+- `server/src/services/search/search-items.service.ts` : les trois builders posent les codes ;
+  projections étendues à `code_commune_insee` et `workplace_address_zipcode`.
+- `server/src/services/geo-administrative/admin-area.ts` : parsing de `admin_area` et clause `equals`.
+- `search.service.ts` : `buildGeoClause` unique pour la recherche et les facettes ; `admin_area`
+  prime sur le cercle.
+- `shared/src/routes/search.routes.ts` : paramètre `admin_area` validé par regex.
+- UI : `searchAddress(…, withAdminAreas)` ajoute l'index `poi` ; la suggestion porte `adminArea`,
+  transmis jusqu'à l'URL (`admin_area`) puis à l'API. L'élargissement automatique du rayon est
+  désactivé quand une emprise est posée.
+
+## Déployer dans le bon ordre
+
+1. Déployer : `updateSearchIndex` est appliqué au démarrage, mongot reconstruit l'index en
+   arrière-plan. Vérifier `status: READY` avec `[{ $listSearchIndexes: {} }]` (cf. compass.md).
+2. Peupler les codes : `yarn cli fillSearchItemsCollection` (ou attendre le nightly de 6 h).
+   Le job réécrit aussi les items déjà présents : les nouveaux champs sont dans son bloc de
+   backfill. Tant que ce n'est pas fait, `equals` renvoie zéro résultat en silence.
+3. Vérifier la part de `departement_code: null` par type (compass.md, section après déploiement).
+4. Mesurer : `node tools/geo-781/bench.mjs "Nord"`, la ligne 4-code doit être à 0 % hors périmètre.
+
+## Limites connues
+
+- Les tests de pertinence du moteur sont conditionnés à `SEARCH_RELEVANCE_TESTS=true` et à une
+  base peuplée : la non-régression du filtre géo n'est pas couverte automatiquement.
+- Quatre entités dépassent le plafond de 200 km de l'API v3 : Nouvelle-Aquitaine (261 km),
+  Occitanie (228), Auvergne-Rhône-Alpes (213), Guyane (244). C'est la raison pour laquelle le
+  rayon ne pouvait pas être la solution générale.
+- `search_queries` (log des requêtes) n'enregistre pas encore `admin_area` : la télémétrie ne
+  distingue pas une recherche par département d'une recherche sans lieu.
+- Les items dont la commune n'est pas résolue (CP inconnu du référentiel, CP à cheval sans
+  géopoint) ont `departement_code: null` et sortent du filtre par emprise. Ils restent trouvables
+  par point + rayon. La part exacte est à relever en production (compass.md).

--- a/tools/geo-781/admin-areas-bbox.json
+++ b/tools/geo-781/admin-areas-bbox.json
@@ -1,0 +1,1434 @@
+{
+  "generated_at": "2026-09-11T14:21:00.556Z",
+  "source": "data.geopf.fr geocodage/search returntruegeometry",
+  "areas": [
+    {
+      "kind": "region",
+      "code": "11",
+      "label": "Île-de-France",
+      "bbox": [
+        1.4463,
+        48.12008,
+        3.55903,
+        49.24149
+      ],
+      "covering_radius_km": 88
+    },
+    {
+      "kind": "region",
+      "code": "24",
+      "label": "Centre-Val de Loire",
+      "bbox": [
+        0.05274,
+        46.3469,
+        3.1286,
+        48.94103
+      ],
+      "covering_radius_km": 146
+    },
+    {
+      "kind": "region",
+      "code": "27",
+      "label": "Bourgogne-Franche-Comté",
+      "bbox": [
+        2.8449,
+        46.15607,
+        7.14336,
+        48.40005
+      ],
+      "covering_radius_km": 189
+    },
+    {
+      "kind": "region",
+      "code": "28",
+      "label": "Normandie",
+      "bbox": [
+        -1.95497,
+        48.17989,
+        1.80286,
+        50.0722
+      ],
+      "covering_radius_km": 154
+    },
+    {
+      "kind": "region",
+      "code": "32",
+      "label": "Hauts-de-France",
+      "bbox": [
+        1.38022,
+        48.83721,
+        4.25584,
+        51.08915
+      ],
+      "covering_radius_km": 134
+    },
+    {
+      "kind": "region",
+      "code": "44",
+      "label": "Grand Est",
+      "bbox": [
+        3.38367,
+        47.42034,
+        8.2325,
+        50.1693
+      ],
+      "covering_radius_km": 192
+    },
+    {
+      "kind": "region",
+      "code": "52",
+      "label": "Pays de la Loire",
+      "bbox": [
+        -2.62547,
+        46.26662,
+        0.91665,
+        48.56799
+      ],
+      "covering_radius_km": 155
+    },
+    {
+      "kind": "region",
+      "code": "53",
+      "label": "Bretagne",
+      "bbox": [
+        -5.14116,
+        47.27789,
+        -1.01561,
+        48.9008
+      ],
+      "covering_radius_km": 158
+    },
+    {
+      "kind": "region",
+      "code": "75",
+      "label": "Nouvelle-Aquitaine",
+      "bbox": [
+        -1.79235,
+        42.77786,
+        2.61129,
+        47.17599
+      ],
+      "covering_radius_km": 261
+    },
+    {
+      "kind": "region",
+      "code": "76",
+      "label": "Occitanie",
+      "bbox": [
+        -0.32718,
+        42.33292,
+        4.84557,
+        45.04663
+      ],
+      "covering_radius_km": 228
+    },
+    {
+      "kind": "region",
+      "code": "84",
+      "label": "Auvergne-Rhône-Alpes",
+      "bbox": [
+        2.06288,
+        44.11549,
+        7.18557,
+        46.80429
+      ],
+      "covering_radius_km": 213
+    },
+    {
+      "kind": "region",
+      "code": "93",
+      "label": "Provence-Alpes-Côte d'Azur",
+      "bbox": [
+        4.23022,
+        42.98203,
+        7.71898,
+        45.12684
+      ],
+      "covering_radius_km": 155
+    },
+    {
+      "kind": "region",
+      "code": "94",
+      "label": "Corse",
+      "bbox": [
+        8.53494,
+        41.33364,
+        9.55997,
+        43.02763
+      ],
+      "covering_radius_km": 99
+    },
+    {
+      "kind": "region",
+      "code": "01",
+      "label": "Guadeloupe",
+      "bbox": [
+        -61.8098,
+        15.83202,
+        -61.00203,
+        16.51449
+      ],
+      "covering_radius_km": 47
+    },
+    {
+      "kind": "region",
+      "code": "02",
+      "label": "Martinique",
+      "bbox": [
+        -61.22904,
+        14.38868,
+        -60.80965,
+        14.87872
+      ],
+      "covering_radius_km": 32
+    },
+    {
+      "kind": "region",
+      "code": "03",
+      "label": "Guyane",
+      "bbox": [
+        -54.60242,
+        2.11132,
+        -51.61907,
+        5.74868
+      ],
+      "covering_radius_km": 244
+    },
+    {
+      "kind": "region",
+      "code": "04",
+      "label": "La Réunion",
+      "bbox": [
+        55.21655,
+        -21.38963,
+        55.83663,
+        -20.87188
+      ],
+      "covering_radius_km": 37
+    },
+    {
+      "kind": "region",
+      "code": "06",
+      "label": "Mayotte",
+      "bbox": [
+        45.01848,
+        -13.00542,
+        45.29999,
+        -12.63659
+      ],
+      "covering_radius_km": 25
+    },
+    {
+      "kind": "departement",
+      "code": "01",
+      "label": "Ain",
+      "bbox": [
+        4.72813,
+        45.61122,
+        6.17003,
+        46.5199
+      ],
+      "covering_radius_km": 65
+    },
+    {
+      "kind": "departement",
+      "code": "02",
+      "label": "Aisne",
+      "bbox": [
+        2.95804,
+        48.83721,
+        4.25584,
+        50.0695
+      ],
+      "covering_radius_km": 72
+    },
+    {
+      "kind": "departement",
+      "code": "03",
+      "label": "Allier",
+      "bbox": [
+        2.27679,
+        45.93073,
+        4.00574,
+        46.80429
+      ],
+      "covering_radius_km": 67
+    },
+    {
+      "kind": "departement",
+      "code": "04",
+      "label": "Alpes-de-Haute-Provence",
+      "bbox": [
+        5.4968,
+        43.66833,
+        6.96916,
+        44.65999
+      ],
+      "covering_radius_km": 79
+    },
+    {
+      "kind": "departement",
+      "code": "05",
+      "label": "Hautes-Alpes",
+      "bbox": [
+        5.41836,
+        44.18649,
+        7.07711,
+        45.12684
+      ],
+      "covering_radius_km": 72
+    },
+    {
+      "kind": "departement",
+      "code": "06",
+      "label": "Alpes-Maritimes",
+      "bbox": [
+        6.63547,
+        43.48031,
+        7.71898,
+        44.36129
+      ],
+      "covering_radius_km": 54
+    },
+    {
+      "kind": "departement",
+      "code": "07",
+      "label": "Ardèche",
+      "bbox": [
+        3.8611,
+        44.26434,
+        4.88629,
+        45.36611
+      ],
+      "covering_radius_km": 68
+    },
+    {
+      "kind": "departement",
+      "code": "08",
+      "label": "Ardennes",
+      "bbox": [
+        4.02449,
+        49.22696,
+        5.39425,
+        50.1693
+      ],
+      "covering_radius_km": 58
+    },
+    {
+      "kind": "departement",
+      "code": "09",
+      "label": "Ariège",
+      "bbox": [
+        0.826,
+        42.57147,
+        2.17586,
+        43.31598
+      ],
+      "covering_radius_km": 63
+    },
+    {
+      "kind": "departement",
+      "code": "10",
+      "label": "Aube",
+      "bbox": [
+        3.38367,
+        47.92368,
+        4.86461,
+        48.71672
+      ],
+      "covering_radius_km": 58
+    },
+    {
+      "kind": "departement",
+      "code": "11",
+      "label": "Aude",
+      "bbox": [
+        1.68843,
+        42.6489,
+        3.24016,
+        43.46005
+      ],
+      "covering_radius_km": 68
+    },
+    {
+      "kind": "departement",
+      "code": "12",
+      "label": "Aveyron",
+      "bbox": [
+        1.83977,
+        43.69061,
+        3.45176,
+        44.94144
+      ],
+      "covering_radius_km": 77
+    },
+    {
+      "kind": "departement",
+      "code": "13",
+      "label": "Bouches-du-Rhône",
+      "bbox": [
+        4.23022,
+        43.1574,
+        5.81343,
+        43.92413
+      ],
+      "covering_radius_km": 67
+    },
+    {
+      "kind": "departement",
+      "code": "14",
+      "label": "Calvados",
+      "bbox": [
+        -1.15961,
+        48.75169,
+        0.44649,
+        49.42991
+      ],
+      "covering_radius_km": 66
+    },
+    {
+      "kind": "departement",
+      "code": "15",
+      "label": "Cantal",
+      "bbox": [
+        2.06288,
+        44.61577,
+        3.37126,
+        45.48347
+      ],
+      "covering_radius_km": 63
+    },
+    {
+      "kind": "departement",
+      "code": "16",
+      "label": "Charente",
+      "bbox": [
+        -0.46316,
+        45.19167,
+        0.94711,
+        46.14085
+      ],
+      "covering_radius_km": 69
+    },
+    {
+      "kind": "departement",
+      "code": "17",
+      "label": "Charente-Maritime",
+      "bbox": [
+        -1.56246,
+        45.08874,
+        0.00593,
+        46.37142
+      ],
+      "covering_radius_km": 91
+    },
+    {
+      "kind": "departement",
+      "code": "18",
+      "label": "Cher",
+      "bbox": [
+        1.77367,
+        46.42069,
+        3.07962,
+        47.62911
+      ],
+      "covering_radius_km": 70
+    },
+    {
+      "kind": "departement",
+      "code": "19",
+      "label": "Corrèze",
+      "bbox": [
+        1.22649,
+        44.92028,
+        2.52872,
+        45.76527
+      ],
+      "covering_radius_km": 65
+    },
+    {
+      "kind": "departement",
+      "code": "21",
+      "label": "Côte-d'Or",
+      "bbox": [
+        4.0652,
+        46.89984,
+        5.51865,
+        48.0313
+      ],
+      "covering_radius_km": 66
+    },
+    {
+      "kind": "departement",
+      "code": "22",
+      "label": "Côtes-d'Armor",
+      "bbox": [
+        -3.66587,
+        48.03259,
+        -1.90905,
+        48.9008
+      ],
+      "covering_radius_km": 71
+    },
+    {
+      "kind": "departement",
+      "code": "23",
+      "label": "Creuse",
+      "bbox": [
+        1.37259,
+        45.66355,
+        2.61128,
+        46.45535
+      ],
+      "covering_radius_km": 55
+    },
+    {
+      "kind": "departement",
+      "code": "24",
+      "label": "Dordogne",
+      "bbox": [
+        -0.0416,
+        44.57076,
+        1.44824,
+        45.71476
+      ],
+      "covering_radius_km": 71
+    },
+    {
+      "kind": "departement",
+      "code": "25",
+      "label": "Doubs",
+      "bbox": [
+        5.6987,
+        46.5538,
+        7.06239,
+        47.57969
+      ],
+      "covering_radius_km": 67
+    },
+    {
+      "kind": "departement",
+      "code": "26",
+      "label": "Drôme",
+      "bbox": [
+        4.64689,
+        44.11549,
+        5.83044,
+        45.34396
+      ],
+      "covering_radius_km": 74
+    },
+    {
+      "kind": "departement",
+      "code": "27",
+      "label": "Eure",
+      "bbox": [
+        0.29679,
+        48.66643,
+        1.80286,
+        49.48511
+      ],
+      "covering_radius_km": 67
+    },
+    {
+      "kind": "departement",
+      "code": "28",
+      "label": "Eure-et-Loir",
+      "bbox": [
+        0.75574,
+        47.95382,
+        1.99457,
+        48.94103
+      ],
+      "covering_radius_km": 56
+    },
+    {
+      "kind": "departement",
+      "code": "29",
+      "label": "Finistère",
+      "bbox": [
+        -5.14118,
+        47.70149,
+        -3.38662,
+        48.75354
+      ],
+      "covering_radius_km": 76
+    },
+    {
+      "kind": "departement",
+      "code": "2A",
+      "label": "Corse-du-Sud",
+      "bbox": [
+        8.53494,
+        41.33364,
+        9.40797,
+        42.38157
+      ],
+      "covering_radius_km": 68
+    },
+    {
+      "kind": "departement",
+      "code": "2B",
+      "label": "Haute-Corse",
+      "bbox": [
+        8.57326,
+        41.83221,
+        9.55997,
+        43.02763
+      ],
+      "covering_radius_km": 72
+    },
+    {
+      "kind": "departement",
+      "code": "30",
+      "label": "Gard",
+      "bbox": [
+        3.26245,
+        43.46025,
+        4.84557,
+        44.45966
+      ],
+      "covering_radius_km": 65
+    },
+    {
+      "kind": "departement",
+      "code": "31",
+      "label": "Haute-Garonne",
+      "bbox": [
+        0.44168,
+        42.68916,
+        2.0483,
+        43.92152
+      ],
+      "covering_radius_km": 92
+    },
+    {
+      "kind": "departement",
+      "code": "32",
+      "label": "Gers",
+      "bbox": [
+        -0.28231,
+        43.31088,
+        1.20325,
+        44.08001
+      ],
+      "covering_radius_km": 61
+    },
+    {
+      "kind": "departement",
+      "code": "33",
+      "label": "Gironde",
+      "bbox": [
+        -1.26095,
+        44.19389,
+        0.31512,
+        45.58643
+      ],
+      "covering_radius_km": 95
+    },
+    {
+      "kind": "departement",
+      "code": "34",
+      "label": "Hérault",
+      "bbox": [
+        2.53956,
+        43.2102,
+        4.19455,
+        43.97275
+      ],
+      "covering_radius_km": 72
+    },
+    {
+      "kind": "departement",
+      "code": "35",
+      "label": "Ille-et-Vilaine",
+      "bbox": [
+        -2.28899,
+        47.63167,
+        -1.01561,
+        48.72125
+      ],
+      "covering_radius_km": 69
+    },
+    {
+      "kind": "departement",
+      "code": "36",
+      "label": "Indre",
+      "bbox": [
+        0.86741,
+        46.3469,
+        2.20456,
+        47.27744
+      ],
+      "covering_radius_km": 65
+    },
+    {
+      "kind": "departement",
+      "code": "37",
+      "label": "Indre-et-Loire",
+      "bbox": [
+        0.05274,
+        46.73671,
+        1.36605,
+        47.70987
+      ],
+      "covering_radius_km": 57
+    },
+    {
+      "kind": "departement",
+      "code": "38",
+      "label": "Isère",
+      "bbox": [
+        4.74209,
+        44.69593,
+        6.3593,
+        45.88339
+      ],
+      "covering_radius_km": 80
+    },
+    {
+      "kind": "departement",
+      "code": "39",
+      "label": "Jura",
+      "bbox": [
+        5.25204,
+        46.26069,
+        6.20719,
+        47.30578
+      ],
+      "covering_radius_km": 61
+    },
+    {
+      "kind": "departement",
+      "code": "40",
+      "label": "Landes",
+      "bbox": [
+        -1.5333,
+        43.48741,
+        0.13676,
+        44.53237
+      ],
+      "covering_radius_km": 86
+    },
+    {
+      "kind": "departement",
+      "code": "41",
+      "label": "Loir-et-Cher",
+      "bbox": [
+        0.5806,
+        47.18639,
+        2.24789,
+        48.13324
+      ],
+      "covering_radius_km": 69
+    },
+    {
+      "kind": "departement",
+      "code": "42",
+      "label": "Loire",
+      "bbox": [
+        3.68842,
+        45.23103,
+        4.76038,
+        46.27658
+      ],
+      "covering_radius_km": 65
+    },
+    {
+      "kind": "departement",
+      "code": "43",
+      "label": "Haute-Loire",
+      "bbox": [
+        3.08219,
+        44.74396,
+        4.49082,
+        45.42761
+      ],
+      "covering_radius_km": 61
+    },
+    {
+      "kind": "departement",
+      "code": "44",
+      "label": "Loire-Atlantique",
+      "bbox": [
+        -2.62546,
+        46.86008,
+        -0.94666,
+        47.83594
+      ],
+      "covering_radius_km": 64
+    },
+    {
+      "kind": "departement",
+      "code": "45",
+      "label": "Loiret",
+      "bbox": [
+        1.51238,
+        47.48302,
+        3.12868,
+        48.34495
+      ],
+      "covering_radius_km": 62
+    },
+    {
+      "kind": "departement",
+      "code": "46",
+      "label": "Lot",
+      "bbox": [
+        0.98151,
+        44.20334,
+        2.21089,
+        45.04665
+      ],
+      "covering_radius_km": 54
+    },
+    {
+      "kind": "departement",
+      "code": "47",
+      "label": "Lot-et-Garonne",
+      "bbox": [
+        -0.14069,
+        43.97257,
+        1.07833,
+        44.76567
+      ],
+      "covering_radius_km": 54
+    },
+    {
+      "kind": "departement",
+      "code": "48",
+      "label": "Lozère",
+      "bbox": [
+        2.9812,
+        44.10958,
+        3.99837,
+        44.97575
+      ],
+      "covering_radius_km": 57
+    },
+    {
+      "kind": "departement",
+      "code": "49",
+      "label": "Maine-et-Loire",
+      "bbox": [
+        -1.3542,
+        46.96889,
+        0.23456,
+        47.80999
+      ],
+      "covering_radius_km": 69
+    },
+    {
+      "kind": "departement",
+      "code": "50",
+      "label": "Manche",
+      "bbox": [
+        -1.95497,
+        48.45583,
+        -0.73491,
+        49.72997
+      ],
+      "covering_radius_km": 83
+    },
+    {
+      "kind": "departement",
+      "code": "51",
+      "label": "Marne",
+      "bbox": [
+        3.39589,
+        48.51524,
+        5.03965,
+        49.40782
+      ],
+      "covering_radius_km": 67
+    },
+    {
+      "kind": "departement",
+      "code": "52",
+      "label": "Haute-Marne",
+      "bbox": [
+        4.62661,
+        47.57655,
+        5.89094,
+        48.6893
+      ],
+      "covering_radius_km": 69
+    },
+    {
+      "kind": "departement",
+      "code": "53",
+      "label": "Mayenne",
+      "bbox": [
+        -1.23878,
+        47.7334,
+        -0.04914,
+        48.56799
+      ],
+      "covering_radius_km": 58
+    },
+    {
+      "kind": "departement",
+      "code": "54",
+      "label": "Meurthe-et-Moselle",
+      "bbox": [
+        5.42619,
+        48.34901,
+        7.1232,
+        49.56326
+      ],
+      "covering_radius_km": 86
+    },
+    {
+      "kind": "departement",
+      "code": "55",
+      "label": "Meuse",
+      "bbox": [
+        4.88839,
+        48.40897,
+        5.85421,
+        49.61684
+      ],
+      "covering_radius_km": 68
+    },
+    {
+      "kind": "departement",
+      "code": "56",
+      "label": "Morbihan",
+      "bbox": [
+        -3.7349,
+        47.27789,
+        -2.03534,
+        48.21088
+      ],
+      "covering_radius_km": 76
+    },
+    {
+      "kind": "departement",
+      "code": "57",
+      "label": "Moselle",
+      "bbox": [
+        5.89189,
+        48.5267,
+        7.64003,
+        49.51494
+      ],
+      "covering_radius_km": 83
+    },
+    {
+      "kind": "departement",
+      "code": "58",
+      "label": "Nièvre",
+      "bbox": [
+        2.8449,
+        46.65102,
+        4.23191,
+        47.58828
+      ],
+      "covering_radius_km": 70
+    },
+    {
+      "kind": "departement",
+      "code": "59",
+      "label": "Nord",
+      "bbox": [
+        2.08932,
+        49.96908,
+        4.23126,
+        51.08915
+      ],
+      "covering_radius_km": 93
+    },
+    {
+      "kind": "departement",
+      "code": "60",
+      "label": "Oise",
+      "bbox": [
+        1.68885,
+        49.06053,
+        3.16576,
+        49.76386
+      ],
+      "covering_radius_km": 63
+    },
+    {
+      "kind": "departement",
+      "code": "61",
+      "label": "Orne",
+      "bbox": [
+        -0.86054,
+        48.17989,
+        0.97659,
+        48.97254
+      ],
+      "covering_radius_km": 70
+    },
+    {
+      "kind": "departement",
+      "code": "62",
+      "label": "Pas-de-Calais",
+      "bbox": [
+        1.55537,
+        50.01985,
+        3.18822,
+        51.01051
+      ],
+      "covering_radius_km": 73
+    },
+    {
+      "kind": "departement",
+      "code": "63",
+      "label": "Puy-de-Dôme",
+      "bbox": [
+        2.38806,
+        45.28707,
+        3.98534,
+        46.25659
+      ],
+      "covering_radius_km": 72
+    },
+    {
+      "kind": "departement",
+      "code": "64",
+      "label": "Pyrénées-Atlantiques",
+      "bbox": [
+        -1.79235,
+        42.77786,
+        0.02979,
+        43.59684
+      ],
+      "covering_radius_km": 77
+    },
+    {
+      "kind": "departement",
+      "code": "65",
+      "label": "Hautes-Pyrénées",
+      "bbox": [
+        -0.32718,
+        42.67323,
+        0.64612,
+        43.61332
+      ],
+      "covering_radius_km": 56
+    },
+    {
+      "kind": "departement",
+      "code": "66",
+      "label": "Pyrénées-Orientales",
+      "bbox": [
+        1.72146,
+        42.33292,
+        3.17759,
+        42.91853
+      ],
+      "covering_radius_km": 63
+    },
+    {
+      "kind": "departement",
+      "code": "67",
+      "label": "Bas-Rhin",
+      "bbox": [
+        6.94064,
+        48.12035,
+        8.2325,
+        49.07783
+      ],
+      "covering_radius_km": 65
+    },
+    {
+      "kind": "departement",
+      "code": "68",
+      "label": "Haut-Rhin",
+      "bbox": [
+        6.84101,
+        47.42034,
+        7.62182,
+        48.31118
+      ],
+      "covering_radius_km": 50
+    },
+    {
+      "kind": "departement",
+      "code": "69",
+      "label": "Rhône",
+      "bbox": [
+        4.24386,
+        45.45431,
+        5.16011,
+        46.30645
+      ],
+      "covering_radius_km": 52
+    },
+    {
+      "kind": "departement",
+      "code": "70",
+      "label": "Haute-Saône",
+      "bbox": [
+        5.36697,
+        47.25255,
+        6.82489,
+        48.02414
+      ],
+      "covering_radius_km": 59
+    },
+    {
+      "kind": "departement",
+      "code": "71",
+      "label": "Saône-et-Loire",
+      "bbox": [
+        3.62259,
+        46.15607,
+        5.46529,
+        47.15576
+      ],
+      "covering_radius_km": 73
+    },
+    {
+      "kind": "departement",
+      "code": "72",
+      "label": "Sarthe",
+      "bbox": [
+        -0.44806,
+        47.56841,
+        0.91665,
+        48.48503
+      ],
+      "covering_radius_km": 57
+    },
+    {
+      "kind": "departement",
+      "code": "73",
+      "label": "Savoie",
+      "bbox": [
+        5.6219,
+        45.05168,
+        7.18557,
+        45.93853
+      ],
+      "covering_radius_km": 66
+    },
+    {
+      "kind": "departement",
+      "code": "74",
+      "label": "Haute-Savoie",
+      "bbox": [
+        5.80502,
+        45.68165,
+        7.04447,
+        46.40817
+      ],
+      "covering_radius_km": 50
+    },
+    {
+      "kind": "departement",
+      "code": "75",
+      "label": "Paris",
+      "bbox": [
+        2.22422,
+        48.81556,
+        2.46985,
+        48.90215
+      ],
+      "covering_radius_km": 10
+    },
+    {
+      "kind": "departement",
+      "code": "76",
+      "label": "Seine-Maritime",
+      "bbox": [
+        0.06565,
+        49.25065,
+        1.79078,
+        50.0722
+      ],
+      "covering_radius_km": 65
+    },
+    {
+      "kind": "departement",
+      "code": "77",
+      "label": "Seine-et-Marne",
+      "bbox": [
+        2.39234,
+        48.12008,
+        3.55891,
+        49.11776
+      ],
+      "covering_radius_km": 68
+    },
+    {
+      "kind": "departement",
+      "code": "78",
+      "label": "Yvelines",
+      "bbox": [
+        1.4463,
+        48.43856,
+        2.22914,
+        49.08541
+      ],
+      "covering_radius_km": 43
+    },
+    {
+      "kind": "departement",
+      "code": "79",
+      "label": "Deux-Sèvres",
+      "bbox": [
+        -0.90352,
+        45.96966,
+        0.22039,
+        47.10855
+      ],
+      "covering_radius_km": 66
+    },
+    {
+      "kind": "departement",
+      "code": "80",
+      "label": "Somme",
+      "bbox": [
+        1.38022,
+        49.57178,
+        3.20277,
+        50.36774
+      ],
+      "covering_radius_km": 68
+    },
+    {
+      "kind": "departement",
+      "code": "81",
+      "label": "Tarn",
+      "bbox": [
+        1.5352,
+        43.38227,
+        2.93748,
+        44.20148
+      ],
+      "covering_radius_km": 59
+    },
+    {
+      "kind": "departement",
+      "code": "82",
+      "label": "Tarn-et-Garonne",
+      "bbox": [
+        0.73787,
+        43.76758,
+        2.0009,
+        44.39391
+      ],
+      "covering_radius_km": 53
+    },
+    {
+      "kind": "departement",
+      "code": "83",
+      "label": "Var",
+      "bbox": [
+        5.65591,
+        42.98203,
+        6.93355,
+        43.80888
+      ],
+      "covering_radius_km": 58
+    },
+    {
+      "kind": "departement",
+      "code": "84",
+      "label": "Vaucluse",
+      "bbox": [
+        4.64915,
+        43.65872,
+        5.75734,
+        44.43153
+      ],
+      "covering_radius_km": 57
+    },
+    {
+      "kind": "departement",
+      "code": "85",
+      "label": "Vendée",
+      "bbox": [
+        -2.40073,
+        46.26662,
+        -0.53831,
+        47.08502
+      ],
+      "covering_radius_km": 79
+    },
+    {
+      "kind": "departement",
+      "code": "86",
+      "label": "Vienne",
+      "bbox": [
+        -0.10503,
+        46.04834,
+        1.21322,
+        47.17599
+      ],
+      "covering_radius_km": 75
+    },
+    {
+      "kind": "departement",
+      "code": "87",
+      "label": "Haute-Vienne",
+      "bbox": [
+        0.62924,
+        45.43662,
+        1.91107,
+        46.40158
+      ],
+      "covering_radius_km": 56
+    },
+    {
+      "kind": "departement",
+      "code": "88",
+      "label": "Vosges",
+      "bbox": [
+        5.39363,
+        47.81328,
+        7.19835,
+        48.51362
+      ],
+      "covering_radius_km": 73
+    },
+    {
+      "kind": "departement",
+      "code": "89",
+      "label": "Yonne",
+      "bbox": [
+        2.84844,
+        47.31057,
+        4.3403,
+        48.40005
+      ],
+      "covering_radius_km": 69
+    },
+    {
+      "kind": "departement",
+      "code": "90",
+      "label": "Territoire de Belfort",
+      "bbox": [
+        6.75625,
+        47.43332,
+        7.14336,
+        47.8251
+      ],
+      "covering_radius_km": 23
+    },
+    {
+      "kind": "departement",
+      "code": "91",
+      "label": "Essonne",
+      "bbox": [
+        1.91453,
+        48.28456,
+        2.58565,
+        48.77614
+      ],
+      "covering_radius_km": 34
+    },
+    {
+      "kind": "departement",
+      "code": "92",
+      "label": "Hauts-de-Seine",
+      "bbox": [
+        2.14573,
+        48.72949,
+        2.3369,
+        48.95076
+      ],
+      "covering_radius_km": 13
+    },
+    {
+      "kind": "departement",
+      "code": "93",
+      "label": "Seine-Saint-Denis",
+      "bbox": [
+        2.28833,
+        48.80725,
+        2.60331,
+        49.01233
+      ],
+      "covering_radius_km": 16
+    },
+    {
+      "kind": "departement",
+      "code": "94",
+      "label": "Val-de-Marne",
+      "bbox": [
+        2.30869,
+        48.68763,
+        2.61568,
+        48.86149
+      ],
+      "covering_radius_km": 12
+    },
+    {
+      "kind": "departement",
+      "code": "95",
+      "label": "Val-d'Oise",
+      "bbox": [
+        1.60875,
+        48.90863,
+        2.595,
+        49.24149
+      ],
+      "covering_radius_km": 36
+    },
+    {
+      "kind": "departement",
+      "code": "971",
+      "label": "Guadeloupe",
+      "bbox": [
+        -61.8098,
+        15.83202,
+        -61.00203,
+        16.51449
+      ],
+      "covering_radius_km": 47
+    },
+    {
+      "kind": "departement",
+      "code": "972",
+      "label": "Martinique",
+      "bbox": [
+        -61.22904,
+        14.38868,
+        -60.80965,
+        14.87872
+      ],
+      "covering_radius_km": 32
+    },
+    {
+      "kind": "departement",
+      "code": "973",
+      "label": "Guyane",
+      "bbox": [
+        -54.60242,
+        2.11132,
+        -51.61907,
+        5.74868
+      ],
+      "covering_radius_km": 244
+    },
+    {
+      "kind": "departement",
+      "code": "974",
+      "label": "La Réunion",
+      "bbox": [
+        55.21655,
+        -21.38963,
+        55.83663,
+        -20.87188
+      ],
+      "covering_radius_km": 37
+    },
+    {
+      "kind": "departement",
+      "code": "976",
+      "label": "Mayotte",
+      "bbox": [
+        45.01848,
+        -13.00542,
+        45.29999,
+        -12.63659
+      ],
+      "covering_radius_km": 25
+    }
+  ]
+}

--- a/tools/geo-781/bench.mjs
+++ b/tools/geo-781/bench.mjs
@@ -1,0 +1,186 @@
+// Banc d'essai des 3 solutions d'emprise administrative (issue #781).
+//
+//   node tools/geo-781/bench.mjs "Bretagne"
+//   LBA_MONGODB_URI="mongodb://..." node tools/geo-781/bench.mjs "Nord" --limit 500
+//
+// Sans LBA_MONGODB_URI (la variable du server/.env) : compare les emprises entre elles.
+// Avec : exécute les requêtes sur `search_items` et mesure ce que
+// chaque stratégie ramène VRAIMENT, la vérité terrain étant l'appartenance au
+// contour officiel (point-in-polygon), pas la stratégie elle-même.
+
+import { areaOf, bboxOf, contains, coveringRadius, resolve, SUPRA_COMMUNAL, trueGeometry } from "./lib.mjs"
+
+const query = process.argv[2]
+if (!query) {
+  console.error('usage : node tools/geo-781/bench.mjs "<saisie>" [--limit N] [--diff]')
+  process.exit(2)
+}
+const limitArg = process.argv.indexOf("--limit")
+const LIMIT = limitArg > -1 ? Number(process.argv[limitArg + 1]) : 1000
+const DIFF = process.argv.includes("--diff")
+
+const fmt = (n, d = 0) => n.toLocaleString("fr-FR", { minimumFractionDigits: d, maximumFractionDigits: d })
+const pct = (n) => `${fmt(n * 100, n > 0 && n * 100 < 1 ? 2 : 0)} %`
+
+// ---------------------------------------------------------------- résolution
+
+const candidates = await resolve(query)
+if (!candidates.length) {
+  console.error(`Aucune entité administrative pour "${query}".`)
+  process.exit(1)
+}
+const area = candidates.find((c) => SUPRA_COMMUNAL.includes(c.kind)) ?? candidates[0]
+
+console.log(`\nSaisie      "${query}"`)
+console.log(`Résolue en  ${area.label} (${area.kind}, code ${area.code}, score ${area.score})`)
+if (candidates.length > 1) {
+  console.log(
+    `Autres      ${candidates
+      .slice(0, 4)
+      .filter((c) => c !== area)
+      .map((c) => `${c.label} [${c.kind}]`)
+      .join(", ")}`
+  )
+}
+
+const geometry = await trueGeometry(area.kind, area.label)
+if (!geometry) {
+  console.error("Contour indisponible, impossible de mesurer.")
+  process.exit(1)
+}
+
+const bbox = bboxOf(geometry)
+const radius = coveringRadius(area.center, geometry)
+const realArea = areaOf(geometry)
+const bboxArea = areaOf({
+  type: "Polygon",
+  coordinates: [
+    [
+      [bbox[0], bbox[1]],
+      [bbox[2], bbox[1]],
+      [bbox[2], bbox[3]],
+      [bbox[0], bbox[3]],
+      [bbox[0], bbox[1]],
+    ],
+  ],
+})
+const discArea = Math.PI * radius * radius
+
+console.log(`\nEmprises`)
+console.log(`  contour officiel   ${fmt(realArea)} km²`)
+console.log(`  bbox               ${fmt(bboxArea)} km²   (+${pct(bboxArea / realArea - 1)})`)
+console.log(`  disque r=${fmt(radius)} km      ${fmt(discArea)} km²   (+${pct(discArea / realArea - 1)})`)
+if (radius > 200) console.log(`  /!\\ rayon ${fmt(radius)} km au-dessus du plafond de 200 km de l'API v3`)
+
+// ---------------------------------------------------------------- stratégies
+
+const strategies = [
+  {
+    id: "1-rayon (actuel)",
+    note: "point + rayon, ce que fait LBA aujourd'hui",
+    clause: { geoWithin: { circle: { center: { type: "Point", coordinates: area.center }, radius: Math.round(radius * 1000) }, path: "location" } },
+  },
+  {
+    id: "2-bbox",
+    note: "bbox précalculée (4 nombres, aucun contour transporté)",
+    clause: {
+      geoWithin: { box: { bottomLeft: { type: "Point", coordinates: [bbox[0], bbox[1]] }, topRight: { type: "Point", coordinates: [bbox[2], bbox[3]] } }, path: "location" },
+    },
+  },
+  {
+    id: "3-contour",
+    note: "contour officiel en $geoWithin.geometry",
+    clause: { geoWithin: { geometry, path: "location" } },
+  },
+  {
+    id: "4-code (retenu)",
+    note: "equals sur le code indexé à la construction des items",
+    clause: { equals: { path: area.kind === "région" ? "region_code" : "departement_code", value: area.code } },
+  },
+]
+
+const mongoUri = process.env.LBA_MONGODB_URI ?? process.env.MONGODB_URI
+if (!mongoUri) {
+  console.log(`\nLBA_MONGODB_URI absent : mesure géométrique seulement.`)
+  console.log(`Relancer avec LBA_MONGODB_URI (celle de server/.env) pour compter les offres réellement ramenées.\n`)
+  for (const s of strategies) console.log(`  ${s.id.padEnd(18)} ${s.note}`)
+  console.log()
+  process.exit(0)
+}
+
+// ------------------------------------------------------- exécution sur la base
+
+const { MongoClient } = await import("mongodb")
+const client = new MongoClient(mongoUri)
+await client.connect()
+const items = client.db().collection("search_items")
+
+async function run(clause) {
+  const started = Date.now()
+  const docs = await items
+    .aggregate([
+      { $search: { index: "search_items_index", compound: { must: [{ exists: { path: "location" } }], filter: [clause] } } },
+      { $limit: LIMIT },
+      { $project: { _id: 0, url_id: 1, type: 1, address: 1, location: 1, departement_code: 1, region_code: 1 } },
+    ])
+    .toArray()
+  return { docs, ms: Date.now() - started }
+}
+
+const results = []
+for (const s of strategies) {
+  try {
+    const { docs, ms } = await run(s.clause)
+    const inside = docs.filter((d) => d.location && contains(geometry, d.location.coordinates))
+    results.push({ ...s, total: docs.length, inside: inside.length, ms, truncated: docs.length === LIMIT, docs })
+  } catch (err) {
+    results.push({ ...s, error: err.message })
+  }
+}
+
+const reference = results.find((r) => r.id === "3-contour")
+
+console.log(`\nRésultats sur search_items (limite ${fmt(LIMIT)})\n`)
+console.log(`  stratégie          ramenés   dans le périmètre   hors périmètre   rappel    temps`)
+for (const r of results) {
+  if (r.error) {
+    console.log(`  ${r.id.padEnd(18)} ERREUR ${r.error}`)
+    continue
+  }
+  const noise = r.total ? 1 - r.inside / r.total : 0
+  const recall = reference?.inside ? r.inside / reference.inside : NaN
+  console.log(
+    `  ${r.id.padEnd(18)} ${String(r.total).padStart(7)}   ${String(r.inside).padStart(17)}   ${pct(noise).padStart(14)}   ${(Number.isNaN(recall) ? "-" : pct(recall)).padStart(6)}   ${String(r.ms).padStart(5)} ms`
+  )
+}
+for (const r of results) if (r.truncated) console.log(`\n  /!\\ ${r.id} a atteint la limite de ${LIMIT} : relancer avec --limit plus haut pour des chiffres exploitables.`)
+
+const codes = results.find((r) => r.id.startsWith("4-code"))
+if (codes && !codes.error && codes.total === 0) {
+  console.log(`\n  /!\\ 4-code ramène 0 : soit les champs departement_code/region_code ne sont pas encore`)
+  console.log(`  peuplés (relancer la génération de search_items), soit l'index Atlas Search n'a pas`)
+  console.log(`  fini sa reconstruction (db.search_items.aggregate([{ $listSearchIndexes: {} }])).\n`)
+}
+console.log(`\n  Lecture : "hors périmètre" compare chaque résultat au contour officiel. 4-code doit`)
+console.log(`  être à 0 % de bruit et 100 % de rappel par rapport à 3-contour ; un écart signale`)
+console.log(`  une commune mal rattachée dans le référentiel ou un CP à cheval non tranché.\n`)
+
+if (DIFF && reference && !reference.error && codes && !codes.error) {
+  const key = (d) => `${d.type}:${d.url_id}`
+  const byCode = new Map(codes.docs.map((d) => [key(d), d]))
+  const byContour = new Map(reference.docs.map((d) => [key(d), d]))
+  const missing = reference.docs.filter((d) => !byCode.has(key(d)))
+  const intruders = codes.docs.filter((d) => !contains(geometry, d.location.coordinates))
+  const show = (d) => `    ${d.type.padEnd(9)} dep=${String(d.departement_code).padEnd(4)} [${d.location.coordinates.map((c) => c.toFixed(4)).join(", ")}]  ${d.address}`
+
+  console.log(`  Dans le contour mais sans le code (${missing.length}) : la source contredit le géopoint, ou le CP est inconnu`)
+  for (const d of missing) console.log(show(d))
+  console.log(`\n  Avec le code mais hors du contour (${intruders.length}) : géopoint au large du trait de côte, ou CP d'un autre département`)
+  for (const d of intruders) console.log(show(d))
+  const unknownToContour = intruders.filter((d) => !byContour.has(key(d))).length
+  if (unknownToContour !== intruders.length)
+    console.log(`\n  (incohérence : ${intruders.length - unknownToContour} intrus sont aussi dans 3-contour, le point-in-polygon local diverge de mongot)`)
+  console.log()
+}
+
+await client.close()

--- a/tools/geo-781/build-bbox.mjs
+++ b/tools/geo-781/build-bbox.mjs
@@ -1,0 +1,55 @@
+// Solution 2 : précalcule l'emprise des entités supra-communales une fois pour toutes.
+// L'API ne renvoie pas de bbox ; on la dérive de `returntruegeometry` au build,
+// pour ne plus jamais transporter 46 Ko à 416 Ko de contour à l'exécution.
+//
+//   node tools/geo-781/build-bbox.mjs > tools/geo-781/admin-areas-bbox.json
+//
+// Les écarts (code renvoyé ≠ code attendu, entité introuvable) partent sur stderr
+// et font sortir en code 1 : une génération partielle ne doit pas passer pour un succès.
+
+import { bboxOf, coveringRadius, trueGeometry } from "./lib.mjs"
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function listOf(kind) {
+  const res = await fetch(`https://geo.api.gouv.fr/${kind}?fields=nom,code`)
+  if (!res.ok) throw new Error(`listing ${kind} : ${res.status}`)
+  return res.json()
+}
+
+const [departements, regions] = await Promise.all([listOf("departements"), listOf("regions")])
+const wanted = [...regions.map((r) => ({ kind: "région", ...r })), ...departements.map((d) => ({ kind: "département", ...d }))]
+
+const areas = []
+const problems = []
+
+for (const entity of wanted) {
+  try {
+    const geometry = await trueGeometry(entity.kind, entity.nom)
+    if (!geometry) {
+      problems.push(`${entity.kind} ${entity.code} ${entity.nom} : aucun contour`)
+      continue
+    }
+    const bbox = bboxOf(geometry)
+    const center = [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2]
+    areas.push({
+      kind: entity.kind === "région" ? "region" : "departement",
+      code: entity.code,
+      label: entity.nom,
+      bbox: bbox.map((n) => Math.round(n * 1e5) / 1e5),
+      covering_radius_km: Math.round(coveringRadius(center, geometry)),
+    })
+  } catch (err) {
+    problems.push(`${entity.kind} ${entity.code} ${entity.nom} : ${err.message}`)
+  }
+  await sleep(120)
+}
+
+process.stdout.write(JSON.stringify({ generated_at: new Date().toISOString(), source: "data.geopf.fr geocodage/search returntruegeometry", areas }, null, 2) + "\n")
+
+if (problems.length) {
+  console.error(`\n${problems.length} entité(s) manquante(s) sur ${wanted.length} :`)
+  for (const p of problems) console.error(`  - ${p}`)
+  process.exit(1)
+}
+console.error(`${areas.length} entités générées, aucun écart.`)

--- a/tools/geo-781/compass.md
+++ b/tools/geo-781/compass.md
@@ -161,3 +161,58 @@ silence : ne pas activer la sélection UI avant.
 
 À faire avec `node tools/geo-781/bench.mjs "<département>"` plutôt qu'en Compass : la ligne
 `4-code` doit afficher 0 % hors périmètre face au contour officiel.
+
+## Dérive de position dans `search_items` (hors #781, découvert en chemin)
+
+### `search_items` — offres dont la position indexée ne correspond plus à la source
+
+```js
+[
+  { $match: { type: "offre" } },
+  { $lookup: { from: "jobs_partners", localField: "_id", foreignField: "_id", as: "src" } },
+  { $unwind: "$src" },
+  { $project: {
+      location_identique: { $eq: ["$location.coordinates", "$src.workplace_geopoint.coordinates"] },
+      updated_recent: { $gt: ["$src.updated_at", new Date(Date.now() - 30 * 864e5)] }
+  } },
+  { $group: {
+      _id: null,
+      total: { $sum: 1 },
+      location_perimee: { $sum: { $cond: ["$location_identique", 0, 1] } },
+      location_perimee_source_modifiee_30j: { $sum: { $cond: [{ $and: [{ $not: "$location_identique" }, "$updated_recent"] }, 1, 0] } }
+  } },
+  { $project: { _id: 0, mesure: "search_items_location_perimee", total: 1, location_perimee: 1, location_perimee_source_modifiee_30j: 1 } }
+]
+```
+
+Relevé du 2026-09-11 : 1 593 périmées sur 328 606, dont 965 avec une source modifiée depuis
+moins de 30 jours. Le nightly rattrape les premières depuis que son backfill réécrit `location` ;
+les secondes sont le symptôme du trou ci-dessous.
+
+### Cause : `updated_at` horodaté au début de l'import, pas à l'écriture
+
+Si l'hypothèse est juste, les `updated_at` des offres périmées se concentrent sur une poignée de
+valeurs exactes (une par import nocturne, vers 00:01), portées chacune par des centaines d'offres,
+et l'écart entre `updated_at` et l'écriture réelle dépasse la fenêtre de 10 min du delta.
+
+```js
+[
+  { $match: { type: "offre" } },
+  { $lookup: { from: "jobs_partners", localField: "_id", foreignField: "_id", as: "src" } },
+  { $unwind: "$src" },
+  { $match: { $expr: { $ne: ["$location.coordinates", "$src.workplace_geopoint.coordinates"] } } },
+  { $group: { _id: "$src.updated_at", offres: { $sum: 1 }, partenaires: { $addToSet: "$src.partner_label" } } },
+  { $sort: { offres: -1 } },
+  { $group: {
+      _id: null,
+      nb_valeurs_updated_at_distinctes: { $sum: 1 },
+      valeurs: { $push: { updated_at: "$_id", offres: "$offres", partenaires: "$partenaires" } }
+  } },
+  { $project: { _id: 0, mesure: "search_items_perimees_par_updated_at", nb_valeurs_updated_at_distinctes: 1, top: { $slice: ["$valeurs", 10] } } }
+]
+```
+
+Lecture : `nb_valeurs_updated_at_distinctes` très inférieur au nombre d'offres périmées, et des
+`updated_at` à `00:01:xx` dans `top`, confirment que les documents partagent l'horodatage du début
+d'import. Correctif : `updated_at: new Date()` par document dans
+`import-from-computed-to-jobs-partners.ts` et dans la factory `fill-fields-for-partners-factory.ts`.

--- a/tools/geo-781/compass.md
+++ b/tools/geo-781/compass.md
@@ -1,0 +1,163 @@
+# Chiffres de production à relever dans MongoDB Compass
+
+Onglet Aggregations de la collection indiquée, coller le pipeline, copier l'objet résultat.
+Chaque pipeline renvoie **un seul document** avec un champ `mesure` qui l'identifie : les
+résultats peuvent être collés tels quels, dans n'importe quel ordre.
+
+## Avant déploiement
+
+### `search_items` — volume par type et part sans géopoint
+
+```js
+[
+  { $group: { _id: "$type", total: { $sum: 1 }, sans_location: { $sum: { $cond: [{ $ifNull: ["$location", false] }, 0, 1] } } } },
+  { $group: { _id: null, total: { $sum: "$total" }, par_type: { $push: { type: "$_id", total: "$total", sans_location: "$sans_location" } } } },
+  { $project: { _id: 0, mesure: "search_items_volume", total: 1, par_type: 1 } }
+]
+```
+
+### `jobs_partners` — résolution du département des offres actives
+
+Jointure sur le référentiel : dit directement combien d'offres auront `departement_code: null`
+(CP inconnu) et combien dépendent du géopoint pour trancher (CP à cheval).
+
+```js
+[
+  { $match: { offer_status: "Active" } },
+  { $lookup: { from: "referentiel.communes", localField: "workplace_address_zipcode", foreignField: "codesPostaux", as: "communes" } },
+  { $project: {
+      zipcode_absent: { $in: ["$workplace_address_zipcode", [null, ""]] },
+      zipcode_malforme: { $and: [{ $ne: ["$workplace_address_zipcode", null] }, { $not: { $regexMatch: { input: { $ifNull: ["$workplace_address_zipcode", ""] }, regex: /^[0-9]{5}$/ } } }] },
+      nb_departements: { $size: { $setUnion: ["$communes.codeDepartement"] } },
+      sans_geopoint: { $eq: [{ $ifNull: ["$workplace_geopoint", null] }, null] }
+  } },
+  { $group: {
+      _id: null,
+      total: { $sum: 1 },
+      zipcode_absent: { $sum: { $cond: ["$zipcode_absent", 1, 0] } },
+      zipcode_malforme: { $sum: { $cond: ["$zipcode_malforme", 1, 0] } },
+      cp_inconnu_du_referentiel: { $sum: { $cond: [{ $and: [{ $not: "$zipcode_absent" }, { $eq: ["$nb_departements", 0] }] }, 1, 0] } },
+      cp_a_cheval: { $sum: { $cond: [{ $gt: ["$nb_departements", 1] }, 1, 0] } },
+      cp_a_cheval_sans_geopoint: { $sum: { $cond: [{ $and: [{ $gt: ["$nb_departements", 1] }, "$sans_geopoint"] }, 1, 0] } },
+      resolu_directement: { $sum: { $cond: [{ $eq: ["$nb_departements", 1] }, 1, 0] } }
+  } },
+  { $project: { _id: 0, mesure: "jobs_partners_resolution_departement", total: 1, resolu_directement: 1, cp_a_cheval: 1, cp_a_cheval_sans_geopoint: 1, cp_inconnu_du_referentiel: 1, zipcode_absent: 1, zipcode_malforme: 1 } }
+]
+```
+
+Lecture : `resolu_directement + cp_a_cheval - cp_a_cheval_sans_geopoint` = offres qui auront un
+code ; le reste tombe à `null`.
+
+### `formationcatalogues` — résolution du département des formations
+
+```js
+[
+  { $lookup: { from: "referentiel.communes", localField: "code_commune_insee", foreignField: "code", as: "par_insee" } },
+  { $lookup: { from: "referentiel.communes", localField: "code_postal", foreignField: "codesPostaux", as: "par_cp" } },
+  { $project: {
+      insee_absent: { $in: ["$code_commune_insee", [null, ""]] },
+      insee_resolu: { $gt: [{ $size: "$par_insee" }, 0] },
+      cp_absent: { $in: ["$code_postal", [null, ""]] },
+      cp_nb_departements: { $size: { $setUnion: ["$par_cp.codeDepartement"] } },
+      sans_geopoint: { $eq: [{ $ifNull: ["$lieu_formation_geopoint", null] }, null] }
+  } },
+  { $group: {
+      _id: null,
+      total: { $sum: 1 },
+      resolu_par_insee: { $sum: { $cond: ["$insee_resolu", 1, 0] } },
+      insee_absent: { $sum: { $cond: ["$insee_absent", 1, 0] } },
+      insee_inconnu_du_referentiel: { $sum: { $cond: [{ $and: [{ $not: "$insee_absent" }, { $not: "$insee_resolu" }] }, 1, 0] } },
+      repli_cp_resolu: { $sum: { $cond: [{ $and: [{ $not: "$insee_resolu" }, { $eq: ["$cp_nb_departements", 1] }] }, 1, 0] } },
+      repli_cp_a_cheval_sans_geopoint: { $sum: { $cond: [{ $and: [{ $not: "$insee_resolu" }, { $gt: ["$cp_nb_departements", 1] }, "$sans_geopoint"] }, 1, 0] } },
+      irresolu: { $sum: { $cond: [{ $and: [{ $not: "$insee_resolu" }, { $eq: ["$cp_nb_departements", 0] }] }, 1, 0] } }
+  } },
+  { $project: { _id: 0, mesure: "formations_resolution_departement", total: 1, resolu_par_insee: 1, repli_cp_resolu: 1, repli_cp_a_cheval_sans_geopoint: 1, irresolu: 1, insee_absent: 1, insee_inconnu_du_referentiel: 1 } }
+]
+```
+
+### `referentiel.communes` — codes postaux à cheval sur plusieurs départements
+
+Le seul cas où la dérivation dépend du géopoint. Renvoie le compte et la liste.
+
+```js
+[
+  { $unwind: "$codesPostaux" },
+  { $group: { _id: "$codesPostaux", departements: { $addToSet: "$codeDepartement" }, communes: { $push: "$nom" } } },
+  { $match: { "departements.1": { $exists: true } } },
+  { $sort: { _id: 1 } },
+  { $group: { _id: null, nb_cp_a_cheval: { $sum: 1 }, liste: { $push: { cp: "$_id", departements: "$departements", communes: "$communes" } } } },
+  { $project: { _id: 0, mesure: "referentiel_cp_a_cheval", nb_cp_a_cheval: 1, liste: 1 } }
+]
+```
+
+### `referentiel.communes` — fraîcheur et complétude du référentiel
+
+Le cron tourne le dimanche à 15 h. Un référentiel incomplet fait tomber des items à `null`.
+
+```js
+[
+  { $group: {
+      _id: null,
+      nb_communes: { $sum: 1 },
+      sans_centre: { $sum: { $cond: [{ $eq: [{ $ifNull: ["$centre", null] }, null] }, 1, 0] } },
+      sans_code_postal: { $sum: { $cond: [{ $eq: [{ $size: { $ifNull: ["$codesPostaux", []] } }, 0] }, 1, 0] } },
+      departements: { $addToSet: "$codeDepartement" },
+      regions: { $addToSet: "$codeRegion" }
+  } },
+  { $project: { _id: 0, mesure: "referentiel_communes_completude", nb_communes: 1, sans_centre: 1, sans_code_postal: 1, nb_departements: { $size: "$departements" }, nb_regions: { $size: "$regions" } } }
+]
+```
+
+Attendu : ~34 900 communes, 101 départements, 18 régions.
+
+## Après déploiement
+
+### `search_items` — part résolue par type
+
+`champ_absent` > 0 : des items n'ont pas encore été reconstruits depuis le déploiement.
+
+```js
+[
+  { $group: {
+      _id: "$type",
+      total: { $sum: 1 },
+      champ_absent: { $sum: { $cond: [{ $eq: [{ $type: "$departement_code" }, "missing"] }, 1, 0] } },
+      non_resolu: { $sum: { $cond: [{ $eq: ["$departement_code", null] }, 1, 0] } },
+      resolu: { $sum: { $cond: [{ $eq: [{ $type: "$departement_code" }, "string"] }, 1, 0] } }
+  } },
+  { $group: { _id: null, par_type: { $push: { type: "$_id", total: "$total", resolu: "$resolu", non_resolu: "$non_resolu", champ_absent: "$champ_absent" } } } },
+  { $project: { _id: 0, mesure: "search_items_resolution_post_deploiement", par_type: 1 } }
+]
+```
+
+### `search_items` — distribution par département
+
+```js
+[
+  { $match: { departement_code: { $type: "string" } } },
+  { $group: { _id: "$departement_code", total: { $sum: 1 } } },
+  { $sort: { _id: 1 } },
+  { $group: { _id: null, nb_departements_representes: { $sum: 1 }, par_departement: { $push: { departement: "$_id", total: "$total" } } } },
+  { $project: { _id: 0, mesure: "search_items_par_departement", nb_departements_representes: 1, par_departement: 1 } }
+]
+```
+
+Attendu : 101 départements représentés. Un code absent de la liste alors que le département a
+des offres pointe un trou dans le référentiel.
+
+### `search_items` — état de l'index Atlas Search
+
+Tant que `status` n'est pas `READY`, un `equals` sur `departement_code` renvoie zéro résultat en
+silence : ne pas activer la sélection UI avant.
+
+```js
+[
+  { $listSearchIndexes: {} },
+  { $project: { _id: 0, mesure: "search_items_index_status", name: 1, status: 1, queryable: 1, a_les_nouveaux_champs: { $and: [{ $ne: [{ $ifNull: ["$latestDefinition.mappings.fields.departement_code", null] }, null] }, { $ne: [{ $ifNull: ["$latestDefinition.mappings.fields.region_code", null] }, null] }] } } }
+]
+```
+
+### Contrôle croisé géométrique
+
+À faire avec `node tools/geo-781/bench.mjs "<département>"` plutôt qu'en Compass : la ligne
+`4-code` doit afficher 0 % hors périmètre face au contour officiel.

--- a/tools/geo-781/lib.mjs
+++ b/tools/geo-781/lib.mjs
@@ -1,0 +1,108 @@
+// Briques partagées par bench.mjs et build-bbox.mjs.
+// Aucune dépendance au serveur LBA : ce dossier est un banc d'essai jetable (issue #781).
+
+const GEOCODE = "https://data.geopf.fr/geocodage"
+
+/** Catégories de l'index `poi` qui portent une entité supra-communale. */
+export const SUPRA_COMMUNAL = ["région", "département", "epci"]
+
+/** Catégories retenues quand on veut aussi la maille communale. */
+export const ADMIN_CATEGORIES = [...SUPRA_COMMUNAL, "commune", "arrondissement municipal"]
+
+async function geopf(path, params) {
+  const url = `${GEOCODE}/${path}?${new URLSearchParams(params)}`
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} sur ${url}`)
+  return res.json()
+}
+
+/**
+ * Résout une saisie libre en entités administratives.
+ * L'index `poi` ne renvoie ni `label` ni `postcode` : on normalise ici ce que
+ * l'UI devra normaliser aussi (cf. ui/services/base-adresse.ts).
+ */
+export async function resolve(query, { limit = 10, categories = ADMIN_CATEGORIES } = {}) {
+  const data = await geopf("search", { index: "address,poi", q: query, limit: String(limit) })
+  return data.features
+    .filter((f) => f.properties._type === "poi")
+    .filter((f) => categories.includes(f.properties.category?.[1]))
+    .map((f) => ({
+      kind: f.properties.category[1],
+      // Le code administratif est logé dans `citycode`, pas dans un champ dédié.
+      code: f.properties.citycode?.[0] ?? null,
+      label: f.properties.toponym,
+      center: f.geometry.coordinates,
+      score: f.properties.score,
+    }))
+}
+
+/** Contour officiel d'une entité. Lourd : 46 Ko pour un département, 416 Ko pour la Bretagne. */
+export async function trueGeometry(kind, label) {
+  const data = await geopf("search", {
+    index: "poi",
+    category: kind,
+    q: label,
+    limit: "1",
+    returntruegeometry: "true",
+  })
+  const feature = data.features[0]
+  if (!feature) return null
+  const raw = feature.properties.truegeometry
+  return typeof raw === "string" ? JSON.parse(raw) : raw
+}
+
+export function rings(geometry) {
+  if (!geometry) return []
+  return geometry.type === "Polygon" ? [geometry.coordinates[0]] : geometry.coordinates.map((p) => p[0])
+}
+
+export function bboxOf(geometry) {
+  const pts = rings(geometry).flat()
+  const xs = pts.map((c) => c[0])
+  const ys = pts.map((c) => c[1])
+  return [Math.min(...xs), Math.min(...ys), Math.max(...xs), Math.max(...ys)]
+}
+
+const R = 6371
+
+export function haversine(a, b) {
+  const p1 = (a[1] * Math.PI) / 180
+  const p2 = (b[1] * Math.PI) / 180
+  const dp = p2 - p1
+  const dl = ((b[0] - a[0]) * Math.PI) / 180
+  const h = Math.sin(dp / 2) ** 2 + Math.cos(p1) * Math.cos(p2) * Math.sin(dl / 2) ** 2
+  return 2 * R * Math.asin(Math.sqrt(h))
+}
+
+/** Rayon couvrant toute l'entité depuis son centroïde. C'est ce que coûte un filtre point+rayon. */
+export function coveringRadius(center, geometry) {
+  const pts = rings(geometry).flat()
+  return Math.max(...pts.map((c) => haversine(center, c)))
+}
+
+/** Aire sphérique approchée, en km². */
+export function areaOf(geometry) {
+  return rings(geometry).reduce((total, ring) => {
+    let s = 0
+    for (let i = 0; i < ring.length; i++) {
+      const [x1, y1] = ring[i]
+      const [x2, y2] = ring[(i + 1) % ring.length]
+      s += (((x2 - x1) * Math.PI) / 180) * (2 + Math.sin((y1 * Math.PI) / 180) + Math.sin((y2 * Math.PI) / 180))
+    }
+    return total + Math.abs((s * R * R) / 2)
+  }, 0)
+}
+
+/** Ray casting. Sert à mesurer combien de résultats tombent réellement hors du périmètre. */
+export function contains(geometry, point) {
+  const [x, y] = point
+  let inside = false
+  for (const ring of rings(geometry)) {
+    for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+      const [xi, yi] = ring[i]
+      const [xj, yj] = ring[j]
+      if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) inside = !inside
+    }
+  }
+  return inside
+}

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
@@ -144,7 +144,7 @@ export function highlightMatch(label: string, input: string): ReactNode {
   )
 }
 
-type LieuOption = { label: string; latitude: number; longitude: number }
+type LieuOption = { label: string; latitude: number; longitude: number; adminArea?: string }
 
 // Option « France entière » du champ lieu : proposée quand le champ est vide (Entrée la
 // sélectionne — autoHighlight), elle retire le lieu de la recherche. Le placeholder
@@ -161,7 +161,7 @@ interface SearchBarProps {
   initialLieuLabel?: string
   /** source : "suggestion" si l'utilisateur a sélectionné une option d'autocomplete, "free_text" sinon (télémétrie moteur de suggestion). */
   onSubmit: (q: string, source: "suggestion" | "free_text") => void
-  onLieuChange: (lieu: { label: string; latitude: number; longitude: number } | null) => void
+  onLieuChange: (lieu: { label: string; latitude: number; longitude: number; adminArea?: string } | null) => void
   /** Saisie courante du champ métier (formulaire home : le bouton Rechercher lit la valeur non validée). */
   onQChange?: (q: string) => void
   /** "row" : barre desktop ; "column" : panneau mobile ; "responsive" : colonne en xs, rangée en md+ (home). */
@@ -303,7 +303,8 @@ export function SearchBar({
   // Suggestions pour le champ lieu
   const { data: lieuOptions } = useQuery({
     queryKey: ["lieu-suggestions", debouncedLieu],
-    queryFn: ({ signal }) => searchAddress(debouncedLieu, undefined, signal),
+    // withAdminAreas : les départements et régions remontent dans les suggestions (index poi).
+    queryFn: ({ signal }) => searchAddress(debouncedLieu, undefined, signal, true),
     enabled: debouncedLieu.length >= 2,
     staleTime: 1000 * 60 * 5,
     throwOnError: false,
@@ -312,6 +313,7 @@ export function SearchBar({
     label: item.label,
     latitude: item.value.coordinates[1],
     longitude: item.value.coordinates[0],
+    adminArea: item.adminArea,
   }))
 
   // Champ vide : seule l'option « France entière » est proposée ; en saisie, les suggestions

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
@@ -144,7 +144,7 @@ export function highlightMatch(label: string, input: string): ReactNode {
   )
 }
 
-type LieuOption = { label: string; latitude: number; longitude: number; adminArea?: string }
+type LieuOption = { label: string; latitude: number; longitude: number; adminArea?: string; displayLabel?: string }
 
 // Option « France entière » du champ lieu : proposée quand le champ est vide (Entrée la
 // sélectionne — autoHighlight), elle retire le lieu de la recherche. Le placeholder
@@ -314,6 +314,7 @@ export function SearchBar({
     latitude: item.value.coordinates[1],
     longitude: item.value.coordinates[0],
     adminArea: item.adminArea,
+    displayLabel: item.displayLabel,
   }))
 
   // Champ vide : seule l'option « France entière » est proposée ; en saisie, les suggestions
@@ -563,7 +564,8 @@ export function SearchBar({
               </Box>
             ) : (
               <Box component="li" key={option.label} {...optionProps} sx={{ minHeight: 40, px: "16px !important", display: "block !important" }}>
-                <Box sx={{ fontSize: "1rem", color: fr.colors.decisions.text.default.grey.default }}>{highlightMatch(option.label, lieuInput)}</Box>
+                {/* Libellé de liste (« Bretagne (région) ») distinct du libellé appliqué au champ et à l'URL. */}
+                <Box sx={{ fontSize: "1rem", color: fr.colors.decisions.text.default.grey.default }}>{highlightMatch(option.displayLabel ?? option.label, lieuInput)}</Box>
                 {index === 0 && <Box sx={{ fontSize: "0.75rem", color: fr.colors.decisions.text.mention.grey.default }}>ou appuyer sur Entrée</Box>}
               </Box>
             )

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
@@ -146,6 +146,10 @@ export function highlightMatch(label: string, input: string): ReactNode {
 
 type LieuOption = { label: string; latitude: number; longitude: number; adminArea?: string; displayLabel?: string }
 
+// Identité d'une option lieu : le libellé ne suffit plus depuis que régions et départements sont
+// proposés (une région et une commune peuvent s'appeler « Bretagne »).
+const lieuOptionKey = (o: LieuOption) => o.adminArea ?? o.label
+
 // Option « France entière » du champ lieu : proposée quand le champ est vide (Entrée la
 // sélectionne — autoHighlight), elle retire le lieu de la recherche. Le placeholder
 // « France entière » du champ vide reflète ensuite l'état appliqué.
@@ -511,7 +515,7 @@ export function SearchBar({
           getOptionLabel={(o) => (typeof o === "string" ? o : "kind" in o ? "" : o.label)}
           isOptionEqualToValue={(o, v) => {
             if ("kind" in o) return false
-            return typeof v === "string" ? o.label === v : !("kind" in v) && o.label === v.label
+            return typeof v === "string" ? o.label === v : !("kind" in v) && lieuOptionKey(o) === lieuOptionKey(v)
           }}
           slots={inlineSuggestions ? { popper: InlineSuggestionsContainer } : undefined}
           blurOnSelect={inlineSuggestions}
@@ -563,7 +567,7 @@ export function SearchBar({
                 </Box>
               </Box>
             ) : (
-              <Box component="li" key={option.label} {...optionProps} sx={{ minHeight: 40, px: "16px !important", display: "block !important" }}>
+              <Box component="li" key={lieuOptionKey(option)} {...optionProps} sx={{ minHeight: 40, px: "16px !important", display: "block !important" }}>
                 {/* Libellé de liste (« Bretagne (région) ») distinct du libellé appliqué au champ et à l'URL. */}
                 <Box sx={{ fontSize: "1rem", color: fr.colors.decisions.text.default.grey.default }}>{highlightMatch(option.displayLabel ?? option.label, lieuInput)}</Box>
                 {index === 0 && <Box sx={{ fontSize: "0.75rem", color: fr.colors.decisions.text.mention.grey.default }}>ou appuyer sur Entrée</Box>}

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
@@ -175,8 +175,8 @@ interface SearchBarProps {
   /** source : "suggestion" si l'utilisateur a sélectionné une option d'autocomplete, "free_text" sinon (télémétrie moteur de suggestion). */
   onSubmit: (q: string, source: "suggestion" | "free_text") => void
   onLieuChange: (lieu: { label: string; latitude: number; longitude: number; adminArea?: string } | null) => void
-  /** Saisie courante du champ métier (formulaire home : le bouton Rechercher lit la valeur non validée). */
-  onQChange?: (q: string) => void
+  /** Saisie courante du champ métier et son origine (formulaire home : le bouton Rechercher lit la valeur non validée). */
+  onQChange?: (q: string, source: "suggestion" | "free_text") => void
   /** "row" : barre desktop ; "column" : panneau mobile ; "responsive" : colonne en xs, rangée en md+ (home). */
   layout?: "row" | "column" | "responsive"
   /**
@@ -310,7 +310,7 @@ export function SearchBar({
   const lieuWrapperSx = activeField === "lieu" ? activeWrapperSx : { flex: rowSx.lieuFlex, width: rowSx.fieldWidth, display: activeField === "metier" ? "none" : undefined }
 
   // Suggestions pour le champ métier — autocomplétion par préfixe (endpoint dédié, min 3 caractères)
-  const { data: suggestionData } = useQuery({
+  const { data: suggestionData, isPending: suggestionsPending } = useQuery({
     queryKey: ["/v1/search/suggest", debouncedInput],
     queryFn: ({ signal }) => apiGet("/v1/search/suggest", { querystring: { q: debouncedInput, limit: 8 } }, { signal }),
     enabled: debouncedInput.length >= 3,
@@ -319,10 +319,21 @@ export function SearchBar({
   })
   const suggestions = suggestionData?.suggestions ?? []
 
-  // Options du dropdown : ligne d'action « Rechercher : {saisie} » + groupe Suggestions.
-  const metierOptions: MetierOption[] = inputValue.trim()
-    ? [{ kind: "free_text", value: inputValue }, ...suggestions.map((s): MetierOption => ({ kind: "suggestion", value: s }))]
-    : []
+  // Options du dropdown : groupe Suggestions puis ligne d'action « Rechercher : {saisie} ».
+  // Les suggestions passent en premier pour qu'autoHighlight surligne la meilleure (Entrée
+  // l'accepte, comme pour le lieu) ; sans suggestion, la ligne d'action est seule et surlignée.
+  // Tant que les suggestions de la saisie courante ne sont pas arrivées, la liste est VIDE
+  // (état loading) : si la ligne d'action était affichée seule puis rejointe par les
+  // suggestions, MUI la « retrouverait » par son libellé et déplacerait son index surligné
+  // interne sans mettre à jour le DOM — Entrée lancerait le texte libre alors que l'écran
+  // surligne la 1ʳᵉ suggestion (useAutocomplete.syncHighlightedIndex, MUI 7.3).
+  const trimmedInput = inputValue.trim()
+  const suggestionsLoading = trimmedInput.length >= 3 && (debouncedInput !== inputValue || suggestionsPending)
+  const metierOptions: MetierOption[] = !trimmedInput
+    ? []
+    : suggestionsLoading
+      ? []
+      : [...suggestions.map((s): MetierOption => ({ kind: "suggestion", value: s })), { kind: "free_text", value: inputValue }]
 
   // Suggestions pour le champ lieu
   const { data: lieuOptions } = useQuery({
@@ -347,12 +358,40 @@ export function SearchBar({
   const showsFranceEntiere = isFranceEntiereLabel(lieuInput)
   const lieuDropdownOptions: LieuDropdownOption[] = lieuInput.trim() && !showsFranceEntiere ? lieuSuggestions : [FRANCE_ENTIERE_OPTION]
 
+  // Origine de la saisie métier courante, pour un lancement depuis le champ lieu ou le bouton
+  // (une suggestion acceptée puis relancée depuis ailleurs reste une « suggestion »).
+  const qSourceRef = useRef<"suggestion" | "free_text">("free_text")
   const handleSubmit = useCallback(
     (value: string, source: "suggestion" | "free_text") => {
+      qSourceRef.current = source
       onSubmit(value, source)
     },
     [onSubmit]
   )
+
+  // Touche Entrée : MUI accepte l'option surlignée (son index interne, pas le DOM) et fait
+  // preventDefault — onChange décide alors (suggestion = remplir, ligne « Rechercher » = lancer,
+  // lieu = appliquer). Sans option surlignée ou liste fermée, MUI ne bloque rien : la soumission
+  // implicite HTML du navigateur déclenche onSubmit ci-dessous, qui lance une fois. Aucun
+  // gestionnaire clavier maison : c'est le pattern combobox de l'APG tel que le navigateur
+  // et MUI l'implémentent.
+  const submitFromField = () => {
+    // Champ lieu : un texte non validé est résolu comme au blur — suggestion exacte (le parent
+    // reçoit le lieu, le lancement attend le prochain Entrée pour lire un état à jour), sinon
+    // libellé appliqué restauré.
+    if (lieuInput.trim() !== appliedLieuLabel.trim()) {
+      const exact = lieuSuggestions.find((option) => normalizeLieu(option.label) === normalizeLieu(lieuInput))
+      if (exact) {
+        selectLieu(exact)
+        return
+      }
+      setLieuInput(appliedLieuLabel)
+    }
+    // Écran de saisie mobile : Entrée vaut validation du champ — ferme le clavier virtuel et
+    // revient à la vue formulaire (via le blur → changeActiveField).
+    if (inlineSuggestions && document.activeElement instanceof HTMLElement) document.activeElement.blur()
+    handleSubmit(inputValue, qSourceRef.current)
+  }
 
   const normalizeLieu = (s: string) => s.normalize("NFD").replace(/[̀-ͯ]/g, "").toLowerCase().trim()
 
@@ -377,7 +416,28 @@ export function SearchBar({
   }
 
   return (
+    // Formulaire de recherche (landmark `search`) : Entrée dans un champ passe par la soumission
+    // implicite HTML (cf. submitFromField). Elle exige un bouton submit « par défaut » dans le
+    // formulaire (deux champs texte la bloquent sinon) : le bouton caché ci-dessous joue ce
+    // rôle — le bouton Rechercher visible de la home est un bouton simple hors formulaire, et
+    // la page de résultats n'en a pas.
     <Box
+      component="form"
+      role="search"
+      aria-label="Recherche d'offres et de formations"
+      noValidate
+      onSubmit={(e) => {
+        e.preventDefault()
+        submitFromField()
+      }}
+      // Cmd+Entrée (macOS) / Ctrl+Entrée : le navigateur ne fait pas de soumission implicite
+      // avec un modificateur — on la déclenche. Après MUI (bulle depuis l'Autocomplete) : s'il a
+      // accepté une option il a fait preventDefault, on ne lance pas par-dessus.
+      onKeyDown={(e) => {
+        if (e.key !== "Enter" || !(e.metaKey || e.ctrlKey) || e.defaultPrevented) return
+        e.preventDefault()
+        e.currentTarget.requestSubmit()
+      }}
       sx={{
         display: "flex",
         flexDirection: rowSx.direction,
@@ -396,6 +456,13 @@ export function SearchBar({
         <Autocomplete
           freeSolo
           options={metierOptions}
+          // Comme le lieu : la 1ʳᵉ option est pré-surlignée, Entrée l'accepte. Pattern APG : une
+          // suggestion acceptée remplit le champ et ferme la liste sans lancer ; liste fermée,
+          // Entrée lance (soumission implicite). Seule la ligne « Rechercher : … » lance
+          // directement — c'est son libellé.
+          autoHighlight
+          loading={suggestionsLoading}
+          loadingText="Recherche de suggestions…"
           getOptionLabel={(o) => (typeof o === "string" ? o : o.value)}
           slots={inlineSuggestions ? { popper: InlineSuggestionsContainer } : undefined}
           blurOnSelect={inlineSuggestions}
@@ -412,25 +479,31 @@ export function SearchBar({
             // avec le libellé de la ligne « Rechercher : … ».
             if (reason === "reset") return
             setInputValue(value)
-            onQChange?.(value)
+            qSourceRef.current = "free_text"
+            onQChange?.(value, "free_text")
             if (value === "") handleSubmit("", "free_text")
           }}
           onChange={(_e, value) => {
-            if (!value) return
-            if (typeof value === "string") {
-              handleSubmit(value, "free_text")
-              return
-            }
+            // Chaîne = createOption de MUI (Entrée sans option surlignée, freeSolo) : MUI ne fait
+            // pas preventDefault, la soumission implicite qui suit lance la recherche — rien ici
+            // (sinon double lancement).
+            if (!value || typeof value === "string") return
             // Reflète la sélection dans le champ (onInputChange ignore le reason "reset",
             // le libellé sélectionné ne serait pas affiché sinon).
             setInputValue(value.value)
-            onQChange?.(value.value)
-            handleSubmit(value.value, value.kind === "suggestion" ? "suggestion" : "free_text")
+            if (value.kind === "free_text") {
+              handleSubmit(value.value, "free_text")
+              return
+            }
+            // Suggestion acceptée : le champ est rempli, la recherche part au prochain Entrée
+            // ou au bouton — avec l'origine « suggestion » (cf. qSourceRef).
+            qSourceRef.current = "suggestion"
+            onQChange?.(value.value, "suggestion")
           }}
           // key AVANT le spread, et retiré des props MUI : `key` après un spread fait
           // retomber SWC sur createElement — les enfants du li deviennent un tableau
           // non marqué statique et React exige alors un key sur chacun (warning).
-          renderOption={({ key: _muiKey, ...optionProps }, option) =>
+          renderOption={({ key: _muiKey, ...optionProps }, option, { index }) =>
             option.kind === "free_text" ? (
               <Box
                 component="li"
@@ -453,7 +526,8 @@ export function SearchBar({
                       {option.value}
                     </Box>
                   </Box>
-                  <Box sx={{ fontSize: "0.75rem", color: fr.colors.decisions.text.mention.grey.default }}>ou appuyer sur Entrée</Box>
+                  {/* L'indice n'est vrai que pour l'option pré-surlignée (cf. autoHighlight). */}
+                  {index === 0 && <Box sx={{ fontSize: "0.75rem", color: fr.colors.decisions.text.mention.grey.default }}>ou appuyer sur Entrée</Box>}
                 </Box>
               </Box>
             ) : (
@@ -461,10 +535,11 @@ export function SearchBar({
                 component="li"
                 key={option.value}
                 {...optionProps}
-                sx={{ minHeight: 40, px: "16px !important", fontSize: "1rem", color: fr.colors.decisions.text.default.grey.default }}
+                sx={{ minHeight: 40, px: "16px !important", fontSize: "1rem", color: fr.colors.decisions.text.default.grey.default, display: "block !important" }}
               >
-                {/* Span unique : le li MUI est en display:flex — des fragments texte séparés y perdent leurs espaces de bord. */}
-                <Box component="span">{highlightMatch(option.value, inputValue)}</Box>
+                {/* Bloc (pas flex) : libellé + indice Entrée sur la 1ʳᵉ suggestion, comme le champ lieu. */}
+                <Box>{highlightMatch(option.value, inputValue)}</Box>
+                {index === 0 && <Box sx={{ fontSize: "0.75rem", color: fr.colors.decisions.text.mention.grey.default }}>ou appuyer sur Entrée</Box>}
               </Box>
             )
           }
@@ -495,18 +570,12 @@ export function SearchBar({
                 htmlInput: {
                   ...params.inputProps,
                   maxLength: 200,
+                  // Clavier virtuel : touche « rechercher » (loupe) à la place de « retour ».
+                  enterKeyHint: "search",
                   "aria-labelledby": metierLabelId,
                   "aria-describedby": qError ? metierErrorId : undefined,
                   "aria-invalid": Boolean(qError),
                 },
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  handleSubmit(inputValue, "free_text")
-                  // Écran de saisie : Entrée vaut validation du champ — ferme le clavier
-                  // virtuel et revient à la vue formulaire (via le blur → changeActiveField).
-                  if (inlineSuggestions) (e.target as HTMLElement).blur()
-                }
               }}
             />
           )}
@@ -534,6 +603,9 @@ export function SearchBar({
           // Le champ affiche « France entière » : le focus sélectionne le texte pour qu'une
           // saisie le remplace directement (sinon l'usager doit l'effacer à la main).
           selectOnFocus={showsFranceEntiere}
+          // Pattern APG : une option surlignée est acceptée sans lancer (l'usager enchaîne
+          // souvent sur le métier) ; liste fermée, Entrée lance (soumission implicite →
+          // submitFromField, qui résout un éventuel texte non validé).
           options={lieuDropdownOptions}
           // Le reset post-sélection de MUI réécrit l'input avec getOptionLabel : pour
           // « France entière » c'est son libellé qui doit s'afficher (cf. onChange).
@@ -616,6 +688,7 @@ export function SearchBar({
               slotProps={{
                 htmlInput: {
                   ...params.inputProps,
+                  enterKeyHint: "search",
                   "aria-labelledby": lieuLabelId,
                   "aria-describedby": lieuError ? lieuErrorId : undefined,
                   "aria-invalid": Boolean(lieuError),
@@ -628,6 +701,12 @@ export function SearchBar({
         />
         {lieuError && <FieldError id={lieuErrorId}>{lieuError}</FieldError>}
       </Box>
+      {/* Bouton submit par défaut du formulaire (soumission implicite sur Entrée). `hidden` : hors
+          rendu et hors arbre d'accessibilité, non focusable — le lancement visible est le bouton
+          Rechercher de la home ou Entrée. */}
+      <button type="submit" hidden tabIndex={-1}>
+        Rechercher
+      </button>
     </Box>
   )
 }

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchBar.tsx
@@ -151,9 +151,12 @@ type LieuOption = { label: string; latitude: number; longitude: number; adminAre
 const lieuOptionKey = (o: LieuOption) => o.adminArea ?? o.label
 
 // Option « France entière » du champ lieu : proposée quand le champ est vide (Entrée la
-// sélectionne — autoHighlight), elle retire le lieu de la recherche. Le placeholder
-// « France entière » du champ vide reflète ensuite l'état appliqué.
+// sélectionne — autoHighlight), elle retire le lieu de la recherche. Une fois choisie, son
+// libellé s'affiche dans le champ comme un lieu ordinaire (le critère appliqué est « aucun
+// lieu ») ; le champ vide garde le placeholder qui décrit la saisie attendue (ville,
+// département, région — l'adresse et le code postal sont acceptés sans être annoncés).
 const FRANCE_ENTIERE_OPTION = { kind: "france_entiere", label: "France entière" } as const
+const isFranceEntiereLabel = (s: string) => s.trim() === FRANCE_ENTIERE_OPTION.label
 type LieuDropdownOption = LieuOption | typeof FRANCE_ENTIERE_OPTION
 
 // Option du dropdown métier : la 1ʳᵉ ligne relance la recherche en texte libre, les
@@ -163,6 +166,12 @@ type MetierOption = { kind: "free_text"; value: string } | { kind: "suggestion";
 interface SearchBarProps {
   initialQ?: string
   initialLieuLabel?: string
+  /**
+   * Page de résultats : sans lieu dans l'URL, la recherche porte sur la France entière et le
+   * champ l'affiche (le choix fait sur la home n'a pas de trace dans l'URL, « aucun lieu » = France
+   * entière). La home laisse le champ vide (placeholder) tant qu'aucun choix n'est fait.
+   */
+  franceEntiereIfEmpty?: boolean
   /** source : "suggestion" si l'utilisateur a sélectionné une option d'autocomplete, "free_text" sinon (télémétrie moteur de suggestion). */
   onSubmit: (q: string, source: "suggestion" | "free_text") => void
   onLieuChange: (lieu: { label: string; latitude: number; longitude: number; adminArea?: string } | null) => void
@@ -220,6 +229,7 @@ function FieldError({ children, id }: { children: ReactNode; id?: string }) {
 export function SearchBar({
   initialQ = "",
   initialLieuLabel,
+  franceEntiereIfEmpty = false,
   onSubmit,
   onLieuChange,
   onQChange,
@@ -234,11 +244,12 @@ export function SearchBar({
   const metierErrorId = useId()
   const lieuErrorId = useId()
   const [inputValue, setInputValue] = useState(initialQ)
-  const [lieuInput, setLieuInput] = useState(initialLieuLabel ?? "")
+  const emptyLieuLabel = franceEntiereIfEmpty ? FRANCE_ENTIERE_OPTION.label : ""
+  const [lieuInput, setLieuInput] = useState(initialLieuLabel ?? emptyLieuLabel)
   const [lieuValue, setLieuValue] = useState<LieuOption | null>(null)
   // Libellé du lieu réellement APPLIQUÉ à la recherche — source de vérité pour la
   // restauration au blur (le champ ne doit jamais afficher un texte ≠ critère actif).
-  const [appliedLieuLabel, setAppliedLieuLabel] = useState(initialLieuLabel ?? "")
+  const [appliedLieuLabel, setAppliedLieuLabel] = useState(initialLieuLabel ?? emptyLieuLabel)
 
   // Cache Components (<Activity>) garde l'instance de ce composant montée (masquée, pas
   // démontée) d'une navigation à l'autre — sans ceci, revenir en arrière puis relancer une
@@ -250,9 +261,18 @@ export function SearchBar({
     setInputValue(initialQ)
   }, [initialQ])
   useEffect(() => {
-    setLieuInput(initialLieuLabel ?? "")
-    setAppliedLieuLabel(initialLieuLabel ?? "")
-  }, [initialLieuLabel])
+    // Prop repassée à undefined (« aucun lieu ») : trois origines à distinguer par ce que le
+    // champ affichait — la croix l'a vidé (il reste vide, placeholder), l'option « France
+    // entière » l'a rempli (on garde), ou l'URL a perdu son lieu (retour navigateur : le champ
+    // reflète l'état appliqué, « France entière » sur la page de résultats, vide sur la home).
+    const next = (prev: string) => {
+      if (initialLieuLabel) return initialLieuLabel
+      if (prev === "") return ""
+      return isFranceEntiereLabel(prev) ? prev : emptyLieuLabel
+    }
+    setLieuInput(next)
+    setAppliedLieuLabel(next)
+  }, [initialLieuLabel, emptyLieuLabel])
 
   const debouncedInput = useThrottle(inputValue, 300)
   const debouncedLieu = useThrottle(lieuInput, 300)
@@ -309,7 +329,7 @@ export function SearchBar({
     queryKey: ["lieu-suggestions", debouncedLieu],
     // withAdminAreas : les départements et régions remontent dans les suggestions (index poi).
     queryFn: ({ signal }) => searchAddress(debouncedLieu, undefined, signal, true),
-    enabled: debouncedLieu.length >= 2,
+    enabled: debouncedLieu.length >= 2 && !isFranceEntiereLabel(debouncedLieu),
     staleTime: 1000 * 60 * 5,
     throwOnError: false,
   })
@@ -321,9 +341,11 @@ export function SearchBar({
     displayLabel: item.displayLabel,
   }))
 
-  // Champ vide : seule l'option « France entière » est proposée ; en saisie, les suggestions
-  // BAN (Entrée sélectionne la 1ʳᵉ dans les deux cas, cf. autoHighlight).
-  const lieuDropdownOptions: LieuDropdownOption[] = lieuInput.trim() ? lieuSuggestions : [FRANCE_ENTIERE_OPTION]
+  // Champ vide (ou affichant « France entière ») : seule l'option « France entière » est
+  // proposée ; en saisie, les suggestions BAN (Entrée sélectionne la 1ʳᵉ dans les deux cas,
+  // cf. autoHighlight).
+  const showsFranceEntiere = isFranceEntiereLabel(lieuInput)
+  const lieuDropdownOptions: LieuDropdownOption[] = lieuInput.trim() && !showsFranceEntiere ? lieuSuggestions : [FRANCE_ENTIERE_OPTION]
 
   const handleSubmit = useCallback(
     (value: string, source: "suggestion" | "free_text") => {
@@ -509,10 +531,13 @@ export function SearchBar({
           autoHighlight
           // Ouvre le dropdown au focus : l'option « France entière » est proposée avant toute saisie.
           openOnFocus
+          // Le champ affiche « France entière » : le focus sélectionne le texte pour qu'une
+          // saisie le remplace directement (sinon l'usager doit l'effacer à la main).
+          selectOnFocus={showsFranceEntiere}
           options={lieuDropdownOptions}
-          // Libellé vide pour « France entière » : le reset post-sélection de MUI réécrit
-          // l'input avec getOptionLabel — le champ doit rester vide (placeholder visible).
-          getOptionLabel={(o) => (typeof o === "string" ? o : "kind" in o ? "" : o.label)}
+          // Le reset post-sélection de MUI réécrit l'input avec getOptionLabel : pour
+          // « France entière » c'est son libellé qui doit s'afficher (cf. onChange).
+          getOptionLabel={(o) => (typeof o === "string" ? o : o.label)}
           isOptionEqualToValue={(o, v) => {
             if ("kind" in o) return false
             return typeof v === "string" ? o.label === v : !("kind" in v) && lieuOptionKey(o) === lieuOptionKey(v)
@@ -541,11 +566,12 @@ export function SearchBar({
           }}
           onChange={(_e, value) => {
             if (!value || typeof value === "string") return
-            // « France entière » : retire le lieu (équivalent de la croix, au clavier).
+            // « France entière » : retire le lieu et affiche le libellé dans le champ. La croix
+            // MUI (reason "clear") retire aussi le lieu mais laisse le champ vide (placeholder).
             if ("kind" in value) {
               setLieuValue(null)
-              setLieuInput("")
-              setAppliedLieuLabel("")
+              setLieuInput(FRANCE_ENTIERE_OPTION.label)
+              setAppliedLieuLabel(FRANCE_ENTIERE_OPTION.label)
               onLieuChange(null)
               return
             }
@@ -582,7 +608,7 @@ export function SearchBar({
             <TextField
               {...params}
               inputRef={lieuListbox.inputRef}
-              placeholder="France entière"
+              placeholder="Ville, département ou région"
               variant="outlined"
               size="small"
               fullWidth

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
@@ -17,7 +17,7 @@ import { SearchBar } from "./SearchBar"
 import { SearchMobilePanel } from "./SearchMobilePanel"
 import { SEARCH_MODE_OPTIONS, SearchTypeRechercheSelect } from "./SearchTypeRechercheSelect"
 
-type Lieu = { label: string; latitude: number; longitude: number }
+type Lieu = { label: string; latitude: number; longitude: number; adminArea?: string }
 
 // Placeholder court du faux champ (cf. design mobile) — le champ réel de la modale garde
 // le placeholder long de SearchBar.
@@ -113,6 +113,7 @@ export function SearchHomeForm() {
         lieu_label: lieu?.label,
         latitude: lieu?.latitude,
         longitude: lieu?.longitude,
+        admin_area: lieu?.adminArea,
         mode,
         radius: 20,
         page: 0,

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
@@ -65,8 +65,9 @@ function MobileFakeField({ value, onOpen }: { value?: string; onOpen: () => void
 /**
  * Formulaire du nouveau moteur affiché sur la page d'accueil pour les utilisateurs ayant
  * opté pour la nouvelle version : champs + type de recherche, SANS filtres (cf. Figma).
- * State local — la recherche ne part vers /recherche qu'au clic sur le bouton
- * Rechercher (Entrée et la sélection d'une suggestion ne font que remplir le champ).
+ * State local — la recherche part vers /recherche au clic sur le bouton Rechercher, sur
+ * Entrée dans un champ (sans suggestion surlignée) ou à l'acceptation d'une suggestion
+ * métier : même comportement que la barre de la page de résultats.
  * En mobile, la saisie passe par une modale plein écran ouverte par un faux champ —
  * champ ancré en haut, suggestions visibles au-dessus du clavier.
  */
@@ -143,17 +144,12 @@ export function SearchHomeForm() {
     )
   }
 
-  /* Comportement voulu (07/2026, susceptible d'évoluer) : Entrée ou la sélection d'une
-     suggestion REMPLIT le champ métier sans déclencher la recherche — seul le bouton
-     Rechercher lance la navigation. Pour revenir au lancement direct, rebrancher
-     launchSearch sur onSubmit. */
-  const fillQ = (query: string, source: QSource) => {
-    setQ(query)
-    setQSource(source)
-  }
-  const handleQChange = (value: string) => {
+  /* 07/2026 : Entrée et la sélection d'une suggestion ne faisaient que remplir le champ, seul
+     le bouton lançait. Abandonné 09/2026 pour aligner la home sur la page de résultats
+     (Entrée = lancer, convention des barres de recherche) et supprimer l'écart de comportement. */
+  const handleQChange = (value: string, source: QSource) => {
     setQ(value)
-    setQSource("free_text")
+    setQSource(source)
   }
 
   // Même événement que le sélecteur de la page de résultats (spec tracking filtres).
@@ -205,7 +201,7 @@ export function SearchHomeForm() {
       {/* Grand écran : rangée champs + type de recherche + bouton. */}
       <Box sx={{ display: { xs: "none", lg: "flex" }, flexDirection: "row", gap: fr.spacing("3v"), alignItems: "flex-end" }}>
         <Box sx={{ flex: 1 }}>
-          <SearchBar key={formKey} layout="row" onSubmit={fillQ} onQChange={handleQChange} onLieuChange={setLieu} />
+          <SearchBar key={formKey} layout="row" onSubmit={launchSearch} onQChange={handleQChange} onLieuChange={setLieu} />
         </Box>
         <SearchTypeRechercheSelect value={mode} onChange={handleModeChange} />
         {/* Même hauteur que les champs (48px — le bouton DSFR fait 40px par défaut). */}
@@ -228,7 +224,7 @@ export function SearchHomeForm() {
               onActiveFieldChange={(field) => setMobileFieldActive(field !== null)}
               initialQ={q}
               initialLieuLabel={lieu?.label}
-              onSubmit={fillQ}
+              onSubmit={launchSearch}
               onQChange={handleQChange}
               onLieuChange={setLieu}
             />

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
@@ -5,7 +5,7 @@ import Button from "@codegouvfr/react-dsfr/Button"
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons"
 import { Box, ButtonBase } from "@mui/material"
 import { useRouter } from "next/navigation"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { RechercheFormTitle } from "@/app/_components/RechercheForm/RechercheFormTitle"
 import { MATOMO_EVENTS, pushMatomoEvent, SEARCH_ENGINES } from "@/utils/matomo-utils"
@@ -90,11 +90,31 @@ export function SearchHomeForm() {
     setMobileFieldActive(false)
   }
 
+  // Retour sur la home après une recherche : formulaire vierge, comme après un montage à neuf.
+  // Selon le chemin de navigation, cacheComponents remonte la home ou réaffiche l'instance
+  // conservée (<Activity> masquée) avec tout son état — le dernier choix réapparaissait alors
+  // (« France entière » notamment) là où une instance neuve n'en garde rien. Les effets d'une
+  // Activity masquée sont rejoués au réaffichage : c'est le signal de retour. Le reset ne
+  // s'applique qu'après un lancement (searchLaunched), jamais au premier montage.
+  // SearchBar (desktop) garde sa saisie en interne : le changement de key la remonte.
+  const [formKey, setFormKey] = useState(0)
+  const searchLaunched = useRef(false)
+  useEffect(() => {
+    if (!searchLaunched.current) return
+    searchLaunched.current = false
+    setQ("")
+    setQSource("free_text")
+    setLieu(null)
+    setMode(DEFAULT_SEARCH_MODE)
+    setFormKey((k) => k + 1)
+  }, [])
+
   const launchSearch = (query: string, source: QSource) => {
     // cacheComponents (<Activity>) garde cette instance montée — pas démontée — pendant la
     // navigation : sans fermeture explicite, la modale serait encore ouverte en revenant
     // sur l'accueil (logo LBA, bouton retour).
     closeMobilePanel()
+    searchLaunched.current = true
     // Même événement que le formulaire home legacy, enrichi de search_engine.
     pushMatomoEvent({
       event: MATOMO_EVENTS.SEARCH_LAUNCHED,
@@ -185,7 +205,7 @@ export function SearchHomeForm() {
       {/* Grand écran : rangée champs + type de recherche + bouton. */}
       <Box sx={{ display: { xs: "none", lg: "flex" }, flexDirection: "row", gap: fr.spacing("3v"), alignItems: "flex-end" }}>
         <Box sx={{ flex: 1 }}>
-          <SearchBar layout="row" onSubmit={fillQ} onQChange={handleQChange} onLieuChange={setLieu} />
+          <SearchBar key={formKey} layout="row" onSubmit={fillQ} onQChange={handleQChange} onLieuChange={setLieu} />
         </Box>
         <SearchTypeRechercheSelect value={mode} onChange={handleModeChange} />
         {/* Même hauteur que les champs (48px — le bouton DSFR fait 40px par défaut). */}
@@ -202,6 +222,7 @@ export function SearchHomeForm() {
               l'espace du panneau (borné au viewport visible, donc au-dessus du clavier). */}
           <Box sx={{ display: "flex", flexDirection: "column", gap: fr.spacing("4v"), height: mobileFieldActive ? "100%" : undefined }}>
             <SearchBar
+              key={formKey}
               layout="column"
               inlineSuggestions
               onActiveFieldChange={(field) => setMobileFieldActive(field !== null)}

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchHomeForm.tsx
@@ -100,6 +100,7 @@ export function SearchHomeForm() {
       event: MATOMO_EVENTS.SEARCH_LAUNCHED,
       search_job_name: query.trim() || "non_renseigné",
       search_address: lieu?.label || "non_renseigné",
+      search_admin_area: lieu?.adminArea ?? "non_renseigné",
       search_radius: 20,
       search_diploma: "indifferent",
       search_origin: "page_accueil",

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
@@ -202,12 +202,12 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
     navigateSilent({ ...params, q: q || undefined, q_source: q ? source : undefined, page: 0 })
   }
 
-  function handleLieuChange(lieu: { label: string; latitude: number; longitude: number } | null) {
+  function handleLieuChange(lieu: { label: string; latitude: number; longitude: number; adminArea?: string } | null) {
     // Nouveau lieu → on repart du rayon le plus étroit (élargissement auto ensuite).
     if (lieu) {
-      navigateSilent({ ...params, lieu_label: lieu.label, latitude: lieu.latitude, longitude: lieu.longitude, radius: 20, page: 0 })
+      navigateSilent({ ...params, lieu_label: lieu.label, latitude: lieu.latitude, longitude: lieu.longitude, admin_area: lieu.adminArea, radius: 20, page: 0 })
     } else {
-      navigateSilent({ ...params, lieu_label: undefined, latitude: undefined, longitude: undefined, radius: 20, page: 0 })
+      navigateSilent({ ...params, lieu_label: undefined, latitude: undefined, longitude: undefined, admin_area: undefined, radius: 20, page: 0 })
     }
   }
 

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
@@ -302,7 +302,7 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
               >
                 <Box id="search-form" tabIndex={-1} sx={{ display: "flex", gap: fr.spacing("3v"), alignItems: "flex-end" }}>
                   <Box sx={{ flex: 1 }}>
-                    <SearchBar initialQ={params.q} initialLieuLabel={params.lieu_label} onSubmit={handleSearch} onLieuChange={handleLieuChange} />
+                    <SearchBar initialQ={params.q} initialLieuLabel={params.lieu_label} franceEntiereIfEmpty onSubmit={handleSearch} onLieuChange={handleLieuChange} />
                   </Box>
                   <SearchTypeRechercheSelect value={params.mode} onChange={handleModeChange} />
                 </Box>
@@ -371,6 +371,7 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
                 onActiveFieldChange={(field) => setSearchFieldActive(field !== null)}
                 initialQ={params.q}
                 initialLieuLabel={params.lieu_label}
+                franceEntiereIfEmpty
                 onSubmit={handleSearch}
                 onLieuChange={handleLieuChange}
               />

--- a/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
+++ b/ui/app/(candidat)/(recherche)/recherche/_components/SearchPageClient.tsx
@@ -169,6 +169,9 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
       count_company_algo: facets?.sub_type?.[LBA_ITEM_TYPE.RECRUTEURS_LBA] ?? 0,
       search_job_name: params.q || "non_renseigné",
       search_address: params.lieu_label || "non_renseigné",
+      // Emprise administrative (region:53, departement:44) : distingue une recherche « Bretagne »
+      // d'une recherche par point + rayon, que search_address seul ne permet pas.
+      search_admin_area: params.admin_area ?? "non_renseigné",
       search_diploma: params.level?.[0] ?? "indifferent",
       search_engine: SEARCH_ENGINES.BETA,
     })
@@ -193,6 +196,7 @@ export function SearchPageClient({ initialParams }: SearchPageClientProps) {
       event: MATOMO_EVENTS.SEARCH_LAUNCHED,
       search_job_name: q || "non_renseigné",
       search_address: params.lieu_label || "non_renseigné",
+      search_admin_area: params.admin_area ?? "non_renseigné",
       search_radius: params.radius,
       search_diploma: params.level?.[0] ?? "indifferent",
       search_origin: "page_resultat",

--- a/ui/app/(candidat)/(recherche)/recherche/_hooks/use-auto-radius.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_hooks/use-auto-radius.ts
@@ -20,7 +20,8 @@ export function useAutoRadius({
   result: ReturnType<typeof useSearchResults>
   onRadiusChange: (radius: number) => void
 }) {
-  const hasGeo = params.latitude !== undefined && params.longitude !== undefined
+  // Emprise administrative : le rayon n'intervient plus dans le filtre, l'élargir ne changerait rien.
+  const hasGeo = params.latitude !== undefined && params.longitude !== undefined && !params.admin_area
   const nbHits = result.data?.pages.at(-1)?.nbHits ?? 0
   const busy = result.isLoading || result.isFetching
 

--- a/ui/app/(candidat)/(recherche)/recherche/_hooks/use-search-results.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_hooks/use-search-results.ts
@@ -34,6 +34,7 @@ export function paramsToQuerystring(params: ISearchPageParams) {
   if (params.sort) qs.sort = params.sort
   if (params.latitude !== undefined) qs.latitude = params.latitude
   if (params.longitude !== undefined) qs.longitude = params.longitude
+  if (params.admin_area) qs.admin_area = params.admin_area
   return qs
 }
 

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.test.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.test.ts
@@ -53,6 +53,28 @@ describe("search_source (origine de q)", () => {
   })
 })
 
+describe("admin_area (emprise administrative exacte)", () => {
+  it("rejette toute forme qui n'est pas maille:code", () => {
+    for (const bad of ["foo", "region:", "epci:244400404", "departement:nantes", "departement:2a", "region:53:x"]) {
+      expect(parseSearchPageParams(new URLSearchParams(`admin_area=${bad}`)).admin_area, bad).toBeUndefined()
+    }
+  })
+
+  it("accepte région, département, Corse et DROM", () => {
+    expect(parseSearchPageParams(new URLSearchParams("admin_area=region:53")).admin_area).toBe("region:53")
+    expect(parseSearchPageParams(new URLSearchParams("admin_area=departement:2A")).admin_area).toBe("departement:2A")
+    expect(parseSearchPageParams(new URLSearchParams("admin_area=departement:974")).admin_area).toBe("departement:974")
+  })
+
+  it("round-trip URL avec la paire lat/lon conservée pour la distance affichée", () => {
+    const url = buildSearchUrl({ ...base, lieu_label: "Bretagne", latitude: 48.1569, longitude: -3.54511, admin_area: "region:53" })
+    const parsed = parseSearchPageParams(new URL(url, "https://x").searchParams)
+    expect(parsed.admin_area).toBe("region:53")
+    expect(parsed.latitude).toBe(48.1569)
+    expect(parsed.lieu_label).toBe("Bretagne")
+  })
+})
+
 describe("buildSearchPageTitle", () => {
   it("sans métier : titre de base seul, quel que soit le lieu", () => {
     expect(buildSearchPageTitle(base)).toBe("Offres en alternance | La bonne alternance")

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
@@ -22,9 +22,17 @@ export interface ISearchPageParams {
   latitude?: number
   longitude?: number
   radius: number
+  /**
+   * Emprise administrative exacte ("region:53", "departement:44") quand le lieu sélectionné est
+   * un département ou une région. L'API filtre dessus et ignore le rayon ; lat/lon restent posés
+   * pour la distance affichée et le tri par proximité.
+   */
+  admin_area?: string
   page: number
   hitsPerPage: number
 }
+
+const ADMIN_AREA_PATTERN = /^(region|departement):([0-9]{1,3}|2[AB])$/
 
 export type SearchMode = "emplois" | "formations" | "emplois_formation"
 export const SEARCH_MODES: SearchMode[] = ["emplois", "formations", "emplois_formation"]
@@ -110,6 +118,7 @@ export function parseSearchPageParams(search: URLSearchParams): ISearchPageParam
     latitude: hasGeoPair ? latitude : undefined,
     longitude: hasGeoPair ? longitude : undefined,
     radius: getInt("radius", 20),
+    admin_area: ADMIN_AREA_PATTERN.test(search.get("admin_area") ?? "") ? search.get("admin_area")! : undefined,
     page: getInt("page", 0),
     hitsPerPage: getInt("hitsPerPage", 20),
   }
@@ -138,6 +147,7 @@ export function buildSearchUrl(params: ISearchPageParams, basePath = "/recherche
   if (params.latitude !== undefined) query.set("latitude", params.latitude.toString())
   if (params.longitude !== undefined) query.set("longitude", params.longitude.toString())
   if (params.radius !== 20) query.set("radius", params.radius.toString())
+  if (params.admin_area) query.set("admin_area", params.admin_area)
   if (params.page !== 0) query.set("page", params.page.toString())
   if (params.hitsPerPage !== 20) query.set("hitsPerPage", params.hitsPerPage.toString())
 

--- a/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
+++ b/ui/app/(candidat)/(recherche)/recherche/_utils/search.params.utils.ts
@@ -1,6 +1,7 @@
 // Import profond et non via le barrel "shared" : ce module part dans le bundle de la home.
 
 import { LBA_ITEM_TYPE } from "shared/constants/lbaitem"
+import { ADMIN_AREA_PATTERN } from "shared/utils/admin-area"
 import { toKebabCase } from "shared/utils/string-utils"
 
 export interface ISearchPageParams {
@@ -31,8 +32,6 @@ export interface ISearchPageParams {
   page: number
   hitsPerPage: number
 }
-
-const ADMIN_AREA_PATTERN = /^(region|departement):([0-9]{1,3}|2[AB])$/
 
 export type SearchMode = "emplois" | "formations" | "emplois_formation"
 export const SEARCH_MODES: SearchMode[] = ["emplois", "formations", "emplois_formation"]

--- a/ui/services/base-adresse.test.ts
+++ b/ui/services/base-adresse.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { searchAddress } from "./base-adresse"
+
+/**
+ * Réponse modelée sur ce que renvoie data.geopf.fr pour « Breta » avec `index=address,poi` :
+ * les items `poi` n'ont ni `label` ni `population`, et leurs `postcode` / `citycode` sont des
+ * tableaux. L'ordre est volontairement défavorable (communes d'abord) pour tester le tri.
+ */
+const poi = (category: string, toponym: string, citycode: string, postcode?: string[]) => ({
+  type: "Feature",
+  geometry: { type: "Point", coordinates: [-3.5, 48.1] },
+  properties: { _type: "poi", toponym, name: [toponym], category: ["administratif", category], citycode: [citycode], ...(postcode ? { postcode } : {}), score: 0.9 },
+})
+const municipality = (label: string, citycode: string, postcode: string, population: number) => ({
+  type: "Feature",
+  geometry: { type: "Point", coordinates: [6.99, 47.59] },
+  properties: { _type: "address", type: "municipality", label, name: label, citycode, postcode, population, score: 0.85 },
+})
+
+const stubFetch = (features: unknown[]) => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ features }) })
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("searchAddress avec les entités administratives", () => {
+  it("demande les deux index, et ne filtre poi que sur département et région", async () => {
+    const fetchMock = stubFetch([])
+    await searchAddress("Breta", undefined, undefined, true)
+    const url = new URL(fetchMock.mock.calls[0][0] as string)
+    expect(url.searchParams.get("index")).toBe("address,poi")
+    expect(url.searchParams.get("category")).toBe("département,région")
+    // Sous 6 caractères, le filtre historique de l'index address reste posé.
+    expect(url.searchParams.get("type")).toBe("municipality")
+  })
+
+  it("sans l'option, la requête est celle d'avant : index address seul, aucun filtre poi", async () => {
+    const fetchMock = stubFetch([])
+    await searchAddress("Breta")
+    const url = new URL(fetchMock.mock.calls[0][0] as string)
+    expect(url.searchParams.has("index")).toBe(false)
+    expect(url.searchParams.has("category")).toBe(false)
+  })
+
+  it("région, puis département, puis les communes par population", async () => {
+    stubFetch([
+      municipality("Bretagne", "90019", "90130", 200),
+      municipality("Bretagne-de-Marsan", "40055", "40280", 1400),
+      poi("département", "Nord", "59"),
+      municipality("Bretagne", "36024", "36110", 1000),
+      poi("région", "Bretagne", "53"),
+    ])
+    const items = await searchAddress("Breta", undefined, undefined, true)
+    expect(items.map((i) => i.label)).toEqual(["Bretagne", "Nord", "Bretagne-de-Marsan 40280", "Bretagne 36110", "Bretagne 90130"])
+  })
+
+  it("porte le code administratif et un libellé de liste explicite, sans toucher au libellé appliqué", async () => {
+    stubFetch([poi("région", "Bretagne", "53"), poi("département", "Nord", "59")])
+    const [bretagne, nord] = await searchAddress("Breta", undefined, undefined, true)
+    expect(bretagne).toMatchObject({ label: "Bretagne", displayLabel: "Bretagne (région)", adminArea: "region:53", insee: "53", zipcode: "" })
+    expect(nord).toMatchObject({ label: "Nord", displayLabel: "Nord (département)", adminArea: "departement:59" })
+  })
+
+  it("ne sérialise jamais un tableau de codes postaux dans le libellé", async () => {
+    // Cas de la capture d'écran : « Bretagne 76200,76370 ». Exclu par le filtre category, mais le
+    // mapping doit rester sain si le filtre s'élargit un jour.
+    stubFetch([poi("commune", "Bretagne", "76136", ["76200", "76370"])])
+    const [item] = await searchAddress("Breta", undefined, undefined, true)
+    expect(item.label).toBe("Bretagne 76200")
+    expect(item.zipcode).toBe("76200")
+    expect(item.adminArea).toBeUndefined()
+  })
+
+  it("une commune de l'index address garde son format historique, sans adminArea ni displayLabel", async () => {
+    stubFetch([municipality("Nantes", "44109", "44000", 320000)])
+    const [nantes] = await searchAddress("Nantes", undefined, undefined, true)
+    expect(nantes).toEqual({ value: { type: "Point", coordinates: [6.99, 47.59] }, insee: "44109", zipcode: "44000", label: "Nantes 44000" })
+  })
+})

--- a/ui/services/base-adresse.test.ts
+++ b/ui/services/base-adresse.test.ts
@@ -74,6 +74,13 @@ describe("searchAddress avec les entités administratives", () => {
     expect(item.adminArea).toBeUndefined()
   })
 
+  it("outre-mer : une seule ligne quand la région et le département portent le même nom, le département", async () => {
+    stubFetch([poi("région", "Guadeloupe", "01"), poi("département", "Guadeloupe", "971"), poi("région", "Bretagne", "53")])
+    const items = await searchAddress("Guad", undefined, undefined, true)
+    expect(items.map((i) => i.displayLabel)).toEqual(["Bretagne (région)", "Guadeloupe (département)"])
+    expect(items[1].adminArea).toBe("departement:971")
+  })
+
   it("une commune de l'index address garde son format historique, sans adminArea ni displayLabel", async () => {
     stubFetch([municipality("Nantes", "44109", "44000", 320000)])
     const [nantes] = await searchAddress("Nantes", undefined, undefined, true)

--- a/ui/services/base-adresse.ts
+++ b/ui/services/base-adresse.ts
@@ -7,12 +7,24 @@ import { simplifiedItems } from "./arrondissements"
 
 type AddressFeature = {
   properties: {
-    label: string
-    postcode: string
-    citycode: string
+    // Présents sur l'index `address` uniquement. L'index `poi` renvoie `toponym` et
+    // `category` à la place, sans `label` ni `postcode` (cf. ban-plateforme#781) : tout
+    // accès direct à `label` plante sur une feature poi.
+    label?: string
+    postcode?: string
+    citycode?: string | string[]
     population?: number
+    toponym?: string
+    category?: string[]
+    _type?: "address" | "poi"
   }
   geometry: IPointGeometry
+}
+
+/** Catégories `poi` retenues comme emprise de recherche, et leur nom côté API LBA. */
+const ADMIN_CATEGORIES: Record<string, "region" | "departement"> = {
+  région: "region",
+  département: "departement",
 }
 
 type Coordinates = [number, number]
@@ -22,9 +34,16 @@ type IAddressItem = {
   insee: string
   zipcode: string
   label: string
+  /** `"region:53"` / `"departement:44"` : renseigné uniquement pour une entité supra-communale. */
+  adminArea?: string
 }
 
-export async function searchAddress(value: string, type?: string, signal?: AbortSignal): Promise<IAddressItem[]> {
+/**
+ * `withAdminAreas` ajoute l'index `poi` à la requête : les départements et régions remontent
+ * alors dans les suggestions, avec leur code dans `adminArea`. Opt-in tant que le filtrage
+ * par emprise n'est pas généralisé côté API.
+ */
+export async function searchAddress(value: string, type?: string, signal?: AbortSignal, withAdminAreas = false): Promise<IAddressItem[]> {
   if (value && value.length > 2) {
     let term = value
     const limit = 10
@@ -42,7 +61,9 @@ export async function searchAddress(value: string, type?: string, signal?: Abort
     }
     if (type) filter = "&type=" + type
 
-    const addressURL = `https://data.geopf.fr/geocodage/search/?limit=${limit}&q=${term}${filter}`
+    // `index=address,poi` : un seul appel, les deux index scorés ensemble par le service.
+    const index = withAdminAreas ? "&index=address,poi" : ""
+    const addressURL = `https://data.geopf.fr/geocodage/search/?limit=${limit}&q=${term}${filter}${index}`
 
     try {
       const response = await fetch(addressURL, { signal })
@@ -57,14 +78,23 @@ export async function searchAddress(value: string, type?: string, signal?: Abort
       })
 
       const returnedItems = data.features.map((feature) => {
-        let label = feature.properties.label
-        if (label.indexOf(feature.properties.postcode) < 0) label += " " + feature.properties.postcode
+        const { label: addressLabel, postcode, citycode, toponym, category } = feature.properties
+        // `citycode` porte le code commune sur l'index address, et le code département ou
+        // région sur l'index poi : l'API n'expose pas de champ `code` dédié.
+        const code = Array.isArray(citycode) ? citycode[0] : citycode
+        const adminKind = category ? ADMIN_CATEGORIES[category[1]] : undefined
+
+        let label = addressLabel ?? toponym ?? ""
+        // Une entité supra-communale n'a pas de code postal : concaténer produirait
+        // "Bretagne undefined".
+        if (postcode && label.indexOf(postcode) < 0) label += " " + postcode
 
         return {
           value: feature.geometry,
-          insee: feature.properties.citycode,
-          zipcode: feature.properties.postcode,
+          insee: code ?? "",
+          zipcode: postcode ?? "",
           label,
+          ...(adminKind && code ? { adminArea: `${adminKind}:${code}` } : {}),
         }
       })
 
@@ -89,9 +119,9 @@ export const fetchAddressFromCoordinates = async (coordinates: Coordinates, type
     const data: { features: AddressFeature[] } = await response.json()
     const returnedItems: IAddressItem[] = data.features.map((feature) => ({
       value: feature.geometry,
-      insee: feature.properties.citycode,
-      zipcode: feature.properties.postcode,
-      label: feature.properties.label,
+      insee: (Array.isArray(feature.properties.citycode) ? feature.properties.citycode[0] : feature.properties.citycode) ?? "",
+      zipcode: feature.properties.postcode ?? "",
+      label: feature.properties.label ?? feature.properties.toponym ?? "",
     }))
 
     return returnedItems

--- a/ui/services/base-adresse.ts
+++ b/ui/services/base-adresse.ts
@@ -21,11 +21,28 @@ type AddressFeature = {
   geometry: IPointGeometry
 }
 
-/** Catégories `poi` retenues comme emprise de recherche, et leur nom côté API LBA. */
-const ADMIN_CATEGORIES: Record<string, "region" | "departement"> = {
-  région: "region",
-  département: "departement",
+/**
+ * Catégories `poi` retenues comme emprise de recherche, leur nom côté API LBA et leur rang
+ * d'affichage : la région avant le département, tous deux avant les communes.
+ */
+const ADMIN_CATEGORIES: Record<string, { kind: "region" | "departement"; rank: number }> = {
+  région: { kind: "region", rank: 0 },
+  département: { kind: "departement", rank: 1 },
 }
+const COMMUNE_RANK = 2
+
+/**
+ * Seules catégories demandées à l'index `poi`. `type=municipality` ne filtre que l'index
+ * `address` : sans cette restriction, `poi` remplissait les 10 places avec tout ce qui porte le
+ * nom saisi (hameaux, arrêt de tram « Bretagne » à Nantes, forêt…) et plus aucune commune de
+ * l'index `address` ne passait. Les communes restent servies par `address`, dans leur format
+ * historique : pas de doublon, pas d'EPCI sans code, arrondissements déjà couverts (75115…).
+ */
+const POI_CATEGORIES = "département,région"
+
+const firstOf = (value: string | string[] | undefined): string | undefined => (Array.isArray(value) ? value[0] : value)
+
+const adminRank = (feature: AddressFeature): number => (feature.properties.category && ADMIN_CATEGORIES[feature.properties.category[1]]?.rank) ?? COMMUNE_RANK
 
 type Coordinates = [number, number]
 
@@ -36,6 +53,11 @@ type IAddressItem = {
   label: string
   /** `"region:53"` / `"departement:44"` : renseigné uniquement pour une entité supra-communale. */
   adminArea?: string
+  /**
+   * Libellé de la liste de suggestions quand il diffère du libellé appliqué : « Bretagne (région) »
+   * dans la liste, « Bretagne » dans le champ, l'URL et le H1.
+   */
+  displayLabel?: string
 }
 
 /**
@@ -62,7 +84,8 @@ export async function searchAddress(value: string, type?: string, signal?: Abort
     if (type) filter = "&type=" + type
 
     // `index=address,poi` : un seul appel, les deux index scorés ensemble par le service.
-    const index = withAdminAreas ? "&index=address,poi" : ""
+    // `category` ne s'applique qu'à `poi` : l'index `address` reste entier (communes, rues, numéros).
+    const index = withAdminAreas ? `&index=address,poi&category=${encodeURIComponent(POI_CATEGORIES)}` : ""
     const addressURL = `https://data.geopf.fr/geocodage/search/?limit=${limit}&q=${term}${filter}${index}`
 
     try {
@@ -71,18 +94,26 @@ export async function searchAddress(value: string, type?: string, signal?: Abort
 
       const data: { features: AddressFeature[] } = await response.json()
       data.features.sort((a, b) => {
+        // Région, puis département, puis le reste : une entité que l'API score à 1 ne doit pas
+        // passer derrière une commune de 200 habitants parce qu'elle n'a pas de population.
+        const rank = adminRank(a) - adminRank(b)
+        if (rank !== 0) return rank
         if (a.properties.population && b.properties.population) return b.properties.population - a.properties.population
         else if (a.properties.population) return -1
         else if (b.properties.population) return 1
         else return 0
       })
 
-      const returnedItems = data.features.map((feature) => {
-        const { label: addressLabel, postcode, citycode, toponym, category } = feature.properties
-        // `citycode` porte le code commune sur l'index address, et le code département ou
-        // région sur l'index poi : l'API n'expose pas de champ `code` dédié.
-        const code = Array.isArray(citycode) ? citycode[0] : citycode
-        const adminKind = category ? ADMIN_CATEGORIES[category[1]] : undefined
+      const returnedItems = data.features.map((feature): IAddressItem => {
+        const { label: addressLabel, citycode, toponym, category } = feature.properties
+        // Sur `poi`, `postcode` et `citycode` sont des tableaux : sans ce premier élément, le
+        // libellé sérialisait le tableau (« Bretagne 76200,76370 »). `citycode` porte le code
+        // commune sur `address`, et le code département ou région sur `poi` : l'API n'expose pas
+        // de champ `code` dédié.
+        const postcode = firstOf(feature.properties.postcode)
+        const code = firstOf(citycode)
+        const adminCategory = category?.[1]
+        const admin = adminCategory ? ADMIN_CATEGORIES[adminCategory] : undefined
 
         let label = addressLabel ?? toponym ?? ""
         // Une entité supra-communale n'a pas de code postal : concaténer produirait
@@ -94,7 +125,7 @@ export async function searchAddress(value: string, type?: string, signal?: Abort
           insee: code ?? "",
           zipcode: postcode ?? "",
           label,
-          ...(adminKind && code ? { adminArea: `${adminKind}:${code}` } : {}),
+          ...(admin && code ? { adminArea: `${admin.kind}:${code}`, displayLabel: `${label} (${adminCategory})` } : {}),
         }
       })
 

--- a/ui/services/base-adresse.ts
+++ b/ui/services/base-adresse.ts
@@ -11,7 +11,7 @@ type AddressFeature = {
     // `category` à la place, sans `label` ni `postcode` (cf. ban-plateforme#781) : tout
     // accès direct à `label` plante sur une feature poi.
     label?: string
-    postcode?: string
+    postcode?: string | string[]
     citycode?: string | string[]
     population?: number
     toponym?: string
@@ -41,6 +41,17 @@ const COMMUNE_RANK = 2
 const POI_CATEGORIES = "département,région"
 
 const firstOf = (value: string | string[] | undefined): string | undefined => (Array.isArray(value) ? value[0] : value)
+
+/**
+ * Guadeloupe, Martinique, Guyane, La Réunion, Mayotte : la région et le département portent le
+ * même nom et couvrent le même territoire. Proposer les deux, c'est deux lignes « Guadeloupe »
+ * pour un seul choix. On garde le département, dont le code (971…) est celui que tout le monde
+ * connaît ; le filtre renvoie exactement les mêmes résultats.
+ */
+const dedupeSingleDepartmentRegions = (items: IAddressItem[]): IAddressItem[] => {
+  const departementLabels = new Set(items.filter((i) => i.adminArea?.startsWith("departement:")).map((i) => i.label))
+  return items.filter((i) => !(i.adminArea?.startsWith("region:") && departementLabels.has(i.label)))
+}
 
 const adminRank = (feature: AddressFeature): number => (feature.properties.category && ADMIN_CATEGORIES[feature.properties.category[1]]?.rank) ?? COMMUNE_RANK
 
@@ -129,7 +140,7 @@ export async function searchAddress(value: string, type?: string, signal?: Abort
         }
       })
 
-      return simplifiedItems(returnedItems)
+      return simplifiedItems(dedupeSingleDepartmentRegions(returnedItems))
     } catch (err) {
       // Requête supplantée par une saisie plus récente (React Query annule via signal à chaque
       // frappe) : flux normal de l'autocomplétion, pas une erreur à faire remonter.
@@ -151,7 +162,7 @@ export const fetchAddressFromCoordinates = async (coordinates: Coordinates, type
     const returnedItems: IAddressItem[] = data.features.map((feature) => ({
       value: feature.geometry,
       insee: (Array.isArray(feature.properties.citycode) ? feature.properties.citycode[0] : feature.properties.citycode) ?? "",
-      zipcode: feature.properties.postcode ?? "",
+      zipcode: firstOf(feature.properties.postcode) ?? "",
       label: feature.properties.label ?? feature.properties.toponym ?? "",
     }))
 


### PR DESCRIPTION
Closes #5248

## Changements

**Recherche par emprise administrative**
- Le champ « lieu » propose les régions et les départements en tête des suggestions (« Bretagne (région) », « Nord (département) »), puis les communes comme avant. Un seul appel Géoplateforme : `index=address,poi&category=département,région`, l'index `address` reste entier.
- `search_items` porte `departement_code` et `region_code`, indexés en `token`, dérivés à la construction de chaque item depuis le référentiel communes en base : INSEE, sinon code postal, sinon règle de numérotation (CEDEX), sinon géopoint dans l'emprise d'une commune. Saint-Martin, Saint-Barthélemy et Saint-Pierre-et-Miquelon restent à `null`, ce ne sont pas des départements.
- `/v1/search?admin_area=departement:44` filtre par `equals` et prime sur le point + rayon. Le tri par pertinence s'applique sur tout le périmètre ; la distance n'est plus affichée (elle serait mesurée depuis le centroïde). Sans `admin_area`, rien ne change.
- Migration : mise à jour de la définition de l'index Atlas Search et mise en file de `fillSearchItemsCollection` pour peupler les deux champs.
- Télémétrie : `admin_area` dans `search_queries`, `search_admin_area` dans les événements Matomo de recherche.

**Barre de recherche : touche Entrée et double comptage Matomo**
- `search_launched` était envoyé **deux fois** par frappe Entrée sur le champ métier : `onChange` de MUI (option acceptée) et le `onKeyDown` maison appelaient chacun `handleSubmit`, donc `pushMatomoEvent`. Corrigé par un `<form role="search">` avec un seul point d'entrée `onSubmit` (soumission implicite HTML, bouton submit caché) : un lancement, un événement.
- Entrée = sélection de l'option pré-surlignée (`autoHighlight`) dans les deux champs, home et page de résultats ; la ligne « Rechercher : … » disparaît. Page de résultats : une suggestion acceptée applique la recherche aussitôt, comme le lieu (`submitOnSuggestion`). Home : la suggestion remplit le champ, le bouton lance. Liste fermée ou sans suggestion, Entrée soumet le formulaire.
- État vide affiché sans délai en emprise administrative : la liste attendait la fin d'un élargissement de rayon que `useAutoRadius` ne fait pas avec `admin_area` (skeleton infini). Condition partagée `isAutoRadiusActive`.

**Défauts de données mis au jour par la mesure, corrigés**
- Sync delta : `updated_at` horodaté à l'écriture dans les imports, plus au début de l'import. 965 offres en prod n'étaient jamais resynchronisées.
- Nightly : les items existants sont réécrits complètement (`keywords` préservés) au lieu d'une liste fermée de champs qui laissait dériver `address` et `location` (1 593 offres).
- Formations : géopoint hors de l'emprise de sa commune recentré sur la commune, compteur loggé (85 formations, dont La Roche-sur-Yon affichée près de Nantes).
- Recruteurs LBA : projection SIRENE choisie par le code INSEE quand le code postal manque (7 établissements réunionnais projetés en mer du Nord).

**Tests** : `geo-api-gouv.test.ts` appelait réellement `geo.api.gouv.fr` et dépassait le timeout de 5 s sur les runners (deux tentatives rouges sans rapport avec la PR). Réponses rejouées par `nock` comme pour les autres clients, `getDepartements` réactivé, cas 500 ajouté.

**Mesures**, offres actives de prod importées en local, Loire-Atlantique : code 9 422 items en 124 ms, 1 seul hors du contour officiel (tracé) ; rayon couvrant 67 km, 21 % hors périmètre et au moins 16 % du département manqué ; bbox, 18 %. Résolution : 99,96 % des offres, 99,87 % des formations. Contexte et banc dans `tools/geo-781`, issue amont https://github.com/BaseAdresseNationale/ban-plateforme/issues/781.

## Plan de test

- [ ] `yarn workspace shared build && yarn workspace server build`, puis `yarn cli migrations:up` (ou `indexes:recreate` + `fillSearchItemsCollection`) ; attendre `status: READY` sur `[{ $listSearchIndexes: {} }]`
- [ ] `curl "http://localhost:5001/api/v1/search?admin_area=departement:44&hitsPerPage=5" | jq '.nbHits, [.hits[].address], [.hits[].distance]'` : adresses toutes en 44, distances `null`
- [ ] Même chose avec `region:53` et `departement:2A`
- [ ] UI, champ lieu : « Breta » → `Bretagne (région)` en tête puis les communes ; « Nord » → `Nord (département)` puis Nordausques ; « Nantes » → inchangé
- [ ] Sélection de « Bretagne (région) » : URL avec `admin_area=region:53`, libellé du champ « Bretagne », pas de distance sur les cartes, aucun élargissement automatique du rayon
- [ ] Sans sélection d'entité administrative : recherche par rayon identique à `main`
- [ ] `node tools/geo-781/bench.mjs "Loire-Atlantique" --limit 10000 --diff` : ligne `4-code` à 0 % hors périmètre hors cas de tracé
- [ ] `search_queries` : `admin_area` renseigné sur une recherche par emprise, `null` sinon
- [ ] Champ métier, « carbo » : suggestion pré-surlignée, Entrée remplit le champ (home) / applique la recherche (résultats) ; un seul événement Matomo `search_launched` par lancement
- [ ] « carbonisateur » + Occitanie ou Pyrénées-Orientales : « Aucun résultat trouvé » affiché, pas de skeleton

